### PR TITLE
Forgot to update pyproject toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vellum-ai"
-version = "0.9.16-pre2"
+version = "0.9.16-pre4"
 description = ""
 readme = "README.md"
 authors = []


### PR DESCRIPTION
Messed up `pre3` [prerelease](https://github.com/vellum-ai/vellum-client-python/releases/tag/0.9.16-pre3) by forgetting to update the pyproject toml's version. Now this should work