### PR TITLE
fix: Handle import for both pydantic v1 and v2 in generate_response.py

### DIFF
--- a/src/vellum/types/generate_response.py
+++ b/src/vellum/types/generate_response.py
@@ -3,7 +3,10 @@
 import datetime as dt
 import typing
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic
 
 from ..core.datetime_utils import serialize_datetime
 from .generate_result import GenerateResult


### PR DESCRIPTION
The fix is related to [this comment](https://github.com/vellum-ai/vellum-client-python/issues/7#issuecomment-1783016451) 