### PR TITLE
Add Support for Using Test Suite Name

### DIFF
--- a/examples/Running a Test Suite on an External Function.ipynb
+++ b/examples/Running a Test Suite on an External Function.ipynb
@@ -38,11 +38,11 @@
      "text": [
       "Looking in indexes: https://pypi.org/simple, https://_json_key_base64:****@us-central1-python.pkg.dev/vocify-prod/vocify/simple/\n",
       "Requirement already satisfied: vellum-ai in /Users/noaflaherty/Repos/vellum-ai/vellum-client-python/venv/lib/python3.11/site-packages (0.5.0)\n",
-      "\u001B[31mERROR: Could not find a version that satisfies the requirement getpass (from versions: none)\u001B[0m\u001B[31m\n",
-      "\u001B[0m\u001B[31mERROR: No matching distribution found for getpass\u001B[0m\u001B[31m\n",
-      "\u001B[0m\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m23.2.1\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m24.0\u001B[0m\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n"
+      "\u001b[31mERROR: Could not find a version that satisfies the requirement getpass (from versions: none)\u001b[0m\u001b[31m\n",
+      "\u001b[0m\u001b[31mERROR: No matching distribution found for getpass\u001b[0m\u001b[31m\n",
+      "\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.2.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
      ]
     }
    ],
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "46070a6d-c661-49ea-b15d-0123fc8c8da5",
    "metadata": {},
    "outputs": [],
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "95384013-0636-42db-8d33-4f641d4d7e75",
    "metadata": {},
    "outputs": [
@@ -132,17 +132,18 @@
      "name": "stdin",
      "output_type": "stream",
      "text": [
-      " 9580c9c2-ed5d-4206-a103-d6e487f6a54b\n"
+      " my_test_suite\n"
      ]
     }
    ],
    "source": [
-    "TEST_SUITE_ID = input()"
+    "# Ether the Test Suite's ID or name\n",
+    "TEST_SUITE_IDENTIFIER = input()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "57b72cff-0c3e-4fe5-ab7a-7f03b4bf04ad",
    "metadata": {},
    "outputs": [],
@@ -153,7 +154,7 @@
     "\n",
     "# Create a new VellumTestSuite object\n",
     "client = Vellum(api_key=VELLUM_API_KEY)\n",
-    "test_suite = VellumTestSuite(test_suite_id=TEST_SUITE_ID, client=client)"
+    "test_suite = VellumTestSuite(TEST_SUITE_IDENTIFIER, client=client)"
    ]
   },
   {
@@ -296,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/examples/Running a Test Suite on an External Function.ipynb
+++ b/examples/Running a Test Suite on an External Function.ipynb
@@ -28,20 +28,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "cc8ea10c-d5f0-4557-972b-7f9aa293ad1a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Looking in indexes: https://pypi.org/simple, https://_json_key_base64:****@us-central1-python.pkg.dev/vocify-prod/vocify/simple/\n",
+      "Requirement already satisfied: vellum-ai in /Users/noaflaherty/Repos/vellum-ai/vellum-client-python/venv/lib/python3.11/site-packages (0.5.0)\n",
+      "\u001b[31mERROR: Could not find a version that satisfies the requirement getpass (from versions: none)\u001b[0m\u001b[31m\n",
+      "\u001b[0m\u001b[31mERROR: No matching distribution found for getpass\u001b[0m\u001b[31m\n",
+      "\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.2.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "!pip install vellum-ai getpass\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "f61c3873-bf84-4a61-b1a0-36089704c360",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " ········\n"
+     ]
+    }
+   ],
    "source": [
     "from getpass import getpass\n",
     "\n",
@@ -82,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "46070a6d-c661-49ea-b15d-0123fc8c8da5",
    "metadata": {},
    "outputs": [],
@@ -102,10 +124,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "95384013-0636-42db-8d33-4f641d4d7e75",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " external-eval-example\n"
+     ]
+    }
+   ],
    "source": [
     "# Ether the Test Suite's ID or name\n",
     "TEST_SUITE_IDENTIFIER = input()"
@@ -113,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "57b72cff-0c3e-4fe5-ab7a-7f03b4bf04ad",
    "metadata": {},
    "outputs": [],
@@ -139,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "421c76de-20f9-4b11-bd4e-f6787148d695",
    "metadata": {},
    "outputs": [],
@@ -150,10 +180,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "2bd38cf7-78bf-4cf6-996d-31f22530efa2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[TestSuiteRunMetricNumberOutput(value=1.0, type='NUMBER', name='score'),\n",
+       " TestSuiteRunMetricNumberOutput(value=1.0, type='NUMBER', name='score'),\n",
+       " TestSuiteRunMetricNumberOutput(value=0.0, type='NUMBER', name='score')]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Filter down to a specific metric and a specific output that it produces.\n",
     "results.get_metric_outputs(\"Exact Match\", \"score\")"
@@ -179,10 +222,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "c98609c5-754e-4e45-9155-f9a5e52f20e4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Do all Test Cases pass? No\n",
+      "66.66666666666666% of Test Cases pass. Acceptable? Yes\n",
+      "Is the average score acceptable? Yes\n",
+      "Is the minimum score acceptable? No\n",
+      "Is the maximum regressing? No\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[VellumTestSuiteRunExecution(id='ffc8102f-9e8b-4a03-9cdc-9e6fc9ab7928', test_case_id='99971a73-429d-4a28-9003-afbe5cadb868', outputs=[TestSuiteRunExecutionStringOutput(name='output', type='STRING', value='Hello, world!', output_variable_id='c3f48fd5-6df7-4116-bd69-fb624d8d7d88')], metric_results=[TestSuiteRunExecutionMetricResult(metric_id='c4ac96a5-2101-4e1e-8dfb-3fccdc1ebde0', outputs=[TestSuiteRunMetricNumberOutput(value=1.0, type='NUMBER', name='score'), TestSuiteRunMetricNumberOutput(value=1.0, type='NUMBER', name='normalized_score')], metric_label='Exact Match', metric_definition=TestSuiteRunExecutionMetricDefinition(id='9a8a4c32-0258-41be-beac-063628fe50e6', label='Exact Match', name='exact-match'))]),\n",
+       " VellumTestSuiteRunExecution(id='fbc9263a-3ae6-4225-ad6e-cc9215c0f758', test_case_id='d4e6885c-4d10-4099-bc2f-9e8dff37c4c2', outputs=[TestSuiteRunExecutionStringOutput(name='output', type='STRING', value='Goodbye cruel, world...', output_variable_id='c3f48fd5-6df7-4116-bd69-fb624d8d7d88')], metric_results=[TestSuiteRunExecutionMetricResult(metric_id='c4ac96a5-2101-4e1e-8dfb-3fccdc1ebde0', outputs=[TestSuiteRunMetricNumberOutput(value=1.0, type='NUMBER', name='score'), TestSuiteRunMetricNumberOutput(value=1.0, type='NUMBER', name='normalized_score')], metric_label='Exact Match', metric_definition=TestSuiteRunExecutionMetricDefinition(id='9a8a4c32-0258-41be-beac-063628fe50e6', label='Exact Match', name='exact-match'))]),\n",
+       " VellumTestSuiteRunExecution(id='fcf54a22-8d52-4d77-9c8a-75cb85cb30a0', test_case_id='3fdb81b7-2147-42c8-92b2-b8f322ad9853', outputs=[TestSuiteRunExecutionStringOutput(name='output', type='STRING', value='Failingtest', output_variable_id='c3f48fd5-6df7-4116-bd69-fb624d8d7d88')], metric_results=[TestSuiteRunExecutionMetricResult(metric_id='c4ac96a5-2101-4e1e-8dfb-3fccdc1ebde0', outputs=[TestSuiteRunMetricNumberOutput(value=0.0, type='NUMBER', name='score'), TestSuiteRunMetricNumberOutput(value=0.0, type='NUMBER', name='normalized_score')], metric_label='Exact Match', metric_definition=TestSuiteRunExecutionMetricDefinition(id='9a8a4c32-0258-41be-beac-063628fe50e6', label='Exact Match', name='exact-match'))])]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def print_result(msg: str, result: bool) -> None:\n",
     "    print(msg, \"Yes\" if result else \"No\")\n",

--- a/examples/Running a Test Suite on an External Function.ipynb
+++ b/examples/Running a Test Suite on an External Function.ipynb
@@ -28,42 +28,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "cc8ea10c-d5f0-4557-972b-7f9aa293ad1a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Looking in indexes: https://pypi.org/simple, https://_json_key_base64:****@us-central1-python.pkg.dev/vocify-prod/vocify/simple/\n",
-      "Requirement already satisfied: vellum-ai in /Users/noaflaherty/Repos/vellum-ai/vellum-client-python/venv/lib/python3.11/site-packages (0.5.0)\n",
-      "\u001b[31mERROR: Could not find a version that satisfies the requirement getpass (from versions: none)\u001b[0m\u001b[31m\n",
-      "\u001b[0m\u001b[31mERROR: No matching distribution found for getpass\u001b[0m\u001b[31m\n",
-      "\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.2.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.2\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!pip install vellum-ai getpass\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "f61c3873-bf84-4a61-b1a0-36089704c360",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      " ········\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from getpass import getpass\n",
     "\n",
@@ -104,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "46070a6d-c661-49ea-b15d-0123fc8c8da5",
    "metadata": {},
    "outputs": [],
@@ -124,18 +102,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "95384013-0636-42db-8d33-4f641d4d7e75",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      " my_test_suite\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Ether the Test Suite's ID or name\n",
     "TEST_SUITE_IDENTIFIER = input()"
@@ -143,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "57b72cff-0c3e-4fe5-ab7a-7f03b4bf04ad",
    "metadata": {},
    "outputs": [],
@@ -169,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "421c76de-20f9-4b11-bd4e-f6787148d695",
    "metadata": {},
    "outputs": [],
@@ -180,23 +150,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "2bd38cf7-78bf-4cf6-996d-31f22530efa2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[TestSuiteRunMetricNumberOutput(value=1.0, name='score', type='NUMBER'),\n",
-       " TestSuiteRunMetricNumberOutput(value=0.0, name='score', type='NUMBER'),\n",
-       " TestSuiteRunMetricNumberOutput(value=1.0, name='score', type='NUMBER')]"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Filter down to a specific metric and a specific output that it produces.\n",
     "results.get_metric_outputs(\"Exact Match\", \"score\")"
@@ -222,34 +179,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "c98609c5-754e-4e45-9155-f9a5e52f20e4",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Do all Test Cases pass? No\n",
-      "66.66666666666666% of Test Cases pass. Acceptable? Yes\n",
-      "Is the average score acceptable? Yes\n",
-      "Is the minimum score acceptable? No\n",
-      "Is the maximum regressing? No\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[VellumTestSuiteRunExecution(id='95431327-d864-4cc1-bd47-50430c39ebeb', test_case_id='99971a73-429d-4a28-9003-afbe5cadb868', outputs=[TestSuiteRunExecutionOutput_String(name='output', value='Hello, world!', output_variable_id='c3f48fd5-6df7-4116-bd69-fb624d8d7d88', type='STRING')], metric_results=[TestSuiteRunExecutionMetricResult(metric_id='c4ac96a5-2101-4e1e-8dfb-3fccdc1ebde0', outputs=[TestSuiteRunMetricNumberOutput(value=1.0, name='score', type='NUMBER'), TestSuiteRunMetricNumberOutput(value=1.0, name='normalized_score', type='NUMBER')], metric_label='Exact Match', metric_definition=TestSuiteRunExecutionMetricDefinition(id='9a8a4c32-0258-41be-beac-063628fe50e6', label='Exact Match', name='exact-match'))]),\n",
-       " VellumTestSuiteRunExecution(id='363833cf-4b0f-4993-876f-ed578d792414', test_case_id='3fdb81b7-2147-42c8-92b2-b8f322ad9853', outputs=[TestSuiteRunExecutionOutput_String(name='output', value='Failingtest', output_variable_id='c3f48fd5-6df7-4116-bd69-fb624d8d7d88', type='STRING')], metric_results=[TestSuiteRunExecutionMetricResult(metric_id='c4ac96a5-2101-4e1e-8dfb-3fccdc1ebde0', outputs=[TestSuiteRunMetricNumberOutput(value=0.0, name='score', type='NUMBER'), TestSuiteRunMetricNumberOutput(value=0.0, name='normalized_score', type='NUMBER')], metric_label='Exact Match', metric_definition=TestSuiteRunExecutionMetricDefinition(id='9a8a4c32-0258-41be-beac-063628fe50e6', label='Exact Match', name='exact-match'))]),\n",
-       " VellumTestSuiteRunExecution(id='21ed2cb5-9d48-44e8-9b58-59bcfe9ef505', test_case_id='d4e6885c-4d10-4099-bc2f-9e8dff37c4c2', outputs=[TestSuiteRunExecutionOutput_String(name='output', value='Goodbye cruel, world...', output_variable_id='c3f48fd5-6df7-4116-bd69-fb624d8d7d88', type='STRING')], metric_results=[TestSuiteRunExecutionMetricResult(metric_id='c4ac96a5-2101-4e1e-8dfb-3fccdc1ebde0', outputs=[TestSuiteRunMetricNumberOutput(value=1.0, name='score', type='NUMBER'), TestSuiteRunMetricNumberOutput(value=1.0, name='normalized_score', type='NUMBER')], metric_label='Exact Match', metric_definition=TestSuiteRunExecutionMetricDefinition(id='9a8a4c32-0258-41be-beac-063628fe50e6', label='Exact Match', name='exact-match'))])]"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "def print_result(msg: str, result: bool) -> None:\n",
     "    print(msg, \"Yes\" if result else \"No\")\n",

--- a/src/vellum/core/client_wrapper.py
+++ b/src/vellum/core/client_wrapper.py
@@ -8,7 +8,13 @@ from .http_client import AsyncHttpClient
 
 
 class BaseClientWrapper:
-    def __init__(self, *, api_key: str, environment: VellumEnvironment, timeout: typing.Optional[float] = None):
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        environment: VellumEnvironment,
+        timeout: typing.Optional[float] = None,
+    ):
         self.api_key = api_key
         self._environment = environment
         self._timeout = timeout
