### PR TITLE
Flesh out implementation for TryNode wrapping a streaming node

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -3,9 +3,6 @@ import inspect
 from uuid import UUID
 from typing import TYPE_CHECKING, Any, Dict, Generic, Optional, Type, TypeVar, get_args
 
-from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.utils.uuids import uuid4_from_hash
-from vellum_ee.workflows.display.vellum import CodeResourceDefinition, NodeDefinition
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.utils import get_wrapped_node, has_wrapped_node
 from vellum.workflows.ports import Port
@@ -14,6 +11,9 @@ from vellum.workflows.types.core import JsonObject
 from vellum.workflows.types.generics import NodeType
 from vellum.workflows.types.utils import get_original_base
 from vellum.workflows.utils.names import pascal_to_title_case
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay, PortDisplayOverrides
+from vellum_ee.workflows.display.utils.uuids import uuid4_from_hash
+from vellum_ee.workflows.display.vellum import CodeResourceDefinition, NodeDefinition
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.types import WorkflowDisplayContext
@@ -31,7 +31,7 @@ class BaseNodeDisplay(Generic[NodeType]):
     def __init__(self, node: Type[NodeType]):
         self._node = node
 
-    def serialize(self, display_context: "WorkflowDisplayContext", **kwargs: Any) -> JsonObject:
+    def serialize(self, display_context: "WorkflowDisplayContext") -> JsonObject:
         raise NotImplementedError(f"Serialization for nodes of type {self._node.__name__} is not supported.")
 
     def get_definition(self) -> NodeDefinition:

--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -31,7 +31,7 @@ class BaseNodeDisplay(Generic[NodeType]):
     def __init__(self, node: Type[NodeType]):
         self._node = node
 
-    def serialize(self, display_context: "WorkflowDisplayContext") -> JsonObject:
+    def serialize(self, display_context: "WorkflowDisplayContext", **kwargs: Any) -> JsonObject:
         raise NotImplementedError(f"Serialization for nodes of type {self._node.__name__} is not supported.")
 
     def get_definition(self) -> NodeDefinition:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
@@ -32,7 +32,9 @@ class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeTy
     # A mapping between node input keys and their ids for inputs representing additional header values
     additional_header_value_input_ids: ClassVar[Optional[Dict[str, UUID]]] = None
 
