### PR TITLE
Successfully infer descriptors pointing to Any type

### DIFF
--- a/src/vellum/workflows/types/tests/test_utils.py
+++ b/src/vellum/workflows/types/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import ClassVar, Generic, List, TypeVar, Union
+from typing import Any, ClassVar, Generic, List, TypeVar, Union
 
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.try_node.node import TryNode
@@ -20,6 +20,7 @@ class ExampleClass:
     )
     zeta: ClassVar[str]
     eta: List[str]
+    kappa: Any
 
 
 T = TypeVar("T")
@@ -53,6 +54,7 @@ class ExampleNode(BaseNode):
         (ExampleInheritedClass, "alpha", (str,)),
         (ExampleInheritedClass, "beta", (int,)),
         (ExampleNode.Outputs, "iota", (str,)),
+        (ExampleClass, "kappa", (Any,)),
     ],
     ids=[
         "str",
@@ -67,6 +69,7 @@ class ExampleNode(BaseNode):
         "inherited_parent_annotation",
         "inherited_parent_class_var",
         "try_node_output",
+        "any",
     ],
 )
 def test_infer_types(cls, attr_name, expected_type):
@@ -76,9 +79,9 @@ def test_infer_types(cls, attr_name, expected_type):
 @pytest.mark.parametrize(
     "cls, expected_attr_names",
     [
-        (ExampleClass, {"alpha", "beta", "gamma", "epsilon", "zeta", "eta"}),
+        (ExampleClass, {"alpha", "beta", "gamma", "epsilon", "zeta", "eta", "kappa"}),
         (ExampleGenericClass, {"delta"}),
-        (ExampleInheritedClass, {"alpha", "beta", "gamma", "epsilon", "zeta", "eta", "theta"}),
+        (ExampleInheritedClass, {"alpha", "beta", "gamma", "epsilon", "zeta", "eta", "theta", "kappa"}),
     ],
 )
 def test_class_attr_names(cls, expected_attr_names):

--- a/src/vellum/workflows/types/utils.py
+++ b/src/vellum/workflows/types/utils.py
@@ -13,6 +13,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
     get_args,
     get_origin,
     get_type_hints,
@@ -81,6 +82,8 @@ def infer_types(object_: Type, attr_name: str, localns: Optional[Dict[str, Any]]
                 if type_hint in type_var_mapping:
                     return (type_var_mapping[type_hint],)
                 return type_hint.__constraints__
+            if type_hint is Any:
+                return cast(Tuple[Type[Any], ...], (Any,))
 
         for base in reversed(class_.__mro__):
             class_attributes = vars(base)


### PR DESCRIPTION
Following up on @peicodes 's request here: https://vellum-ai.slack.com/archives/C06P13ABK0W/p1732930712441959

While we definitely should gracefully handle this case, we should take a second look at those Map Node input types as it's likely we want something like `item: T, items: T[]` over both being `Any`. `MapNode.SubworkflowInputs` attempts to make strides here, but the ux there looking at it now isn't as intuitive as it could be