### PR TITLE
Introducing Parent Context

### DIFF
--- a/src/vellum/workflows/events/tests/test_event.py
+++ b/src/vellum/workflows/events/tests/test_event.py
@@ -90,10 +90,10 @@ module_root = name_parts[: name_parts.index("events")]
                     },
                 ),
                 parent=NodeParentContext(
-                    definition=MockNode,
+                    node_definition=MockNode,
                     span_id=UUID("123e4567-e89b-12d3-a456-426614174000"),
                     parent=WorkflowParentContext(
-                        definition=MockWorkflow,
+                        workflow_definition=MockWorkflow,
                         span_id=UUID("123e4567-e89b-12d3-a456-426614174000")
                     )
                 )

--- a/src/vellum/workflows/events/tests/test_event.py
+++ b/src/vellum/workflows/events/tests/test_event.py
@@ -115,12 +115,12 @@ module_root = name_parts[: name_parts.index("events")]
                     },
                 },
                 "parent": {
-                    "definition": {
+                    "node_definition": {
                         "name": "MockNode",
                         "module": module_root + ["events", "tests", "test_event"],
                     },
                     "parent": {
-                        "definition": {
+                        "workflow_definition": {
                             "name": "MockWorkflow",
                             "module": module_root + ["events", "tests", "test_event"],
                         },

--- a/src/vellum/workflows/events/tests/test_event.py
+++ b/src/vellum/workflows/events/tests/test_event.py
@@ -124,9 +124,11 @@ module_root = name_parts[: name_parts.index("events")]
                             "name": "MockWorkflow",
                             "module": module_root + ["events", "tests", "test_event"],
                         },
+                        "type": "WORKFLOW",
                         "parent": None,
                         "span_id": "123e4567-e89b-12d3-a456-426614174000"
                     },
+                    "type": "WORKFLOW_NODE",
                     "span_id": "123e4567-e89b-12d3-a456-426614174000"
                 },
             },

--- a/src/vellum/workflows/events/tests/test_event.py
+++ b/src/vellum/workflows/events/tests/test_event.py
@@ -73,6 +73,7 @@ module_root = name_parts[: name_parts.index("events")]
                         "foo": "bar",
                     },
                 },
+                "parent": None,
             },
         ),
         (
@@ -104,6 +105,7 @@ module_root = name_parts[: name_parts.index("events")]
                         "node_foo": "bar",
                     },
                 },
+                "parent": None,
             },
         ),
         (
@@ -137,6 +139,7 @@ module_root = name_parts[: name_parts.index("events")]
                         "value": "foo",
                     },
                 },
+                "parent": None
             },
         ),
         (
@@ -168,6 +171,7 @@ module_root = name_parts[: name_parts.index("events")]
                         "example": "foo",
                     },
                 },
+                "parent": None,
             },
         ),
         (
@@ -201,6 +205,7 @@ module_root = name_parts[: name_parts.index("events")]
                         "code": "USER_DEFINED_ERROR",
                     },
                 },
+                "parent": None,
             },
         ),
     ],

--- a/src/vellum/workflows/events/tests/test_event.py
+++ b/src/vellum/workflows/events/tests/test_event.py
@@ -7,6 +7,7 @@ from deepdiff import DeepDiff
 
 from vellum.workflows.errors.types import VellumError, VellumErrorCode
 from vellum.workflows.events.node import NodeExecutionInitiatedBody, NodeExecutionInitiatedEvent
+from vellum.workflows.events.types import NodeParentContext, WorkflowParentContext
 from vellum.workflows.events.workflow import (
     WorkflowExecutionFulfilledBody,
     WorkflowExecutionFulfilledEvent,
@@ -88,6 +89,14 @@ module_root = name_parts[: name_parts.index("events")]
                         MockNode.node_foo: "bar",
                     },
                 ),
+                parent=NodeParentContext(
+                    definition=MockNode,
+                    span_id=UUID("123e4567-e89b-12d3-a456-426614174000"),
+                    parent=WorkflowParentContext(
+                        definition=MockWorkflow,
+                        span_id=UUID("123e4567-e89b-12d3-a456-426614174000")
+                    )
+                )
             ),
             {
                 "id": "123e4567-e89b-12d3-a456-426614174000",
@@ -105,7 +114,21 @@ module_root = name_parts[: name_parts.index("events")]
                         "node_foo": "bar",
                     },
                 },
