### PR TITLE
[Codegen] Handle Unspecified Workspace Secret

### DIFF
--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/__snapshots__/workspace-secret-pointer.test.ts.snap
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/__snapshots__/workspace-secret-pointer.test.ts.snap
@@ -6,6 +6,6 @@ exports[`WorkspaceSecretPointer > should generate correct Python code 1`] = `
 `;
 
 exports[`WorkspaceSecretPointer > should handle the the case where the workspace secret isn't yet specified 1`] = `
-"None
+"VellumSecretReference(None)
 "
 `;

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/__snapshots__/workspace-secret-pointer.test.ts.snap
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/__snapshots__/workspace-secret-pointer.test.ts.snap
@@ -4,3 +4,8 @@ exports[`WorkspaceSecretPointer > should generate correct Python code 1`] = `
 "VellumSecretReference("MY_SECRET")
 "
 `;
+
+exports[`WorkspaceSecretPointer > should handle the the case where the workspace secret isn't yet specified 1`] = `
+"None
+"
+`;

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/__snapshots__/workspace-secret-pointer.test.ts.snap
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/__snapshots__/workspace-secret-pointer.test.ts.snap
@@ -6,6 +6,6 @@ exports[`WorkspaceSecretPointer > should generate correct Python code 1`] = `
 `;
 
 exports[`WorkspaceSecretPointer > should handle the the case where the workspace secret isn't yet specified 1`] = `
-"VellumSecretReference(None)
+"None
 "
 `;

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.test.ts
@@ -31,4 +31,22 @@ describe("WorkspaceSecretPointer", () => {
     workspaceSecretPointer.write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
   });
+
+  it("should handle the the case where the workspace secret isn't yet specified", async () => {
+    const workflowContext = workflowContextFactory();
+
+    const workspaceSecretPointer = new WorkspaceSecretPointerRule({
+      workflowContext: workflowContext,
+      nodeInputValuePointerRule: {
+        type: "WORKSPACE_SECRET",
+        data: {
+          type: "STRING",
+          workspaceSecretId: undefined,
+        },
+      },
+    });
+
+    workspaceSecretPointer.write(writer);
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
 });

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.ts
@@ -11,6 +11,10 @@ export class WorkspaceSecretPointerRule extends BaseNodeInputValuePointerRule<Wo
 
     const workspaceSecretName = workspaceSecretPointerData.workspaceSecretId;
 
+    if (isNil(workspaceSecretName)) {
+      return python.TypeInstantiation.none();
+    }
+
     return python.instantiateClass({
       classReference: python.reference({
         name: "VellumSecretReference",
@@ -21,9 +25,7 @@ export class WorkspaceSecretPointerRule extends BaseNodeInputValuePointerRule<Wo
       }),
       arguments_: [
         python.methodArgument({
-          value: isNil(workspaceSecretName)
-            ? python.TypeInstantiation.none()
-            : python.TypeInstantiation.str(workspaceSecretName),
+          value: python.TypeInstantiation.str(workspaceSecretName),
         }),
       ],
     });

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.ts
@@ -11,10 +11,6 @@ export class WorkspaceSecretPointerRule extends BaseNodeInputValuePointerRule<Wo
 
     const workspaceSecretName = workspaceSecretPointerData.workspaceSecretId;
 
-    if (isNil(workspaceSecretName)) {
-      return python.TypeInstantiation.none();
-    }
-
     return python.instantiateClass({
       classReference: python.reference({
         name: "VellumSecretReference",
@@ -25,7 +21,9 @@ export class WorkspaceSecretPointerRule extends BaseNodeInputValuePointerRule<Wo
       }),
       arguments_: [
         python.methodArgument({
-          value: python.TypeInstantiation.str(workspaceSecretName),
+          value: isNil(workspaceSecretName)
+            ? python.TypeInstantiation.none()
+            : python.TypeInstantiation.str(workspaceSecretName),
         }),
       ],
     });

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.ts
@@ -1,4 +1,5 @@
 import { python } from "@fern-api/python-ast";
+import { isNil } from "lodash";
 
 import { BaseNodeInputValuePointerRule } from "./base";
 
@@ -10,8 +11,8 @@ export class WorkspaceSecretPointerRule extends BaseNodeInputValuePointerRule<Wo
 
     const workspaceSecretName = workspaceSecretPointerData.workspaceSecretId;
 
-    if (!workspaceSecretName) {
-      throw new Error("Workspace secret name is required");
+    if (isNil(workspaceSecretName)) {
+      return python.TypeInstantiation.none();
     }
 
     return python.instantiateClass({


### PR DESCRIPTION
It's possible in the Vellum UI for a Node Input to need a Workspace Secret, but for the user to not yet have specified which secret should be used.

Codegen needs to be able to handle this case.

In the PR currently, we simply generate `None` as the value instead of a `VellumSecretReference`. This is what wSDK supports currently, but it does open an interesting question. How does serialization later know to serialize this value into a Workspace Secret pointer? It doesn't. It'll think it's a constant value string with a null value. Maybe this is fine? I have a reverted commit showing the direction of a second option that's maybe worth exploring.