### PR TITLE
Clean Up API Nodes

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -58,10 +58,10 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
 `;
 
 exports[`ApiNode > basic > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import ApiNode
+"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
-class APINode(ApiNode):
+class APINode(BaseAPINode):
     pass
 "
 `;
@@ -128,12 +128,12 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
 `;
 
 exports[`ApiNode > reject on error enabled > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import ApiNode
+"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 from vellum.workflows.nodes.core import TryNode
 
 
 @TryNode.wrap()
-class APINode(ApiNode):
+class APINode(BaseAPINode):
     pass
 "
 `;

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -7,7 +7,7 @@ import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base"
 import { ApiNode as ApiNodeType } from "src/types/vellum";
 
 export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
-  baseNodeClassName = "ApiNode";
+  baseNodeClassName = "APINode";
   baseNodeDisplayClassName = "BaseAPINodeDisplay";
 
   getNodeClassBodyStatements(): AstNode[] {

--- a/src/vellum/workflows/nodes/displayable/bases/api_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/api_node/node.py
@@ -8,7 +8,7 @@ from vellum.workflows.errors.types import VellumErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.outputs import BaseOutputs
-from vellum.workflows.types.core import JsonObject, VellumSecret
+from vellum.workflows.types.core import Json, JsonObject, VellumSecret
 from vellum.workflows.types.generics import StateType
 
 
@@ -26,11 +26,11 @@ class BaseAPINode(BaseNode, Generic[StateType]):
     url: str
     method: APIRequestMethod
     data: Optional[str] = None
-    json: Optional["JsonObject"] = None
+    json: Optional["Json"] = None
     headers: Optional[Dict[str, Union[str, VellumSecret]]] = None
 
     class Outputs(BaseOutputs):
-        json: Optional["JsonObject"]
+        json: Optional["Json"]
         headers: Dict[str, str]
         status_code: int
         text: str

--- a/src/vellum/workflows/utils/vellum_variables.py
+++ b/src/vellum/workflows/utils/vellum_variables.py
@@ -1,3 +1,4 @@
+import typing
 from typing import List, Tuple, Type, Union, get_args, get_origin
 
 from vellum import (
@@ -17,8 +18,8 @@ from vellum import (
     VellumValueRequest,
     VellumVariableType,
 )
-
 from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.types.core import Json
 
 
 def primitive_type_to_vellum_variable_type(type_: Union[Type, BaseDescriptor]) -> VellumVariableType:
@@ -32,6 +33,17 @@ def primitive_type_to_vellum_variable_type(type_: Union[Type, BaseDescriptor]) -
             return "JSON"
 
         if len(types) != 1:
+            # Check explicitly for our internal JSON type.
+            # Matches the type found at vellum.workflows.utils.vellum_variables.Json
+            if types == [
+                bool,
+                int,
+                float,
+                str,
+                typing.List[typing.ForwardRef('Json')],  # type: ignore [misc]
+                typing.Dict[str, typing.ForwardRef('Json')],  # type: ignore [misc]
+            ]:
+                return "JSON"
             raise ValueError(f"Expected Descriptor to only have one type, got {types}")
 
         type_ = type_.types[0]


### PR DESCRIPTION
Does everything needed to make sure that when you pull down an `APINode`, it generates valid code.