### PR TITLE
Mitigate some issues relating to poetry in path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ setup-python:
 setup-poetry:
 	python -m scripts.install_poetry -y --version 1.5.1
 
+# We use the full path to poetry to avoid any issues with the shell configuration from the setup-poetry step
 install-deps:
-	poetry lock && poetry install
+	$(HOME)/.local/bin/poetry lock && $(HOME)/.local/bin/poetry install
 
 setup-pre-commit:
 	pre-commit install \


### PR DESCRIPTION
The poetry installation script by default simply suggests how to add poetry to your `PATH` variable. While there's no way to edit your PATH in the parent context we could do some light improvements to make the initial onboarding experience smoother:
- We add to your ~/.zshrc or ~/.bashrc a command to add poetry to your PATH
- We instruct you to source after it's over
- We update install deps to use the exact path to poetry to allow `make setup` to run smoothly