@@ -40,7 +46,9 @@ class SyncClientWrapper(BaseClientWrapper):
     ):
         super().__init__(api_key=api_key, environment=environment, timeout=timeout)
         self.httpx_client = HttpClient(
-            httpx_client=httpx_client, base_headers=self.get_headers, base_timeout=self.get_timeout
+            httpx_client=httpx_client,
+            base_headers=self.get_headers,
+            base_timeout=self.get_timeout,
         )
 
 
@@ -55,5 +63,7 @@ class AsyncClientWrapper(BaseClientWrapper):
     ):
         super().__init__(api_key=api_key, environment=environment, timeout=timeout)
         self.httpx_client = AsyncHttpClient(
-            httpx_client=httpx_client, base_headers=self.get_headers, base_timeout=self.get_timeout
+            httpx_client=httpx_client,
+            base_headers=self.get_headers,
+            base_timeout=self.get_timeout,
         )

--- a/src/vellum/lib/test_suites/resources.py
+++ b/src/vellum/lib/test_suites/resources.py
@@ -7,7 +7,7 @@ from typing import Callable, Generator, List, cast, Iterable
 from uuid import UUID
 
 from vellum import TestSuiteRunRead, TestSuiteRunMetricNumberOutput
-from vellum.client import Vellum
+from vellum.client import Vellum, OMIT
 from vellum.lib.test_suites.constants import (
     DEFAULT_MAX_POLLING_DURATION_MS,
     DEFAULT_POLLING_INTERVAL_MS,
@@ -337,14 +337,9 @@ class VellumTestSuite:
                 )
             )
 
