### PR TITLE
remove guardrail node exclusion

### DIFF
--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -36,7 +36,9 @@ describe("WorkflowProjectGenerator", () => {
           // TODO: Fix codegen for inline subworkflow node
           // https://app.shortcut.com/vellum/story/5662/fix-codegen-for-inline-subworkflow-node
           // "simple_inline_subworkflow_node",
-          "simple_guardrail_node",
+          // TODO: Fix codegen for guardrail node
+          // https://app.shortcut.com/vellum/story/5663/fix-codegen-of-guardrail-nodes
+          // "simple_guardrail_node",
           "simple_prompt_node",
           "simple_map_node",
           "simple_code_execution_node",

--- a/ee/codegen_integration/conftest.py
+++ b/ee/codegen_integration/conftest.py
@@ -31,7 +31,6 @@ def _get_fixture_paths(root: str) -> Tuple[str, str]:
         # TODO: Remove exclusions on all of these fixtures
         # https://app.shortcut.com/vellum/story/4649/remove-fixture-exclusions-for-serialization
         exclude_fixtures={
-            "simple_guardrail_node",
             "simple_map_node",
             "simple_code_execution_node",
         }

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/nodes/final_output.py
@@ -1,7 +1,9 @@
 from vellum.workflows.nodes.displayable import FinalOutputNode
 from vellum.workflows.state import BaseState
 
+from ..inputs import Inputs
 
-class FinalOutput(FinalOutputNode[BaseState, float]):
+
+class FinalOutput(FinalOutputNode[BaseState, str]):
     class Outputs(FinalOutputNode.Outputs):
-        value = None
+        value = Inputs.actual

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/nodes/final_output.py
@@ -1,9 +1,9 @@
 from vellum.workflows.nodes.displayable import FinalOutputNode
 from vellum.workflows.state import BaseState
 
-from ..inputs import Inputs
+from .guardrail_node import GuardrailNode
 
 
-class FinalOutput(FinalOutputNode[BaseState, str]):
+class FinalOutput(FinalOutputNode[BaseState, float]):
     class Outputs(FinalOutputNode.Outputs):
-        value = Inputs.actual
+        value = GuardrailNode.Outputs.score

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/display_data/simple_guardrail_node.json
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/display_data/simple_guardrail_node.json
@@ -80,7 +80,7 @@
           "name": "final-output",
           "target_handle_id": "0ef13a41-8905-45ad-9aee-09c201368981",
           "output_id": "493cfa4b-5235-4b71-99ef-270955f35fcb",
-          "output_type": "STRING",
+          "output_type": "NUMBER",
           "node_input_id": "ff856e07-ed9a-47fa-8cec-76ebd8795cdb"
         },
         "inputs": [
@@ -90,10 +90,8 @@
             "value": {
               "rules": [
                 {
-                  "type": "INPUT_VARIABLE",
-                  "data": {
-                    "input_variable_id": "1472503c-1662-4da9-beb9-73026be90c68"
-                  }
+                  "type": "NODE_OUTPUT",
+                  "data": {"node_id": "c207b440-6aac-4047-a37c-e25fcb5b9cfb", "output_id": "0e455862-ccc4-47a4-a9a5-061fadc94fd6"}
                 }
               ],
               "combinator": "OR"
@@ -160,7 +158,7 @@
     {
       "id": "493cfa4b-5235-4b71-99ef-270955f35fcb",
       "key": "final-output",
-      "type": "STRING"
+      "type": "NUMBER"
     }
   ]
 }

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/display_data/simple_guardrail_node.json
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/display_data/simple_guardrail_node.json
@@ -16,7 +16,8 @@
             "x": 1545.0,
             "y": 330.0
           }
-        }
+        },
+        "definition": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"], "bases": []}
       },
       {
         "id": "c207b440-6aac-4047-a37c-e25fcb5b9cfb",
@@ -68,7 +69,8 @@
             "x": 1985.9562846580402,
             "y": 180.75743992606283
           }
-        }
+        },
+        "definition": {"name": "GuardrailNode", "module": ["codegen_integration", "fixtures", "simple_guardrail_node", "code", "nodes", "guardrail_node"], "bases": [{"name": "GuardrailNode", "module": ["vellum", "workflows", "nodes", "displayable", "guardrail_node", "node"]}]}
       },
       {
         "id": "a9455dc7-85f5-43a9-8be7-f131bc5f08e2",
@@ -78,7 +80,7 @@
           "name": "final-output",
           "target_handle_id": "0ef13a41-8905-45ad-9aee-09c201368981",
           "output_id": "493cfa4b-5235-4b71-99ef-270955f35fcb",
-          "output_type": "NUMBER",
+          "output_type": "STRING",
           "node_input_id": "ff856e07-ed9a-47fa-8cec-76ebd8795cdb"
         },
         "inputs": [
@@ -86,7 +88,14 @@
             "id": "ff856e07-ed9a-47fa-8cec-76ebd8795cdb",
             "key": "node_input",
             "value": {
-              "rules": [],
+              "rules": [
+                {
+                  "type": "INPUT_VARIABLE",
+                  "data": {
+                    "input_variable_id": "1472503c-1662-4da9-beb9-73026be90c68"
+                  }
+                }
+              ],
               "combinator": "OR"
             }
           }
@@ -98,7 +107,8 @@
             "x": 2750.0,
             "y": 210.0
           }
-        }
+        },
+        "definition": {"name": "FinalOutput", "module": ["codegen_integration", "fixtures", "simple_guardrail_node", "code", "nodes", "final_output"], "bases": [{"name": "FinalOutputNode", "module": ["vellum", "workflows", "nodes", "displayable", "final_output_node", "node"]}]}
       }
     ],
     "edges": [
@@ -126,37 +136,31 @@
         "zoom": 0.59148308095993
       }
     },
-    "definition": {
-      "name": "Workflow",
-      "module": [
-        "vellum",
-        "workflows",
-        "codegen",
-        "tests",
-        "fixtures",
-        "simple_guardrail_node",
-        "code",
-        "workflow"
-      ]
-    }
+    "definition": {"name": "Workflow", "module": ["codegen_integration", "fixtures", "simple_guardrail_node", "code", "workflow"]}
   },
   "input_variables": [
     {
       "id": "a6ef8809-346e-469c-beed-2e5c4e9844c5",
       "key": "expected",
-      "type": "STRING"
+      "type": "STRING",
+      "required": true,
+      "default": null,
+      "extensions": { "color": null }
     },
     {
       "id": "1472503c-1662-4da9-beb9-73026be90c68",
       "key": "actual",
-      "type": "STRING"
+      "type": "STRING",
+      "required": true,
+      "default": null,
+      "extensions": { "color": null }
     }
   ],
   "output_variables": [
     {
       "id": "493cfa4b-5235-4b71-99ef-270955f35fcb",
       "key": "final-output",
-      "type": "NUMBER"
+      "type": "STRING"
     }
   ]
 }


### PR DESCRIPTION
@dvargas92495 I had to change the fixture because setting an output to `None` breaks things:

`node.Outputs.value.instance` on a `FinalOutput(FinalOutputNode)` will resolve to `FinalOutputNode.Outputsvalue` instead of `None`, which is what I would expect. If I set `value` to `lol` instead of `None`, it correctly resoles to `lol`. 