### PR TITLE
add serialization of optional workflow inputs

### DIFF
--- a/.github/workflows/ci-codegen.yaml
+++ b/.github/workflows/ci-codegen.yaml
@@ -49,6 +49,4 @@ jobs:
 
       - name: Test
         run: npm test
-        env:
-          ISORT_CMD: "poetry run isort"
         working-directory: ee/codegen

--- a/ee/codegen/vitest.config.ts
+++ b/ee/codegen/vitest.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
         inline: [/@fern-api\/.*/], // Force inline these packages
       },
     },
+    env: {
+      ISORT_CMD: "poetry run isort",
+    },
   },
 });

--- a/ee/codegen_integration/fixtures/simple_prompt_node/display_data/simple_prompt_node.json
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/display_data/simple_prompt_node.json
@@ -251,8 +251,8 @@
       "key": "text",
       "type": "STRING",
       "default": null,
-      "required": null,
-      "extensions": null
+      "required": true,
+      "extensions": { "color": null }
     }
   ],
   "output_variables": [

--- a/ee/codegen_integration/fixtures/simple_search_node/display_data/simple_search_node.json
+++ b/ee/codegen_integration/fixtures/simple_search_node/display_data/simple_search_node.json
@@ -312,8 +312,8 @@
       "key": "query",
       "type": "STRING",
       "default": null,
-      "required": null,
-      "extensions": null
+      "required": true,
+      "extensions": { "color": null }
     }
   ],
   "output_variables": [

--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from uuid import UUID
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 
 @dataclass
@@ -20,6 +20,7 @@ WorkflowMetaDisplayOverridesType = TypeVar("WorkflowMetaDisplayOverridesType", b
 @dataclass
 class WorkflowInputsDisplayOverrides:
     id: UUID
+    color: Optional[str] = None
 
 
 @dataclass

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_conditional_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_conditional_node_serialization.py
@@ -3,17 +3,6 @@ from unittest import mock
 
 from deepdiff import DeepDiff
 
-from tests.workflows.basic_conditional_node.workflow import CategoryWorkflow
-from tests.workflows.basic_conditional_node.workflow_with_only_one_conditional_node import (
-    create_simple_workflow,
-)
-from vellum_ee.workflows.display.nodes.base_node_vellum_display import (
-    BaseNodeVellumDisplay,
-)
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
-from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import (
-    get_workflow_display,
-)
 from vellum.workflows.expressions.begins_with import BeginsWithExpression
 from vellum.workflows.expressions.between import BetweenExpression
 from vellum.workflows.expressions.contains import ContainsExpression
@@ -24,18 +13,20 @@ from vellum.workflows.expressions.does_not_equal import DoesNotEqualExpression
 from vellum.workflows.expressions.ends_with import EndsWithExpression
 from vellum.workflows.expressions.equals import EqualsExpression
 from vellum.workflows.expressions.greater_than import GreaterThanExpression
-from vellum.workflows.expressions.greater_than_or_equal_to import (
-    GreaterThanOrEqualToExpression,
-)
+from vellum.workflows.expressions.greater_than_or_equal_to import GreaterThanOrEqualToExpression
 from vellum.workflows.expressions.in_ import InExpression
 from vellum.workflows.expressions.is_not_null import IsNotNullExpression
 from vellum.workflows.expressions.is_null import IsNullExpression
 from vellum.workflows.expressions.less_than import LessThanExpression
-from vellum.workflows.expressions.less_than_or_equal_to import (
-    LessThanOrEqualToExpression,
-)
+from vellum.workflows.expressions.less_than_or_equal_to import LessThanOrEqualToExpression
 from vellum.workflows.expressions.not_between import NotBetweenExpression
 from vellum.workflows.expressions.not_in import NotInExpression
+from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
+from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+from tests.workflows.basic_conditional_node.workflow import CategoryWorkflow
+from tests.workflows.basic_conditional_node.workflow_with_only_one_conditional_node import create_simple_workflow
 
 
 def test_serialize_workflow():
@@ -67,9 +58,9 @@ def test_serialize_workflow():
                 "id": "eece050a-432e-4a2c-8c87-9480397e4cbf",
                 "key": "category",
                 "type": "STRING",
-                "required": None,
+                "required": True,
                 "default": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
         ],
         input_variables,

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_guardrail_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_guardrail_node_serialization.py
@@ -1,8 +1,9 @@
 from deepdiff import DeepDiff
 
-from tests.workflows.basic_guardrail_node.workflow import BasicGuardrailNodeWorkflow
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+from tests.workflows.basic_guardrail_node.workflow import BasicGuardrailNodeWorkflow
 
 
 def test_serialize_workflow():
@@ -26,17 +27,17 @@ def test_serialize_workflow():
                 "id": "eb1b1913-9fb8-4b8c-8901-09d9b9edc1c3",
                 "key": "actual",
                 "type": "STRING",
-                "required": None,
+                "required": True,
                 "default": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
             {
                 "id": "545ff95e-e86f-4d06-a991-602781e72605",
                 "key": "expected",
                 "type": "STRING",
-                "required": None,
+                "required": True,
                 "default": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
         ],
         input_variables,

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_inline_subworkflow_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_inline_subworkflow_serialization.py
@@ -2,10 +2,11 @@ from unittest import mock
 
 from deepdiff import DeepDiff
 
-from tests.workflows.basic_inline_subworkflow.workflow import BasicInlineSubworkflowWorkflow
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+from tests.workflows.basic_inline_subworkflow.workflow import BasicInlineSubworkflowWorkflow
 
 
 def test_serialize_workflow():
@@ -37,17 +38,17 @@ def test_serialize_workflow():
                 "id": "fa73da37-34c3-47a9-be58-69cc6cdbfca5",
                 "key": "city",
                 "type": "STRING",
-                "required": None,
+                "required": True,
                 "default": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
             {
                 "id": "aba1e6e0-dfa7-4c15-a4e6-aec6feebfaca",
                 "key": "date",
                 "type": "STRING",
-                "required": None,
+                "required": True,
                 "default": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
         ],
         input_variables,

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_map_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_map_node_serialization.py
@@ -2,10 +2,11 @@ from unittest import mock
 
 from deepdiff import DeepDiff
 
-from tests.workflows.basic_map_node.workflow import SimpleMapExample
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+from tests.workflows.basic_map_node.workflow import SimpleMapExample
 
 
 def test_serialize_workflow():
@@ -35,9 +36,9 @@ def test_serialize_workflow():
                 "id": "db2eb237-38e4-417a-8bfc-5bda0f3165ca",
                 "key": "fruits",
                 "type": "JSON",
-                "required": None,
+                "required": True,
                 "default": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
         ],
         input_variables,

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_prompt_deployment_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_prompt_deployment_serialization.py
@@ -4,10 +4,10 @@ from uuid import uuid4
 from deepdiff import DeepDiff
 
 from vellum import DeploymentRead
