### PR TITLE
[Codegen] Fix e2e Support for Execution Counters

### DIFF
--- a/ee/codegen/package-lock.json
+++ b/ee/codegen/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vellum-ai/vellum-codegen",
-  "version": "0.10.0-post2",
+  "version": "0.10.0-post4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vellum-ai/vellum-codegen",
-      "version": "0.10.0-post2",
+      "version": "0.10.0-post4",
       "dependencies": {
         "@fern-api/python-ast": "^0.0.11",
         "@fern-fern/generator-cli-sdk": "file:./stubs/generator-cli-sdk",

--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellum-ai/vellum-codegen",
-  "version": "0.10.0-post2",
+  "version": "0.10.0-post4",
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",
   "files": [

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/__snapshots__/execution-counter-pointer.test.ts.snap
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/__snapshots__/execution-counter-pointer.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ExecutionCounterPointer > should generate correct Python code 1`] = `
-"SearchNode.Execution.counter
+"SearchNode.Execution.count
 "
 `;

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -39,6 +39,7 @@ describe("WorkflowProjectGenerator", () => {
           "simple_map_node",
           "simple_code_execution_node",
           "simple_conditional_node",
+          "simple_templating_node",
         ],
       })
     )(

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.ts
@@ -15,7 +15,7 @@ export class ExecutionCounterPointerRule extends BaseNodeInputValuePointerRule<E
     return python.reference({
       name: nodeContext.nodeClassName,
       modulePath: nodeContext.nodeModulePath,
-      attribute: ["Execution", "counter"],
+      attribute: ["Execution", "count"],
     });
   }
 }

--- a/ee/codegen_integration/conftest.py
+++ b/ee/codegen_integration/conftest.py
@@ -37,6 +37,7 @@ def _get_fixture_paths(root: str) -> Tuple[str, str]:
             "simple_code_execution_node",
             # TODO: Remove once graph is fleshed out. Current the workflow is not pointing to any port branch
             "simple_conditional_node",
+            "simple_templating_node",
         }
     )
 )

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa: F401, F403
+
+from .display import *

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa: F401, F403
+
+from .nodes import *
+from .workflow import *

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/__init__.py
@@ -1,0 +1,4 @@
+from .final_output import FinalOutputDisplay
+from .templating_node import TemplatingNodeDisplay
+
+__all__ = ["TemplatingNodeDisplay", "FinalOutputDisplay"]

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/final_output.py
@@ -1,0 +1,21 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.final_output import FinalOutput
+
+
+class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
+    label = "Final Output"
+    node_id = UUID("f0347fdc-1611-446c-b1da-408511d4181b")
+    target_handle_id = UUID("f3ad283c-d092-4973-91e0-996e5859002a")
+    output_id = UUID("b0961a8d-f702-4922-b410-2aecf7d34b68")
+    output_name = "final-output"
+    node_input_id = UUID("bb465fa1-defb-493c-8284-7156cd680fb3")
+    node_input_ids_by_name = {"node_input": UUID("bb465fa1-defb-493c-8284-7156cd680fb3")}
+    output_display = {
+        FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"), name="value")
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=2752.5214681440443, y=210), width=478, height=234)

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/templating_node.py
@@ -1,0 +1,21 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.templating_node import TemplatingNode
+
+
+class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
+    label = "Templating Node"
+    node_id = UUID("7dffcbb1-0a5c-4149-a6e9-f83095b0a871")
+    output_id = UUID("4d39036a-fd6d-4a51-b410-7c0623375ebd")
+    target_handle_id = UUID("3522e32d-6735-499b-8d45-c0c6488ae92f")
+    node_input_ids_by_name = {"template": UUID("5d2f0f48-4504-4979-8e24-92a8c08c23a4")}
+    port_displays = {
+        TemplatingNode.Ports.default: PortDisplayOverrides(id=UUID("9bce9d0a-3b0e-478e-8a97-f0510715a5a0"))
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=2001.775709833795, y=296.65438885041556), width=480, height=224
+    )

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -1,0 +1,54 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.vellum import (
+    EdgeVellumDisplayOverrides,
+    EntrypointVellumDisplayOverrides,
+    NodeDisplayData,
+    NodeDisplayPosition,
+    WorkflowDisplayData,
+    WorkflowDisplayDataViewport,
+    WorkflowMetaVellumDisplayOverrides,
+    WorkflowOutputVellumDisplayOverrides,
+)
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+
+from ..nodes.final_output import FinalOutput
+from ..nodes.templating_node import TemplatingNode
+from ..workflow import Workflow
+
+
+class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+    workflow_display = WorkflowMetaVellumDisplayOverrides(
+        entrypoint_node_id=UUID("6b52893a-e649-434d-aedd-e8ad73d78dce"),
+        entrypoint_node_source_handle_id=UUID("b4f25dad-17c6-464d-b347-9945065f17e4"),
+        entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),
+        display_data=WorkflowDisplayData(
+            viewport=WorkflowDisplayDataViewport(x=-992.7774269608426, y=-82.38774859214823, zoom=0.6534253694599966)
+        ),
+    )
+    inputs_display = {}
+    entrypoint_displays = {
+        TemplatingNode: EntrypointVellumDisplayOverrides(
+            id=UUID("6b52893a-e649-434d-aedd-e8ad73d78dce"),
+            edge_display=EdgeVellumDisplayOverrides(id=UUID("662141c0-23b1-4513-9b8a-e382e56c4021")),
+        )
+    }
+    edge_displays = {
+        (TemplatingNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
+            id=UUID("6deb7d8b-b4cc-488f-aa30-e3e5f0957882")
+        )
+    }
+    output_displays = {
+        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+            id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"),
+            node_id=UUID("f0347fdc-1611-446c-b1da-408511d4181b"),
+            node_input_id=UUID("bb465fa1-defb-493c-8284-7156cd680fb3"),
+            name="final-output",
+            label="Final Output",
+            target_handle_id=UUID("f3ad283c-d092-4973-91e0-996e5859002a"),
+            display_data=NodeDisplayData(
+                position=NodeDisplayPosition(x=2752.5214681440443, y=210), width=478, height=234
+            ),
+            edge_id=UUID("6deb7d8b-b4cc-488f-aa30-e3e5f0957882"),
+        )
+    }

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/nodes/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/nodes/__init__.py
@@ -1,0 +1,4 @@
+from .final_output import FinalOutput
+from .templating_node import TemplatingNode
+
+__all__ = ["TemplatingNode", "FinalOutput"]

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/nodes/final_output.py
@@ -1,0 +1,9 @@
+from vellum.workflows.nodes.displayable import FinalOutputNode
+from vellum.workflows.state import BaseState
+
+from .templating_node import TemplatingNode
+
+
+class FinalOutput(FinalOutputNode[BaseState, float]):
+    class Outputs(FinalOutputNode.Outputs):
+        value = TemplatingNode.Execution.count

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/nodes/templating_node.py
@@ -1,0 +1,7 @@
+from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
+from vellum.workflows.state import BaseState
+
+
+class TemplatingNode(BaseTemplatingNode[BaseState, str]):
+    template = "Hello, world!"
+    inputs = {}

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/workflow.py
@@ -1,0 +1,11 @@
+from vellum.workflows import BaseWorkflow
+
+from .nodes.final_output import FinalOutput
+from .nodes.templating_node import TemplatingNode
+
+
+class Workflow(BaseWorkflow):
+    graph = TemplatingNode >> FinalOutput
+
+    class Outputs(BaseWorkflow.Outputs):
+        final_output = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_templating_node/display_data/simple_templating_node.json
+++ b/ee/codegen_integration/fixtures/simple_templating_node/display_data/simple_templating_node.json
@@ -1,0 +1,202 @@
+{
+  "workflow_raw_data": {
+    "nodes": [
+      {
+        "id": "6b52893a-e649-434d-aedd-e8ad73d78dce",
+        "type": "ENTRYPOINT",
+        "data": {
+          "label": "Entrypoint Node",
+          "source_handle_id": "b4f25dad-17c6-464d-b347-9945065f17e4"
+        },
+        "inputs": [],
+        "display_data": {
+          "width": 124,
+          "height": 48,
+          "position": {
+            "x": 1545.0,
+            "y": 330.0
+          }
+        },
+        "definition": {
+          "name": "BaseNode",
+          "module": [
+            "vellum",
+            "workflows",
+            "nodes",
+            "bases",
+            "base"
+          ],
+          "bases": []
+        }
+      },
+      {
+        "id": "7dffcbb1-0a5c-4149-a6e9-f83095b0a871",
+        "type": "TEMPLATING",
+        "data": {
+          "label": "Templating Node",
+          "output_id": "4d39036a-fd6d-4a51-b410-7c0623375ebd",
+          "error_output_id": null,
+          "source_handle_id": "9bce9d0a-3b0e-478e-8a97-f0510715a5a0",
+          "target_handle_id": "3522e32d-6735-499b-8d45-c0c6488ae92f",
+          "template_node_input_id": "5d2f0f48-4504-4979-8e24-92a8c08c23a4",
+          "output_type": "STRING"
+        },
+        "inputs": [
+          {
+            "id": "5d2f0f48-4504-4979-8e24-92a8c08c23a4",
+            "key": "template",
+            "value": {
+              "rules": [
+                {
+                  "type": "CONSTANT_VALUE",
+                  "data": {
+                    "type": "STRING",
+                    "value": "Hello, world!"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          }
+        ],
+        "display_data": {
+          "width": 480,
+          "height": 224,
+          "position": {
+            "x": 2001.775709833795,
+            "y": 296.65438885041556
+          }
+        },
+        "definition": {
+          "bases": [
+            {
+              "module": [
+                "vellum",
+                "workflows",
+                "nodes",
+                "core",
+                "templating_node",
+                "node"
+              ],
+              "name": "TemplatingNode"
+            }
+          ],
+          "module": [
+            "codegen_integration",
+            "fixtures",
+            "simple_templating_node",
+            "code",
+            "nodes",
+            "templating_node"
+          ],
+          "name": "TemplatingNode"
+        }
+      },
+      {
+        "id": "f0347fdc-1611-446c-b1da-408511d4181b",
+        "type": "TERMINAL",
+        "data": {
+          "label": "Final Output",
+          "name": "final-output",
+          "target_handle_id": "f3ad283c-d092-4973-91e0-996e5859002a",
+          "output_id": "b0961a8d-f702-4922-b410-2aecf7d34b68",
+          "output_type": "NUMBER",
+          "node_input_id": "bb465fa1-defb-493c-8284-7156cd680fb3"
+        },
+        "inputs": [
+          {
+            "id": "bb465fa1-defb-493c-8284-7156cd680fb3",
+            "key": "node_input",
+            "value": {
+              "rules": [
+                {
+                  "type": "EXECUTION_COUNTER",
+                  "data": {
+                    "node_id": "7dffcbb1-0a5c-4149-a6e9-f83095b0a871"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          }
+        ],
+        "display_data": {
+          "width": 478,
+          "height": 234,
+          "position": {
+            "x": 2752.5214681440443,
+            "y": 210.0
+          }
+        },
+        "definition": {
+          "bases": [
+            {
+              "module": [
+                "vellum",
+                "workflows",
+                "nodes",
+                "displayable",
+                "final_output_node",
+                "node"
+              ],
+              "name": "FinalOutputNode"
+            }
+          ],
+          "module": [
+            "codegen_integration",
+            "fixtures",
+            "simple_templating_node",
+            "code",
+            "nodes",
+            "final_output"
+          ],
+          "name": "FinalOutput"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "id": "662141c0-23b1-4513-9b8a-e382e56c4021",
+        "source_node_id": "6b52893a-e649-434d-aedd-e8ad73d78dce",
+        "source_handle_id": "b4f25dad-17c6-464d-b347-9945065f17e4",
+        "target_node_id": "7dffcbb1-0a5c-4149-a6e9-f83095b0a871",
+        "target_handle_id": "3522e32d-6735-499b-8d45-c0c6488ae92f",
+        "type": "DEFAULT"
+      },
+      {
+        "id": "6deb7d8b-b4cc-488f-aa30-e3e5f0957882",
+        "source_node_id": "7dffcbb1-0a5c-4149-a6e9-f83095b0a871",
+        "source_handle_id": "9bce9d0a-3b0e-478e-8a97-f0510715a5a0",
+        "target_node_id": "f0347fdc-1611-446c-b1da-408511d4181b",
+        "target_handle_id": "f3ad283c-d092-4973-91e0-996e5859002a",
+        "type": "DEFAULT"
+      }
+    ],
+    "display_data": {
+      "viewport": {
+        "x": -992.7774269608426,
+        "y": -82.38774859214823,
+        "zoom": 0.6534253694599966
+      }
+    },
+    "definition": {
+      "name": "Workflow",
+      "module": [
+        "codegen_integration",
+        "fixtures",
+        "simple_templating_node",
+        "code",
+        "workflow"
+      ]
+    }
+  },
+  "input_variables": [
+  ],
+  "output_variables": [
+    {
+      "id": "b0961a8d-f702-4922-b410-2aecf7d34b68",
+      "key": "final-output",
+      "type": "NUMBER"
+    }
+  ]
+}

--- a/ee/codegen_integration/test_code_to_display.py
+++ b/ee/codegen_integration/test_code_to_display.py
@@ -1,10 +1,10 @@
 import json
 
 from deepdiff import DeepDiff
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
-from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from vellum.workflows.workflows.base import BaseWorkflow
+from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 
 def test_code_to_display_data(code_to_display_fixture_paths):
@@ -29,8 +29,8 @@ def test_code_to_display_data(code_to_display_fixture_paths):
         return False
 
     assert not DeepDiff(
-        actual_serialized_workflow,
         expected_serialized_workflow,
+        actual_serialized_workflow,
         exclude_obj_callback=exclude_obj_callback,
         significant_digits=6,
     )

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -7,7 +7,6 @@ from pydantic import Field
 
 from vellum import ChatMessage, PromptParameters, SearchResult, SearchResultRequest, VellumVariable, VellumVariableType
 from vellum.core import UniversalBaseModel
-
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
     EdgeDisplayOverrides,
@@ -211,11 +210,21 @@ class WorkspaceSecretPointer(UniversalBaseModel):
     data: WorkspaceSecretData
 
 
+class ExecutionCounterData(UniversalBaseModel):
+    node_id: str
+
+
+class ExecutionCounterPointer(UniversalBaseModel):
+    type: Literal["EXECUTION_COUNTER"] = "EXECUTION_COUNTER"
+    data: ExecutionCounterData
+
+
 NodeInputValuePointerRule = Union[
     NodeOutputPointer,
     InputVariablePointer,
     ConstantValuePointer,
     WorkspaceSecretPointer,
+    ExecutionCounterPointer,
 ]
 
 

--- a/src/vellum/workflows/references/execution_count.py
+++ b/src/vellum/workflows/references/execution_count.py
@@ -18,3 +18,7 @@ class ExecutionCountReference(BaseDescriptor[int]):
 
     def resolve(self, state: "BaseState") -> int:
         return state.meta.node_execution_cache.get_execution_count(self._node_class)
+
+    @property
+    def node_class(self) -> Type["BaseNode"]:
+        return self._node_class


### PR DESCRIPTION
This PR:
1. Fixes a typo in codegen for execution counters (I had used `counter` instead of `count`)
2. Adds serialization support for `ExecutionCountReference` descriptors
3. Adds an e2e test feature an execution counter and a templating node. I had to add this test to the exclusion list for serialization due to unrelated issues regarding templating node serialization. We'll tackle those separately.