### PR TITLE
Create Guide on Synthetic Conversation Generation

### DIFF
--- a/examples/Synthetic Conversation Generation.ipynb
+++ b/examples/Synthetic Conversation Generation.ipynb
@@ -1,0 +1,373 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "908e1b66-9e2b-43c9-8bbb-251cae8dec24",
+   "metadata": {},
+   "source": [
+    "# Synthetic Conversation Generation\n",
+    "\n",
+    "## Context\n",
+    "\n",
+    "When building an AI-powered chatbot, it's often helpful to have a large number of realistic conversations between a human and the AI\n",
+    "for testing purposes. Given the conversation up until a point, you can verify whether your AI responds as expected to the latest\n",
+    "user message.\n",
+    "\n",
+    "For example, if you have a conversation with three conversation turns (i.e. the user and AI have responded to each other 3 times), then you\n",
+    "can simulate how changes to the AI system effect the AI's respond on turn 4.\n",
+    "\n",
+    "## The Problem\n",
+    "\n",
+    "However, there are two problems with this.\n",
+    "1. Collecting a large number of realitic conversations can be tricky, making it difficult to simulate your Chatbot's behavior over a wide variety of real-world scenarios; and\n",
+    "2. While you can simulate the _most recent_ AI message, you cannot easily test changes that would have affected the AI's _messages up until that point_.\n",
+    "\n",
+    "To solve for both of these problems, this guide shows you how you can use two Vellum Workflows to \"talk to\" one another and generate a wide set of synthetic conversations.\n",
+    "\n",
+    "One Workflow represents the AI Chatbot itself, and the other represents a user chatting into the system.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "This guide assumes the following pre-requisites:\n",
+    "1. You have a Vellum account and have created a Vellum API key\n",
+    "2. You know how to run and interact with a Jupyter notebook\n",
+    "3. You've created a **Vellum Workflow representing your AI chatbot** that accepts a `CHAT_HISTORY` input variable called `chat_history`. It should have a Final Output Node of type `STRING` called `final-output`.\n",
+    "4. You've created another **Vellum Workflow representing your user** that accepts a `CHAT_HISTORY` input variable called `chat_history`. It should have a Final Output Node of type `STRING` called `final-output`.\n",
+    "5. You've already done manual testing on your User Workflow to ensure that it behaves similarly to your customers.\n",
+    "6. You've updated the csv file located at `datasets/seed_user_messages.csv`. There's one row per conversation you want to generate, and one initial or \"seed\" user message per conversation.\n",
+    "\n",
+    "## Solution\n",
+    "In the rest of this guide, we'll implement everything needed to generate sythetic conversations that could then be uploaded into a Vellum Test Suite for quantitative evaluation of conversation quality."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4c8d1d8-c732-40cd-8e6c-84d491d87839",
+   "metadata": {},
+   "source": [
+    "## Getting Started\n",
+    "\n",
+    "Install dependencies and securely enter your Vellum API key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "63466cce-3b46-403b-8a1e-ff4572fd062a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Looking in indexes: https://pypi.org/simple, https://_json_key_base64:****@us-central1-python.pkg.dev/vocify-prod/vocify/simple/\n",
+      "Requirement already satisfied: vellum-ai in /Users/noaflaherty/Repos/vellum-ai/vellum-client-python/venv/lib/python3.11/site-packages (0.5.0)\n",
+      "\u001b[31mERROR: Could not find a version that satisfies the requirement getpass (from versions: none)\u001b[0m\u001b[31m\n",
+      "\u001b[0m\u001b[31mERROR: No matching distribution found for getpass\u001b[0m\u001b[31m\n",
+      "\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.2.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.0\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install vellum-ai getpass pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a04fff2a-fa94-4c2c-9a93-1db4f0a39275",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " ········\n"
+     ]
+    }
+   ],
+   "source": [
+    "from getpass import getpass\n",
+    "\n",
+    "VELLUM_API_KEY = getpass()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f16975a2-22fd-4d34-a2f4-724ea691e40c",
+   "metadata": {},
+   "source": [
+    "Read in the csv consisting of seed user messages.\n",
+    "\n",
+    "Review the printed out results to ensure your seed messages look good and edit the csv manually if not before proceeding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6de7a41b-c965-4ceb-8e8b-704427a71e36",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0                What is your refund policy?\n",
+       "1              What time are you open until?\n",
+       "2    How much does a one year warranty cost?\n",
+       "Name: 0, dtype: object"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.read_csv(\"datasets/seed_user_messages.csv\", header=None)\n",
+    "\n",
+    "initial_user_messages = df[0]\n",
+    "initial_user_messages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4006f9da-6137-4b31-b9fd-b4e60c7fd7b0",
+   "metadata": {},
+   "source": [
+    "Here we define some helper functions that we'll execute later. Notice that we use our `async` python client so that we can run API calls in parallel later.\n",
+    "\n",
+    "Here you'll have to provide the `name` of your two Vellum Workflow Deployments. You'll also provide how many \"conversation turns\" you want to run per seed user message."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5c9e03a4-51ae-42ad-bbcd-356eea2c4929",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " chat-history-manipulation\n",
+      " chat-history-manipulation\n",
+      " 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "AI_CHATBOT_WORKFLOW_DEPLOYMENT_NAME = input()\n",
+    "SIMULATED_USER_WORKFLOW_DEPLOYMENT_NAME = input()\n",
+    "DEFAULT_NUM_CONVERSATION_TURNS = int(input())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a9a5eb2f-f699-4927-ba3d-fa11f1e2667f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import List\n",
+    "\n",
+    "from vellum.client import AsyncVellum\n",
+    "import vellum.types as types\n",
+    "\n",
+    "client = AsyncVellum(api_key=VELLUM_API_KEY)\n",
+    "\n",
+    "\n",
+    "async def invoke_chat_workflow(\n",
+    "    workflow_name: str,\n",
+    "    chat_history: List[types.ChatMessageRequest],\n",
+    "    output_name: str = \"final-output\"\n",
+    ") -> str:\n",
+    "    \"\"\"\n",
+    "    A helper for invoking a chat-based Workflow Deployment.\n",
+    "    \n",
+    "    Feel free to pass in other input variable values if your Workflow expected them.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    result = await client.execute_workflow(\n",
+    "        workflow_deployment_name=workflow_name,\n",
+    "        inputs=[\n",
+    "            types.WorkflowRequestInputRequest_ChatHistory(\n",
+    "                type=\"CHAT_HISTORY\",\n",
+    "                name=\"chat_history\",\n",
+    "                value=chat_history,\n",
+    "            ),\n",
+    "        ],\n",
+    "    )\n",
+    "    \n",
+    "\n",
+    "    if result.data.state == \"REJECTED\":\n",
+    "        raise Exception(result.data.error.message)\n",
+    "\n",
+    "    reponse = next(\n",
+    "        filter(\n",
+    "            lambda output: output.name == output_name and output.type == \"STRING\",\n",
+    "            result.data.outputs\n",
+    "        )\n",
+    "    ).value\n",
+    "\n",
+    "    return reponse\n",
+    "\n",
+    "\n",
+    "async def get_assistant_response(chat_history: List[types.ChatMessageRequest]) -> str:\n",
+    "    return await invoke_chat_workflow(AI_CHATBOT_WORKFLOW_DEPLOYMENT_NAME, chat_history)\n",
+    "\n",
+    "\n",
+    "async def get_synthetic_user_response(chat_history: List[types.ChatMessageRequest]) -> str:\n",
+    "    return await invoke_chat_workflow(SIMULATED_USER_WORKFLOW_DEPLOYMENT_NAME, chat_history)\n",
+    "\n",
+    "\n",
+    "async def generate_synthetic_conversation(seed_user_message: str, num_conversation_turns: int = DEFAULT_NUM_CONVERSATION_TURNS) -> List[types.ChatMessageRequest]:\n",
+    "    assistant_chat_history: List[types.ChatMessageRequest] = [\n",
+    "        types.ChatMessageRequest(role=\"USER\", text=seed_user_message)\n",
+    "    ]\n",
+    "    synthetic_user_chat_history: List[types.ChatMessageRequest] = [\n",
+    "        types.ChatMessageRequest(role=\"ASSISTANT\", text=seed_user_message)\n",
+    "    ]\n",
+    "    \n",
+    "    for i in range(num_conversation_turns):\n",
+    "        assistant_response = await get_assistant_response(assistant_chat_history)\n",
+    "        \n",
+    "        assistant_chat_history.append(\n",
+    "            types.ChatMessageRequest(role=\"ASSISTANT\", text=assistant_response)\n",
+    "        )\n",
+    "        synthetic_user_chat_history.append(\n",
+    "            types.ChatMessageRequest(role=\"USER\", text=assistant_response)\n",
+    "        )\n",
+    "    \n",
+    "        if i < num_conversation_turns:\n",
+    "            synthetic_user_response = await get_synthetic_user_response(synthetic_user_chat_history)\n",
+    "            \n",
+    "            assistant_chat_history.append(\n",
+    "                types.ChatMessageRequest(role=\"USER\", text=assistant_response)\n",
+    "            )\n",
+    "            synthetic_user_chat_history.append(\n",
+    "                types.ChatMessageRequest(role=\"ASSISTANT\", text=assistant_response)\n",
+    "            )\n",
+    "\n",
+    "    return assistant_chat_history"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0195cce8-a522-41ee-a411-b616b8ef2aed",
+   "metadata": {},
+   "source": [
+    "Here's where we actually invoke our Workflow Deployments. We do so in parallel for faster execution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b42176ed-686b-49d5-9267-3d91312fc3ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[ChatMessageRequest(text='What is your refund policy?', role='USER', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What is your refund policy?', role='ASSISTANT', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What is your refund policy?', role='USER', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What is your refund policy?', role='ASSISTANT', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What is your refund policy?', role='USER', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What is your refund policy?', role='ASSISTANT', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What is your refund policy?', role='USER', content=None, source=None)],\n",
+       " [ChatMessageRequest(text='What time are you open until?', role='USER', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What time are you open until?', role='ASSISTANT', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What time are you open until?', role='USER', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What time are you open until?', role='ASSISTANT', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What time are you open until?', role='USER', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What time are you open until?', role='ASSISTANT', content=None, source=None),\n",
+       "  ChatMessageRequest(text='What time are you open until?', role='USER', content=None, source=None)],\n",
+       " [ChatMessageRequest(text='How much does a one year warranty cost?', role='USER', content=None, source=None),\n",
+       "  ChatMessageRequest(text='How much does a one year warranty cost?', role='ASSISTANT', content=None, source=None),\n",
+       "  ChatMessageRequest(text='How much does a one year warranty cost?', role='USER', content=None, source=None),\n",
+       "  ChatMessageRequest(text='How much does a one year warranty cost?', role='ASSISTANT', content=None, source=None),\n",
+       "  ChatMessageRequest(text='How much does a one year warranty cost?', role='USER', content=None, source=None),\n",
+       "  ChatMessageRequest(text='How much does a one year warranty cost?', role='ASSISTANT', content=None, source=None),\n",
+       "  ChatMessageRequest(text='How much does a one year warranty cost?', role='USER', content=None, source=None)]]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "synthetic_conversations = await asyncio.gather(\n",
+    "    *[generate_synthetic_conversation(seed_message) for seed_message in initial_user_messages]\n",
+    ")\n",
+    "synthetic_conversations\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a5a626e-0b31-4110-bcbe-c1ff1535986b",
+   "metadata": {},
+   "source": [
+    "Finally, we serialize the results and save them to a csv in this same directory.\n",
+    "\n",
+    "You can now upload this csv to a Vellum Test Suite if you want to perform quanitative assertions on the next turn of the conversation!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "409eeb63-ebfa-4b97-be18-0c7f2e7e260b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import csv\n",
+    "\n",
+    "serialized_synthetic_conversations = [\n",
+    "    json.dumps([\n",
+    "        {\n",
+    "            \"text\": message.text,\n",
+    "            \"role\": message.role,\n",
+    "        }\n",
+    "        for message in conversation\n",
+    "    ])\n",
+    "    for conversation in synthetic_conversations\n",
+    "]\n",
+    "\n",
+    "csv_contents = [\n",
+    "    \"chat_history\",\n",
+    "    *serialized_synthetic_conversations,\n",
+    "]\n",
+    "\n",
+    "pd.DataFrame(csv_contents).to_csv(\"synthetic_conversations\", header=False, index=False, quoting=csv.QUOTE_NONE, sep='\\t')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/datasets/seed_user_messages.csv
+++ b/examples/datasets/seed_user_messages.csv
@@ -1,0 +1,3 @@
+What is your refund policy?
+What time are you open until?
+How much does a one year warranty cost?


### PR DESCRIPTION
This jupyter notebook shows how you can use two Vellum Workflows to talk to each other and generate a synthetic conversation for use in Test Case generation.

It also shows the power of the async Vellum API client in running API calls in parallel.

View the readable jupyter notebook here: https://github.com/vellum-ai/vellum-client-python/blob/c62f6ae15a324446d75f936627763a43e980e1a7/examples/Synthetic%20Conversation%20Generation.ipynb