### PR TITLE
[Codegen] Use Fern's New File Imports & Comments

### DIFF
--- a/ee/codegen/src/generators/base-persisted-file.ts
+++ b/ee/codegen/src/generators/base-persisted-file.ts
@@ -2,6 +2,8 @@ import { mkdir, writeFile } from "fs/promises";
 import path, { join } from "path";
 
 import { python } from "@fern-api/python-ast";
+import { Comment } from "@fern-api/python-ast/Comment";
+import { StarImport } from "@fern-api/python-ast/StarImport";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
@@ -29,6 +31,14 @@ export abstract class BasePersistedFile extends AstNode {
 
   protected abstract getFileStatements(): AstNode[] | undefined;
 
+  protected getFileImports(): StarImport[] | undefined {
+    return undefined;
+  }
+
+  protected getComments(): Comment[] | undefined {
+    return undefined;
+  }
+
   public write(writer: Writer): void {
     const fileStatements = this.getFileStatements();
     if (!fileStatements) {
@@ -38,10 +48,12 @@ export abstract class BasePersistedFile extends AstNode {
     const file = python.file({
       path: this.getModulePath(),
       isInitFile: this.isInitFile,
+      statements: fileStatements,
+      imports: this.getFileImports(),
+      comments: this.getComments(),
     });
 
     file.inheritReferences(this);
-    fileStatements.forEach((statement) => file.addStatement(statement));
 
     file.write(writer);
   }

--- a/ee/codegen/src/generators/init-file.ts
+++ b/ee/codegen/src/generators/init-file.ts
@@ -1,3 +1,5 @@
+import { Comment } from "@fern-api/python-ast/Comment";
+import { StarImport } from "@fern-api/python-ast/StarImport";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 
 import { BasePersistedFile } from "./base-persisted-file";
@@ -6,22 +8,35 @@ export declare namespace InitFile {
   interface Args extends BasePersistedFile.Args {
     modulePath: string[] | Readonly<string[]>;
     statements?: AstNode[];
+    imports?: StarImport[];
+    comments?: Comment[];
   }
 }
 
 export class InitFile extends BasePersistedFile {
   private readonly modulePath: string[];
   private readonly statements: AstNode[];
+  private readonly imports: StarImport[] | undefined;
+  private readonly comments: Comment[] | undefined;
 
   public constructor({
     workflowContext,
     modulePath,
     statements,
+    imports,
+    comments,
   }: InitFile.Args) {
     super({ workflowContext, isInitFile: true });
     this.modulePath = [...modulePath];
+
     this.statements = statements ?? [];
     this.statements.forEach((statement) => this.inheritReferences(statement));
+
+    this.imports = imports;
+    this.imports?.forEach((import_) => this.inheritReferences(import_));
+
+    this.comments = comments;
+    this.comments?.forEach((comment) => this.inheritReferences(comment));
   }
 
   getModulePath(): string[] {
@@ -30,5 +45,13 @@ export class InitFile extends BasePersistedFile {
 
   public getFileStatements() {
     return this.statements;
+  }
+
+  protected getFileImports(): StarImport[] | undefined {
+    return this.imports;
+  }
+
+  protected getComments(): Comment[] | undefined {
+    return this.comments;
   }
 }

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -237,20 +237,33 @@ ${errors.slice(0, 3).map((err) => {
   }
 
   private generateDisplayRootInitFile(): InitFile {
-    let statements: AstNode[];
+    const statements: AstNode[] = [];
+    const imports: StarImport[] = [];
+    const comments: Comment[] = [];
 
     const parentNode = this.workflowContext.parentNode;
     if (parentNode) {
-      statements = parentNode.generateNodeDisplayClasses();
+      statements.push(...parentNode.generateNodeDisplayClasses());
     } else {
-      statements = [
-        python.codeBlock(`\
-# flake8: noqa: F401, F403
-
-from .nodes import *
-from .workflow import *\
-`),
-      ];
+      comments.push(python.comment({ docs: "flake8: noqa: F401, F403" }));
+      imports.push(
+        python.starImport({
+          modulePath: [
+            this.workflowContext.moduleName,
+            GENERATED_DISPLAY_MODULE_NAME,
+            "nodes",
+          ],
+        })
+      );
+      imports.push(
+        python.starImport({
+          modulePath: [
+            this.workflowContext.moduleName,
+            GENERATED_DISPLAY_MODULE_NAME,
+            "workflow",
+          ],
+        })
+      );
     }
 
     const rootDisplayInitFile = codegen.initFile({
@@ -259,6 +272,8 @@ from .workflow import *\
         ? [...this.workflowContext.parentNode.getNodeDisplayModulePath()]
         : [this.workflowContext.moduleName, GENERATED_DISPLAY_MODULE_NAME],
       statements,
+      imports,
+      comments,
     });
 
     return rootDisplayInitFile;

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -4,6 +4,8 @@ import { mkdir } from "fs/promises";
 import { join } from "path";
 
 import { python } from "@fern-api/python-ast";
+import { Comment } from "@fern-api/python-ast/Comment";
+import { StarImport } from "@fern-api/python-ast/StarImport";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 
 import {
@@ -202,19 +204,23 @@ ${errors.slice(0, 3).map((err) => {
   }
 
   private generateRootInitFile(): InitFile {
-    let statements: AstNode[];
+    const statements: AstNode[] = [];
+    const imports: StarImport[] = [];
+    const comments: Comment[] = [];
 
     const parentNode = this.workflowContext.parentNode;
     if (parentNode) {
-      statements = [parentNode.generateNodeClass()];
+      statements.push(parentNode.generateNodeClass());
     } else {
-      statements = [
-        python.codeBlock(`\
-# flake8: noqa: F401, F403
-
-from .display import *\
-`),
-      ];
+      comments.push(python.comment({ docs: "flake8: noqa: F401, F403" }));
+      imports.push(
+        python.starImport({
+          modulePath: [
+            this.workflowContext.moduleName,
+            GENERATED_DISPLAY_MODULE_NAME,
+          ],
+        })
+      );
     }
 
     const rootInitFile = codegen.initFile({
@@ -223,6 +229,8 @@ from .display import *\
         ? [...this.workflowContext.parentNode.getNodeModulePath()]
         : [this.workflowContext.moduleName],
       statements,
+      imports,
+      comments,
     });
 
     return rootInitFile;


### PR DESCRIPTION
The end goal is to get the display of inline subworkflow and map nodes working correctly. Doing so will require code comments and explicit "*" imports.

As a stepping stone to getting there, this PR simply refactors the code that's here currently to use the newly exposed fern functionality. This will be extended in an upcoming PR to actually perform the fix that's needed.

What's nice is that with this, we now use native fern ast functionality everywhere, rather than having to eject and use the `CodeBlock` AST Node.