### PR TITLE
Remove Function Call Serializers for Now

### DIFF
--- a/ee/codegen/package-lock.json
+++ b/ee/codegen/package-lock.json
@@ -12,7 +12,7 @@
         "@fern-fern/generator-cli-sdk": "file:./stubs/generator-cli-sdk",
         "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
         "lodash": "^4.17.21",
-        "vellum-ai": "0.9.12"
+        "vellum-ai": "0.10.2"
       },
       "devDependencies": {
         "@types/lodash": "^4.17.13",
@@ -5860,9 +5860,9 @@
       "dev": true
     },
     "node_modules/vellum-ai": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-0.9.12.tgz",
-      "integrity": "sha512-6X2qm/8pYb7R2HYZUt9tgaXsTQt3/H1Ib+PYfatkgvgpvqskjZtATtC4BbDe1Q/zK5RIkSvP1Ad3VGRui23MFw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-0.10.2.tgz",
+      "integrity": "sha512-As1dMpe43I5pV4414ywC2YtNB0fob9wThrqX4ph77VGf77ZJ/qj8mxPZMnNUktgMJ+zAY+sEItdVFh/sEIcXDQ==",
       "dependencies": {
         "cdktf": "^0.20.5",
         "constructs": "10.3.0",
@@ -10091,9 +10091,9 @@
       "dev": true
     },
     "vellum-ai": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-0.9.12.tgz",
