### PR TITLE
[Codegen] Fix Remaining Inline Subworkflow Node Codegen

### DIFF
--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -33,9 +33,7 @@ describe("WorkflowProjectGenerator", () => {
       getFixturesForProjectTest({
         includeFixtures: [
           "simple_search_node",
-          // TODO: Fix codegen for inline subworkflow node
-          // https://app.shortcut.com/vellum/story/5662/fix-codegen-for-inline-subworkflow-node
-          // "simple_inline_subworkflow_node",
+          "simple_inline_subworkflow_node",
           // TODO: Fix codegen for guardrail node
           // https://app.shortcut.com/vellum/story/5663/fix-codegen-of-guardrail-nodes
           // "simple_guardrail_node",

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -244,6 +244,17 @@ ${errors.slice(0, 3).map((err) => {
     const parentNode = this.workflowContext.parentNode;
     if (parentNode) {
       statements.push(...parentNode.generateNodeDisplayClasses());
+      comments.push(python.comment({ docs: "flake8: noqa: F401, F403" }));
+      imports.push(
+        python.starImport({
+          modulePath: [...parentNode.getNodeDisplayModulePath(), "nodes"],
+        })
+      );
+      imports.push(
+        python.starImport({
+          modulePath: [...parentNode.getNodeDisplayModulePath(), "workflow"],
+        })
+      );
     } else {
       comments.push(python.comment({ docs: "flake8: noqa: F401, F403" }));
       imports.push(

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
@@ -1,3 +1,5 @@
+# flake8: noqa: F401, F403
+
 from uuid import UUID
 
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -44,7 +44,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"),
+            id=UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6"),
             node_id=UUID("075932b7-c6ba-4c3a-8c8f-d6b043f8fe48"),
             node_input_id=UUID("e4585fda-2016-40fb-8ceb-6553a73f0311"),
             name="final-output",

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/display_data/simple_inline_subworkflow_node.json
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/display_data/simple_inline_subworkflow_node.json
@@ -378,7 +378,7 @@
   ],
   "output_variables": [
     {
-      "id": "6ab3665f-881d-488b-9124-a6da40136c68",
+      "id": "b38e08c7-904d-4f49-b8fb-56e1eff254d6",
       "key": "final-output",
       "type": "STRING"
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/__init__.py
@@ -1,3 +1,5 @@
+# flake8: noqa: F401, F403
+
 from uuid import UUID
 
 from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
@@ -5,6 +7,8 @@ from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDispl
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ....nodes.map_node import MapNode
+from .nodes import *
+from .workflow import *
 
 
 class MapNodeDisplay(BaseMapNodeDisplay[MapNode]):


### PR DESCRIPTION
This takes the work started in https://github.com/vellum-ai/vellum-python-sdks/pull/266 across the finish line.

Here we now include the extra comments and imports needed for Inline Subworkflow Node codegen to behave as expected.