### PR TITLE
remove unused override on templating node display

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
@@ -1,19 +1,18 @@
 from uuid import UUID
 from typing import Any, ClassVar, Dict, Generic, Optional, TypeVar
 
+from vellum.workflows.nodes.core.templating_node import TemplatingNode
+from vellum.workflows.types.core import JsonObject
+from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum.workflows.nodes.core.templating_node import TemplatingNode
-from vellum.workflows.types.core import JsonObject
-from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
 
 _TemplatingNodeType = TypeVar("_TemplatingNodeType", bound=TemplatingNode)
 
 
 class BaseTemplatingNodeDisplay(BaseNodeVellumDisplay[_TemplatingNodeType], Generic[_TemplatingNodeType]):
-    output_id: ClassVar[Optional[UUID]] = None
     template_input_id: ClassVar[Optional[UUID]] = None
     input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 


### PR DESCRIPTION
`output_id` is not used for overrides. Output IDs are supposed to be overridden using `node_output_displays`.