-      "integrity": "sha512-6X2qm/8pYb7R2HYZUt9tgaXsTQt3/H1Ib+PYfatkgvgpvqskjZtATtC4BbDe1Q/zK5RIkSvP1Ad3VGRui23MFw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-0.10.2.tgz",
+      "integrity": "sha512-As1dMpe43I5pV4414ywC2YtNB0fob9wThrqX4ph77VGf77ZJ/qj8mxPZMnNUktgMJ+zAY+sEItdVFh/sEIcXDQ==",
       "requires": {
         "cdktf": "^0.20.5",
         "constructs": "10.3.0",

--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -33,7 +33,7 @@
     "@fern-fern/generator-cli-sdk": "file:./stubs/generator-cli-sdk",
     "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
     "lodash": "^4.17.21",
-    "vellum-ai": "0.9.12"
+    "vellum-ai": "0.10.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.13",

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1,6 +1,5 @@
 import {
   ChatMessagePromptBlock,
-  FunctionDefinitionPromptBlock,
   JinjaPromptBlock,
   RichTextPromptBlock,
   VellumVariableType,
@@ -302,7 +301,6 @@ const generateBlockGivenType = (
 ):
   | JinjaPromptBlock
   | ChatMessagePromptBlock
-  | FunctionDefinitionPromptBlock
   | VariablePromptBlock
   | RichTextPromptBlock => {
   if (blockType === "JINJA") {
@@ -334,13 +332,6 @@ const generateBlockGivenType = (
       ],
       chatRole: "SYSTEM",
       chatMessageUnterminated: false,
-      state: "ENABLED",
-    };
-  } else if (blockType === "FUNCTION_DEFINITION") {
-    return {
-      blockType: "FUNCTION_DEFINITION",
-      functionName: "functionTest",
-      functionDescription: "This is a test function",
       state: "ENABLED",
     };
   } else if (blockType === "VARIABLE") {

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -1,4 +1,5 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
+import { PromptBlock } from "vellum-ai/api";
 import { beforeEach } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
@@ -31,10 +32,9 @@ describe("InlinePromptNode", () => {
     );
   });
 
-  const promptInputBlockTypes = [
+  const promptInputBlockTypes: PromptBlock["blockType"][] = [
     "JINJA",
     "CHAT_MESSAGE",
-    "FUNCTION_DEFINITION",
     "VARIABLE",
     "RICH_TEXT",
   ];

--- a/ee/codegen/src/generators/base-prompt-block.ts
+++ b/ee/codegen/src/generators/base-prompt-block.ts
@@ -1,0 +1,67 @@
+import { python } from "@fern-api/python-ast";
+import { ClassInstantiation } from "@fern-api/python-ast/ClassInstantiation";
+import { MethodArgument } from "@fern-api/python-ast/MethodArgument";
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import {
+  PromptBlock as PromptBlockType,
+  FunctionDefinition as FunctionDefinitionType,
+} from "vellum-ai/api";
+
+export declare namespace BasePromptBlock {
+  interface Args<T extends PromptBlockType | FunctionDefinitionType> {
+    promptBlock: T;
+  }
+}
+
+export abstract class BasePromptBlock<
+  T extends PromptBlockType | FunctionDefinitionType
+> extends AstNode {
+  private astNode: python.ClassInstantiation;
+
+  public constructor({ promptBlock }: BasePromptBlock.Args<T>) {
+    super();
+    this.astNode = this.generateAstNode(promptBlock);
+  }
+
+  protected abstract generateAstNode(promptBlock: T): ClassInstantiation;
+
+  protected constructCommonClassArguments(promptBlock: T): MethodArgument[] {
+    const args: MethodArgument[] = [];
+
+    if (promptBlock.state) {
+      args.push(
+        new MethodArgument({
+          name: "state",
+          value: python.TypeInstantiation.str(promptBlock.state),
+        })
+      );
+    }
+
+    const cacheConfigValue = this.extractCacheConfig(promptBlock);
+    args.push(
+      new MethodArgument({
+        name: "cache_config",
+        value: cacheConfigValue,
+      })
+    );
+
+    return args;
+  }
+
+  private extractCacheConfig(promptBlock: T): python.TypeInstantiation {
+    if (
+      promptBlock.cacheConfig !== undefined &&
+      promptBlock.cacheConfig !== null
+    ) {
+      if (promptBlock.cacheConfig.type) {
+        return python.TypeInstantiation.str(promptBlock.cacheConfig.type);
+      }
+    }
+    return python.TypeInstantiation.none();
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
+  }
+}

--- a/ee/codegen/src/generators/function-definition.ts
+++ b/ee/codegen/src/generators/function-definition.ts
@@ -1,0 +1,75 @@
+import { python } from "@fern-api/python-ast";
+import { MethodArgument } from "@fern-api/python-ast/MethodArgument";
+import { isNil } from "lodash";
+import { FunctionDefinition as FunctionDefinitionType } from "vellum-ai/api";
+
+import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
+import { BasePromptBlock } from "src/generators/base-prompt-block";
+
+export class FunctionDefinition extends BasePromptBlock<FunctionDefinitionType> {
+  protected generateAstNode(
+    functionDefinition: FunctionDefinitionType
+  ): python.ClassInstantiation {
+    const classArgs: MethodArgument[] = [
+      ...this.constructCommonClassArguments(functionDefinition),
+    ];
+
+    if (!isNil(functionDefinition.name)) {
+      classArgs.push(
+        new MethodArgument({
+          name: "name",
+          value: python.TypeInstantiation.str(functionDefinition.name),
+        })
+      );
+    }
+
+    if (!isNil(functionDefinition.description)) {
+      classArgs.push(
+        new MethodArgument({
+          name: "description",
+          value: python.TypeInstantiation.str(functionDefinition.description),
+        })
+      );
+    }
+
+    if (!isNil(functionDefinition.parameters)) {
+      classArgs.push(
+        new MethodArgument({
+          name: "parameters",
+          value: python.codeBlock(
+            JSON.stringify(functionDefinition.parameters)
+          ),
+        })
+      );
+    }
+
+    if (!isNil(functionDefinition.forced)) {
+      classArgs.push(
+        new MethodArgument({
+          name: "function_forced",
+          value: python.TypeInstantiation.bool(functionDefinition.forced),
+        })
+      );
+    }
+
+    if (!isNil(functionDefinition.strict)) {
+      classArgs.push(
+        new MethodArgument({
+          name: "function_strict",
+          value: python.TypeInstantiation.bool(functionDefinition.strict),
+        })
+      );
+    }
+
+    const functionDefinitionClass = python.instantiateClass({
+      classReference: python.reference({
+        name: "FunctionDefinition",
+        modulePath: VELLUM_CLIENT_MODULE_PATH,
+      }),
+      arguments_: classArgs,
+    });
+
+    this.inheritReferences(functionDefinitionClass);
+    return functionDefinitionClass;
+  }
+}

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -1,7 +1,6 @@
 import {
   ChatMessagePromptBlock,
   ChatMessageRole,
-  FunctionDefinitionPromptBlock,
   JinjaPromptBlock,
   PlainTextPromptBlock,
   PromptBlock,
@@ -203,82 +202,6 @@ export declare namespace ChatMessagePromptTemplateBlockSerializer {
   }
 }
 
-export const FunctionDefinitionPromptTemplateBlockSerializer: ObjectSchema<
-  FunctionDefinitionPromptTemplateBlockSerializer.Raw,
-  FunctionDefinitionPromptBlock
-> = objectSchema({
-  id: stringSchema(),
-  blockType: propertySchema(
-    "block_type",
-    stringLiteralSchema("FUNCTION_DEFINITION")
-  ),
-  state: propertySchema("state", PromptBlockStateSerializer),
-  cacheConfig: propertySchema("cache_config", CacheConfigSerializer.optional()),
-  properties: objectSchema({
-    functionName: propertySchema("function_name", stringSchema().optional()),
-    functionDescription: propertySchema(
-      "function_description",
-      stringSchema().optional()
-    ),
-    functionParameters: propertySchema(
-      "function_parameters",
-      anySchema().optional()
-    ),
-    functionForced: propertySchema(
-      "function_forced",
-      booleanSchema().optional()
-    ),
-    functionStrict: propertySchema(
-      "function_strict",
-      booleanSchema().optional()
-    ),
-  }),
-}).transform({
-  transform: (block) =>
-    ({
-      blockType: block.blockType,
-      state: block.state,
-      cacheConfig: block.cacheConfig,
-      functionName: block.properties.functionName,
-      functionDescription: block.properties.functionDescription,
-      functionParameters: block.properties.functionParameters,
-      functionForced: block.properties.functionForced,
-      functionStrict: block.properties.functionStrict,
-    } as FunctionDefinitionPromptBlock),
-  untransform: (block) => ({
-    id: block.id,
-    blockType: block.blockType,
-    state: block.state,
-    cacheConfig: block.cacheConfig,
-    properties: {
-      functionName: block.functionName,
-      functionDescription: block.functionDescription,
-      functionParameters: block.functionParameters,
-      functionForced: block.functionForced,
-      functionStrict: block.functionStrict,
-    },
-  }),
-}) as ObjectSchema<
-  FunctionDefinitionPromptTemplateBlockSerializer.Raw,
-  FunctionDefinitionPromptBlock
->;
-
-export declare namespace FunctionDefinitionPromptTemplateBlockSerializer {
-  interface Raw {
-    id: string;
-    block_type: "FUNCTION_DEFINITION";
-    state: PromptBlockState;
-    cache_config?: { type: "EPHEMERAL" } | null;
-    properties: {
-      function_name?: string | null;
-      function_description?: string | null;
-      function_parameters?: Record<string, unknown> | null;
-      function_forced?: boolean | null;
-      function_strict?: boolean | null;
-    };
-  }
-}
-
 export const VariablePromptTemplateBlockSerializer: ObjectSchema<
   VariablePromptTemplateBlockSerializer.Raw,
   VariablePromptBlock
@@ -408,7 +331,6 @@ export declare namespace PromptTemplateBlockSerializer {
   type Raw =
     | JinjaPromptTemplateBlockSerializer.Raw
     | ChatMessagePromptTemplateBlockSerializer.Raw
-    | FunctionDefinitionPromptTemplateBlockSerializer.Raw
     | VariablePromptTemplateBlockSerializer.Raw
     | RichTextPromptTemplateBlockSerializer.Raw;
 }
@@ -416,7 +338,6 @@ export declare namespace PromptTemplateBlockSerializer {
 const PromptTemplateBlockSerializer = undiscriminatedUnionSchema([
   JinjaPromptTemplateBlockSerializer,
   ChatMessagePromptTemplateBlockSerializer,
-  FunctionDefinitionPromptTemplateBlockSerializer,
   VariablePromptTemplateBlockSerializer,
   RichTextPromptTemplateBlockSerializer,
 ]);


### PR DESCRIPTION
I'm removing serialization support for function call prompt blocks for now, just to unlock our ability to upgrade our vellum-ai api version. We can reintroduce more methodically/holistically, since we didn't have true codegen support for function calling yet anyway.