### PR TITLE
Add a Tooling section to the CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,18 @@ make setup
 make test
 ```
 
+## Tooling
+
+This section talks through the tooling you should be familiar with to contribute to the Vellum Python SDKs.
+
+### Fern
+
+[Fern](https://buildwithfern.com/) is used to auto-generate the Vellum Python SDKs. It's a CLI tool that can generate SDKs in a variety of languages. All files not specified in the `.fernignore` file are assumed to be auto-generated and should not be modified manually. All files and directories specified there explicitly are assumed to be manually maintained and are open to direct contribution from this repository.
+
+### Poetry
+
+[Poetry](https://python-poetry.org/) is used to manage dependencies, build, and publish the Vellum Python SDKs. It manages a virtual environment in the `.venv` directory and allows you to install dependencies in an isolated environment. It additionally supports building and publishing to PyPI.
+
 ## Development
 
 Each contribution should be made in its own branch, and accompanied with a test:


### PR DESCRIPTION
Responding to this comment: https://vellum-ai.slack.com/archives/C06P13ABK0W/p1732642673413169?thread_ts=1732642622.231739&cid=C06P13ABK0W

Let me know if there are specific questions that we should flesh out further. Note that the following poetry specific issues are still being tracked:
- poetry not automatically in path
- python version 3.11 fails to install poetry
- poetry not assuming 3.9
- other virtual env activated during poetry setup
- pycharm test runner