### PR TITLE
[Codegen][SC-5269] Add Partial Codegen Support for Subworkflow Deployment Nodes

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -19,6 +19,7 @@ import {
   ApiNode,
   MergeNode,
   GenericNode,
+  SubworkflowNode,
 } from "src/types/vellum";
 
 export function entrypointNodeDataFactory(): EntrypointNode {
@@ -574,6 +575,39 @@ export function templatingNodeFactory({
     ],
   };
   return nodeData;
+}
+
+export function subworkflowDeploymentNodeDataFactory(): SubworkflowNode {
+  return {
+    id: "c8f2964c-09b8-44e0-a06d-606319fe5e2a",
+    type: "SUBWORKFLOW",
+    data: {
+      label: "Subworkflow Node",
+      sourceHandleId: "600efd51-8677-4ba3-a582-b298bebb2868",
+      targetHandleId: "f5e6bd33-527a-4ba6-8906-cd5e96a4321c",
+      errorOutputId: undefined,
+      variant: "DEPLOYMENT",
+      workflowDeploymentId: "58171df8-cdf9-4d10-a9ed-22eaf545b22a",
+      releaseTag: "LATEST",
+    },
+    inputs: [
+      {
+        id: "f62b7511-dd69-4dff-a4fc-718a9db3ceba",
+        key: "input",
+        value: {
+          rules: [],
+          combinator: "OR",
+        },
+      },
+    ],
+    displayData: {
+      position: {
+        x: 2239.986322714681,
+        y: 484.74458968144046,
+      },
+    },
+    definition: undefined,
+  };
 }
 
 export function conditionalNodeFactory(): ConditionalNode {

--- a/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
@@ -1,0 +1,38 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SubworkflowDeploymentNode > basic > getNodeDisplayFile 1`] = `
+"from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
+from ...nodes.subworkflow_node import SubworkflowNode
+from uuid import UUID
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class SubworkflowNodeDisplay(BaseSubworkflowDeploymentNodeDisplay[SubworkflowNode]):
+    label = "Subworkflow Node"
+    node_id = UUID("c8f2964c-09b8-44e0-a06d-606319fe5e2a")
+    target_handle_id = UUID("f5e6bd33-527a-4ba6-8906-cd5e96a4321c")
+    node_input_ids_by_name = {"input": UUID("f62b7511-dd69-4dff-a4fc-718a9db3ceba")}
+    port_displays = {
+        SubworkflowNode.Ports.default: PortDisplayOverrides(
+            id=UUID("600efd51-8677-4ba3-a582-b298bebb2868")
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=2239.986322714681, y=484.74458968144046),
+        width=None,
+        height=None,
+    )
+"
+`;
+
+exports[`SubworkflowDeploymentNode > basic > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import SubworkflowDeploymentNode
+
+
+class SubworkflowNode(SubworkflowDeploymentNode):
+    deployment = "58171df8-cdf9-4d10-a9ed-22eaf545b22a"
+    release_tag = "LATEST"
+    subworkflow_inputs = {"input": None}
+"
+`;

--- a/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
@@ -2,7 +2,6 @@ import { Writer } from "@fern-api/python-ast/core/Writer";
 import { beforeEach } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
-import { inputVariableContextFactory } from "src/__test__/helpers/input-variable-context-factory";
 import { promptDeploymentNodeDataFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { PromptDeploymentNodeContext } from "src/context/node-context/prompt-deployment-node";
@@ -10,25 +9,13 @@ import { PromptDeploymentNode } from "src/generators/nodes/prompt-deployment-nod
 
 describe("PromptDeploymentNode", () => {
   let workflowContext: WorkflowContext;
+  let node: PromptDeploymentNode;
   let writer: Writer;
 
   beforeEach(() => {
     workflowContext = workflowContextFactory();
     writer = new Writer();
-
-    workflowContext.addInputVariableContext(
-      inputVariableContextFactory({
-        inputVariableData: {
-          id: "90c6afd3-06cc-430d-aed1-35937c062531",
-          key: "text",
-          type: "STRING",
-        },
-        workflowContext,
-      })
-    );
   });
-
-  let node: PromptDeploymentNode;
 
   describe("basic", () => {
     beforeEach(() => {

--- a/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
@@ -9,8 +9,8 @@ import { SubworkflowDeploymentNode } from "src/generators/nodes/subworkflow-depl
 
 describe("SubworkflowDeploymentNode", () => {
   let workflowContext: WorkflowContext;
-  let writer: Writer;
   let node: SubworkflowDeploymentNode;
+  let writer: Writer;
 
   beforeEach(() => {
     workflowContext = workflowContextFactory();

--- a/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
@@ -1,0 +1,46 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { beforeEach } from "vitest";
+
+import { workflowContextFactory } from "src/__test__/helpers";
+import { subworkflowDeploymentNodeDataFactory } from "src/__test__/helpers/node-data-factories";
+import { createNodeContext, WorkflowContext } from "src/context";
+import { SubworkflowDeploymentNodeContext } from "src/context/node-context/subworkflow-deployment-node";
+import { SubworkflowDeploymentNode } from "src/generators/nodes/subworkflow-deployment-node";
+
+describe("SubworkflowDeploymentNode", () => {
+  let workflowContext: WorkflowContext;
+  let writer: Writer;
+  let node: SubworkflowDeploymentNode;
+
+  beforeEach(() => {
+    workflowContext = workflowContextFactory();
+    writer = new Writer();
+  });
+
+  describe("basic", () => {
+    beforeEach(() => {
+      const nodeData = subworkflowDeploymentNodeDataFactory();
+
+      const nodeContext = createNodeContext({
+        workflowContext,
+        nodeData,
+      }) as SubworkflowDeploymentNodeContext;
+      workflowContext.addNodeContext(nodeContext);
+
+      node = new SubworkflowDeploymentNode({
+        workflowContext,
+        nodeContext,
+      });
+    });
+
+    it(`getNodeFile`, async () => {
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it(`getNodeDisplayFile`, async () => {
+      node.getNodeDisplayFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+});

--- a/ee/codegen/src/context/node-context/create-node-context.ts
+++ b/ee/codegen/src/context/node-context/create-node-context.ts
@@ -14,6 +14,7 @@ import { MapNodeContext } from "src/context/node-context/map-node";
 import { MergeNodeContext } from "src/context/node-context/merge-node";
 import { NoteNodeContext } from "src/context/node-context/note-node";
 import { PromptDeploymentNodeContext } from "src/context/node-context/prompt-deployment-node";
+import { SubworkflowDeploymentNodeContext } from "src/context/node-context/subworkflow-deployment-node";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import {
   InlinePromptNodeData,
@@ -47,8 +48,10 @@ export function createNodeContext(
           });
         }
         case "DEPLOYMENT": {
-          // TODO: https://app.shortcut.com/vellum/story/5269
-          throw new Error(`DEPLOYMENT variant not yet supported`);
+          return new SubworkflowDeploymentNodeContext({
+            ...args,
+            nodeData: subworkflowNodeData,
+          });
         }
         default: {
           assertUnreachable(subworkflowVariant);

--- a/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
@@ -1,0 +1,22 @@
+import { BaseNodeContext } from "./base";
+
+import { PortContext } from "src/context/port-context";
+import { SubworkflowNode as SubworkflowNodeType } from "src/types/vellum";
+
+export class SubworkflowDeploymentNodeContext extends BaseNodeContext<SubworkflowNodeType> {
+  // TODO: Hit an API to get a subworkflow deployment node's outputs at runtime
+  // https://app.shortcut.com/vellum/story/5638/fetch-subworkflow-deployment-node-outputs-via-api
+  getNodeOutputNamesById(): Record<string, string> {
+    return {};
+  }
+
+  createPortContexts(): PortContext[] {
+    return [
+      new PortContext({
+        workflowContext: this.workflowContext,
+        nodeContext: this,
+        portId: this.nodeData.data.sourceHandleId,
+      }),
+    ];
+  }
+}

--- a/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
@@ -1,0 +1,92 @@
+import { python } from "@fern-api/python-ast";
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+
+import { SubworkflowDeploymentNodeContext } from "src/context/node-context/subworkflow-deployment-node";
+import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base";
+import { SubworkflowNode as SubworkflowNodeType } from "src/types/vellum";
+
+export class SubworkflowDeploymentNode extends BaseSingleFileNode<
+  SubworkflowNodeType,
+  SubworkflowDeploymentNodeContext
+> {
+  baseNodeClassName = "SubworkflowDeploymentNode";
+  baseNodeDisplayClassName = "BaseSubworkflowDeploymentNodeDisplay";
+
+  getNodeClassBodyStatements(): AstNode[] {
+    const statements: AstNode[] = [];
+
+    if (this.nodeData.data.variant !== "DEPLOYMENT") {
+      throw new Error(
+        `SubworkflowDeploymentNode only supports DEPLOYMENT variant. Received ${this.nodeData.data.variant}`
+      );
+    }
+
+    statements.push(
+      python.field({
+        name: "deployment",
+        initializer: python.TypeInstantiation.str(
+          this.nodeData.data.workflowDeploymentId
+        ),
+      })
+    );
+
+    statements.push(
+      python.field({
+        name: "release_tag",
+        initializer: python.TypeInstantiation.str(
+          this.nodeData.data.releaseTag
+        ),
+      })
+    );
+
+    statements.push(
+      python.field({
+        name: "subworkflow_inputs",
+        initializer: python.TypeInstantiation.dict(
+          Array.from(this.nodeInputsByKey.entries()).map(([key, value]) => ({
+            key: python.TypeInstantiation.str(key),
+            value: value,
+          }))
+        ),
+      })
+    );
+
+    return statements;
+  }
+
+  getNodeDisplayClassBodyStatements(): AstNode[] {
+    const statements: AstNode[] = [];
+
+    statements.push(
+      python.field({
+        name: "label",
+        initializer: python.TypeInstantiation.str(this.nodeData.data.label),
+      })
+    );
+
+    statements.push(
+      python.field({
+        name: "node_id",
+        initializer: python.TypeInstantiation.uuid(this.nodeData.id),
+      })
+    );
+
+    statements.push(
+      python.field({
+        name: "target_handle_id",
+        initializer: python.TypeInstantiation.uuid(
+          this.nodeData.data.targetHandleId
+        ),
+      })
+    );
+
+    // TODO: Add stable id references for inputs and outputs
+    // https://app.shortcut.com/vellum/story/5639
+
+    return statements;
+  }
+
+  protected getErrorOutputId(): string | undefined {
+    return this.nodeData.data.errorOutputId;
+  }
+}

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -53,6 +53,7 @@ import { MapNode } from "src/generators/nodes/map-node";
 import { MergeNode } from "src/generators/nodes/merge-node";
 import { NoteNode } from "src/generators/nodes/note-node";
 import { PromptDeploymentNode } from "src/generators/nodes/prompt-deployment-node";
+import { SubworkflowDeploymentNode } from "src/generators/nodes/subworkflow-deployment-node";
 import { WorkflowVersionExecConfigSerializer } from "src/serializers/vellum";
 import {
   EntrypointNode,
@@ -347,8 +348,11 @@ from .workflow import *\
               });
               break;
             case "DEPLOYMENT":
-              // TODO: https://app.shortcut.com/vellum/story/5269
-              throw new Error(`DEPLOYMENT variant not yet supported`);
+              node = new SubworkflowDeploymentNode({
+                workflowContext: this.workflowContext,
+                nodeContext: nodeContext as InlineSubworkflowNodeContext,
+              });
+              break;
             default: {
               assertUnreachable(variant);
             }


### PR DESCRIPTION
This adds partial codegen support for Subworkflow Deployment Nodes.

We still need to do some work around generating their outputs, but that'll come in a future PR.