### PR TITLE
🌿 Temporarily Fern Ignore Import Fix

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -3,5 +3,8 @@
 README.md
 LICENSE
 
+
+src/vellum/types/variable_value.py
+
 # added computed properties
 src/vellum/types/generate_response.py

--- a/src/vellum/types/variable_value.py
+++ b/src/vellum/types/variable_value.py
@@ -99,4 +99,4 @@ VariableValue = typing.Union[
     VariableValue_FunctionCall,
 ]
 
-VariableValue_Array.update_forward_refs()
+VariableValue_Array.update_forward_refs(ArrayVariableValue=ArrayVariableValue, VariableValue=VariableValue)


### PR DESCRIPTION
This is a workaround while we take a deeper look into circular reference generation and resulting imports.

In this PR, we add `src/vellum/types/variable_value.py` to the `.fernignore`. Adding a file to `.fernignore` makes sure that manual edits to the file will not be overwritten by the generator and that the SDK will compile properly. 

Note that this change only impacts `VariableValue`, not any of its subtypes. For example, if you add a property to `ChatHistoryVariableValue` in your OpenAPI spec, that will continue to automatically come through via Fern. 