### PR TITLE
Implement Boilerplate for Generic Nodes

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -876,12 +876,7 @@ export function apiNodeFactory({
 
 export function genericNodeFactory(): GenericNode {
   const nodeData: GenericNode = {
-    id: "7e09927b-6d6f-4829-92c9-54e66bdcaf80",
     type: WorkflowNodeType.GENERIC,
-    data: {
-      label: "Generic Node",
-    },
-    inputs: [],
   };
   return nodeData;
 }

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -874,11 +874,13 @@ export function apiNodeFactory({
   return nodeData;
 }
 
-export function genericNodeFactory(): GenericNode {
+export function genericNodeFactory(
+  { name }: { name: string } = { name: "MyCustomNode" }
+): GenericNode {
   const nodeData: GenericNode = {
     type: WorkflowNodeType.GENERIC,
     definition: {
-      name: "MyCustomNode",
+      name,
       module: ["my_nodes", "my_custom_node"],
       bases: [
         {

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -877,6 +877,16 @@ export function apiNodeFactory({
 export function genericNodeFactory(): GenericNode {
   const nodeData: GenericNode = {
     type: WorkflowNodeType.GENERIC,
+    definition: {
+      name: "MyCustomNode",
+      module: ["my_nodes", "my_custom_node"],
+      bases: [
+        {
+          module: ["vellum", "workflows", "nodes", "bases", "base"],
+          name: "BaseNode",
+        },
+      ],
+    },
   };
   return nodeData;
 }

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -18,6 +18,7 @@ import {
   ConditionalNode,
   ApiNode,
   MergeNode,
+  GenericNode,
 } from "src/types/vellum";
 
 export function entrypointNodeDataFactory(): EntrypointNode {
@@ -499,7 +500,7 @@ export function inlinePromptNodeDataLegacyVariantFactory({
   return nodeData;
 }
 
-export function inlineTemplatingNodeDataFactory({
+export function templatingNodeFactory({
   errorOutputId,
 }: {
   errorOutputId?: string;
@@ -617,7 +618,7 @@ export function conditionalNodeFactory(): ConditionalNode {
   return nodeData;
 }
 
-export function ApiNodeFactory({
+export function apiNodeFactory({
   errorOutputId,
 }: {
   errorOutputId?: string;
@@ -869,6 +870,18 @@ export function ApiNodeFactory({
         y: 234.65663468515768,
       },
     },
+  };
+  return nodeData;
+}
+
+export function genericNodeFactory(): GenericNode {
+  const nodeData: GenericNode = {
+    id: "7e09927b-6d6f-4829-92c9-54e66bdcaf80",
+    type: WorkflowNodeType.GENERIC,
+    data: {
+      label: "Generic Node",
+    },
+    inputs: [],
   };
   return nodeData;
 }

--- a/ee/codegen/src/__test__/nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/generic-node.test.ts.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GenericNode > basic > getNodeDisplayFile 1`] = `
+"from vellum_ee.workflows.display.nodes import BaseNodeDisplay
+from ...nodes.generic_node import GenericNode
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class GenericNodeDisplay(BaseNodeDisplay[GenericNode]):
+    node_input_ids_by_name = {}
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=0, y=0), width=None, height=None
+    )
+"
+`;
+
+exports[`GenericNode > basic > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import BaseNode
+
+
+class GenericNode(BaseNode):
+    pass
+"
+`;

--- a/ee/codegen/src/__test__/nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/generic-node.test.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`GenericNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseNodeDisplay
-from ...nodes.generic_node import GenericNode
+from ...nodes.my_custom_node import MyCustomNode
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 
-class GenericNodeDisplay(BaseNodeDisplay[GenericNode]):
+class MyCustomNodeDisplay(BaseNodeDisplay[MyCustomNode]):
     node_input_ids_by_name = {}
     display_data = NodeDisplayData(
         position=NodeDisplayPosition(x=0, y=0), width=None, height=None
@@ -18,7 +18,7 @@ exports[`GenericNode > basic > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import BaseNode
 
 
-class GenericNode(BaseNode):
+class MyCustomNode(BaseNode):
     pass
 "
 `;

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -3,7 +3,7 @@ import { beforeEach } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
 import { inputVariableContextFactory } from "src/__test__/helpers/input-variable-context-factory";
-import { ApiNodeFactory } from "src/__test__/helpers/node-data-factories";
+import { apiNodeFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { ApiNodeContext } from "src/context/node-context/api-node";
 import { ApiNode } from "src/generators/nodes/api-node";
@@ -41,7 +41,7 @@ describe("ApiNode", () => {
 
   describe("basic", () => {
     beforeEach(() => {
-      const nodeData = ApiNodeFactory();
+      const nodeData = apiNodeFactory();
 
       const nodeContext = createNodeContext({
         workflowContext,
@@ -68,7 +68,7 @@ describe("ApiNode", () => {
 
   describe("reject on error enabled", () => {
     beforeEach(() => {
-      const nodeData = ApiNodeFactory({
+      const nodeData = apiNodeFactory({
         errorOutputId: "af589f73-effe-4a80-b48f-fb912ac6ce67",
       });
 

--- a/ee/codegen/src/__test__/nodes/generic-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-node.test.ts
@@ -1,0 +1,46 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { beforeEach } from "vitest";
+
+import { workflowContextFactory } from "src/__test__/helpers";
+import { genericNodeFactory } from "src/__test__/helpers/node-data-factories";
+import { createNodeContext, WorkflowContext } from "src/context";
+import { GenericNodeContext } from "src/context/node-context/generic-node";
+import { GenericNode } from "src/generators/nodes/generic-node";
+
+describe("GenericNode", () => {
+  let workflowContext: WorkflowContext;
+  let writer: Writer;
+  let node: GenericNode;
+
+  beforeEach(() => {
+    workflowContext = workflowContextFactory();
+    writer = new Writer();
+  });
+
+  describe("basic", () => {
+    beforeEach(() => {
+      const nodeData = genericNodeFactory();
+
+      const nodeContext = createNodeContext({
+        workflowContext,
+        nodeData,
+      }) as GenericNodeContext;
+      workflowContext.addNodeContext(nodeContext);
+
+      node = new GenericNode({
+        workflowContext: workflowContext,
+        nodeContext,
+      });
+    });
+
+    it("getNodeFile", async () => {
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("getNodeDisplayFile", async () => {
+      node.getNodeDisplayFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+});

--- a/ee/codegen/src/__test__/nodes/templating-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/templating-node.test.ts
@@ -3,7 +3,7 @@ import { beforeEach } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
 import { inputVariableContextFactory } from "src/__test__/helpers/input-variable-context-factory";
-import { inlineTemplatingNodeDataFactory } from "src/__test__/helpers/node-data-factories";
+import { templatingNodeFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import { TemplatingNode } from "src/generators/nodes/templating-node";
@@ -31,7 +31,7 @@ describe("TemplatingNode", () => {
 
   describe("basic", () => {
     beforeEach(() => {
-      const nodeData = inlineTemplatingNodeDataFactory();
+      const nodeData = templatingNodeFactory();
 
       const nodeContext = createNodeContext({
         workflowContext,
@@ -58,7 +58,7 @@ describe("TemplatingNode", () => {
 
   describe("reject on error enabled", () => {
     beforeEach(() => {
-      const nodeData = inlineTemplatingNodeDataFactory({
+      const nodeData = templatingNodeFactory({
         errorOutputId: "e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f",
       });
 

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -2,6 +2,7 @@ import { WorkflowContext } from "src/context";
 import { PortContext } from "src/context/port-context";
 import { WorkflowDataNode } from "src/types/vellum";
 import { toPascalCase, toSnakeCase } from "src/utils/casing";
+import { getNodeId, getNodeLabel } from "src/utils/nodes";
 import {
   getGeneratedNodeDisplayModulePath,
   getGeneratedNodeModulePath,
@@ -33,7 +34,9 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
   constructor(args: BaseNodeContext.Args<T>) {
     this.workflowContext = args.workflowContext;
 
-    const nodeLabel = args.nodeData.data.label;
+    this.nodeData = args.nodeData;
+
+    const nodeLabel = this.getNodeLabel();
 
     this.nodeModuleName =
       args.nodeData.definition?.module?.[
@@ -55,7 +58,6 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
       this.nodeDisplayModuleName
     );
 
-    this.nodeData = args.nodeData;
     this.nodeOutputNamesById = this.getNodeOutputNamesById();
 
     const portContexts = this.createPortContexts();
@@ -76,7 +78,11 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
   protected abstract createPortContexts(): PortContext[];
 
   public getNodeId(): string {
-    return this.nodeData.id;
+    return getNodeId(this.nodeData);
+  }
+
+  public getNodeLabel(): string {
+    return getNodeLabel(this.nodeData);
   }
 
   public getNodeOutputNameById(outputId: string): string {

--- a/ee/codegen/src/context/node-context/create-node-context.ts
+++ b/ee/codegen/src/context/node-context/create-node-context.ts
@@ -8,6 +8,7 @@ import { CodeExecutionContext } from "src/context/node-context/code-execution-no
 import { ConditionalNodeContext } from "src/context/node-context/conditional-node";
 import { ErrorNodeContext } from "src/context/node-context/error-node";
 import { FinalOutputNodeContext } from "src/context/node-context/final-output-node";
+import { GenericNodeContext } from "src/context/node-context/generic-node";
 import { InlinePromptNodeContext } from "src/context/node-context/inline-prompt-node";
 import { MapNodeContext } from "src/context/node-context/map-node";
 import { MergeNodeContext } from "src/context/node-context/merge-node";
@@ -174,6 +175,13 @@ export function createNodeContext(
       return new NoteNodeContext({
         ...args,
         nodeData: noteNodeData,
+      });
+    }
+    case WorkflowNodeType.GENERIC: {
+      const genericNodeData = nodeData;
+      return new GenericNodeContext({
+        ...args,
+        nodeData: genericNodeData,
       });
     }
     default:

--- a/ee/codegen/src/context/node-context/generic-node.ts
+++ b/ee/codegen/src/context/node-context/generic-node.ts
@@ -1,0 +1,13 @@
+import { BaseNodeContext } from "src/context/node-context/base";
+import { PortContext } from "src/context/port-context";
+import { GenericNode as GenericNodeType } from "src/types/vellum";
+
+export class GenericNodeContext extends BaseNodeContext<GenericNodeType> {
+  getNodeOutputNamesById(): Record<string, string> {
+    return {};
+  }
+
+  protected createPortContexts(): PortContext[] {
+    return [];
+  }
+}

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -134,6 +134,10 @@ export abstract class BaseNode<
   private generateNodeInputs(): Map<string, NodeInput> {
     const generatedNodeInputs = new Map<string, NodeInput>();
 
+    if (!("inputs" in this.nodeData)) {
+      return generatedNodeInputs;
+    }
+
     this.nodeData.inputs.forEach((nodeInputData) => {
       const nodeInput = codegen.nodeInput({
         workflowContext: this.workflowContext,
@@ -147,7 +151,10 @@ export abstract class BaseNode<
   }
 
   private getPortDisplay(): python.Field | undefined {
-    if (!("sourceHandleId" in this.nodeData.data)) {
+    if (
+      !("data" in this.nodeData) ||
+      !("sourceHandleId" in this.nodeData.data)
+    ) {
       return;
     }
 

--- a/ee/codegen/src/generators/nodes/bases/nested-workflow-base.ts
+++ b/ee/codegen/src/generators/nodes/bases/nested-workflow-base.ts
@@ -54,7 +54,7 @@ export abstract class BaseNestedWorkflowNode<
   }
 
   protected generateNestedWorkflowContexts(): Map<string, WorkflowContext> {
-    const nestedWorkflowLabel = `${this.nodeData.data.label} Workflow`;
+    const nestedWorkflowLabel = `${this.nodeContext.getNodeLabel()} Workflow`;
     const nestedWorkflowContext = new WorkflowContext({
       absolutePathToOutputDirectory:
         this.workflowContext.absolutePathToOutputDirectory,

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -1,0 +1,27 @@
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+
+import { GenericNodeContext } from "src/context/node-context/generic-node";
+import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base";
+import { GenericNode as GenericNodeType } from "src/types/vellum";
+
+export class GenericNode extends BaseSingleFileNode<
+  GenericNodeType,
+  GenericNodeContext
+> {
+  baseNodeClassName = "BaseNode";
+  baseNodeDisplayClassName = "BaseNodeDisplay";
+
+  getNodeClassBodyStatements(): AstNode[] {
+    const statements: AstNode[] = [];
+    return statements;
+  }
+
+  getNodeDisplayClassBodyStatements(): AstNode[] {
+    const statements: AstNode[] = [];
+    return statements;
+  }
+
+  getGenericOutputId(): string | undefined {
+    return undefined;
+  }
+}

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -21,7 +21,7 @@ export class GenericNode extends BaseSingleFileNode<
     return statements;
   }
 
-  getGenericOutputId(): string | undefined {
+  protected getErrorOutputId(): string | undefined {
     return undefined;
   }
 }

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -59,6 +59,7 @@ import {
   WorkflowVersionExecConfig,
 } from "src/types/vellum";
 import { toSnakeCase } from "src/utils/casing";
+import { getNodeId } from "src/utils/nodes";
 import { assertUnreachable } from "src/utils/typing";
 
 export class ProjectSerializationError extends Error {
@@ -296,7 +297,7 @@ from .workflow import *\
       workflowContext: this.workflowContext,
     });
 
-    const nodeIds = nodesToGenerate.map((nodeData) => nodeData.id);
+    const nodeIds = nodesToGenerate.map((nodeData) => getNodeId(nodeData));
     const nodes = this.generateNodes(nodeIds);
 
     const workflow = codegen.workflow({

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -29,6 +29,7 @@ import { CodeExecutionContext } from "src/context/node-context/code-execution-no
 import { ConditionalNodeContext } from "src/context/node-context/conditional-node";
 import { ErrorNodeContext } from "src/context/node-context/error-node";
 import { FinalOutputNodeContext } from "src/context/node-context/final-output-node";
+import { GenericNodeContext } from "src/context/node-context/generic-node";
 import { GuardrailNodeContext } from "src/context/node-context/guardrail-node";
 import { InlinePromptNodeContext } from "src/context/node-context/inline-prompt-node";
 import { InlineSubworkflowNodeContext } from "src/context/node-context/inline-subworkflow-node";
@@ -45,6 +46,7 @@ import { CodeExecutionNode } from "src/generators/nodes/code-execution-node";
 import { ConditionalNode } from "src/generators/nodes/conditional-node";
 import { ErrorNode } from "src/generators/nodes/error-node";
 import { FinalOutputNode } from "src/generators/nodes/final-output-node";
+import { GenericNode } from "src/generators/nodes/generic-node";
 import { InlinePromptNode } from "src/generators/nodes/inline-prompt-node";
 import { MapNode } from "src/generators/nodes/map-node";
 import { MergeNode } from "src/generators/nodes/merge-node";
@@ -448,6 +450,12 @@ from .workflow import *\
           node = new ApiNode({
             workflowContext: this.workflowContext,
             nodeContext: nodeContext as ApiNodeContext,
+          });
+          break;
+        case WorkflowNodeTypeEnum.GENERIC:
+          node = new GenericNode({
+            workflowContext: this.workflowContext,
+            nodeContext: nodeContext as GenericNodeContext,
           });
           break;
         default: {

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -678,22 +678,19 @@ export declare namespace PromptVersionExecConfigSerializer {
   }
 }
 
-export const BaseWorkflowNodeSerializer = objectSchema({
-  id: stringSchema(),
-  type: stringSchema(),
-  inputs: listSchema(NodeInputSerializer),
-  displayData: propertySchema("display_data", anySchema()),
-  definition: WorkflowNodeDefinitionSerializer.optional(),
-});
-
 export declare namespace BaseWorkflowNodeSerializer {
   interface Raw {
-    id: string;
     type: string;
-    inputs: NodeInputSerializer.Raw[];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     display_data?: any;
     definition?: WorkflowNodeDefinitionSerializer.Raw | null;
+  }
+}
+
+export declare namespace BaseDisplayableWorkflowNodeSerializer {
+  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+    id: string;
+    inputs: NodeInputSerializer.Raw[];
   }
 }
 
@@ -713,7 +710,7 @@ export const EntrypointNodeSerializer: ObjectSchema<
 });
 
 export declare namespace EntrypointNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "ENTRYPOINT";
     data: {
       label: string;
@@ -810,7 +807,7 @@ export const SubworkflowNodeSerializer: ObjectSchema<
 });
 
 export declare namespace SubworkflowNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "SUBWORKFLOW";
     data: SubworkflowNodeDataSerializer.Raw;
   }
@@ -1011,7 +1008,7 @@ export const PromptNodeSerializer: ObjectSchema<
 });
 
 export declare namespace PromptNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "PROMPT";
     data: PromptNodeDataSerializer.Raw;
   }
@@ -1122,7 +1119,7 @@ export const MapNodeSerializer: ObjectSchema<MapNodeSerializer.Raw, MapNode> =
   });
 
 export declare namespace MapNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "MAP";
     data: MapNodeDataSerializer.Raw;
   }
@@ -1148,7 +1145,7 @@ export const GuardrailNodeSerializer: ObjectSchema<
 });
 
 export declare namespace GuardrailNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "METRIC";
     data: {
       label: string;
@@ -1223,7 +1220,7 @@ export const CodeExecutionNodeSerializer: ObjectSchema<
 });
 
 export declare namespace CodeExecutionNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "CODE_EXECUTION";
     data: CodeExecutionNodeDataSerializer.Raw;
   }
@@ -1296,7 +1293,7 @@ export const SearchNodeSerializer: ObjectSchema<
 });
 
 export declare namespace SearchNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "SEARCH";
     data: SearchNodeDataSerializer.Raw;
   }
@@ -1384,7 +1381,7 @@ export const ConditionalNodeSerializer: ObjectSchema<
 });
 
 export declare namespace ConditionalNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "CONDITIONAL";
     data: ConditionalNodeDataSerializer.Raw;
   }
@@ -1414,7 +1411,7 @@ export const TemplatingNodeSerializer: ObjectSchema<
 });
 
 export declare namespace TemplatingNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "TEMPLATING";
     data: {
       label: string;
@@ -1448,7 +1445,7 @@ export const FinalOutputNodeSerializer: ObjectSchema<
 });
 
 export declare namespace FinalOutputNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "TERMINAL";
     data: {
       label: string;
@@ -1501,7 +1498,7 @@ export const MergeNodeSerializer: ObjectSchema<
 });
 
 export declare namespace MergeNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "MERGE";
     data: {
       label: string;
@@ -1575,7 +1572,7 @@ export const ApiNodeSerializer: ObjectSchema<ApiNodeSerializer.Raw, ApiNode> =
   });
 
 export declare namespace ApiNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "API";
     data: {
       label: string;
@@ -1614,7 +1611,7 @@ export const NoteNodeSerializer: ObjectSchema<
 });
 
 export declare namespace NoteNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "NOTE";
     data: {
       label: string;
@@ -1644,7 +1641,7 @@ export const ErrorNodeSerializer: ObjectSchema<
 });
 
 export declare namespace ErrorNodeSerializer {
-  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     type: "ERROR";
     data: {
       label: string;
@@ -1661,11 +1658,6 @@ export const GenericNodeSerializer: ObjectSchema<
   GenericNode
 > = objectSchema({
   type: stringLiteralSchema("GENERIC"),
-  id: stringSchema(),
-  data: objectSchema({
-    label: stringSchema(),
-  }),
-  inputs: listSchema(NodeInputSerializer),
   displayData: propertySchema("display_data", anySchema()),
   definition: WorkflowNodeDefinitionSerializer.optional(),
 });
@@ -1673,9 +1665,6 @@ export const GenericNodeSerializer: ObjectSchema<
 export declare namespace GenericNodeSerializer {
   interface Raw extends BaseWorkflowNodeSerializer.Raw {
     type: "GENERIC";
-    data: {
-      label: string;
-    };
   }
 }
 

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -89,6 +89,7 @@ import {
   PromptNodeDeployment,
   PromptVersionData,
   LegacyPromptNodeData,
+  GenericNode,
 } from "src/types/vellum";
 
 const CacheConfigSerializer = objectSchema({
@@ -1655,6 +1656,29 @@ export declare namespace ErrorNodeSerializer {
   }
 }
 
+export const GenericNodeSerializer: ObjectSchema<
+  GenericNodeSerializer.Raw,
+  GenericNode
+> = objectSchema({
+  type: stringLiteralSchema("GENERIC"),
+  id: stringSchema(),
+  data: objectSchema({
+    label: stringSchema(),
+  }),
+  inputs: listSchema(NodeInputSerializer),
+  displayData: propertySchema("display_data", anySchema()),
+  definition: WorkflowNodeDefinitionSerializer.optional(),
+});
+
+export declare namespace GenericNodeSerializer {
+  interface Raw extends BaseWorkflowNodeSerializer.Raw {
+    type: "GENERIC";
+    data: {
+      label: string;
+    };
+  }
+}
+
 export const WorkflowNodeSerializer: Schema<
   WorkflowNodeSerializer.Raw,
   WorkflowNode
@@ -1673,6 +1697,7 @@ export const WorkflowNodeSerializer: Schema<
   ApiNodeSerializer,
   NoteNodeSerializer,
   ErrorNodeSerializer,
+  GenericNodeSerializer,
 ]);
 
 export declare namespace WorkflowNodeSerializer {
@@ -1690,7 +1715,8 @@ export declare namespace WorkflowNodeSerializer {
     | ConditionalNodeSerializer.Raw
     | ApiNodeSerializer.Raw
     | NoteNodeSerializer.Raw
-    | ErrorNodeSerializer.Raw;
+    | ErrorNodeSerializer.Raw
+    | GenericNodeSerializer.Raw;
 }
 
 const workflowEdgeSerializer: ObjectSchema<

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -16,7 +16,6 @@ export enum WorkflowNodeType {
   CODE_EXECUTION = "CODE_EXECUTION",
   METRIC = "METRIC",
   SEARCH = "SEARCH",
-  WEBHOOK = "WEBHOOK",
   MERGE = "MERGE",
   CONDITIONAL = "CONDITIONAL",
   API = "API",
@@ -25,6 +24,7 @@ export enum WorkflowNodeType {
   SUBWORKFLOW = "SUBWORKFLOW",
   MAP = "MAP",
   ERROR = "ERROR",
+  GENERIC = "GENERIC",
 }
 
 export enum ConditionalCombinator {
@@ -486,6 +486,15 @@ export interface ErrorNode extends BaseWorkflowNode {
   data: ErrorNodeData;
 }
 
+export interface GenericNodeData {
+  label: string;
+}
+
+export interface GenericNode extends BaseWorkflowNode {
+  type: "GENERIC";
+  data: GenericNodeData;
+}
+
 export type WorkflowDataNode =
   | PromptNode
   | SearchNode
@@ -499,7 +508,8 @@ export type WorkflowDataNode =
   | ConditionalNode
   | ApiNode
   | NoteNode
-  | ErrorNode;
+  | ErrorNode
+  | GenericNode;
 
 export type WorkflowNode = WorkflowDataNode | EntrypointNode | FinalOutputNode;
 

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -138,6 +138,12 @@ export interface WorkflowNodeDefinition {
 }
 
 export interface BaseWorkflowNode {
+  type: string;
+  displayData?: NodeDisplayData;
+  definition?: WorkflowNodeDefinition;
+}
+
+export interface BaseDisplayableWorkflowNode extends BaseWorkflowNode {
   id: string;
   inputs: NodeInput[];
   type: string;
@@ -150,7 +156,7 @@ export interface EntrypointNodeData {
   sourceHandleId: string;
 }
 
-export interface EntrypointNode extends BaseWorkflowNode {
+export interface EntrypointNode extends BaseDisplayableWorkflowNode {
   type: "ENTRYPOINT";
   data: EntrypointNodeData;
 }
@@ -225,7 +231,7 @@ export type PromptNodeData =
   | DeploymentPromptNodeData
   | LegacyPromptNodeData;
 
-export interface PromptNode extends BaseWorkflowNode {
+export interface PromptNode extends BaseDisplayableWorkflowNode {
   type: "PROMPT";
   data: PromptNodeData;
 }
@@ -247,7 +253,7 @@ export interface SearchNodeData {
   metadataFiltersNodeInputId: string;
 }
 
-export interface SearchNode extends BaseWorkflowNode {
+export interface SearchNode extends BaseDisplayableWorkflowNode {
   type: "SEARCH";
   data: SearchNodeData;
 }
@@ -278,7 +284,7 @@ export type SubworkflowNodeData =
   | ({
       variant: "INLINE";
     } & InlineSubworkflowNodeData);
-export interface SubworkflowNode extends BaseWorkflowNode {
+export interface SubworkflowNode extends BaseDisplayableWorkflowNode {
   type: "SUBWORKFLOW";
   data: SubworkflowNodeData;
 }
@@ -318,7 +324,7 @@ export type MapNodeData =
       variant: "INLINE";
     } & InlineMapNodeData);
 
-export interface MapNode extends BaseWorkflowNode {
+export interface MapNode extends BaseDisplayableWorkflowNode {
   type: "MAP";
   data: MapNodeData;
 }
@@ -331,7 +337,7 @@ export interface GuardrailNodeData {
   metricDefinitionId: string;
   releaseTag: string;
 }
-export interface GuardrailNode extends BaseWorkflowNode {
+export interface GuardrailNode extends BaseDisplayableWorkflowNode {
   type: "METRIC";
   data: GuardrailNodeData;
 }
@@ -354,7 +360,7 @@ export interface CodeExecutionNodeData {
   packages?: CodeExecutionPackage[];
   filepath?: string | null;
 }
-export interface CodeExecutionNode extends BaseWorkflowNode {
+export interface CodeExecutionNode extends BaseDisplayableWorkflowNode {
   type: "CODE_EXECUTION";
   data: CodeExecutionNodeData;
 }
@@ -369,7 +375,7 @@ export interface TemplatingNodeData {
   outputType: VellumVariableType;
 }
 
-export interface TemplatingNode extends BaseWorkflowNode {
+export interface TemplatingNode extends BaseDisplayableWorkflowNode {
   type: "TEMPLATING";
   data: TemplatingNodeData;
 }
@@ -398,7 +404,7 @@ export interface ConditionalNodeData {
   version: string;
 }
 
-export interface ConditionalNode extends BaseWorkflowNode {
+export interface ConditionalNode extends BaseDisplayableWorkflowNode {
   type: "CONDITIONAL";
   data: ConditionalNodeData;
 }
@@ -412,7 +418,7 @@ export interface FinalOutputNodeData {
   nodeInputId: string;
 }
 
-export interface FinalOutputNode extends BaseWorkflowNode {
+export interface FinalOutputNode extends BaseDisplayableWorkflowNode {
   type: "TERMINAL";
   data: FinalOutputNodeData;
 }
@@ -428,7 +434,7 @@ export interface MergeNodeData {
   sourceHandleId: string;
 }
 
-export interface MergeNode extends BaseWorkflowNode {
+export interface MergeNode extends BaseDisplayableWorkflowNode {
   type: "MERGE";
   data: MergeNodeData;
 }
@@ -456,7 +462,7 @@ export interface ApiNodeData {
   sourceHandleId: string;
 }
 
-export interface ApiNode extends BaseWorkflowNode {
+export interface ApiNode extends BaseDisplayableWorkflowNode {
   type: "API";
   data: ApiNodeData;
 }
@@ -468,7 +474,7 @@ export interface NoteNodeData {
   style?: Record<string, any>;
 }
 
-export interface NoteNode extends BaseWorkflowNode {
+export interface NoteNode extends BaseDisplayableWorkflowNode {
   type: "NOTE";
   data: NoteNodeData;
 }
@@ -481,18 +487,13 @@ export interface ErrorNodeData {
   errorOutputId: string;
 }
 
-export interface ErrorNode extends BaseWorkflowNode {
+export interface ErrorNode extends BaseDisplayableWorkflowNode {
   type: "ERROR";
   data: ErrorNodeData;
 }
 
-export interface GenericNodeData {
-  label: string;
-}
-
 export interface GenericNode extends BaseWorkflowNode {
   type: "GENERIC";
-  data: GenericNodeData;
 }
 
 export type WorkflowDataNode =

--- a/ee/codegen/src/utils/nodes.ts
+++ b/ee/codegen/src/utils/nodes.ts
@@ -1,0 +1,27 @@
+import { WorkflowNode } from "src/types/vellum";
+
+export function getNodeId(nodeData: WorkflowNode): string {
+  switch (nodeData.type) {
+    case "GENERIC": {
+      if (!nodeData.definition) {
+        throw new Error("Generic node missing definition");
+      }
+      const syntheticId = [
+        ...nodeData.definition.module,
+        nodeData.definition.name,
+      ].join(".");
+      return syntheticId;
+    }
+    default:
+      return nodeData.id;
+  }
+}
+
+export function getNodeLabel(nodeData: WorkflowNode): string {
+  switch (nodeData.type) {
+    case "GENERIC":
+      return nodeData.definition?.name ?? "Generic Node";
+    default:
+      return nodeData.data.label;
+  }
+}


### PR DESCRIPTION
I'll soon be writing unit tests for our `graph` attribute. As part of this, I'm gonna want to keep my tests very basic and just work with custom/generic nodes, rather than instantiating specific nodes of specific types.

As such, I figured it's as good a time as any to introduce the boilerplate needed for generic nodes.