### PR TITLE
[Serialization] Remove Exclusion Callback

### DIFF
--- a/ee/codegen_integration/test_code_to_display.py
+++ b/ee/codegen_integration/test_code_to_display.py
@@ -4,7 +4,6 @@ from typing import Any, Dict
 from deepdiff import DeepDiff
 
 from vellum.workflows.workflows.base import BaseWorkflow
-from vellum_ee.workflows.display.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
@@ -24,16 +23,10 @@ def test_code_to_display_data(code_to_display_fixture_paths):
     with open(expected_display_data_file_path) as file:
         expected_serialized_workflow = json.load(file, object_hook=_custom_obj_hook)  # noqa: F841
 
-    def exclude_obj_callback(value, key):
-        if key.endswith("input_id']") or key.endswith("['input_variable_id']"):
-            return True
-
-        return False
 
     assert not DeepDiff(
         expected_serialized_workflow,
         actual_serialized_workflow,
-        exclude_obj_callback=exclude_obj_callback,
         significant_digits=6,
         # This is for the input_variables order being out of order sometimes.
         ignore_order=True


### PR DESCRIPTION
It looks like we can safely remove this exclusion and make our tests a bit more strict.