-    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
+    def serialize(
+        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs: Any
+    ) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -175,7 +177,7 @@ class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeTy
             "inputs": [input.dict() for input in inputs],
             "data": {
                 "label": self.label,
-                "error_output_id": None,
+                "error_output_id": str(error_output_id) if error_output_id else None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "url_input_id": url_node_input.id,

--- a/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
@@ -1,13 +1,13 @@
 from uuid import UUID
 from typing import Any, ClassVar, Dict, Generic, Optional, TypeVar, cast
 
+from vellum.workflows.nodes.displayable import APINode
+from vellum.workflows.references.output import OutputReference
+from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum.workflows.nodes.displayable import APINode
-from vellum.workflows.references.output import OutputReference
-from vellum.workflows.types.core import JsonArray, JsonObject
 
 _APINodeType = TypeVar("_APINodeType", bound=APINode)
 
@@ -32,9 +32,7 @@ class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeTy
     # A mapping between node input keys and their ids for inputs representing additional header values
     additional_header_value_input_ids: ClassVar[Optional[Dict[str, UUID]]] = None
 
-    def serialize(
-        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs: Any
-    ) -> JsonObject:
+    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -177,7 +175,7 @@ class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeTy
             "inputs": [input.dict() for input in inputs],
             "data": {
                 "label": self.label,
-                "error_output_id": str(error_output_id) if error_output_id else None,
+                "error_output_id": None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "url_input_id": url_node_input.id,

--- a/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
@@ -1,14 +1,14 @@
 from uuid import UUID
 from typing import ClassVar, Generic, Optional, TypeVar
 
-from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
-from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
-from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
-from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum.workflows.nodes.displayable.code_execution_node import CodeExecutionNode
 from vellum.workflows.nodes.displayable.code_execution_node.utils import read_file_from_path
 from vellum.workflows.types.core import JsonObject
 from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
+from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
+from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
+from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
+from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
 _CodeExecutionNodeType = TypeVar("_CodeExecutionNodeType", bound=CodeExecutionNode)
 
@@ -20,9 +20,7 @@ class BaseCodeExecutionNodeDisplay(BaseNodeVellumDisplay[_CodeExecutionNodeType]
     output_id: ClassVar[Optional[UUID]] = None
     log_output_id: ClassVar[Optional[UUID]] = None
 
-    def serialize(
-        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
-    ) -> JsonObject:
+    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -56,7 +54,7 @@ class BaseCodeExecutionNodeDisplay(BaseNodeVellumDisplay[_CodeExecutionNodeType]
             "inputs": [input.dict() for input in inputs],
             "data": {
                 "label": self.label,
-                "error_output_id": str(error_output_id) if error_output_id else None,
+                "error_output_id": None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "code_input_id": str(self.code_input_id) if self.code_input_id else code_node_input.id,

--- a/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
@@ -20,7 +20,9 @@ class BaseCodeExecutionNodeDisplay(BaseNodeVellumDisplay[_CodeExecutionNodeType]
     output_id: ClassVar[Optional[UUID]] = None
     log_output_id: ClassVar[Optional[UUID]] = None
 
-    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
+    def serialize(
+        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
+    ) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -54,7 +56,7 @@ class BaseCodeExecutionNodeDisplay(BaseNodeVellumDisplay[_CodeExecutionNodeType]
             "inputs": [input.dict() for input in inputs],
             "data": {
                 "label": self.label,
-                "error_output_id": None,
+                "error_output_id": str(error_output_id) if error_output_id else None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "code_input_id": str(self.code_input_id) if self.code_input_id else code_node_input.id,

--- a/ee/vellum_ee/workflows/display/nodes/vellum/guardrail_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/guardrail_node.py
@@ -14,7 +14,9 @@ _GuardrailNodeType = TypeVar("_GuardrailNodeType", bound=GuardrailNode)
 class BaseGuardrailNodeDisplay(BaseNodeVellumDisplay[_GuardrailNodeType], Generic[_GuardrailNodeType]):
     metric_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
+    def serialize(
+        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
+    ) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -38,7 +40,7 @@ class BaseGuardrailNodeDisplay(BaseNodeVellumDisplay[_GuardrailNodeType], Generi
                 "label": self.label,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
-                "error_output_id": None,
+                "error_output_id": str(error_output_id) if error_output_id else None,
                 "metric_definition_id": str(raise_if_descriptor(node.metric_definition)),
                 "release_tag": raise_if_descriptor(node.release_tag),
             },

--- a/ee/vellum_ee/workflows/display/nodes/vellum/guardrail_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/guardrail_node.py
@@ -1,12 +1,12 @@
 from uuid import UUID
 from typing import Any, ClassVar, Dict, Generic, Optional, TypeVar
 
+from vellum.workflows.nodes import GuardrailNode
+from vellum.workflows.types.core import JsonObject
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum.workflows.nodes import GuardrailNode
-from vellum.workflows.types.core import JsonObject
 
 _GuardrailNodeType = TypeVar("_GuardrailNodeType", bound=GuardrailNode)
 
@@ -14,9 +14,7 @@ _GuardrailNodeType = TypeVar("_GuardrailNodeType", bound=GuardrailNode)
 class BaseGuardrailNodeDisplay(BaseNodeVellumDisplay[_GuardrailNodeType], Generic[_GuardrailNodeType]):
     metric_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(
-        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs: Any
-    ) -> JsonObject:
+    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -40,7 +38,7 @@ class BaseGuardrailNodeDisplay(BaseNodeVellumDisplay[_GuardrailNodeType], Generi
                 "label": self.label,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
-                "error_output_id": str(error_output_id) if error_output_id else None,
+                "error_output_id": None,
                 "metric_definition_id": str(raise_if_descriptor(node.metric_definition)),
                 "release_tag": raise_if_descriptor(node.release_tag),
             },

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
@@ -2,7 +2,9 @@ from uuid import UUID
 from typing import Any, ClassVar, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union, cast
 
 from vellum import PromptBlock, RichTextChildBlock, VellumVariable
-
+from vellum.workflows.nodes import InlinePromptNode
+from vellum.workflows.references import OutputReference
+from vellum.workflows.types.core import JsonObject
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
@@ -10,9 +12,6 @@ from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum_ee.workflows.display.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.utils.vellum import infer_vellum_variable_type
 from vellum_ee.workflows.display.vellum import NodeInput
-from vellum.workflows.nodes import InlinePromptNode
-from vellum.workflows.references import OutputReference
-from vellum.workflows.types.core import JsonObject
 
 _InlinePromptNodeType = TypeVar("_InlinePromptNodeType", bound=InlinePromptNode)
 
@@ -22,9 +21,7 @@ class BaseInlinePromptNodeDisplay(BaseNodeVellumDisplay[_InlinePromptNodeType], 
     array_output_id: ClassVar[Optional[UUID]] = None
     prompt_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(
-        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs: Any
-    ) -> JsonObject:
+    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -42,7 +39,7 @@ class BaseInlinePromptNodeDisplay(BaseNodeVellumDisplay[_InlinePromptNodeType], 
             "data": {
                 "label": self.label,
                 "output_id": str(output_display.id),
-                "error_output_id": str(error_output_id) if error_output_id else None,
+                "error_output_id": None,
                 "array_output_id": str(array_display.id),
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
@@ -21,7 +21,9 @@ class BaseInlinePromptNodeDisplay(BaseNodeVellumDisplay[_InlinePromptNodeType], 
     array_output_id: ClassVar[Optional[UUID]] = None
     prompt_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
+    def serialize(
+        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
+    ) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -39,7 +41,7 @@ class BaseInlinePromptNodeDisplay(BaseNodeVellumDisplay[_InlinePromptNodeType], 
             "data": {
                 "label": self.label,
                 "output_id": str(output_display.id),
-                "error_output_id": None,
+                "error_output_id": str(error_output_id) if error_output_id else None,
                 "array_output_id": str(array_display.id),
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_subworkflow_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_subworkflow_node.py
@@ -2,7 +2,8 @@ from uuid import UUID
 from typing import Any, ClassVar, Dict, Generic, List, Optional, Tuple, Type, TypeVar
 
 from vellum import VellumVariable
-
+from vellum.workflows.nodes import InlineSubworkflowNode
+from vellum.workflows.types.core import JsonObject
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
@@ -10,8 +11,6 @@ from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum_ee.workflows.display.utils.vellum import infer_vellum_variable_type
 from vellum_ee.workflows.display.vellum import NodeInput
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum.workflows.nodes import InlineSubworkflowNode
-from vellum.workflows.types.core import JsonObject
 
 _InlineSubworkflowNodeType = TypeVar("_InlineSubworkflowNodeType", bound=InlineSubworkflowNode)
 
@@ -21,9 +20,7 @@ class BaseInlineSubworkflowNodeDisplay(
 ):
     workflow_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(
-        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs: Any
-    ) -> JsonObject:
+    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -43,7 +40,7 @@ class BaseInlineSubworkflowNodeDisplay(
             "inputs": [node_input.dict() for node_input in node_inputs],
             "data": {
                 "label": self.label,
-                "error_output_id": str(error_output_id) if error_output_id else None,
+                "error_output_id": None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "variant": "INLINE",

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_subworkflow_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_subworkflow_node.py
@@ -20,7 +20,9 @@ class BaseInlineSubworkflowNodeDisplay(
 ):
     workflow_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
+    def serialize(
+        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
+    ) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -40,7 +42,7 @@ class BaseInlineSubworkflowNodeDisplay(
             "inputs": [node_input.dict() for node_input in node_inputs],
             "data": {
                 "label": self.label,
-                "error_output_id": None,
+                "error_output_id": str(error_output_id) if error_output_id else None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "variant": "INLINE",

--- a/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
@@ -18,7 +18,9 @@ _MapNodeType = TypeVar("_MapNodeType", bound=MapNode)
 class BaseMapNodeDisplay(BaseNodeVellumDisplay[_MapNodeType], Generic[_MapNodeType]):
     workflow_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
+    def serialize(
+        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
+    ) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -67,7 +69,7 @@ class BaseMapNodeDisplay(BaseNodeVellumDisplay[_MapNodeType], Generic[_MapNodeTy
             "inputs": [node_input.dict() for node_input in node_inputs],
             "data": {
                 "label": self.label,
-                "error_output_id": None,
+                "error_output_id": str(error_output_id) if error_output_id else None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "variant": "INLINE",

--- a/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
@@ -2,7 +2,8 @@ from uuid import UUID
 from typing import Any, ClassVar, Dict, Generic, List, Optional, Type, TypeVar
 
 from vellum import VellumVariable
-
+from vellum.workflows.nodes import MapNode
+from vellum.workflows.types.core import JsonObject
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
@@ -10,8 +11,6 @@ from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum_ee.workflows.display.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.utils.vellum import infer_vellum_variable_type
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum.workflows.nodes import MapNode
-from vellum.workflows.types.core import JsonObject
 
 _MapNodeType = TypeVar("_MapNodeType", bound=MapNode)
 
@@ -19,9 +18,7 @@ _MapNodeType = TypeVar("_MapNodeType", bound=MapNode)
 class BaseMapNodeDisplay(BaseNodeVellumDisplay[_MapNodeType], Generic[_MapNodeType]):
     workflow_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(
-        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs: Any
-    ) -> JsonObject:
+    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -32,7 +29,8 @@ class BaseMapNodeDisplay(BaseNodeVellumDisplay[_MapNodeType], Generic[_MapNodeTy
             # In Vellum it's always 'items'
             variable_name = descriptor.name if descriptor.name != "all_items" else "items"
             variable_id = str(
-                self.workflow_input_ids_by_name.get(variable_name) or uuid4_from_hash(f"{self.node_id}|{variable_name}")
+                self.workflow_input_ids_by_name.get(variable_name)
+                or uuid4_from_hash(f"{self.node_id}|{variable_name}")
             )
             workflow_inputs.append(
                 VellumVariable(
@@ -69,7 +67,7 @@ class BaseMapNodeDisplay(BaseNodeVellumDisplay[_MapNodeType], Generic[_MapNodeTy
             "inputs": [node_input.dict() for node_input in node_inputs],
             "data": {
                 "label": self.label,
-                "error_output_id": str(error_output_id) if error_output_id else None,
+                "error_output_id": None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "variant": "INLINE",

--- a/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
@@ -20,7 +20,9 @@ class BasePromptDeploymentNodeDisplay(
     array_output_id: ClassVar[Optional[UUID]] = None
     prompt_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
+    def serialize(
+        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
+    ) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -53,7 +55,7 @@ class BasePromptDeploymentNodeDisplay(
             "data": {
                 "label": self.label,
                 "output_id": str(output_display.id),
-                "error_output_id": None,
+                "error_output_id": str(error_output_id) if error_output_id else None,
                 "array_output_id": str(array_display.id),
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
@@ -1,14 +1,14 @@
 from uuid import UUID
 from typing import Any, ClassVar, Dict, Generic, Optional, TypeVar, cast
 
-from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
-from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
-from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
-from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum.workflows.nodes.displayable.prompt_deployment_node import PromptDeploymentNode
 from vellum.workflows.references import OutputReference
 from vellum.workflows.types.core import JsonObject
 from vellum.workflows.vellum_client import create_vellum_client
+from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
+from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
+from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
+from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
 _PromptDeploymentNodeType = TypeVar("_PromptDeploymentNodeType", bound=PromptDeploymentNode)
 
@@ -20,9 +20,7 @@ class BasePromptDeploymentNodeDisplay(
     array_output_id: ClassVar[Optional[UUID]] = None
     prompt_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(
-        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs: Any
-    ) -> JsonObject:
+    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -55,7 +53,7 @@ class BasePromptDeploymentNodeDisplay(
             "data": {
                 "label": self.label,
                 "output_id": str(output_display.id),
-                "error_output_id": str(error_output_id) if error_output_id else None,
+                "error_output_id": None,
                 "array_output_id": str(array_display.id),
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
@@ -30,7 +30,9 @@ class VariableIdMap:
 class BaseSearchNodeDisplay(BaseNodeVellumDisplay[_SearchNodeType], Generic[_SearchNodeType]):
     variable_ids: Optional[VariableIdMap] = None
 
-    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
+    def serialize(
+        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
+    ) -> JsonObject:
         node = self._node
         node_id = self.node_id
         node_inputs = self._generate_search_node_inputs(node_id, node, display_context)
@@ -46,7 +48,7 @@ class BaseSearchNodeDisplay(BaseNodeVellumDisplay[_SearchNodeType], Generic[_Sea
                 "label": self.label,
                 "results_output_id": str(results_output_display.id),
                 "text_output_id": str(text_output_display.id),
-                "error_output_id": None,
+                "error_output_id": str(error_output_id) if error_output_id else None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "query_node_input_id": str(node_inputs["query"].id),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
@@ -30,9 +30,7 @@ class VariableIdMap:
 class BaseSearchNodeDisplay(BaseNodeVellumDisplay[_SearchNodeType], Generic[_SearchNodeType]):
     variable_ids: Optional[VariableIdMap] = None
 
-    def serialize(
-        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs: Any
-    ) -> JsonObject:
+    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
         node = self._node
         node_id = self.node_id
         node_inputs = self._generate_search_node_inputs(node_id, node, display_context)
@@ -48,7 +46,7 @@ class BaseSearchNodeDisplay(BaseNodeVellumDisplay[_SearchNodeType], Generic[_Sea
                 "label": self.label,
                 "results_output_id": str(results_output_display.id),
                 "text_output_id": str(text_output_display.id),
-                "error_output_id": str(error_output_id) if error_output_id else None,
+                "error_output_id": None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "query_node_input_id": str(node_inputs["query"].id),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
@@ -16,10 +16,8 @@ class BaseSubworkflowDeploymentNodeDisplay(
     BaseNodeVellumDisplay[_SubworkflowDeploymentNodeType], Generic[_SubworkflowDeploymentNodeType]
 ):
     subworkflow_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
-    
-    def serialize(
-        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs: Any
-    ) -> JsonObject:
+
+    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -48,7 +46,7 @@ class BaseSubworkflowDeploymentNodeDisplay(
             "inputs": [node_input.dict() for node_input in node_inputs],
             "data": {
                 "label": self.label,
-                "error_output_id": str(error_output_id) if error_output_id else None,
+                "error_output_id": None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "variant": "DEPLOYMENT",

--- a/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
@@ -17,7 +17,9 @@ class BaseSubworkflowDeploymentNodeDisplay(
 ):
     subworkflow_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
+    def serialize(
+        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
+    ) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -46,7 +48,7 @@ class BaseSubworkflowDeploymentNodeDisplay(
             "inputs": [node_input.dict() for node_input in node_inputs],
             "data": {
                 "label": self.label,
-                "error_output_id": None,
+                "error_output_id": str(error_output_id) if error_output_id else None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "variant": "DEPLOYMENT",

--- a/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
@@ -16,7 +16,9 @@ class BaseTemplatingNodeDisplay(BaseNodeVellumDisplay[_TemplatingNodeType], Gene
     template_input_id: ClassVar[Optional[UUID]] = None
     input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
+    def serialize(
+        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
+    ) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -53,7 +55,7 @@ class BaseTemplatingNodeDisplay(BaseNodeVellumDisplay[_TemplatingNodeType], Gene
             "data": {
                 "label": self.label,
                 "output_id": str(output_display.id),
-                "error_output_id": None,
+                "error_output_id": str(error_output_id) if error_output_id else None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "template_node_input_id": str(template_node_input.id),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
@@ -16,9 +16,7 @@ class BaseTemplatingNodeDisplay(BaseNodeVellumDisplay[_TemplatingNodeType], Gene
     template_input_id: ClassVar[Optional[UUID]] = None
     input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
-    def serialize(
-        self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs: Any
-    ) -> JsonObject:
+    def serialize(self, display_context: WorkflowDisplayContext) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
@@ -55,7 +53,7 @@ class BaseTemplatingNodeDisplay(BaseNodeVellumDisplay[_TemplatingNodeType], Gene
             "data": {
                 "label": self.label,
                 "output_id": str(output_display.id),
-                "error_output_id": str(error_output_id) if error_output_id else None,
+                "error_output_id": None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
                 "template_node_input_id": str(template_node_input.id),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
@@ -30,13 +30,10 @@ class BaseTryNodeDisplay(BaseNodeVellumDisplay[_TryNodeType], Generic[_TryNodeTy
         node_display_class = get_node_display_class(BaseNodeVellumDisplay, inner_node)
         node_display = node_display_class(inner_node)
 
-        serialized_node = node_display.serialize(display_context)
-
-        serialized_node_data = serialized_node.get("data")
-        if isinstance(serialized_node_data, dict):
-            serialized_node_data["error_output_id"] = str(
-                self.error_output_id or uuid4_from_hash(f"{node_display.node_id}|error_output_id")
-            )
+        serialized_node = node_display.serialize(
+            display_context,
+            error_output_id=self.error_output_id or uuid4_from_hash(f"{node_display.node_id}|error_output_id"),
+        )
 
         serialized_node_definition = serialized_node.get("definition")
         if isinstance(serialized_node_definition, dict):

--- a/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
@@ -2,7 +2,7 @@ from uuid import UUID
 from typing import Any, ClassVar, Generic, Optional, TypeVar
 
 from vellum.workflows.nodes.core.try_node.node import TryNode
-from vellum.workflows.nodes.utils import get_wrapped_node
+from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME, get_wrapped_node
 from vellum.workflows.types.core import JsonObject
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
@@ -45,7 +45,7 @@ class BaseTryNodeDisplay(BaseNodeVellumDisplay[_TryNodeType], Generic[_TryNodeTy
                 serialized_node_definition_module.extend(
                     [
                         serialized_node_definition["name"],
-                        "<decorator>",
+                        ADORNMENT_MODULE_NAME,
                     ]
                 )
                 serialized_node_definition["name"] = node.__name__

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
@@ -1,9 +1,10 @@
 from deepdiff import DeepDiff
 
-from tests.workflows.basic_code_execution_node.try_workflow import TrySimpleCodeExecutionWorkflow
-from tests.workflows.basic_code_execution_node.workflow import SimpleCodeExecutionWorkflow
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+from tests.workflows.basic_code_execution_node.try_workflow import TrySimpleCodeExecutionWorkflow
+from tests.workflows.basic_code_execution_node.workflow import SimpleCodeExecutionWorkflow
 
 
 def test_serialize_workflow():
@@ -428,8 +429,10 @@ def test_serialize_workflow__try_wrapped():
                 "workflows",
                 "basic_code_execution_node",
                 "try_workflow",
+                "SimpleCodeExecutionNode",
+                "<decorator>",
             ],
-            "name": "SimpleCodeExecutionNode",
+            "name": "TryNode",
         },
     }
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
@@ -1,5 +1,6 @@
 from deepdiff import DeepDiff
 
+from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
@@ -430,7 +431,7 @@ def test_serialize_workflow__try_wrapped():
                 "basic_code_execution_node",
                 "try_workflow",
                 "SimpleCodeExecutionNode",
-                "<decorator>",
+                ADORNMENT_MODULE_NAME,
             ],
             "name": "TryNode",
         },

--- a/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
+++ b/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
@@ -57,7 +57,7 @@ class InlineSubworkflowNode(BaseSubworkflowNode[StateType], Generic[StateType, W
         if outputs is None:
             raise NodeException(
                 message="Expected to receive outputs from Workflow Deployment",
-                code=VellumErrorCode.INTERNAL_ERROR,
+                code=VellumErrorCode.INVALID_OUTPUTS,
             )
 
         # For any outputs somehow in our final fulfilled outputs array,

--- a/src/vellum/workflows/nodes/core/try_node/node.py
+++ b/src/vellum/workflows/nodes/core/try_node/node.py
@@ -1,10 +1,10 @@
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Iterator, Optional, Set, Tuple, Type, TypeVar
 
 from vellum.workflows.errors.types import VellumError, VellumErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.bases.base import BaseNodeMeta
-from vellum.workflows.outputs.base import BaseOutputs
+from vellum.workflows.outputs.base import BaseOutput, BaseOutputs
 from vellum.workflows.types.generics import StateType
 
 if TYPE_CHECKING:
@@ -56,33 +56,59 @@ class TryNode(BaseNode[StateType], Generic[StateType], metaclass=_TryNodeMeta):
     class Outputs(BaseNode.Outputs):
         error: Optional[VellumError] = None
 
-    def run(self) -> Outputs:
+    def run(self) -> Iterator[BaseOutput]:
         subworkflow = self.subworkflow(
             parent_state=self.state,
             context=self._context,
         )
-        terminal_event = subworkflow.run()
+        subworkflow_stream = subworkflow.stream()
 
-        if terminal_event.name == "workflow.execution.fulfilled":
-            outputs = self.Outputs()
-            for descriptor, value in terminal_event.outputs:
-                setattr(outputs, descriptor.name, value)
-            return outputs
-        elif terminal_event.name == "workflow.execution.paused":
+        outputs: Optional[BaseOutputs] = None
+        exception: Optional[NodeException] = None
+        fulfilled_output_names: Set[str] = set()
+
+        for event in subworkflow_stream:
+            if exception:
+                continue
+
+            if event.name == "workflow.execution.streaming":
+                if event.output.is_fulfilled:
+                    fulfilled_output_names.add(event.output.name)
+                yield event.output
+            elif event.name == "workflow.execution.fulfilled":
+                outputs = event.outputs
+            elif event.name == "workflow.execution.paused":
+                exception = NodeException(
+                    code=VellumErrorCode.INVALID_OUTPUTS,
+                    message="Subworkflow unexpectedly paused within Try Node",
+                )
+            elif event.name == "workflow.execution.rejected":
+                if self.on_error_code and self.on_error_code != event.error.code:
+                    exception = NodeException(
+                        code=VellumErrorCode.INVALID_OUTPUTS,
+                        message=f"""Unexpected rejection: {event.error.code.value}.
+Message: {event.error.message}""",
+                    )
+                else:
+                    outputs = self.Outputs(error=event.error)
+
+        if exception:
+            raise exception
+
+        if outputs is None:
             raise NodeException(
                 code=VellumErrorCode.INVALID_OUTPUTS,
-                message="Subworkflow unexpectedly paused within Try Node",
+                message="Expected to receive outputs from Try Node's subworkflow",
             )
-        elif self.on_error_code and self.on_error_code != terminal_event.error.code:
-            raise NodeException(
-                code=VellumErrorCode.INVALID_OUTPUTS,
-                message=f"""Unexpected rejection: {terminal_event.error.code.value}.
-Message: {terminal_event.error.message}""",
-            )
-        else:
-            return self.Outputs(
-                error=terminal_event.error,
-            )
+
+        # For any outputs somehow in our final fulfilled outputs array,
+        # but not fulfilled by the stream.
+        for descriptor, value in outputs:
+            if descriptor.name not in fulfilled_output_names:
+                yield BaseOutput(
+                    name=descriptor.name,
+                    value=value,
+                )
 
     @classmethod
     def wrap(cls, on_error_code: Optional[VellumErrorCode] = None) -> Callable[..., Type["TryNode"]]:
@@ -101,11 +127,15 @@ Message: {terminal_event.error.message}""",
                 class Outputs(inner_cls.Outputs):  # type: ignore[name-defined]
                     pass
 
-            class WrappedNode(TryNode[StateType]):
-                on_error_code = _on_error_code
-
-                subworkflow = Subworkflow
-
+            WrappedNode = type(
+                cls.__name__,
+                (TryNode,),
+                {
+                    "__module__": f"{inner_cls.__module__}.{inner_cls.__name__}.<adornment>",
+                    "on_error_code": _on_error_code,
+                    "subworkflow": Subworkflow,
+                },
+            )
             return WrappedNode
 
         return decorator

--- a/src/vellum/workflows/nodes/core/try_node/node.py
+++ b/src/vellum/workflows/nodes/core/try_node/node.py
@@ -4,6 +4,7 @@ from vellum.workflows.errors.types import VellumError, VellumErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.bases.base import BaseNodeMeta
+from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
 from vellum.workflows.outputs.base import BaseOutput, BaseOutputs
 from vellum.workflows.types.generics import StateType
 
@@ -131,7 +132,7 @@ Message: {event.error.message}""",
                 cls.__name__,
                 (TryNode,),
                 {
-                    "__module__": f"{inner_cls.__module__}.{inner_cls.__name__}.<adornment>",
+                    "__module__": f"{inner_cls.__module__}.{inner_cls.__name__}.{ADORNMENT_MODULE_NAME}",
                     "on_error_code": _on_error_code,
                     "subworkflow": Subworkflow,
                 },

--- a/src/vellum/workflows/nodes/core/try_node/node.py
+++ b/src/vellum/workflows/nodes/core/try_node/node.py
@@ -134,6 +134,7 @@ Message: {event.error.message}""",
             # This dynamic module allows calls to `type_hints` to work
             sys.modules[dynamic_module] = ModuleType(dynamic_module)
 
+            # We use a dynamic wrapped node class to be uniquely tied to this `inner_cls` node during serialization
             WrappedNode = type(
                 cls.__name__,
                 (TryNode,),

--- a/src/vellum/workflows/nodes/displayable/tests/test_inline_text_prompt_node.py
+++ b/src/vellum/workflows/nodes/displayable/tests/test_inline_text_prompt_node.py
@@ -11,13 +11,13 @@ from vellum import (
     StringVellumValue,
     VellumError,
 )
-
 from vellum.workflows.constants import UNDEF
 from vellum.workflows.errors import VellumError as WacVellumError
 from vellum.workflows.errors.types import VellumErrorCode
 from vellum.workflows.inputs import BaseInputs
 from vellum.workflows.nodes import InlinePromptNode
 from vellum.workflows.nodes.core.try_node.node import TryNode
+from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.state import BaseState
 from vellum.workflows.state.base import StateMeta
 
@@ -136,13 +136,13 @@ def test_inline_text_prompt_node__catch_provider_error(vellum_adhoc_prompt_clien
             meta=StateMeta(workflow_inputs=Inputs(input="Say something.")),
         )
     )
-    outputs = node.run()
+    outputs = list(node.run())
 
     # THEN the node should have produced the outputs we expect
-    # We need mypy support for annotations to remove these type ignores
-    # https://app.shortcut.com/vellum/story/4890
-    assert outputs.error == WacVellumError(  # type: ignore[attr-defined]
-        message="OpenAI failed",
-        code=VellumErrorCode.PROVIDER_ERROR,
-    )
-    assert outputs.text is UNDEF  # type: ignore[attr-defined]
+    assert BaseOutput(
+        name="error",
+        value=WacVellumError(
+            message="OpenAI failed",
+            code=VellumErrorCode.PROVIDER_ERROR,
+        ),
+    ) in outputs

--- a/src/vellum/workflows/nodes/displayable/tests/test_inline_text_prompt_node.py
+++ b/src/vellum/workflows/nodes/displayable/tests/test_inline_text_prompt_node.py
@@ -11,8 +11,7 @@ from vellum import (
     StringVellumValue,
     VellumError,
 )
-from vellum.workflows.constants import UNDEF
-from vellum.workflows.errors import VellumError as WacVellumError
+from vellum.workflows.errors import VellumError as SdkVellumError
 from vellum.workflows.errors.types import VellumErrorCode
 from vellum.workflows.inputs import BaseInputs
 from vellum.workflows.nodes import InlinePromptNode
@@ -141,7 +140,7 @@ def test_inline_text_prompt_node__catch_provider_error(vellum_adhoc_prompt_clien
     # THEN the node should have produced the outputs we expect
     assert BaseOutput(
         name="error",
-        value=WacVellumError(
+        value=SdkVellumError(
             message="OpenAI failed",
             code=VellumErrorCode.PROVIDER_ERROR,
         ),

--- a/src/vellum/workflows/nodes/utils.py
+++ b/src/vellum/workflows/nodes/utils.py
@@ -5,6 +5,8 @@ from vellum.workflows.nodes import BaseNode
 from vellum.workflows.references import NodeReference
 from vellum.workflows.types.generics import NodeType
 
+ADORNMENT_MODULE_NAME = "<adornment>"
+
 
 @cache
 def get_wrapped_node(node: Type[NodeType]) -> Type[BaseNode]:

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -170,32 +170,37 @@ class WorkflowRunner(Generic[StateType]):
                 streaming_output_queues: Dict[str, Queue] = {}
                 outputs = node.Outputs()
 
+                def initiate_node_streaming_output(output: BaseOutput) -> None:
+                    streaming_output_queues[output.name] = Queue()
+                    output_descriptor = OutputReference(
+                        name=output.name,
+                        types=(type(output.delta),),
+                        instance=None,
+                        outputs_class=node.Outputs,
+                    )
+                    node.state.meta.node_outputs[output_descriptor] = streaming_output_queues[output.name]
+                    self._work_item_event_queue.put(
+                        WorkItemEvent(
+                            node=node,
+                            event=NodeExecutionStreamingEvent(
+                                trace_id=node.state.meta.trace_id,
+                                span_id=span_id,
+                                body=NodeExecutionStreamingBody(
+                                    node_definition=node.__class__,
+                                    output=BaseOutput(name=output.name),
+                                ),
+                            ),
+                            invoked_ports=invoked_ports,
+                        )
+                    )
+
                 for output in node_run_response:
                     invoked_ports = output > ports
-                    if not output.is_fulfilled:
+                    if output.is_initiated:
+                        initiate_node_streaming_output(output)
+                    elif output.is_streaming:
                         if output.name not in streaming_output_queues:
-                            streaming_output_queues[output.name] = Queue()
-                            output_descriptor = OutputReference(
-                                name=output.name,
-                                types=(type(output.delta),),
-                                instance=None,
-                                outputs_class=node.Outputs,
-                            )
-                            node.state.meta.node_outputs[output_descriptor] = streaming_output_queues[output.name]
-                            self._work_item_event_queue.put(
-                                WorkItemEvent(
-                                    node=node,
-                                    event=NodeExecutionStreamingEvent(
-                                        trace_id=node.state.meta.trace_id,
-                                        span_id=span_id,
-                                        body=NodeExecutionStreamingBody(
-                                            node_definition=node.__class__,
-                                            output=BaseOutput(name=output.name),
-                                        ),
-                                    ),
-                                    invoked_ports=invoked_ports,
-                                )
-                            )
+                            initiate_node_streaming_output(output)
 
                         streaming_output_queues[output.name].put(output.delta)
                         self._work_item_event_queue.put(
@@ -212,7 +217,7 @@ class WorkflowRunner(Generic[StateType]):
                                 invoked_ports=invoked_ports,
                             )
                         )
-                    else:
+                    elif output.is_fulfilled:
                         if output.name in streaming_output_queues:
                             streaming_output_queues[output.name].put(UNDEF)
 
@@ -233,6 +238,11 @@ class WorkflowRunner(Generic[StateType]):
                         )
 
             for descriptor, output_value in outputs:
+                if output_value is UNDEF:
+                    if descriptor in node.state.meta.node_outputs:
+                        del node.state.meta.node_outputs[descriptor]
+                    continue
+
                 node.state.meta.node_outputs[descriptor] = output_value
 
             invoked_ports = ports(outputs, node.state)
@@ -540,11 +550,15 @@ class WorkflowRunner(Generic[StateType]):
         )
 
     def stream(self) -> WorkflowEventStream:
-        background_thread = Thread(target=self._run_background_thread)
+        background_thread = Thread(
+            target=self._run_background_thread, name=f"{self.workflow.__class__.__name__}.background_thread"
+        )
         background_thread.start()
 
         if self._cancel_signal:
-            cancel_thread = Thread(target=self._run_cancel_thread)
+            cancel_thread = Thread(
+                target=self._run_cancel_thread, name=f"{self.workflow.__class__.__name__}.cancel_thread"
+            )
             cancel_thread.start()
 
         event: WorkflowEvent
@@ -557,7 +571,7 @@ class WorkflowRunner(Generic[StateType]):
         self._initial_state.meta.is_terminated = False
 
         # The extra level of indirection prevents the runner from waiting on the caller to consume the event stream
-        stream_thread = Thread(target=self._stream)
+        stream_thread = Thread(target=self._stream, name=f"{self.workflow.__class__.__name__}.stream_thread")
         stream_thread.start()
 
         while stream_thread.is_alive():

--- a/src/vellum/workflows/types/tests/test_utils.py
+++ b/src/vellum/workflows/types/tests/test_utils.py
@@ -1,6 +1,8 @@
 import pytest
 from typing import ClassVar, Generic, List, TypeVar, Union
 
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.nodes.core.try_node.node import TryNode
 from vellum.workflows.outputs.base import BaseOutputs
 from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.utils import get_class_attr_names, infer_types
@@ -30,6 +32,11 @@ class ExampleGenericClass(Generic[T]):
 class ExampleInheritedClass(ExampleClass):
     theta: int
 
+@TryNode.wrap()
+class ExampleNode(BaseNode):
+    class Outputs(BaseNode.Outputs):
+        iota: str
+
 
 @pytest.mark.parametrize(
     "cls, attr_name, expected_type",
@@ -45,6 +52,7 @@ class ExampleInheritedClass(ExampleClass):
         (ExampleInheritedClass, "theta", (int,)),
         (ExampleInheritedClass, "alpha", (str,)),
         (ExampleInheritedClass, "beta", (int,)),
+        (ExampleNode.Outputs, "iota", (str,)),
     ],
     ids=[
         "str",
@@ -58,6 +66,7 @@ class ExampleInheritedClass(ExampleClass):
         "inherited_int",
         "inherited_parent_annotation",
         "inherited_parent_class_var",
+        "try_node_output",
     ],
 )
 def test_infer_types(cls, attr_name, expected_type):

--- a/src/vellum/workflows/types/utils.py
+++ b/src/vellum/workflows/types/utils.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from datetime import datetime
 import importlib
+import sys
 from typing import (
     Any,
     ClassVar,
@@ -18,7 +19,6 @@ from typing import (
 )
 
 from vellum import ArrayVellumValue, ArrayVellumValueRequest, ChatMessagePromptBlock
-
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.types.core import Json, SpecialGenericAlias, UnderGenericAlias, UnionGenericAlias
 

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -35,11 +35,17 @@ from vellum.workflows.emitters.base import BaseWorkflowEmitter
 from vellum.workflows.errors import VellumError, VellumErrorCode
 from vellum.workflows.events.node import (
     NodeExecutionFulfilledBody,
+    NodeExecutionFulfilledEvent,
     NodeExecutionInitiatedBody,
+    NodeExecutionInitiatedEvent,
     NodeExecutionPausedBody,
+    NodeExecutionPausedEvent,
     NodeExecutionRejectedBody,
+    NodeExecutionRejectedEvent,
     NodeExecutionResumedBody,
+    NodeExecutionResumedEvent,
     NodeExecutionStreamingBody,
+    NodeExecutionStreamingEvent,
 )
 from vellum.workflows.events.types import WorkflowEventType
 from vellum.workflows.events.workflow import (
@@ -55,6 +61,7 @@ from vellum.workflows.events.workflow import (
     WorkflowExecutionResumedBody,
     WorkflowExecutionResumedEvent,
     WorkflowExecutionStreamingBody,
+    WorkflowExecutionStreamingEvent,
 )
 from vellum.workflows.graph import Graph
 from vellum.workflows.inputs.base import BaseInputs
@@ -204,7 +211,9 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
                 trace_id=uuid4(),
                 span_id=uuid4(),
                 body=WorkflowExecutionRejectedBody(
-                    error=VellumError(code=VellumErrorCode.INTERNAL_ERROR, message="Initiated event was never emitted"),
+                    error=VellumError(
+                        code=VellumErrorCode.INTERNAL_ERROR, message="Initiated event was never emitted"
+                    ),
                     workflow_definition=self.__class__,
                 ),
             )
@@ -363,3 +372,17 @@ NodeExecutionRejectedBody.model_rebuild()
 NodeExecutionPausedBody.model_rebuild()
 NodeExecutionResumedBody.model_rebuild()
 NodeExecutionStreamingBody.model_rebuild()
+
+WorkflowExecutionInitiatedEvent.model_rebuild()
+WorkflowExecutionFulfilledEvent.model_rebuild()
+WorkflowExecutionRejectedEvent.model_rebuild()
+WorkflowExecutionPausedEvent.model_rebuild()
+WorkflowExecutionResumedEvent.model_rebuild()
+WorkflowExecutionStreamingEvent.model_rebuild()
+
+NodeExecutionInitiatedEvent.model_rebuild()
+NodeExecutionFulfilledEvent.model_rebuild()
+NodeExecutionRejectedEvent.model_rebuild()
+NodeExecutionPausedEvent.model_rebuild()
+NodeExecutionResumedEvent.model_rebuild()
+NodeExecutionStreamingEvent.model_rebuild()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,17 @@
+import sys
+import threading
+import time
+import traceback
+
+
+def debug_threads(wait_time: float = 1):
+    print("\nCurrent threads:")
+    time.sleep(wait_time)
+
+    for thread in threading.enumerate():
+        if not thread.ident:
+            continue
+        print(f"\nThread {thread.name} ({thread.ident}):")
+        frame = sys._current_frames().get(thread.ident)
+        if frame:
+            traceback.print_stack(frame)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,17 +1,26 @@
+import logging
 import sys
 import threading
 import time
 import traceback
 
+logger = logging.getLogger(__name__)
+
 
 def debug_threads(wait_time: float = 1):
-    print("\nCurrent threads:")
+    """
+    A utility to help debug issues where a hanging thread is preventing a process from exiting.
+
+    It's most useful to call this at the end of a test, where it will print out the stack trace of all running threads.
+    """
+
+    logger.info("\nCurrent threads:")
     time.sleep(wait_time)
 
     for thread in threading.enumerate():
         if not thread.ident:
             continue
-        print(f"\nThread {thread.name} ({thread.ident}):")
+        logger.info(f"\nThread {thread.name} ({thread.ident}):")
         frame = sys._current_frames().get(thread.ident)
         if frame:
             traceback.print_stack(frame)

--- a/tests/workflows/basic_try_node/tests/test_workflow.py
+++ b/tests/workflows/basic_try_node/tests/test_workflow.py
@@ -2,8 +2,10 @@ import pytest
 
 from pytest_mock import MockerFixture
 
-from tests.workflows.basic_try_node.workflow import SimpleTryExample
+from vellum.workflows.constants import UNDEF
 from vellum.workflows.errors.types import VellumError, VellumErrorCode
+
+from tests.workflows.basic_try_node.workflow import SimpleTryExample
 
 
 @pytest.fixture
@@ -43,6 +45,7 @@ def test_run_workflow__catch_error(mock_random_int):
     assert terminal_event.name == "workflow.execution.fulfilled", terminal_event
 
     # AND the output should match the expected value
-    assert terminal_event.outputs == {
-        "error": VellumError(message="This is a flaky node", code=VellumErrorCode.INTERNAL_ERROR),
-    }
+    assert terminal_event.outputs.error == VellumError(
+        message="This is a flaky node", code=VellumErrorCode.INTERNAL_ERROR
+    )
+    assert terminal_event.outputs.final_value is UNDEF

--- a/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
+++ b/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
@@ -1,4 +1,5 @@
 from vellum.workflows.events.types import WorkflowEventType
+from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
 
 from tests.workflows.stream_try_node_annotation.workflow import InnerNode, Inputs, StreamingTryExample
 
@@ -26,7 +27,7 @@ def test_workflow_stream__happy_path():
     assert events[1].node_definition == InnerNode
     assert events[1].model_dump(mode="json")["body"]["node_definition"] == {
         "name": "TryNode",
-        "module": ["tests", "workflows", "stream_try_node_annotation", "workflow", "InnerNode", "<adornment>"],
+        "module": ["tests", "workflows", "stream_try_node_annotation", "workflow", "InnerNode", ADORNMENT_MODULE_NAME],
     }
 
     assert events[2].name == "node.execution.streaming"

--- a/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
+++ b/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
@@ -1,0 +1,71 @@
+from vellum.workflows.events.types import WorkflowEventType
+
+from tests.workflows.stream_try_node_annotation.workflow import InnerNode, Inputs, StreamingTryExample
+
+
+def test_workflow_stream__happy_path():
+    """
+    Ensure that we can stream the events of a Workflow that contains a TryNode,
+    with a particular focus on ensuring that the definitions of the events are correct.
+    """
+
+    # GIVEN a Workflow with a TryNode
+    workflow = StreamingTryExample()
+
+    # WHEN we stream the events of the Workflow
+    stream = workflow.stream(
+        inputs=Inputs(items=["apple", "banana", "cherry"]),
+        event_types={WorkflowEventType.NODE, WorkflowEventType.WORKFLOW},
+    )
+    events = list(stream)
+
+    # THEN we see the expected events in the correct order
+    assert events[0].name == "workflow.execution.initiated"
+
+    assert events[1].name == "node.execution.initiated"
+    assert events[1].node_definition == InnerNode
+    assert events[1].model_dump(mode="json")["body"]["node_definition"] == {
+        "name": "TryNode",
+        "module": ["tests", "workflows", "stream_try_node_annotation", "workflow", "InnerNode", "<adornment>"],
+    }
+
+    assert events[2].name == "node.execution.streaming"
+    assert events[2].output.name == "processed"
+    assert events[2].output.is_initiated
+
+    assert events[3].name == "workflow.execution.streaming"
+    assert events[3].output.name == "final_value"
+    assert events[3].output.is_initiated
+
+    assert events[4].name == "node.execution.streaming"
+    assert events[4].output.delta == "apple apple"
+
+    assert events[5].name == "workflow.execution.streaming"
+    assert events[5].output.delta == "apple apple"
+
+    assert events[6].name == "node.execution.streaming"
+    assert events[6].output.name == "processed"
+    assert events[6].output.delta == "banana banana"
+
+    assert events[7].name == "workflow.execution.streaming"
+    assert events[7].output.delta == "banana banana"
+
+    assert events[8].name == "node.execution.streaming"
+    assert events[8].output.delta == "cherry cherry"
+
+    assert events[9].name == "workflow.execution.streaming"
+    assert events[9].output.delta == "cherry cherry"
+
+    assert events[10].name == "node.execution.streaming"
+    assert events[10].output.value == ["apple apple", "banana banana", "cherry cherry"]
+
+    assert events[11].name == "workflow.execution.streaming"
+    assert events[11].output.value == ["apple apple", "banana banana", "cherry cherry"]
+
+    assert events[12].name == "node.execution.fulfilled"
+    assert events[12].outputs.processed == ["apple apple", "banana banana", "cherry cherry"]
+
+    assert events[13].name == "workflow.execution.fulfilled"
+    assert events[13].outputs.final_value == ["apple apple", "banana banana", "cherry cherry"]
+
+    assert len(events) == 14

--- a/tests/workflows/stream_try_node_annotation/workflow.py
+++ b/tests/workflows/stream_try_node_annotation/workflow.py
@@ -1,0 +1,39 @@
+from typing import Iterator, List
+
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.inputs import BaseInputs
+from vellum.workflows.nodes.bases import BaseNode
+from vellum.workflows.nodes.core.try_node import TryNode
+from vellum.workflows.outputs.base import BaseOutput
+
+
+class Inputs(BaseInputs):
+    items: List[str]
+
+
+@TryNode.wrap()
+class InnerNode(BaseNode):
+    items = Inputs.items
+
+    class Outputs(BaseNode.Outputs):
+        processed: List[str]
+
+    def run(self) -> Iterator[BaseOutput]:
+        processed_fruits = []
+        for item in self.items:
+            processed = item + " " + item
+            processed_fruits.append(processed)
+            yield BaseOutput(delta=processed, name="processed")
+
+        yield BaseOutput(value=processed_fruits, name="processed")
+
+
+class StreamingTryExample(BaseWorkflow):
+    """
+    This Workflow ensures that we support streaming within the context of a Node wrapped in a TryNode.
+    """
+
+    graph = InnerNode
+
+    class Outputs(BaseWorkflow.Outputs):
+        final_value = InnerNode.Outputs.processed


### PR DESCRIPTION
This PR adds streaming support for TryNode's. It enables the p80 case of prompt nodes that have reject on error toggle on today.

This PR was blocking basic rag execution and has serialization implications as well