### PR TITLE
Handle Case of Zombie Edges

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -53,9 +53,12 @@ exports[`Workflow > write > should handle edges pointing to non-existent nodes 1
 "from vellum.workflows import BaseWorkflow
 from .inputs import Inputs
 from vellum.workflows.state import BaseState
+from .nodes.search_node import SearchNode
 
 
 class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
+    graph = SearchNode
+
     class Outputs(BaseWorkflow.Outputs):
         pass
 "

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -48,3 +48,15 @@ class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
         query = FinalOutput.Outputs.value
 "
 `;
+
+exports[`Workflow > write > should handle edges pointing to non-existent nodes 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .inputs import Inputs
+from vellum.workflows.state import BaseState
+
+
+class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
+    class Outputs(BaseWorkflow.Outputs):
+        pass
+"
+`;

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -892,3 +892,45 @@ export function genericNodeFactory(
   };
   return nodeData;
 }
+
+export function finalOutputNodeFactory(): FinalOutputNode {
+  const nodeData: FinalOutputNode = {
+    id: "48e0d88b-a544-4a14-b49f-38aca82e0e13",
+    type: "TERMINAL",
+    data: {
+      label: "Final Output Node",
+      outputType: "STRING",
+      name: "final-output",
+      targetHandleId: "<target-handle-id>",
+      nodeInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+      outputId: "<output-id>",
+    },
+    inputs: [
+      {
+        id: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+        key: "node_input",
+        value: {
+          rules: [
+            {
+              type: "CONSTANT_VALUE",
+              data: {
+                type: "STRING",
+                value: "<my-output>",
+              },
+            },
+          ],
+          combinator: "OR",
+        },
+      },
+    ],
+    displayData: {
+      width: 462,
+      height: 288,
+      position: {
+        x: 2075.7067885117494,
+        y: 234.65663468515768,
+      },
+    },
+  };
+  return nodeData;
+}

--- a/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
@@ -1,0 +1,43 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`FinalOutputNode > basic > getNodeDisplayFile 1`] = `
+"from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
+from ...nodes.final_output_node import FinalOutputNode
+from uuid import UUID
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class FinalOutputNodeDisplay(BaseFinalOutputNodeDisplay[FinalOutputNode]):
+    label = "Final Output Node"
+    node_id = UUID("48e0d88b-a544-4a14-b49f-38aca82e0e13")
+    target_handle_id = UUID("<target-handle-id>")
+    output_id = UUID("<output-id>")
+    output_name = "final-output"
+    node_input_id = UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
+    node_input_ids_by_name = {
+        "node_input": UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
+    }
+    output_display = {
+        FinalOutputNode.Outputs.value: NodeOutputDisplay(
+            id=UUID("<output-id>"), name="value"
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=2075.7067885117494, y=234.65663468515768),
+        width=462,
+        height=288,
+    )
+"
+`;
+
+exports[`FinalOutputNode > basic > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import FinalOutputNode as BaseFinalOutputNode
+from vellum.workflows.state import BaseState
+
+
+class FinalOutputNode(BaseFinalOutputNode[BaseState, str]):
+    class Outputs(BaseFinalOutputNode.Outputs):
+        value = "<my-output>"
+"
+`;

--- a/ee/codegen/src/__test__/nodes/final-output-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/final-output-node.test.ts
@@ -1,0 +1,46 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { beforeEach } from "vitest";
+
+import { workflowContextFactory } from "src/__test__/helpers";
+import { finalOutputNodeFactory } from "src/__test__/helpers/node-data-factories";
+import { createNodeContext, WorkflowContext } from "src/context";
+import { FinalOutputNodeContext } from "src/context/node-context/final-output-node";
+import { FinalOutputNode } from "src/generators/nodes/final-output-node";
+
+describe("FinalOutputNode", () => {
+  let workflowContext: WorkflowContext;
+  let writer: Writer;
+  let node: FinalOutputNode;
+
+  beforeEach(() => {
+    workflowContext = workflowContextFactory();
+    writer = new Writer();
+  });
+
+  describe("basic", () => {
+    beforeEach(() => {
+      const nodeData = finalOutputNodeFactory();
+
+      const nodeContext = createNodeContext({
+        workflowContext,
+        nodeData,
+      }) as FinalOutputNodeContext;
+      workflowContext.addNodeContext(nodeContext);
+
+      node = new FinalOutputNode({
+        workflowContext: workflowContext,
+        nodeContext,
+      });
+    });
+
+    it("getNodeFile", async () => {
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("getNodeDisplayFile", async () => {
+      node.getNodeDisplayFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+});

--- a/ee/codegen/src/context/workflow-context/index.ts
+++ b/ee/codegen/src/context/workflow-context/index.ts
@@ -1,1 +1,1 @@
-export { WorkflowContext } from './workflow-context';
+export { WorkflowContext } from "./workflow-context";

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -78,7 +78,10 @@ export class Workflow {
     nodes: WorkflowDataNode[];
     edges: WorkflowEdge[];
   }) {
-    const nodeIds = new Set<string>(nodes.map((node) => getNodeId(node)));
+    const nodeIds = new Set<string>([
+      ...nodes.map((node) => getNodeId(node)),
+      this.workflowContext.getEntrypointNode().id,
+    ]);
     const edgesByPortId = new Map<string, WorkflowEdge[]>();
     let entrypointPortContexts: PortContext[] = [];
     const entrypointNodeEdges: WorkflowEdge[] = [];

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -23,6 +23,7 @@ import {
   WorkflowDisplayData,
   WorkflowEdge,
 } from "src/types/vellum";
+import { getNodeId } from "src/utils/nodes";
 import { isDefined } from "src/utils/typing";
 
 export declare namespace Workflow {
@@ -64,18 +65,30 @@ export class Workflow {
     this.displayData = displayData;
 
     const { edgesByPortId, entrypointPortContexts, entrypointNodeEdges } =
-      this.getEdgesAndEntrypointNodeContexts(edges);
+      this.getEdgesAndEntrypointNodeContexts({ nodes, edges });
     this.edgesByPortId = edgesByPortId;
     this.entrypointPortContexts = entrypointPortContexts;
     this.entrypointNodeEdges = entrypointNodeEdges;
   }
 
-  private getEdgesAndEntrypointNodeContexts(edges: WorkflowEdge[]) {
+  private getEdgesAndEntrypointNodeContexts({
+    nodes,
+    edges,
+  }: {
+    nodes: WorkflowDataNode[];
+    edges: WorkflowEdge[];
+  }) {
+    const nodeIds = new Set<string>(nodes.map((node) => getNodeId(node)));
     const edgesByPortId = new Map<string, WorkflowEdge[]>();
     let entrypointPortContexts: PortContext[] = [];
     const entrypointNodeEdges: WorkflowEdge[] = [];
 
     edges.forEach((edge) => {
+      // Handle edge case where there are zombie edges that point to nodes that don't exist
+      if (!nodeIds.has(edge.sourceNodeId) || !nodeIds.has(edge.targetNodeId)) {
+        return;
+      }
+
       if (edge.sourceNodeId === this.workflowContext.getEntrypointNode().id) {
         const targetNodeContext = this.workflowContext.getNodeContext(
           edge.targetNodeId


### PR DESCRIPTION
Our Basic RAG Examples was failing Vellum pull due to trying to look up nodes that don't exist. Turns out this is because the data itself is bad and there are zombie edges pointing to node that no longer exist.

This adds robustness to codegen to handle this case.

I confirm that with this, we can successfully run `vellum pull` for our Basic RAG Workflow! https://app.vellum.ai/workflow-sandboxes/732ee8a4-7f65-4685-8cb4-a13667944321

I will note though that the `graph` attribute isn't coming through correctly, so will start looking into that next.