### PR TITLE
adds text and texts as computed properties on `GenerateResponse`

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,3 +1,6 @@
 # Specify files that shouldn't be modified by Fern
 
 README.md
+
+# added computed properties 
+src/vellum/api/types/generate_response.py

--- a/src/vellum/types/generate_response.py
+++ b/src/vellum/types/generate_response.py
@@ -20,6 +20,20 @@ class GenerateResponse(pydantic.BaseModel):
         kwargs_with_defaults: typing.Any = {"by_alias": True, "exclude_unset": True, **kwargs}
         return super().dict(**kwargs_with_defaults)
 
+    @property
+    def texts(self) -> typing.List[str]:
+        return [
+            completion.text
+            for result in self.results
+            for completion in (result.data.completions if result.data else [])
+        ]
+
+    @property
+    def text(self) -> str:
+        if len(self.texts) != 1:
+            raise ValueError(f"Expected exactly one completion, but got {len(self.texts)}")
+        return self.texts[0]
+
     class Config:
         frozen = True
         json_encoders = {dt.datetime: serialize_datetime}


### PR DESCRIPTION
Add helper methods to `GenerateResponse` that make it easy to retrieve the contents of the generated message.