### PR TITLE
[Codegen] Finish Codegen for Code Execution Nodes

### DIFF
--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -40,6 +40,8 @@ export abstract class BaseNode<
     this.errorOutputId = this.getErrorOutputId();
   }
 
+  public abstract persist(): Promise<void>;
+
   protected abstract getNodeClassBodyStatements(): AstNode[];
 
   protected abstract getNodeDisplayClassBodyStatements(): AstNode[];

--- a/ee/codegen/src/generators/nodes/bases/nested-workflow-base.ts
+++ b/ee/codegen/src/generators/nodes/bases/nested-workflow-base.ts
@@ -27,7 +27,12 @@ export abstract class BaseNestedWorkflowNode<
     this.nestedProjectsByName = this.generateNestedProjectsByName();
   }
 
-  public getNestedProjects(): WorkflowProjectGenerator[] {
+  public async persist(): Promise<void> {
+    const nestedProjects = this.getNestedProjects();
+    await Promise.all(nestedProjects.map((project) => project.generateCode()));
+  }
+
+  private getNestedProjects(): WorkflowProjectGenerator[] {
     return Array.from(this.nestedProjectsByName.values());
   }
 

--- a/ee/codegen/src/generators/nodes/bases/single-file-base.ts
+++ b/ee/codegen/src/generators/nodes/bases/single-file-base.ts
@@ -10,6 +10,13 @@ export abstract class BaseSingleFileNode<
   T extends WorkflowDataNode,
   V extends BaseNodeContext<T>
 > extends BaseNode<T, V> {
+  public async persist(): Promise<void> {
+    await Promise.all([
+      this.getNodeFile().persist(),
+      this.getNodeDisplayFile().persist(),
+    ]);
+  }
+
   public getNodeFile(): NodeImplementationFile<T, V> {
     return new NodeImplementationFile({ node: this });
   }

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/nodes/code_execution_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/nodes/code_execution_node/__init__.py
@@ -2,7 +2,7 @@ from vellum.types import CodeExecutionPackage
 from vellum.workflows.nodes.displayable import CodeExecutionNode as BaseCodeExecutionNode
 from vellum.workflows.state import BaseState
 
-from ..inputs import Inputs
+from ...inputs import Inputs
 
 
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/nodes/code_execution_node/script.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/nodes/code_execution_node/script.py
@@ -1,0 +1,3 @@
+def main(arg: str) -> str:
+    return arg
+    


### PR DESCRIPTION
Codegen for Code Execution Nodes wasn't yet generating the actual code for the script itself. Now we do.

Specifically, we:
1. Generate `my_node_name/__init__.py`, which contains the node's actual implementation
2. Generate `my_node_name/script.py`, which generates the script itself.

For reviewers, I suggest reviewing one commit at a time.