### PR TITLE
Save invoked ports in Node events

### DIFF
--- a/src/vellum/workflows/events/node.py
+++ b/src/vellum/workflows/events/node.py
@@ -1,13 +1,13 @@
-from typing import Any, Dict, Generic, Literal, Type, Union
+from typing import Any, Dict, Generic, Iterable, List, Literal, Optional, Set, Type, Union
 
 from pydantic import field_serializer
 
 from vellum.core.pydantic_utilities import UniversalBaseModel
-
 from vellum.workflows.errors import VellumError
 from vellum.workflows.expressions.accessor import AccessorExpression
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.outputs.base import BaseOutput
+from vellum.workflows.ports.port import Port
 from vellum.workflows.references.node import NodeReference
 from vellum.workflows.types.generics import OutputsType
 
@@ -31,6 +31,7 @@ class _BaseNodeEvent(BaseEvent):
 
 
 NodeInputName = Union[NodeReference, AccessorExpression]
+InvokedPorts = Optional[Set["Port"]]
 
 
 class NodeExecutionInitiatedBody(_BaseNodeExecutionBody):
@@ -52,10 +53,17 @@ class NodeExecutionInitiatedEvent(_BaseNodeEvent):
 
 class NodeExecutionStreamingBody(_BaseNodeExecutionBody):
     output: BaseOutput
+    invoked_ports: InvokedPorts = None
 
     @field_serializer("output")
     def serialize_output(self, output: BaseOutput, _info: Any) -> Dict[str, Any]:
         return default_serializer(output)
+
+    @field_serializer("invoked_ports")
+    def serialize_invoked_ports(self, invoked_ports: InvokedPorts, _info: Any) -> Optional[List[Dict[str, Any]]]:
+        if invoked_ports is None:
+            return None
+        return [default_serializer(port) for port in invoked_ports]
 
 
 class NodeExecutionStreamingEvent(_BaseNodeEvent):
@@ -66,13 +74,24 @@ class NodeExecutionStreamingEvent(_BaseNodeEvent):
     def output(self) -> BaseOutput:
         return self.body.output
 
+    @property
+    def invoked_ports(self) -> InvokedPorts:
+        return self.body.invoked_ports
+
 
 class NodeExecutionFulfilledBody(_BaseNodeExecutionBody, Generic[OutputsType]):
     outputs: OutputsType
+    invoked_ports: InvokedPorts = None
 
     @field_serializer("outputs")
     def serialize_outputs(self, outputs: OutputsType, _info: Any) -> Dict[str, Any]:
         return default_serializer(outputs)
+
+    @field_serializer("invoked_ports")
+    def serialize_invoked_ports(self, invoked_ports: InvokedPorts, _info: Any) -> Optional[List[Dict[str, Any]]]:
+        if invoked_ports is None:
+            return None
+        return [default_serializer(port) for port in invoked_ports]
 
 
 class NodeExecutionFulfilledEvent(_BaseNodeEvent, Generic[OutputsType]):
@@ -82,6 +101,10 @@ class NodeExecutionFulfilledEvent(_BaseNodeEvent, Generic[OutputsType]):
     @property
     def outputs(self) -> OutputsType:
         return self.body.outputs
+
+    @property
+    def invoked_ports(self) -> InvokedPorts:
+        return self.body.invoked_ports
 
 
 class NodeExecutionRejectedBody(_BaseNodeExecutionBody):

--- a/src/vellum/workflows/events/types.py
+++ b/src/vellum/workflows/events/types.py
@@ -4,7 +4,7 @@ import json
 from uuid import UUID, uuid4
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Type, Union
 
-from pydantic import Field, field_serializer
+from pydantic import ConfigDict, Field, field_serializer
 
 from vellum.core.pydantic_utilities import UniversalBaseModel
 from vellum.workflows.state.encoder import DefaultStateEncoder

--- a/src/vellum/workflows/events/types.py
+++ b/src/vellum/workflows/events/types.py
@@ -4,7 +4,7 @@ import json
 from uuid import UUID, uuid4
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Type, Union
 
-from pydantic import ConfigDict, Field, field_serializer
+from pydantic import Field, field_serializer
 
 from vellum.core.pydantic_utilities import UniversalBaseModel
 from vellum.workflows.state.encoder import DefaultStateEncoder