-                "parent": None,
+                "parent": {
+                    "definition": {
+                        "name": "MockNode",
+                        "module": module_root + ["events", "tests", "test_event"],
+                    },
+                    "parent": {
+                        "definition": {
+                            "name": "MockWorkflow",
+                            "module": module_root + ["events", "tests", "test_event"],
+                        },
+                        "parent": None,
+                        "span_id": "123e4567-e89b-12d3-a456-426614174000"
+                    },
+                    "span_id": "123e4567-e89b-12d3-a456-426614174000"
+                },
             },
         ),
         (

--- a/src/vellum/workflows/events/types.py
+++ b/src/vellum/workflows/events/types.py
@@ -80,4 +80,4 @@ class BaseEvent(UniversalBaseModel):
     api_version: Literal["2024-10-25"] = "2024-10-25"
     trace_id: UUID
     span_id: UUID
-    parent: ParentContext | None = None
+    parent: Optional[ParentContext] = None

--- a/src/vellum/workflows/events/types.py
+++ b/src/vellum/workflows/events/types.py
@@ -62,18 +62,18 @@ class DeploymentParentContext(BaseParentContext):
 
 
 class NodeParentContext(BaseParentContext):
-    definition: Type['BaseNode']
+    node_definition: Type['BaseNode']
 
-    @field_serializer("definition")
+    @field_serializer("node_definition")
     def serialize_node_definition(self, definition: Type, _info: Any) -> Dict[str, Any]:
         return serialize_type_encoder(definition)
 
 
 class WorkflowParentContext(BaseParentContext):
-    definition: Type['BaseWorkflow']
+    workflow_definition: Type['BaseWorkflow']
 
-    @field_serializer("definition")
-    def serialize_node_definition(self, definition: Type, _info: Any) -> Dict[str, Any]:
+    @field_serializer("workflow_definition")
+    def serialize_workflow_definition(self, definition: Type, _info: Any) -> Dict[str, Any]:
         return serialize_type_encoder(definition)
 
 

--- a/src/vellum/workflows/events/types.py
+++ b/src/vellum/workflows/events/types.py
@@ -55,10 +55,11 @@ class DeploymentParentContext(BaseParentContext):
     deployment_id: UUID
     deployment_name: str
     deployment_history_item_id: UUID
-    workflow_version_id: UUID
+    version_id: UUID
     release_tag_id: UUID
     release_tag_name: str
     external_id: Optional[str]
+    # TODO: Discriminator between Workflow and Prompt? (waiting on feedback)
 
 
 class NodeParentContext(BaseParentContext):

--- a/src/vellum/workflows/events/types.py
+++ b/src/vellum/workflows/events/types.py
@@ -46,23 +46,33 @@ def default_serializer(obj: Any) -> Any:
         )
     )
 
+
 class BaseParentContext(UniversalBaseModel):
     span_id: UUID
     parent: Optional['ParentContext'] = None
 
 
-class DeploymentParentContext(BaseParentContext):
+class BaseDeploymentParentContext(BaseParentContext):
     deployment_id: UUID
     deployment_name: str
     deployment_history_item_id: UUID
-    version_id: UUID
     release_tag_id: UUID
     release_tag_name: str
     external_id: Optional[str]
-    # TODO: Discriminator between Workflow and Prompt? (waiting on feedback)
+
+
+class WorkflowDeploymentParentContext(BaseDeploymentParentContext):
+    type: Literal["WORKFLOW_RELEASE_TAG"] = "WORKFLOW_RELEASE_TAG"
+    version_id: UUID
+
+
+class PromptDeploymentParentContext(BaseDeploymentParentContext):
+    type: Literal["PROMPT_RELEASE_TAG"] = "PROMPT_RELEASE_TAG"
+    version_id: UUID
 
 
 class NodeParentContext(BaseParentContext):
+    type: Literal["WORKFLOW_NODE"] = "WORKFLOW_NODE"
     node_definition: Type['BaseNode']
 
     @field_serializer("node_definition")
@@ -71,6 +81,7 @@ class NodeParentContext(BaseParentContext):
 
 
 class WorkflowParentContext(BaseParentContext):
+    type: Literal["WORKFLOW"] = "WORKFLOW"
     workflow_definition: Type['BaseWorkflow']
 
     @field_serializer("workflow_definition")
@@ -81,7 +92,8 @@ class WorkflowParentContext(BaseParentContext):
 ParentContext = Union[
     NodeParentContext,
     WorkflowParentContext,
-    DeploymentParentContext,
+    PromptDeploymentParentContext,
+    WorkflowDeploymentParentContext,
 ]
 
 

--- a/src/vellum/workflows/events/types.py
+++ b/src/vellum/workflows/events/types.py
@@ -63,12 +63,12 @@ class BaseDeploymentParentContext(BaseParentContext):
 
 class WorkflowDeploymentParentContext(BaseDeploymentParentContext):
     type: Literal["WORKFLOW_RELEASE_TAG"] = "WORKFLOW_RELEASE_TAG"
-    version_id: UUID
+    workflow_version_id: UUID
 
 
 class PromptDeploymentParentContext(BaseDeploymentParentContext):
     type: Literal["PROMPT_RELEASE_TAG"] = "PROMPT_RELEASE_TAG"
-    version_id: UUID
+    prompt_version_id: UUID
 
 
 class NodeParentContext(BaseParentContext):

--- a/tests/workflows/basic_map_node/tests/test_workflow.py
+++ b/tests/workflows/basic_map_node/tests/test_workflow.py
@@ -13,3 +13,6 @@ def test_run_workflow__happy_path():
 
     # AND the output should match the mapped items
     assert terminal_event.outputs == {"final_value": [5, 7, 6]}
+
+    # Assert that parent is a valid field, for now empty
+    assert terminal_event.parent is None


### PR DESCRIPTION
Introducing Parent Context to events. 
Should default to None
Focusing on Nodes, Deployments, and Workflows (for now)