-
-from tests.workflows.basic_text_prompt_deployment.workflow import BasicTextPromptDeployment
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+from tests.workflows.basic_text_prompt_deployment.workflow import BasicTextPromptDeployment
 
 
 def test_serialize_workflow(vellum_client):
@@ -46,17 +46,17 @@ def test_serialize_workflow(vellum_client):
                 "id": "52995b50-84c9-465f-8a4b-a4ee2a92e388",
                 "key": "city",
                 "type": "STRING",
-                "required": None,
+                "required": True,
                 "default": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
             {
                 "id": "aa3ca842-250c-4a3f-853f-23928c28d0f8",
                 "key": "date",
                 "type": "STRING",
-                "required": None,
+                "required": True,
                 "default": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
         ],
         input_variables,

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_subworkflow_deployment_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_subworkflow_deployment_serialization.py
@@ -4,10 +4,10 @@ from uuid import uuid4
 from deepdiff import DeepDiff
 
 from vellum import WorkflowDeploymentRead
-
-from tests.workflows.basic_subworkflow_deployment.workflow import BasicSubworkflowDeploymentWorkflow
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+from tests.workflows.basic_subworkflow_deployment.workflow import BasicSubworkflowDeploymentWorkflow
 
 
 def test_serialize_workflow(vellum_client):
@@ -46,17 +46,17 @@ def test_serialize_workflow(vellum_client):
                 "id": "693cc9a5-8d74-4a58-bdcf-2b4989cdf250",
                 "key": "city",
                 "type": "STRING",
-                "required": None,
+                "required": True,
                 "default": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
             {
                 "id": "19a78824-9a98-4ae8-a1fc-61f81a422a17",
                 "key": "date",
                 "type": "STRING",
-                "required": None,
+                "required": True,
                 "default": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
         ],
         input_variables,

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_terminal_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_terminal_node_serialization.py
@@ -1,6 +1,7 @@
-from tests.workflows.basic_final_output_node.workflow import BasicFinalOutputNodeWorkflow
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+from tests.workflows.basic_final_output_node.workflow import BasicFinalOutputNodeWorkflow
 
 
 def test_serialize_workflow():
@@ -26,9 +27,9 @@ def test_serialize_workflow():
             "id": "e39a7b63-de15-490a-ae9b-8112c767aea0",
             "key": "input",
             "type": "STRING",
-            "required": None,
+            "required": True,
             "default": None,
-            "extensions": None,
+            "extensions": { "color": None },
         }
     ]
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_complex_terminal_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_complex_terminal_node_serialization.py
@@ -3,11 +3,12 @@ from unittest import mock
 
 from deepdiff import DeepDiff
 
-from tests.workflows.complex_final_output_node.missing_final_output_node import MissingFinalOutputNodeWorkflow
-from tests.workflows.complex_final_output_node.missing_workflow_output import MissingWorkflowOutputWorkflow
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+from tests.workflows.complex_final_output_node.missing_final_output_node import MissingFinalOutputNodeWorkflow
+from tests.workflows.complex_final_output_node.missing_workflow_output import MissingWorkflowOutputWorkflow
 
 
 def test_serialize_workflow__missing_final_output_node():
@@ -40,17 +41,17 @@ def test_serialize_workflow__missing_final_output_node():
                 "id": "da086239-d743-4246-b666-5c91e22fb88c",
                 "key": "alpha",
                 "type": "STRING",
+                "required": True,
                 "default": None,
-                "required": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
             {
                 "id": "a8b6c5d4-a0e9-4457-834b-46b633c466a6",
                 "key": "beta",
                 "type": "STRING",
+                "required": True,
                 "default": None,
-                "required": None,
-                "extensions": None,
+                "extensions": { "color": None },
             },
         ],
         input_variables,

--- a/tests/workflows/basic_final_output_node/workflow.py
+++ b/tests/workflows/basic_final_output_node/workflow.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.displayable.final_output_node import FinalOutputNode
 from vellum.workflows.state.base import BaseState

--- a/tests/workflows/basic_final_output_node/workflow.py
+++ b/tests/workflows/basic_final_output_node/workflow.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.displayable.final_output_node import FinalOutputNode
 from vellum.workflows.state.base import BaseState


### PR DESCRIPTION
This is to support the future usage of required vs optional inputs for workflows in Vellum

https://app.shortcut.com/vellum/story/5429/add-support-for-serializing-default-required-and-extensions?vc_group_by=day&ct_workflow=all&cf_workflow=500003284