### PR TITLE
[Codegen] `ErrorVellumValue` Support + Fixes

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
@@ -4,6 +4,11 @@ exports[`VellumValue > CHAT_HISTORY > should write a CHAT_HISTORY value with a s
 
 exports[`VellumValue > CHAT_HISTORY > should write a CHAT_HISTORY value with just text 1`] = `"[ChatMessageRequest(role="USER", text="Hello, AI!")]"`;
 
+exports[`VellumValue > ERROR > should write a ERROR value correctly 1`] = `
+"VellumError(message="This is an error!", code="INTERNAL_SERVER_ERROR")
+"
+`;
+
 exports[`VellumValue > JSON > should write a JSON value correctly 1`] = `
 "{"key": "value", "nested": {"array": [1, 2, 3]}}
 "

--- a/ee/codegen/src/__test__/vellum-variable-value.test.ts
+++ b/ee/codegen/src/__test__/vellum-variable-value.test.ts
@@ -97,4 +97,20 @@ describe("VellumValue", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });
+
+  describe("ERROR", () => {
+    it("should write a ERROR value correctly", async () => {
+      const errorValue = codegen.vellumValue({
+        vellumValue: {
+          type: "ERROR",
+          value: {
+            message: "This is an error!",
+            code: "INTERNAL_SERVER_ERROR",
+          },
+        },
+      });
+      errorValue.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -63,12 +63,8 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
       this.workflowContext.addPortContext(portContext);
     });
 
-    this.portContextsById = portContexts.reduce<Map<string, PortContext>>(
-      (acc, portContext) => {
-        acc.set(portContext.portId, portContext);
-        return acc;
-      },
-      new Map()
+    this.portContextsById = new Map(
+      portContexts.map((portContext) => [portContext.portId, portContext])
     );
   }
 

--- a/src/vellum/workflows/references/__init__.py
+++ b/src/vellum/workflows/references/__init__.py
@@ -4,6 +4,7 @@ from .lazy import LazyReference
 from .node import NodeReference
 from .output import OutputReference
 from .state_value import StateValueReference
+from .vellum_secret import VellumSecretReference
 from .workflow_input import WorkflowInputReference
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "NodeReference",
     "OutputReference",
     "StateValueReference",
+    "VellumSecretReference",
     "WorkflowInputReference",
 ]


### PR DESCRIPTION
This PR:
1. Fixes an import for `VellumSecretReference`
2. Correctly creates a `Map` object via `map` rather than `reduce`
3. Adds codegen support for `ErrorVellumValue` – needed for Error Nodes