### PR TITLE
[SC-5591][Codegen] Fetch ML Model Name

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-context-factory.ts
+++ b/ee/codegen/src/__test__/helpers/node-context-factory.ts
@@ -8,13 +8,13 @@ import {
   WorkflowNodeType as WorkflowNodeTypeEnum,
 } from "src/types/vellum";
 
-export function nodeContextFactory({
+export async function nodeContextFactory({
   workflowContext,
   nodeData,
-}: Partial<
-  BaseNodeContext.Args<WorkflowDataNode>
-> = {}): BaseNodeContext<WorkflowDataNode> {
-  return createNodeContext({
+}: Partial<BaseNodeContext.Args<WorkflowDataNode>> = {}): Promise<
+  BaseNodeContext<WorkflowDataNode>
+> {
+  return await createNodeContext({
     workflowContext: workflowContext ?? workflowContextFactory(),
     nodeData: nodeData ?? {
       id: "search",

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.test.ts
@@ -23,7 +23,7 @@ describe("ExecutionCounterPointer", () => {
 
     const node = searchNodeDataFactory();
     workflowContext.addNodeContext(
-      nodeContextFactory({ workflowContext, nodeData: node })
+      await nodeContextFactory({ workflowContext, nodeData: node })
     );
 
     const executionCounterPointer = new ExecutionCounterPointerRule({

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -40,13 +40,13 @@ describe("ApiNode", () => {
   });
 
   describe("basic", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = apiNodeFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as ApiNodeContext;
+      })) as ApiNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new ApiNode({
@@ -67,15 +67,15 @@ describe("ApiNode", () => {
   });
 
   describe("reject on error enabled", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = apiNodeFactory({
         errorOutputId: "af589f73-effe-4a80-b48f-fb912ac6ce67",
       });
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as ApiNodeContext;
+      })) as ApiNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new ApiNode({

--- a/ee/codegen/src/__test__/nodes/conditional-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/conditional-node.test.ts
@@ -13,7 +13,7 @@ describe("ConditionalNode", () => {
   let writer: Writer;
   let node: ConditionalNode;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     workflowContext = workflowContextFactory();
     writer = new Writer();
 
@@ -30,10 +30,10 @@ describe("ConditionalNode", () => {
       })
     );
 
-    const nodeContext = createNodeContext({
+    const nodeContext = (await createNodeContext({
       workflowContext,
       nodeData,
-    }) as ConditionalNodeContext;
+    })) as ConditionalNodeContext;
     workflowContext.addNodeContext(nodeContext);
 
     node = new ConditionalNode({

--- a/ee/codegen/src/__test__/nodes/final-output-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/final-output-node.test.ts
@@ -18,13 +18,13 @@ describe("FinalOutputNode", () => {
   });
 
   describe("basic", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = finalOutputNodeFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as FinalOutputNodeContext;
+      })) as FinalOutputNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new FinalOutputNode({

--- a/ee/codegen/src/__test__/nodes/generic-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-node.test.ts
@@ -18,13 +18,13 @@ describe("GenericNode", () => {
   });
 
   describe("basic", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = genericNodeFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as GenericNodeContext;
+      })) as GenericNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new GenericNode({

--- a/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
@@ -52,13 +52,13 @@ describe("GuardrailNode", () => {
   });
 
   describe("basic", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = guardrailNodeDataFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as GuardrailNodeContext;
+      })) as GuardrailNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new GuardrailNode({
@@ -79,15 +79,15 @@ describe("GuardrailNode", () => {
   });
 
   describe("reject on error enabled", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = guardrailNodeDataFactory({
         errorOutputId: "38361ff1-c826-49b8-aa8d-28179c3684cc",
       });
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as GuardrailNodeContext;
+      })) as GuardrailNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new GuardrailNode({

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -43,15 +43,15 @@ describe("InlinePromptNode", () => {
     let node: InlinePromptNode;
 
     describe("basic", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         const nodeData = inlinePromptNodeDataInlineVariantFactory({
           blockType,
         });
 
-        const nodeContext = createNodeContext({
+        const nodeContext = (await createNodeContext({
           workflowContext,
           nodeData,
-        }) as InlinePromptNodeContext;
+        })) as InlinePromptNodeContext;
         workflowContext.addNodeContext(nodeContext);
 
         node = new InlinePromptNode({
@@ -72,16 +72,16 @@ describe("InlinePromptNode", () => {
     });
 
     describe("reject on error enabled", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         const nodeData = inlinePromptNodeDataInlineVariantFactory({
           blockType,
           errorOutputId: "e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f",
         });
 
-        const nodeContext = createNodeContext({
+        const nodeContext = (await createNodeContext({
           workflowContext,
           nodeData,
-        }) as InlinePromptNodeContext;
+        })) as InlinePromptNodeContext;
         workflowContext.addNodeContext(nodeContext);
 
         node = new InlinePromptNode({
@@ -102,15 +102,15 @@ describe("InlinePromptNode", () => {
     });
 
     describe("legacy prompt variant", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         const nodeData = inlinePromptNodeDataLegacyVariantFactory({
           blockType,
         });
 
-        const nodeContext = createNodeContext({
+        const nodeContext = (await createNodeContext({
           workflowContext,
           nodeData,
-        }) as InlinePromptNodeContext;
+        })) as InlinePromptNodeContext;
         workflowContext.addNodeContext(nodeContext);
 
         node = new InlinePromptNode({

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -107,6 +107,10 @@ describe("InlinePromptNode", () => {
           blockType,
         });
 
+        vi.spyOn(workflowContext, "getMLModelNameById").mockResolvedValue(
+          "gpt-4o-mini"
+        );
+
         const nodeContext = (await createNodeContext({
           workflowContext,
           nodeData,

--- a/ee/codegen/src/__test__/nodes/merge-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/merge-node.test.ts
@@ -18,13 +18,13 @@ describe("MergeNode", () => {
   });
 
   describe("basic", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = mergeNodeDataFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as MergeNodeContext;
+      })) as MergeNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new MergeNode({

--- a/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
@@ -18,13 +18,13 @@ describe("PromptDeploymentNode", () => {
   });
 
   describe("basic", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = promptDeploymentNodeDataFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as PromptDeploymentNodeContext;
+      })) as PromptDeploymentNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new PromptDeploymentNode({

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -30,13 +30,13 @@ describe("TextSearchNode", () => {
   });
 
   describe("basic", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = searchNodeDataFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as TextSearchNodeContext;
+      })) as TextSearchNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new SearchNode({
@@ -57,15 +57,15 @@ describe("TextSearchNode", () => {
   });
 
   describe("reject on error enabled", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = searchNodeDataFactory({
         errorOutputId: "af589f73-effe-4a80-b48f-fb912ac6ce67",
       });
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as TextSearchNodeContext;
+      })) as TextSearchNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new SearchNode({

--- a/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
@@ -18,13 +18,13 @@ describe("SubworkflowDeploymentNode", () => {
   });
 
   describe("basic", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = subworkflowDeploymentNodeDataFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as SubworkflowDeploymentNodeContext;
+      })) as SubworkflowDeploymentNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new SubworkflowDeploymentNode({

--- a/ee/codegen/src/__test__/nodes/templating-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/templating-node.test.ts
@@ -30,13 +30,13 @@ describe("TemplatingNode", () => {
   });
 
   describe("basic", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = templatingNodeFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as TemplatingNodeContext;
+      })) as TemplatingNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new TemplatingNode({
@@ -57,15 +57,15 @@ describe("TemplatingNode", () => {
   });
 
   describe("reject on error enabled", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const nodeData = templatingNodeFactory({
         errorOutputId: "e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f",
       });
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as TemplatingNodeContext;
+      })) as TemplatingNodeContext;
       workflowContext.addNodeContext(nodeContext);
 
       node = new TemplatingNode({

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -18,7 +18,7 @@ describe("Workflow", () => {
   const moduleName = "test";
   const entrypointNode = entrypointNodeDataFactory();
 
-  beforeEach(() => {
+  beforeEach(async () => {
     workflowContext = workflowContextFactory({
       workflowLabel: "TestWorkflow",
       workflowClassName: "TestWorkflow",
@@ -27,7 +27,7 @@ describe("Workflow", () => {
 
     const nodeData = terminalNodeDataFactory();
     workflowContext.addNodeContext(
-      createNodeContext({
+      await createNodeContext({
         workflowContext: workflowContext,
         nodeData,
       })
@@ -108,7 +108,7 @@ describe("Workflow", () => {
       const inputs = codegen.inputs({ workflowContext });
 
       const searchNodeData = searchNodeDataFactory();
-      const searchNodeContext = createNodeContext({
+      const searchNodeContext = await createNodeContext({
         workflowContext: workflowContext,
         nodeData: searchNodeData,
       });
@@ -163,7 +163,7 @@ describe("Workflow", () => {
         );
 
         const searchNodeData = searchNodeDataFactory();
-        const searchNodeContext = createNodeContext({
+        const searchNodeContext = await createNodeContext({
           workflowContext: workflowContext,
           nodeData: searchNodeData,
         });

--- a/ee/codegen/src/context/node-context/create-node-context.ts
+++ b/ee/codegen/src/context/node-context/create-node-context.ts
@@ -24,9 +24,9 @@ import {
 } from "src/types/vellum";
 import { assertUnreachable } from "src/utils/typing";
 
-export function createNodeContext(
+export async function createNodeContext(
   args: BaseNodeContext.Args<WorkflowDataNode>
-): BaseNodeContext<WorkflowDataNode> {
+): Promise<BaseNodeContext<WorkflowDataNode>> {
   const nodeData = args.nodeData;
   switch (nodeData.type) {
     case WorkflowNodeType.SEARCH: {
@@ -108,12 +108,15 @@ export function createNodeContext(
             throw new Error(`Prompt version data not found`);
           }
 
+          // Dynamically fetch the ML Model's name via API
+          const mlModelName = await args.workflowContext.getMLModelNameById(
+            promptVersionData.mlModelToWorkspaceId
+          );
+
           const inlinePromptNodeData: InlinePromptNodeData = {
             ...legacyNodeData,
             variant: "INLINE",
-            // TODO: Make sure we can operate on mlModelName vs mlModelToWorkspaceId interchangeably
-            // https://app.shortcut.com/vellum/story/5591
-            mlModelName: promptVersionData.mlModelToWorkspaceId,
+            mlModelName,
             execConfig: promptVersionData.execConfig,
           };
 

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -1,3 +1,5 @@
+import { MlModels } from "vellum-ai/api/resources/mlModels/client/Client";
+
 import { GENERATED_WORKFLOW_MODULE_NAME } from "src/constants";
 import { InputVariableContext } from "src/context/input-variable-context";
 import { BaseNodeContext } from "src/context/node-context/base";
@@ -60,8 +62,9 @@ export class WorkflowContext {
 
   public readonly portContextById: PortContextById;
 
-  // Used to make API requests to Vellum
+  // Used by the vellum api client
   public readonly vellumApiKey: string;
+  private readonly mlModelNamesById: Record<string, string> = {};
 
   constructor({
     absolutePathToOutputDirectory,
@@ -181,5 +184,18 @@ export class WorkflowContext {
     }
 
     return portContext;
+  }
+
+  public async getMLModelNameById(mlModelId: string): Promise<string> {
+    if (this.mlModelNamesById[mlModelId]) {
+      return this.mlModelNamesById[mlModelId];
+    }
+
+    const mlModel = await new MlModels({ apiKey: this.vellumApiKey }).retrieve(
+      mlModelId
+    );
+
+    this.mlModelNamesById[mlModelId] = mlModel.name;
+    return mlModel.name;
   }
 }


### PR DESCRIPTION
This is our first example of hitting a Vellum API during codegen. Here we use it to fetch a ML Model name given its id so that we can convert LEGACY prompt nodes to INLINE prompt nodes.