--- a/src/vellum/workflows/nodes/displayable/conditional_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/conditional_node/node.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import Set
 
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.outputs.base import BaseOutputs
@@ -15,7 +15,7 @@ class ConditionalNode(BaseNode):
     """
 
     class Ports(NodePorts):
-        def __call__(self, outputs: BaseOutputs, state: BaseState) -> Iterable[Port]:
+        def __call__(self, outputs: BaseOutputs, state: BaseState) -> Set[Port]:    
             all_ports = [port for port in self.__class__]
             enforce_single_invoked_port = validate_ports(all_ports)
 

--- a/src/vellum/workflows/ports/node_ports.py
+++ b/src/vellum/workflows/ports/node_ports.py
@@ -33,7 +33,7 @@ class _NodePortsMeta(type):
 
 
 class NodePorts(metaclass=_NodePortsMeta):
-    def __call__(self, outputs: BaseOutputs, state: BaseState) -> Iterable[Port]:
+    def __call__(self, outputs: BaseOutputs, state: BaseState) -> Set[Port]:
         """
         Invokes the appropriate ports based on the fulfilled outputs and state.
         """
@@ -67,7 +67,7 @@ class NodePorts(metaclass=_NodePortsMeta):
 
         return invoked_ports
 
-    def __lt__(self, output: BaseOutput) -> Iterable[Port]:
+    def __lt__(self, output: BaseOutput) -> Set[Port]:
         """
         Invokes the appropriate ports based on the streamed output
         """

--- a/src/vellum/workflows/ports/port.py
+++ b/src/vellum/workflows/ports/port.py
@@ -1,5 +1,8 @@
 from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Type
 
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.edges.edge import Edge
 from vellum.workflows.graph import Graph, GraphTarget
@@ -73,3 +76,9 @@ class Port:
 
         value = self._condition.resolve(state)
         return bool(value)
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Type[Any], handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.is_instance_schema(cls)

--- a/src/vellum/workflows/ports/port.py
+++ b/src/vellum/workflows/ports/port.py
@@ -77,6 +77,11 @@ class Port:
         value = self._condition.resolve(state)
         return bool(value)
 
+    def serialize(self) -> dict:
+        return {
+            "name": self.name,
+        }
+
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source_type: Type[Any], handler: GetCoreSchemaHandler

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -188,9 +188,9 @@ class WorkflowRunner(Generic[StateType]):
                                 body=NodeExecutionStreamingBody(
                                     node_definition=node.__class__,
                                     output=BaseOutput(name=output.name),
+                                    invoked_ports=invoked_ports,
                                 ),
                             ),
-                            invoked_ports=invoked_ports,
                         )
                     )
 
@@ -212,9 +212,9 @@ class WorkflowRunner(Generic[StateType]):
                                     body=NodeExecutionStreamingBody(
                                         node_definition=node.__class__,
                                         output=output,
+                                        invoked_ports=invoked_ports,
                                     ),
                                 ),
-                                invoked_ports=invoked_ports,
                             )
                         )
                     elif output.is_fulfilled:
@@ -231,9 +231,9 @@ class WorkflowRunner(Generic[StateType]):
                                     body=NodeExecutionStreamingBody(
                                         node_definition=node.__class__,
                                         output=output,
+                                        invoked_ports=invoked_ports,
                                     ),
                                 ),
-                                invoked_ports=invoked_ports,
                             )
                         )
 
@@ -257,9 +257,9 @@ class WorkflowRunner(Generic[StateType]):
                         body=NodeExecutionFulfilledBody(
                             node_definition=node.__class__,
                             outputs=outputs,
+                            invoked_ports=invoked_ports,
                         ),
                     ),
-                    invoked_ports=invoked_ports,
                 )
             )
         except NodeException as e:
@@ -339,7 +339,6 @@ class WorkflowRunner(Generic[StateType]):
     def _handle_work_item_event(self, work_item_event: WorkItemEvent[StateType]) -> Optional[VellumError]:
         node = work_item_event.node
         event = work_item_event.event
-        invoked_ports = work_item_event.invoked_ports
 
         if event.name == "node.execution.initiated":
             return None
@@ -368,13 +367,13 @@ class WorkflowRunner(Generic[StateType]):
                     )
                 )
 
-            self._handle_invoked_ports(node.state, invoked_ports)
+            self._handle_invoked_ports(node.state, event.invoked_ports)
 
             return None
 
         if event.name == "node.execution.fulfilled":
             self._active_nodes_by_execution_id.pop(event.span_id)
-            self._handle_invoked_ports(node.state, invoked_ports)
+            self._handle_invoked_ports(node.state, event.invoked_ports)
 
             return None
 

--- a/src/vellum/workflows/runner/types.py
+++ b/src/vellum/workflows/runner/types.py
@@ -1,18 +1,16 @@
 """Only intenral types and enums for WorkflowRunner should be defined in this module."""
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, Iterable, Optional
+from typing import TYPE_CHECKING, Generic
 
 from vellum.workflows.types.generics import StateType
 
 if TYPE_CHECKING:
     from vellum.workflows.events import NodeEvent
     from vellum.workflows.nodes.bases import BaseNode
-    from vellum.workflows.ports import Port
 
 
 @dataclass(frozen=True)
 class WorkItemEvent(Generic[StateType]):
     node: "BaseNode[StateType]"
     event: "NodeEvent"
-    invoked_ports: Optional[Iterable["Port"]] = None

--- a/src/vellum/workflows/state/encoder.py
+++ b/src/vellum/workflows/state/encoder.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.outputs.base import BaseOutput, BaseOutputs
+from vellum.workflows.ports.port import Port
 from vellum.workflows.state.base import BaseState, NodeExecutionCache
 
 
@@ -22,7 +23,7 @@ class DefaultStateEncoder(JSONEncoder):
         if isinstance(obj, (BaseInputs, BaseOutputs)):
             return {descriptor.name: value for descriptor, value in obj}
 
-        if isinstance(obj, BaseOutput):
+        if isinstance(obj, (BaseOutput, Port)):
             return obj.serialize()
 
         if isinstance(obj, NodeExecutionCache):

--- a/tests/workflows/basic_conditional_branch/tests/test_workflow.py
+++ b/tests/workflows/basic_conditional_branch/tests/test_workflow.py
@@ -1,22 +1,65 @@
-from tests.workflows.basic_conditional_branch.workflow import BasicConditionalBranchWorkflow, Inputs
 from vellum.workflows.constants import UNDEF
+from vellum.workflows.events.types import WorkflowEventType
+
+from tests.workflows.basic_conditional_branch.workflow import (
+    BasicConditionalBranchWorkflow,
+    BranchANode,
+    Inputs,
+    StartNode,
+)
 
 
 def test_run_workflow__branch_a():
+    """
+    Ensure that a Workflow can successfully invoke the `if` branch.
+    """
+
+    # GIVEN a Workflow that uses a Conditional Branch
     workflow = BasicConditionalBranchWorkflow()
 
+    # WHEN we run the Workflow with a `True` value
     terminal_event = workflow.run(inputs=Inputs(value=True))
 
+    # THEN the Workflow should succeed with the expected outputs
     assert terminal_event.name == "workflow.execution.fulfilled", terminal_event
     assert terminal_event.outputs.branch_a == "Branch A"
     assert terminal_event.outputs.branch_b is UNDEF
 
 
 def test_run_workflow__branch_b():
+    """
+    Ensure that a Workflow can successfully invoke the `else` branch.
+    """
+
+    # GIVEN a Workflow that uses a Conditional Branch
     workflow = BasicConditionalBranchWorkflow()
 
+    # WHEN we run the Workflow with a `False` value
     terminal_event = workflow.run(inputs=Inputs(value=False))
 
+    # THEN the Workflow should succeed with the expected outputs
     assert terminal_event.name == "workflow.execution.fulfilled", terminal_event
     assert terminal_event.outputs.branch_b == "Branch B"
     assert terminal_event.outputs.branch_a is UNDEF
+
+
+def test_stream_workflow__verify_invoked_ports():
+    """
+    Ensure that a Workflow can successfully stream invoked ports in its node events.
+    """
+
+    # GIVEN a Workflow that uses a Conditional Branch
+    workflow = BasicConditionalBranchWorkflow()
+
+    # WHEN we stream the Workflow
+    stream = workflow.stream(
+        inputs=Inputs(value=True),
+        event_types={WorkflowEventType.WORKFLOW, WorkflowEventType.NODE},
+    )
+    events = list(stream)
+
+    # THEN we should see the invoked ports in the node events
+    node_fulfilled_events = [event for event in events if event.name == "node.execution.fulfilled"]
+    assert len(node_fulfilled_events) == 2
+    assert node_fulfilled_events[0].invoked_ports == {StartNode.Ports.branch_a}
+    assert node_fulfilled_events[1].invoked_ports == {BranchANode.Ports.default}

--- a/tests/workflows/streaming_node_pipeline/workflow.py
+++ b/tests/workflows/streaming_node_pipeline/workflow.py
@@ -1,5 +1,5 @@
 import time
-from typing import Iterable, Iterator, List
+from typing import Iterable, Iterator, List, Set
 
 from vellum.workflows.inputs import BaseInputs
 from vellum.workflows.nodes import BaseNode
@@ -27,10 +27,10 @@ class FirstNode(BaseNode[State]):
     class Ports(BaseNode.Ports):
         default = Port(default=True)
 
-        def __call__(self, outputs: BaseOutputs, state: BaseState) -> Iterable[Port]:
+        def __call__(self, outputs: BaseOutputs, state: BaseState) -> Set[Port]:
             return set()
 
-        def __lt__(self, output: BaseOutput) -> Iterable[Port]:
+        def __lt__(self, output: BaseOutput) -> Set[Port]:
             return {self.default}
 
     def run(self) -> Iterator[BaseOutput]:


### PR DESCRIPTION
Full context: https://vellum-ai.slack.com/archives/C06P13ABK0W/p1732033982824129

In the immediate term, we need a way to backfill a conditional node event's chosen source handle id, referenced [here](https://github.com/vellum-ai/vellum/blob/main/django/app/domain_models/types/workflows.py#L992). Long term, I do believe it will be helpful debugging/monitoring info for events to know exactly which ports were invoked on any given fulfilled or streaming event.

Will block this PR until review