### PR TITLE
[Codegen] Introduce Custom AstNode for Json

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/json.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/json.test.ts.snap
@@ -1,0 +1,90 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Json > write > should handle arrays 1`] = `
+"[1, "test", True]
+"
+`;
+
+exports[`Json > write > should handle booleans 1`] = `
+"True
+"
+`;
+
+exports[`Json > write > should handle booleans 2`] = `
+"False
+"
+`;
+
+exports[`Json > write > should handle complex nested structures 1`] = `
+"{
+    "id": "complex-123",
+    "metadata": {
+        "created": "2024-01-01",
+        "modified": "2024-01-02",
+        "tags": ["important", "test", "complex"],
+    },
+    "data": {
+        "users": [
+            {
+                "id": 1,
+                "name": "John Doe",
+                "settings": {
+                    "preferences": {"theme": "dark", "notifications": True},
+                    "permissions": ["read", "write"],
+                },
+                "scores": [98.5, 87.2, 92],
+            },
+            {
+                "id": 2,
+                "name": "Jane Smith",
+                "settings": {
+                    "preferences": {"theme": "light", "notifications": False},
+                    "permissions": ["read"],
+                },
+                "scores": [95, 88.5, 91.2],
+            },
+        ],
+        "statistics": {
+            "total": 2,
+            "active": True,
+            "averageScore": 92.07,
+            "metadata": {
+                "lastUpdated": "2024-01-02",
+                "source": "system",
+                "flags": [None, True, False],
+            },
+        },
+    },
+}
+"
+`;
+
+exports[`Json > write > should handle floats 1`] = `
+"3.14
+"
+`;
+
+exports[`Json > write > should handle integers 1`] = `
+"42
+"
+`;
+
+exports[`Json > write > should handle nested structures 1`] = `
+"{"array": [1, 2, 3], "nested": {"a": 1, "b": "test"}, "null": None}
+"
+`;
+
+exports[`Json > write > should handle null values 1`] = `
+"None
+"
+`;
+
+exports[`Json > write > should handle objects 1`] = `
+"{"key": "value", "num": 123}
+"
+`;
+
+exports[`Json > write > should handle strings 1`] = `
+""test string"
+"
+`;

--- a/ee/codegen/src/__test__/json.test.ts
+++ b/ee/codegen/src/__test__/json.test.ts
@@ -1,0 +1,133 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+
+import { Json } from "src/generators/json";
+
+describe("Json", () => {
+  let writer: Writer;
+
+  beforeEach(() => {
+    writer = new Writer();
+  });
+
+  describe("write", () => {
+    it("should handle null values", async () => {
+      const json = new Json(null);
+      json.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should handle strings", async () => {
+      const json = new Json("test string");
+      json.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should handle integers", async () => {
+      const json = new Json(42);
+      json.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should handle floats", async () => {
+      const json = new Json(3.14);
+      json.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should handle booleans", async () => {
+      const jsonTrue = new Json(true);
+      jsonTrue.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+
+      writer = new Writer();
+      const jsonFalse = new Json(false);
+      jsonFalse.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should handle arrays", async () => {
+      const json = new Json([1, "test", true]);
+      json.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should handle objects", async () => {
+      const json = new Json({ key: "value", num: 123 });
+      json.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should handle nested structures", async () => {
+      const json = new Json({
+        array: [1, 2, 3],
+        nested: { a: 1, b: "test" },
+        null: null,
+      });
+      json.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should handle complex nested structures", async () => {
+      const json = new Json({
+        id: "complex-123",
+        metadata: {
+          created: "2024-01-01",
+          modified: "2024-01-02",
+          tags: ["important", "test", "complex"],
+        },
+        data: {
+          users: [
+            {
+              id: 1,
+              name: "John Doe",
+              settings: {
+                preferences: {
+                  theme: "dark",
+                  notifications: true,
+                },
+                permissions: ["read", "write"],
+              },
+              scores: [98.5, 87.2, 92.0],
+            },
+            {
+              id: 2,
+              name: "Jane Smith",
+              settings: {
+                preferences: {
+                  theme: "light",
+                  notifications: false,
+                },
+                permissions: ["read"],
+              },
+              scores: [95.0, 88.5, 91.2],
+            },
+          ],
+          statistics: {
+            total: 2,
+            active: true,
+            averageScore: 92.07,
+            metadata: {
+              lastUpdated: "2024-01-02",
+              source: "system",
+              flags: [null, true, false],
+            },
+          },
+        },
+      });
+      json.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should throw error for non-JSON-serializable values", () => {
+      expect(() => new Json(undefined)).toThrow(
+        "Unsupported JSON value type: undefined"
+      );
+      expect(() => new Json(() => {})).toThrow(
+        "Unsupported JSON value type: function"
+      );
+      expect(() => new Json(Symbol())).toThrow(
+        "Unsupported JSON value type: symbol"
+      );
+    });
+  });
+});

--- a/ee/codegen/src/generators/json.ts
+++ b/ee/codegen/src/generators/json.ts
@@ -1,0 +1,71 @@
+import { python } from "@fern-api/python-ast";
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+import { Writer } from "@fern-api/python-ast/core/Writer";
+
+export class Json extends AstNode {
+  private readonly astNode: python.AstNode;
+
+  constructor(value: unknown) {
+    super();
+
+    // Validate that value is JSON serializable
+    try {
+      JSON.stringify(value);
+    } catch {
+      throw new Error("Value is not JSON serializable");
+    }
+
+    this.astNode = this.generateAstNode(value);
+    this.inheritReferences(this.astNode);
+  }
+
+  private generateAstNode(value: unknown): python.AstNode {
+    if (value === null) {
+      return python.TypeInstantiation.none();
+    }
+
+    if (typeof value === "string") {
+      return python.TypeInstantiation.str(value);
+    }
+
+    if (typeof value === "number") {
+      if (Number.isInteger(value)) {
+        return python.TypeInstantiation.int(value);
+      }
+      return python.TypeInstantiation.float(value);
+    }
+
+    if (typeof value === "boolean") {
+      return python.TypeInstantiation.bool(value);
+    }
+
+    if (Array.isArray(value)) {
+      return python.TypeInstantiation.list(
+        value.map((item) => {
+          const jsonValue = new Json(item);
+          this.inheritReferences(jsonValue);
+          return jsonValue;
+        })
+      );
+    }
+
+    if (typeof value === "object") {
+      const entries = Object.entries(value).map(([key, val]) => {
+        const jsonValue = new Json(val);
+        this.inheritReferences(jsonValue);
+
+        return {
+          key: python.TypeInstantiation.str(key),
+          value: jsonValue,
+        };
+      });
+      return python.TypeInstantiation.dict(entries);
+    }
+
+    throw new Error(`Unsupported JSON value type: ${typeof value}`);
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
+  }
+}


### PR DESCRIPTION
We need to be able to convert json serializable objects into python primitive values. This introduces a custom AstNode for this.