### PR TITLE
Add tests/helpers.py to fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -9,4 +9,5 @@ src/vellum/evaluations
 src/vellum/plugins
 src/vellum/workflows
 tests/workflows
+tests/helpers.py
 conftest.py


### PR DESCRIPTION
Prevents our new helpers file from being clobbered by fern: https://github.com/vellum-ai/vellum-python-sdks/pull/236/files