-        identifier_kwargs = {}
-        if self._test_suite_id:
-            identifier_kwargs["test_suite_id"] = self._test_suite_id
-        if self._test_suite_name:
-            identifier_kwargs["test_suite_name"] = self._test_suite_name
-
         test_suite_run = self.client.test_suite_runs.create(
-            **identifier_kwargs,
+            test_suite_id=self._test_suite_id or OMIT,
+            test_suite_name=self._test_suite_name or OMIT,
             exec_config=TestSuiteRunExternalExecConfigRequest(
                 type="EXTERNAL",
                 data=TestSuiteRunExternalExecConfigDataRequest(

--- a/src/vellum/lib/test_suites/resources.py
+++ b/src/vellum/lib/test_suites/resources.py
@@ -305,11 +305,11 @@ class VellumTestSuite:
         )
 
         if is_valid_uuid(test_suite_identifier):
-            self._test_suite_id = test_suite_identifier
+            self._test_suite_id = str(test_suite_identifier)
             self._test_suite_name = None
         else:
             self._test_suite_id = None
-            self._test_suite_name = test_suite_identifier
+            self._test_suite_name = str(test_suite_identifier)
 
     def run_external(
         self,

--- a/src/vellum/lib/test_suites/resources.py
+++ b/src/vellum/lib/test_suites/resources.py
@@ -336,9 +336,14 @@ class VellumTestSuite:
                 )
             )
 
+        identifier_kwargs = {}
+        if self._test_suite_id:
+            identifier_kwargs["test_suite_id"] = self._test_suite_id
+        if self._test_suite_name:
+            identifier_kwargs["test_suite_name"] = self._test_suite_name
+
         test_suite_run = self.client.test_suite_runs.create(
-            test_suite_id=self._test_suite_id,
-            test_suite_name=self._test_suite_name,
+            **identifier_kwargs,
             exec_config=TestSuiteRunExternalExecConfigRequest(
                 type="EXTERNAL",
                 data=TestSuiteRunExternalExecConfigDataRequest(

--- a/src/vellum/lib/test_suites/resources.py
+++ b/src/vellum/lib/test_suites/resources.py
@@ -15,6 +15,7 @@ from vellum.lib.test_suites.constants import (
 from vellum.lib.test_suites.exceptions import TestSuiteRunResultsException
 from vellum.lib.utils.env import get_api_key
 from vellum.lib.utils.paginator import PaginatedResults, get_all_results
+from vellum.lib.utils.typing import cast_not_optional
 from vellum.lib.utils.uuid import is_valid_uuid
 from vellum.types import (
     ExternalTestCaseExecutionRequest,
@@ -322,7 +323,7 @@ class VellumTestSuite:
         Returns a wrapper that polls the generated Test Suite Run until it's done running and returns its results.
         """
         test_cases = self.client.test_suites.list_test_suite_test_cases(
-            id=self._test_suite_id or self._test_suite_name
+            id=cast_not_optional(self._test_suite_id or self._test_suite_name)
         )
         executions: List[ExternalTestCaseExecutionRequest] = []
 

--- a/src/vellum/lib/utils/typing.py
+++ b/src/vellum/lib/utils/typing.py
@@ -1,0 +1,10 @@
+from typing import TypeVar, Optional
+
+_T = TypeVar("_T")
+
+
+def cast_not_optional(optional: Optional[_T]) -> _T:
+    """Convert an optional to its value for type checking purposes. Raises an AssertionError if passed None."""
+    if optional is None:
+        raise AssertionError("Not optional check failed")
+    return optional

--- a/src/vellum/lib/utils/uuid.py
+++ b/src/vellum/lib/utils/uuid.py
@@ -1,0 +1,10 @@
+from typing import Union
+import uuid
+
+
+def is_valid_uuid(val: Union[str, uuid.UUID, None]) -> bool:
+    try:
+        uuid.UUID(str(val))
+        return True
+    except (ValueError, TypeError):
+        return False

--- a/src/vellum/resources/test_suite_runs/client.py
+++ b/src/vellum/resources/test_suite_runs/client.py
@@ -10,7 +10,9 @@ from ...core.pydantic_utilities import parse_obj_as
 from json.decoder import JSONDecodeError
 from ...core.api_error import ApiError
 from ...core.jsonable_encoder import jsonable_encoder
-from ...types.paginated_test_suite_run_execution_list import PaginatedTestSuiteRunExecutionList
+from ...types.paginated_test_suite_run_execution_list import (
+    PaginatedTestSuiteRunExecutionList,
+)
 from ...core.client_wrapper import AsyncClientWrapper
 
 # this is used as the default value for optional parameters
@@ -78,7 +80,9 @@ class TestSuiteRunsClient:
                 "test_suite_id": test_suite_id,
                 "test_suite_name": test_suite_name,
                 "exec_config": convert_and_respect_annotation_metadata(
-                    object_=exec_config, annotation=TestSuiteRunExecConfigRequest, direction="write"
+                    object_=exec_config,
+                    annotation=TestSuiteRunExecConfigRequest,
+                    direction="write",
                 ),
             },
             request_options=request_options,
@@ -98,7 +102,9 @@ class TestSuiteRunsClient:
             raise ApiError(status_code=_response.status_code, body=_response.text)
         raise ApiError(status_code=_response.status_code, body=_response_json)
 
-    def retrieve(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> TestSuiteRunRead:
+    def retrieve(
+        self, id: str, *, request_options: typing.Optional[RequestOptions] = None
+    ) -> TestSuiteRunRead:
         """
         Retrieve a specific Test Suite Run by ID
 
@@ -288,7 +294,9 @@ class AsyncTestSuiteRunsClient:
                 "test_suite_id": test_suite_id,
                 "test_suite_name": test_suite_name,
                 "exec_config": convert_and_respect_annotation_metadata(
-                    object_=exec_config, annotation=TestSuiteRunExecConfigRequest, direction="write"
+                    object_=exec_config,
+                    annotation=TestSuiteRunExecConfigRequest,
+                    direction="write",
                 ),
             },
             request_options=request_options,
@@ -308,7 +316,9 @@ class AsyncTestSuiteRunsClient:
             raise ApiError(status_code=_response.status_code, body=_response.text)
         raise ApiError(status_code=_response.status_code, body=_response_json)
 
-    async def retrieve(self, id: str, *, request_options: typing.Optional[RequestOptions] = None) -> TestSuiteRunRead:
+    async def retrieve(
+        self, id: str, *, request_options: typing.Optional[RequestOptions] = None
+    ) -> TestSuiteRunRead:
         """
         Retrieve a specific Test Suite Run by ID
 

--- a/tests/test_test_suite_runs.py
+++ b/tests/test_test_suite_runs.py
@@ -12,7 +12,11 @@ async def test_create(client: Vellum, async_client: AsyncVellum) -> None:
     expected_response: typing.Any = {
         "id": "id",
         "created": "2024-01-15T09:30:00Z",
-        "test_suite": {"id": "id", "history_item_id": "history_item_id", "label": "label"},
+        "test_suite": {
+            "id": "id",
+            "history_item_id": "history_item_id",
+            "label": "label",
+        },
         "state": "QUEUED",
         "exec_config": {
             "type": "DEPLOYMENT_RELEASE_TAG",
@@ -33,14 +37,18 @@ async def test_create(client: Vellum, async_client: AsyncVellum) -> None:
     }
     response = client.test_suite_runs.create(
         exec_config=TestSuiteRunDeploymentReleaseTagExecConfigRequest(
-            data=TestSuiteRunDeploymentReleaseTagExecConfigDataRequest(deployment_id="deployment_id")
+            data=TestSuiteRunDeploymentReleaseTagExecConfigDataRequest(
+                deployment_id="deployment_id"
+            )
         )
     )
     validate_response(response, expected_response, expected_types)
 
     async_response = await async_client.test_suite_runs.create(
         exec_config=TestSuiteRunDeploymentReleaseTagExecConfigRequest(
-            data=TestSuiteRunDeploymentReleaseTagExecConfigDataRequest(deployment_id="deployment_id")
+            data=TestSuiteRunDeploymentReleaseTagExecConfigDataRequest(
+                deployment_id="deployment_id"
+            )
         )
     )
     validate_response(async_response, expected_response, expected_types)
@@ -50,7 +58,11 @@ async def test_retrieve(client: Vellum, async_client: AsyncVellum) -> None:
     expected_response: typing.Any = {
         "id": "id",
         "created": "2024-01-15T09:30:00Z",
-        "test_suite": {"id": "id", "history_item_id": "history_item_id", "label": "label"},
+        "test_suite": {
+            "id": "id",
+            "history_item_id": "history_item_id",
+            "label": "label",
+        },
         "state": "QUEUED",
         "exec_config": {
             "type": "DEPLOYMENT_RELEASE_TAG",
@@ -85,8 +97,19 @@ async def test_list_executions(client: Vellum, async_client: AsyncVellum) -> Non
             {
                 "id": "id",
                 "test_case_id": "test_case_id",
-                "outputs": [{"name": "name", "type": "STRING", "output_variable_id": "output_variable_id"}],
-                "metric_results": [{"metric_id": "metric_id", "outputs": [{"type": "STRING", "name": "name"}]}],
+                "outputs": [
+                    {
+                        "name": "name",
+                        "type": "STRING",
+                        "output_variable_id": "output_variable_id",
+                    }
+                ],
+                "metric_results": [
+                    {
+                        "metric_id": "metric_id",
+                        "outputs": [{"type": "STRING", "name": "name"}],
+                    }
+                ],
             }
         ],
     }
@@ -100,10 +123,18 @@ async def test_list_executions(client: Vellum, async_client: AsyncVellum) -> Non
                 0: {
                     "id": None,
                     "test_case_id": None,
-                    "outputs": ("list", {0: {"name": None, "type": None, "output_variable_id": None}}),
+                    "outputs": (
+                        "list",
+                        {0: {"name": None, "type": None, "output_variable_id": None}},
+                    ),
                     "metric_results": (
                         "list",
-                        {0: {"metric_id": None, "outputs": ("list", {0: {"type": None, "name": None}})}},
+                        {
+                            0: {
+                                "metric_id": None,
+                                "outputs": ("list", {0: {"type": None, "name": None}}),
+                            }
+                        },
                     ),
                 }
             },


### PR DESCRIPTION
This updates our external evals hand-written lib code to support either a Test Suite's ID or Name in use with external evals.

It also updates the Jupyter notebook example accordingly.