### PR TITLE
[Codegen][SC-5662][Part 1] FIx Output Display for Inline Subworkflow Node Display Class

### DIFF
--- a/ee/codegen/src/context/workflow-output-context.ts
+++ b/ee/codegen/src/context/workflow-output-context.ts
@@ -1,7 +1,4 @@
-import {
-  NodeInput as NodeInputType,
-  FinalOutputNode as FinalOutputNodeType,
-} from "src/types/vellum";
+import { FinalOutputNode as FinalOutputNodeType } from "src/types/vellum";
 import { toSnakeCase } from "src/utils/casing";
 
 export declare namespace WorkflowOutputContext {
@@ -27,19 +24,5 @@ export class WorkflowOutputContext {
 
   public getOutputName(): string {
     return toSnakeCase(this.terminalNodeData.data.name);
-  }
-
-  public getFinalOutputNodeInputData(): NodeInputType {
-    const nodeInputData = this.terminalNodeData.inputs.find(
-      (input) => input.id === this.terminalNodeData.data.nodeInputId
-    );
-
-    if (!nodeInputData) {
-      throw new Error(
-        `Node input data not found for node input ID: ${this.terminalNodeData.data.nodeInputId}`
-      );
-    }
-
-    return nodeInputData;
   }
 }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
@@ -15,11 +15,13 @@ class SubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[SubworkflowNode]):
     target_handle_id = UUID("67ee54dc-2505-4368-8e67-70d89ac2a9e5")
     workflow_input_ids_by_name = {}
     node_input_ids_by_name = {}
+    output_display = {
+        SubworkflowNode.Outputs.final_output: NodeOutputDisplay(
+            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final-output"
+        )
+    }
     port_displays = {
         SubworkflowNode.Ports.default: PortDisplayOverrides(id=UUID("fa5c22bc-2499-43fa-880f-75fb20d0587f"))
-    }
-    output_display = {
-        SubworkflowNode.Outputs.final_output: NodeOutputDisplay(id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final_output")
     }
     display_data = NodeDisplayData(
         position=NodeDisplayPosition(x=1991.684833859175, y=178.94753425793772), width=None, height=None


### PR DESCRIPTION
This gets half of the way there to re-enabling the codegen test for inline subworkflow nodes. The remaining work is currently blocked on [this fern PR](https://github.com/fern-api/fern/pull/5311).