### PR TITLE
[Codegen] Add Codegen Support for Note Nodes

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -19,6 +19,7 @@ import {
   MergeNode,
   GenericNode,
   SubworkflowNode,
+  NoteNode,
 } from "src/types/vellum";
 
 export function entrypointNodeDataFactory(): EntrypointNode {
@@ -242,6 +243,23 @@ export function searchNodeDataFactory({
   };
 
   return nodeData;
+}
+
+export function noteNodeDataFactory(): NoteNode {
+  return {
+    id: "<note-node-id>",
+    type: WorkflowNodeType.NOTE,
+    inputs: [],
+    data: {
+      label: "Note Node",
+      text: "This is a note",
+      style: {
+        color: "red",
+        fontSize: 12,
+        fontWeight: "bold",
+      },
+    },
+  };
 }
 
 export function guardrailNodeDataFactory({

--- a/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
@@ -1,0 +1,26 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NoteNode > basic > getNodeDisplayFile 1`] = `
+"from vellum_ee.workflows.display.nodes import BaseNoteNodeDisplay
+from ...nodes.note_node import NoteNode
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class NoteNodeDisplay(BaseNoteNodeDisplay[NoteNode]):
+    text = "This is a note"
+    style = {"color": "red", "fontSize": 12, "fontWeight": "bold"}
+    node_input_ids_by_name = {}
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=0, y=0), width=None, height=None
+    )
+"
+`;
+
+exports[`NoteNode > basic > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import NoteNode as BaseNoteNode
+
+
+class NoteNode(BaseNoteNode):
+    pass
+"
+`;

--- a/ee/codegen/src/__test__/nodes/note-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/note-node.test.ts
@@ -1,0 +1,46 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { beforeEach } from "vitest";
+
+import { workflowContextFactory } from "src/__test__/helpers";
+import { noteNodeDataFactory } from "src/__test__/helpers/node-data-factories";
+import { createNodeContext, WorkflowContext } from "src/context";
+import { NoteNodeContext } from "src/context/node-context/note-node";
+import { NoteNode } from "src/generators/nodes/note-node";
+
+describe("NoteNode", () => {
+  let workflowContext: WorkflowContext;
+  let writer: Writer;
+  let node: NoteNode;
+
+  beforeEach(() => {
+    workflowContext = workflowContextFactory();
+    writer = new Writer();
+  });
+
+  describe("basic", () => {
+    beforeEach(async () => {
+      const nodeData = noteNodeDataFactory();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as NoteNodeContext;
+      workflowContext.addNodeContext(nodeContext);
+
+      node = new NoteNode({
+        workflowContext: workflowContext,
+        nodeContext,
+      });
+    });
+
+    it("getNodeFile", async () => {
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("getNodeDisplayFile", async () => {
+      node.getNodeDisplayFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+});

--- a/ee/codegen/src/generators/nodes/note-node.ts
+++ b/ee/codegen/src/generators/nodes/note-node.ts
@@ -1,3 +1,4 @@
+import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 
 import { NoteNodeContext } from "src/context/node-context/note-node";
@@ -12,12 +13,32 @@ export class NoteNode extends BaseSingleFileNode<
   baseNodeDisplayClassName = "BaseNoteNodeDisplay";
 
   getNodeClassBodyStatements(): AstNode[] {
-    const statements: AstNode[] = [];
-    return statements;
+    // Note Nodes intentionally have no body statements.
+    return [];
   }
 
   getNodeDisplayClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
+
+    statements.push(
+      python.field({
+        name: "text",
+        initializer: python.TypeInstantiation.str(
+          this.nodeData.data.text ?? ""
+        ),
+      })
+    );
+
+    statements.push(
+      python.field({
+        name: "style",
+        initializer: this.nodeData.data.style
+          ? // TODO: https://app.shortcut.com/vellum/story/5147/correctly-convert-json-to-python-dicts
+            python.codeBlock(JSON.stringify(this.nodeData.data.style))
+          : python.TypeInstantiation.none(),
+      })
+    );
+
     return statements;
   }
 

--- a/ee/vellum_ee/workflows/display/nodes/vellum/__init__.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/__init__.py
@@ -7,6 +7,7 @@ from .inline_prompt_node import BaseInlinePromptNodeDisplay
 from .inline_subworkflow_node import BaseInlineSubworkflowNodeDisplay
 from .map_node import BaseMapNodeDisplay
 from .merge_node import BaseMergeNodeDisplay
+from .note_node import BaseNoteNodeDisplay
 from .prompt_deployment_node import BasePromptDeploymentNodeDisplay
 from .search_node import BaseSearchNodeDisplay
 from .subworkflow_deployment_node import BaseSubworkflowDeploymentNodeDisplay
@@ -23,6 +24,7 @@ __all__ = [
     "BaseAPINodeDisplay",
     "BaseMapNodeDisplay",
     "BaseMergeNodeDisplay",
+    "BaseNoteNodeDisplay",
     "BaseSearchNodeDisplay",
     "BaseSubworkflowDeploymentNodeDisplay",
     "BaseTemplatingNodeDisplay",

--- a/ee/vellum_ee/workflows/display/nodes/vellum/note_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/note_node.py
@@ -1,0 +1,32 @@
+import json
+from typing import Any, ClassVar, Dict, Generic, TypeVar
+
+from vellum.workflows.nodes import NoteNode
+from vellum.workflows.types.core import JsonObject
+from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
+from vellum_ee.workflows.display.types import WorkflowDisplayContext
+
+_NoteNodeType = TypeVar("_NoteNodeType", bound=NoteNode)
+
+
+class BaseNoteNodeDisplay(BaseNodeVellumDisplay[_NoteNodeType], Generic[_NoteNodeType]):
+    text: ClassVar[str] = ""
+    style: ClassVar[Dict[str, Any] | None] = None
+
+    def serialize(
+        self, display_context: WorkflowDisplayContext, **kwargs: Any
+    ) -> JsonObject:
+        node_id = self.node_id
+
+        return {
+            "id": str(node_id),
+            "type": "NOTE",
+            "inputs": [],
+            "data": {
+                "label": self.label,
+                "text": self.text,
+                "style": json.dumps(self.style) if self.style else None,
+            },
+            "display_data": self.get_display_data().dict(),
+            "definition": self.get_definition().dict(),
+        }

--- a/ee/vellum_ee/workflows/display/nodes/vellum/note_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/note_node.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, ClassVar, Dict, Generic, TypeVar
+from typing import Any, ClassVar, Dict, Generic, TypeVar, Union
 
 from vellum.workflows.nodes import NoteNode
 from vellum.workflows.types.core import JsonObject
@@ -11,7 +11,7 @@ _NoteNodeType = TypeVar("_NoteNodeType", bound=NoteNode)
 
 class BaseNoteNodeDisplay(BaseNodeVellumDisplay[_NoteNodeType], Generic[_NoteNodeType]):
     text: ClassVar[str] = ""
-    style: ClassVar[Dict[str, Any] | None] = None
+    style: ClassVar[Union[Dict[str, Any], None]] = None
 
     def serialize(
         self, display_context: WorkflowDisplayContext, **kwargs: Any

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -5,6 +5,15 @@ import logging
 from uuid import UUID
 from typing import Any, Dict, Generic, Optional, Tuple, Type, get_args
 
+from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.edges import Edge
+from vellum.workflows.expressions.coalesce_expression import CoalesceExpression
+from vellum.workflows.nodes.bases import BaseNode
+from vellum.workflows.nodes.utils import get_wrapped_node, has_wrapped_node
+from vellum.workflows.ports import Port
+from vellum.workflows.references import OutputReference, WorkflowInputReference
+from vellum.workflows.types.core import JsonObject
+from vellum.workflows.types.generics import WorkflowType
 from vellum_ee.workflows.display.base import (
     EdgeDisplayOverridesType,
     EdgeDisplayType,
@@ -21,15 +30,6 @@ from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_di
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.types import NodeDisplayType, WorkflowDisplayContext
 from vellum_ee.workflows.display.utils.uuids import uuid4_from_hash
-from vellum.workflows.descriptors.base import BaseDescriptor
-from vellum.workflows.edges import Edge
-from vellum.workflows.expressions.coalesce_expression import CoalesceExpression
-from vellum.workflows.nodes.bases import BaseNode
-from vellum.workflows.nodes.utils import get_wrapped_node, has_wrapped_node
-from vellum.workflows.ports import Port
-from vellum.workflows.references import OutputReference, WorkflowInputReference
-from vellum.workflows.types.core import JsonObject
-from vellum.workflows.types.generics import WorkflowType
 
 logger = logging.getLogger(__name__)
 
@@ -179,6 +179,9 @@ class BaseWorkflowDisplay(
 
         node_displays: Dict[Type[BaseNode], NodeDisplayType] = {}
         port_displays: Dict[Port, PortDisplay] = {}
+
+        # TODO: We should still serialize nodes that are in the workflow's directory but aren't used in the graph.
+        # https://app.shortcut.com/vellum/story/5394
         for node in self._workflow.get_nodes():
             node_display = self._get_node_display(node)
             node_displays[node] = node_display

--- a/src/vellum/workflows/nodes/__init__.py
+++ b/src/vellum/workflows/nodes/__init__.py
@@ -1,5 +1,5 @@
 from vellum.workflows.nodes.bases import BaseNode
-from vellum.workflows.nodes.core import (ErrorNode, InlineSubworkflowNode, MapNode, RetryNode, TemplatingNode, TryNode,)
+from vellum.workflows.nodes.core import ErrorNode, InlineSubworkflowNode, MapNode, RetryNode, TemplatingNode, TryNode
 from vellum.workflows.nodes.displayable import (
     APINode,
     CodeExecutionNode,
@@ -7,6 +7,7 @@ from vellum.workflows.nodes.displayable import (
     FinalOutputNode,
     GuardrailNode,
     InlinePromptNode,
+    NoteNode,
     PromptDeploymentNode,
     SearchNode,
     SubworkflowDeploymentNode,
@@ -28,20 +29,18 @@ __all__ = [
     "TemplatingNode",
     "TryNode",
     # Displayable Base Nodes
-    "BaseSearchNode",
     "BaseInlinePromptNode",
     "BasePromptDeploymentNode",
+    "BaseSearchNode",
     # Displayable Nodes
     "APINode",
     "CodeExecutionNode",
+    "ConditionalNode",
+    "FinalOutputNode",
     "GuardrailNode",
     "InlinePromptNode",
+    "NoteNode",
     "PromptDeploymentNode",
     "SearchNode",
-    "ConditionalNode",
-    "GuardrailNode",
     "SubworkflowDeploymentNode",
-    "FinalOutputNode",
-    "PromptDeploymentNode",
-    "SearchNode",
 ]

--- a/src/vellum/workflows/nodes/displayable/__init__.py
+++ b/src/vellum/workflows/nodes/displayable/__init__.py
@@ -9,6 +9,7 @@ from .final_output_node import FinalOutputNode
 from .guardrail_node import GuardrailNode
 from .inline_prompt_node import InlinePromptNode
 from .merge_node import MergeNode
+from .note_node import NoteNode
 from .prompt_deployment_node import PromptDeploymentNode
 from .search_node import SearchNode
 from .subworkflow_deployment_node import SubworkflowDeploymentNode
@@ -23,6 +24,7 @@ __all__ = [
     "GuardrailNode",
     "MapNode",
     "MergeNode",
+    "NoteNode",
     "SubworkflowDeploymentNode",
     "PromptDeploymentNode",
     "SearchNode",

--- a/src/vellum/workflows/nodes/displayable/note_node/__init__.py
+++ b/src/vellum/workflows/nodes/displayable/note_node/__init__.py
@@ -1,0 +1,5 @@
+from .node import NoteNode
+
+__all__ = [
+    "NoteNode",
+]

--- a/src/vellum/workflows/nodes/displayable/note_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/note_node/node.py
@@ -1,0 +1,10 @@
+from vellum.workflows.nodes.bases import BaseNode
+
+
+class NoteNode(BaseNode):
+    """
+    A no-op Node purely used to display a note in the Vellum UI.
+    """
+
+    def run(self) -> BaseNode.Outputs:
+        raise RuntimeError("NoteNode should never be run")


### PR DESCRIPTION
This adds workflow sdk and codegen support for Note Nodes.

Note that we won't yet successfully serialize Note Nodes, because they aren't present in the Workflow's Graph, but we'll at least codegen them. The follow up for serializing nodes not in the graph is [here](https://app.shortcut.com/vellum/story/5394).