### PR TITLE
[Codegen] Prepare Fixtures for Merge Node Testing

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
@@ -22,7 +22,7 @@ class MergeNodeDisplay(BaseMergeNodeDisplay[MergeNode]):
 
 exports[`MergeNode > basic > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import MergeNode as BaseMergeNode
-from vellum.types import MergeBehavior
+from vellum.workflows.types import MergeBehavior
 
 
 class MergeNode(BaseMergeNode):

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -42,6 +42,7 @@ describe("WorkflowProjectGenerator", () => {
           "simple_code_execution_node",
           "simple_conditional_node",
           "simple_templating_node",
+          "simple_merge_node",
         ],
       })
     )(

--- a/ee/codegen/src/generators/nodes/merge-node.ts
+++ b/ee/codegen/src/generators/nodes/merge-node.ts
@@ -17,7 +17,10 @@ export class MergeNode extends BaseSingleFileNode<
 
     const mergeStrategyRef = python.reference({
       name: "MergeBehavior",
-      modulePath: ["vellum", "types"],
+      modulePath: [
+        ...this.workflowContext.sdkModulePathNames.WORKFLOWS_MODULE_PATH,
+        "types",
+      ],
       attribute: [this.nodeData.data.mergeStrategy],
     });
 

--- a/ee/codegen_integration/conftest.py
+++ b/ee/codegen_integration/conftest.py
@@ -32,7 +32,8 @@ _fixture_paths = _get_fixtures(
     exclude_fixtures={
         "simple_code_execution_node",
         # TODO: Remove after all other map node fixes go in
-        "simple_map_node"
+        "simple_map_node",
+        "simple_merge_node"
     }
 )
 _fixture_ids = [os.path.basename(path) for path in _fixture_paths]

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa: F401, F403
+
+from .display import *

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa: F401, F403
+
+from .nodes import *
+from .workflow import *

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/__init__.py
@@ -1,0 +1,13 @@
+from .final_output import FinalOutputDisplay
+from .merge_node import MergeNodeDisplay
+from .templating_node_1 import TemplatingNode1Display
+from .templating_node_2 import TemplatingNode2Display
+from .templating_node_3 import TemplatingNode3Display
+
+__all__ = [
+    "TemplatingNode2Display",
+    "MergeNodeDisplay",
+    "TemplatingNode3Display",
+    "FinalOutputDisplay",
+    "TemplatingNode1Display",
+]

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/final_output.py
@@ -1,0 +1,23 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.final_output import FinalOutput
+
+
+class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
+    label = "Final Output"
+    node_id = UUID("7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842")
+    target_handle_id = UUID("8a2df326-df6a-4a5e-81a3-12da082e468c")
+    output_id = UUID("8988fa40-5083-4635-a647-bcbbf42c1652")
+    output_name = "final-output"
+    node_input_id = UUID("1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c")
+    node_input_ids_by_name = {"node_input": UUID("1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c")}
+    output_display = {
+        FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"), name="value")
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=3434.5298476454295, y=174.57146814404433), width=480, height=234
+    )

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/merge_node.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/merge_node.py
@@ -1,0 +1,16 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseMergeNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.merge_node import MergeNode
+
+
+class MergeNodeDisplay(BaseMergeNodeDisplay[MergeNode]):
+    target_handle_ids = [UUID("cf6974a6-1676-43ed-99a0-66bd3eac235f"), UUID("dee0633e-0221-40c7-b179-aae1cf67de87")]
+    node_input_ids_by_name = {}
+    port_displays = {MergeNode.Ports.default: PortDisplayOverrides(id=UUID("e0e666c4-a90b-4a95-928e-144bab251356"))}
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=2374.2549861495845, y=205.20096952908594), width=476, height=180
+    )

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_1.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_1.py
@@ -1,0 +1,22 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.templating_node_1 import TemplatingNode1
+
+
+class TemplatingNode1Display(BaseTemplatingNodeDisplay[TemplatingNode1]):
+    label = "Templating Node 1"
+    node_id = UUID("6c5017d1-9aa3-4f34-9a6a-fbe2f7029473")
+    output_id = UUID("6a903b23-d66c-413b-996d-109f6a483056")
+    target_handle_id = UUID("2d2c5559-983f-469c-a1d0-c2fe9f8f3639")
+    template_input_id = UUID("3981811f-6e33-48b6-b7c5-c32ba9a97dc8")
+    node_input_ids_by_name = {"template": UUID("3981811f-6e33-48b6-b7c5-c32ba9a97dc8")}
+    port_displays = {
+        TemplatingNode1.Ports.default: PortDisplayOverrides(id=UUID("e900aa36-b59e-4d13-bb66-21967eb02214"))
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=1824.7678784335756, y=-124.21640253267435), width=480, height=224
+    )

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_2.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_2.py
@@ -1,0 +1,22 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.templating_node_2 import TemplatingNode2
+
+
+class TemplatingNode2Display(BaseTemplatingNodeDisplay[TemplatingNode2]):
+    label = "Templating Node 2"
+    node_id = UUID("5b7d7b3f-e10d-4334-a217-9099dececd8d")
+    output_id = UUID("b96fcdbd-7bd1-4cd1-b91a-49bb50ded865")
+    target_handle_id = UUID("f9a55e22-2cbd-4492-8755-36760320f0d9")
+    template_input_id = UUID("6567617f-57e4-4c11-9175-557108fcf07e")
+    node_input_ids_by_name = {"template": UUID("6567617f-57e4-4c11-9175-557108fcf07e")}
+    port_displays = {
+        TemplatingNode2.Ports.default: PortDisplayOverrides(id=UUID("a5ae5a5c-ad8a-4a19-a726-f3b8ed1fbb1b"))
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=1827.1240707957352, y=438.20962675410783), width=480, height=224
+    )

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_3.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_3.py
@@ -1,0 +1,26 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.templating_node_3 import TemplatingNode3
+
+
+class TemplatingNode3Display(BaseTemplatingNodeDisplay[TemplatingNode3]):
+    label = "Templating Node 3"
+    node_id = UUID("7f7823e9-b97a-4bbe-bfcf-40aed8db24c9")
+    output_id = UUID("a18fbec8-4530-4ca9-a265-e9323dc45fc4")
+    target_handle_id = UUID("2c1e39e0-ce3e-4c2d-8baf-c5d93b244997")
+    template_input_id = UUID("c1cc89c9-7cb7-498d-9dda-e9e5f36fe556")
+    node_input_ids_by_name = {
+        "template": UUID("c1cc89c9-7cb7-498d-9dda-e9e5f36fe556"),
+        "input_a": UUID("56ff5b3f-41e1-492d-80a0-493f170452a1"),
+        "input_b": UUID("553fe161-a16e-48d1-b07c-b51fe7d10bf3"),
+    }
+    port_displays = {
+        TemplatingNode3.Ports.default: PortDisplayOverrides(id=UUID("e51cd1b6-6c1f-4436-aaed-36cb38e7615d"))
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=2877.183015927978, y=185.8336045706372), width=480, height=278
+    )

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -1,0 +1,70 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.vellum import (
+    EdgeVellumDisplayOverrides,
+    EntrypointVellumDisplayOverrides,
+    NodeDisplayData,
+    NodeDisplayPosition,
+    WorkflowDisplayData,
+    WorkflowDisplayDataViewport,
+    WorkflowMetaVellumDisplayOverrides,
+    WorkflowOutputVellumDisplayOverrides,
+)
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+
+from ..nodes.final_output import FinalOutput
+from ..nodes.merge_node import MergeNode
+from ..nodes.templating_node_1 import TemplatingNode1
+from ..nodes.templating_node_2 import TemplatingNode2
+from ..nodes.templating_node_3 import TemplatingNode3
+from ..workflow import Workflow
+
+
+class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+    workflow_display = WorkflowMetaVellumDisplayOverrides(
+        entrypoint_node_id=UUID("b8b9eb69-4af1-4953-b576-aa59eb138696"),
+        entrypoint_node_source_handle_id=UUID("1095ae85-1e2f-4433-aacf-fac30fe12ff3"),
+        entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),
+        display_data=WorkflowDisplayData(
+            viewport=WorkflowDisplayDataViewport(x=-799.056805115941, y=229.9501405115533, zoom=0.5596719538849867)
+        ),
+    )
+    inputs_display = {}
+    entrypoint_displays = {
+        TemplatingNode2: EntrypointVellumDisplayOverrides(
+            id=UUID("b8b9eb69-4af1-4953-b576-aa59eb138696"),
+            edge_display=EdgeVellumDisplayOverrides(id=UUID("22106f5d-fd97-431d-9615-48278f7a954b")),
+        ),
+        TemplatingNode1: EntrypointVellumDisplayOverrides(
+            id=UUID("b8b9eb69-4af1-4953-b576-aa59eb138696"),
+            edge_display=EdgeVellumDisplayOverrides(id=UUID("2c4d2583-af8d-4fd8-972b-c850325d4158")),
+        ),
+    }
+    edge_displays = {
+        (TemplatingNode2.Ports.default, MergeNode): EdgeVellumDisplayOverrides(
+            id=UUID("114b1eab-ad2a-4612-b590-35f6ebdd87bc")
+        ),
+        (MergeNode.Ports.default, TemplatingNode3): EdgeVellumDisplayOverrides(
+            id=UUID("fba82107-15bc-4033-9b38-6a8b0094aa7f")
+        ),
+        (TemplatingNode3.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
+            id=UUID("0c6ddc01-1db6-4b0f-ac7c-8b43ca4cf3c2")
+        ),
+        (TemplatingNode1.Ports.default, MergeNode): EdgeVellumDisplayOverrides(
+            id=UUID("20c8d251-bcf1-497e-8d37-668e661ccabc")
+        ),
+    }
+    output_displays = {
+        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+            id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"),
+            node_id=UUID("7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842"),
+            node_input_id=UUID("1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c"),
+            name="final-output",
+            label="Final Output",
+            target_handle_id=UUID("8a2df326-df6a-4a5e-81a3-12da082e468c"),
+            display_data=NodeDisplayData(
+                position=NodeDisplayPosition(x=3434.5298476454295, y=174.57146814404433), width=480, height=234
+            ),
+            edge_id=UUID("0c6ddc01-1db6-4b0f-ac7c-8b43ca4cf3c2"),
+        )
+    }

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/__init__.py
@@ -1,0 +1,7 @@
+from .final_output import FinalOutput
+from .merge_node import MergeNode
+from .templating_node_1 import TemplatingNode1
+from .templating_node_2 import TemplatingNode2
+from .templating_node_3 import TemplatingNode3
+
+__all__ = ["TemplatingNode2", "MergeNode", "TemplatingNode3", "FinalOutput", "TemplatingNode1"]

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/final_output.py
@@ -1,0 +1,9 @@
+from vellum.workflows.nodes.displayable import FinalOutputNode
+from vellum.workflows.state import BaseState
+
+from .templating_node_3 import TemplatingNode3
+
+
+class FinalOutput(FinalOutputNode[BaseState, str]):
+    class Outputs(FinalOutputNode.Outputs):
+        value = TemplatingNode3.Outputs.result

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/merge_node.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/merge_node.py
@@ -1,0 +1,7 @@
+from vellum.workflows.nodes.displayable import MergeNode as BaseMergeNode
+from vellum.workflows.types import MergeBehavior
+
+
+class MergeNode(BaseMergeNode):
+    class Trigger(BaseMergeNode.Trigger):
+        merge_behavior = MergeBehavior.AWAIT_ALL

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/templating_node_1.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/templating_node_1.py
@@ -1,0 +1,7 @@
+from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+
+
+class TemplatingNode1(TemplatingNode[BaseState, str]):
+    template = "Hello, world!"
+    inputs = {}

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/templating_node_2.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/templating_node_2.py
@@ -1,0 +1,7 @@
+from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+
+
+class TemplatingNode2(TemplatingNode[BaseState, str]):
+    template = "Goodbye, world!"
+    inputs = {}

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/templating_node_3.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/templating_node_3.py
@@ -1,0 +1,10 @@
+from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+
+from .templating_node_1 import TemplatingNode1
+from .templating_node_2 import TemplatingNode2
+
+
+class TemplatingNode3(TemplatingNode[BaseState, str]):
+    template = "{{ input_a }}\n{{ input_b }}"
+    inputs = {"input_a": TemplatingNode1.Outputs.result, "input_b": TemplatingNode2.Outputs.result}

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/workflow.py
@@ -1,0 +1,17 @@
+from vellum.workflows import BaseWorkflow
+
+from .nodes.final_output import FinalOutput
+from .nodes.merge_node import MergeNode
+from .nodes.templating_node_1 import TemplatingNode1
+from .nodes.templating_node_2 import TemplatingNode2
+from .nodes.templating_node_3 import TemplatingNode3
+
+
+class Workflow(BaseWorkflow):
+    graph = {
+        TemplatingNode2 >> MergeNode >> TemplatingNode3 >> FinalOutput,
+        TemplatingNode1 >> MergeNode >> TemplatingNode3 >> FinalOutput,
+    }
+
+    class Outputs(BaseWorkflow.Outputs):
+        final_output = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_merge_node/display_data/simple_merge_node.json
+++ b/ee/codegen_integration/fixtures/simple_merge_node/display_data/simple_merge_node.json
@@ -1,0 +1,318 @@
+{
+  "workflow_raw_data": {
+    "nodes": [
+      {
+        "id": "7f7823e9-b97a-4bbe-bfcf-40aed8db24c9",
+        "type": "TEMPLATING",
+        "data": {
+          "label": "Templating Node 3",
+          "output_id": "a18fbec8-4530-4ca9-a265-e9323dc45fc4",
+          "error_output_id": null,
+          "source_handle_id": "e51cd1b6-6c1f-4436-aaed-36cb38e7615d",
+          "target_handle_id": "2c1e39e0-ce3e-4c2d-8baf-c5d93b244997",
+          "template_node_input_id": "c1cc89c9-7cb7-498d-9dda-e9e5f36fe556",
+          "output_type": "STRING"
+        },
+        "inputs": [
+          {
+            "id": "56ff5b3f-41e1-492d-80a0-493f170452a1",
+            "key": "input_a",
+            "value": {
+              "rules": [
+                {
+                  "type": "NODE_OUTPUT",
+                  "data": {
+                    "node_id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
+                    "output_id": "6a903b23-d66c-413b-996d-109f6a483056"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          },
+          {
+            "id": "c1cc89c9-7cb7-498d-9dda-e9e5f36fe556",
+            "key": "template",
+            "value": {
+              "rules": [
+                {
+                  "type": "CONSTANT_VALUE",
+                  "data": {
+                    "type": "STRING",
+                    "value": "{{ input_a }}\n{{ input_b }}"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          },
+          {
+            "id": "553fe161-a16e-48d1-b07c-b51fe7d10bf3",
+            "key": "input_b",
+            "value": {
+              "rules": [
+                {
+                  "type": "NODE_OUTPUT",
+                  "data": {
+                    "node_id": "5b7d7b3f-e10d-4334-a217-9099dececd8d",
+                    "output_id": "b96fcdbd-7bd1-4cd1-b91a-49bb50ded865"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          }
+        ],
+        "display_data": {
+          "position": {
+            "x": 2877.183015927978,
+            "y": 185.8336045706372
+          },
+          "comment": null,
+          "width": 480.0,
+          "height": 278.0
+        },
+        "definition": null
+      },
+      {
+        "id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
+        "type": "MERGE",
+        "data": {
+          "label": "Merge Node",
+          "merge_strategy": "AWAIT_ALL",
+          "target_handles": [
+            {
+              "id": "cf6974a6-1676-43ed-99a0-66bd3eac235f"
+            },
+            {
+              "id": "dee0633e-0221-40c7-b179-aae1cf67de87"
+            }
+          ],
+          "source_handle_id": "e0e666c4-a90b-4a95-928e-144bab251356"
+        },
+        "inputs": [],
+        "display_data": {
+          "position": {
+            "x": 2374.2549861495845,
+            "y": 205.20096952908594
+          },
+          "comment": null,
+          "width": 476.0,
+          "height": 180.0
+        },
+        "definition": null
+      },
+      {
+        "id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
+        "type": "TEMPLATING",
+        "data": {
+          "label": "Templating Node 1",
+          "output_id": "6a903b23-d66c-413b-996d-109f6a483056",
+          "error_output_id": null,
+          "source_handle_id": "e900aa36-b59e-4d13-bb66-21967eb02214",
+          "target_handle_id": "2d2c5559-983f-469c-a1d0-c2fe9f8f3639",
+          "template_node_input_id": "3981811f-6e33-48b6-b7c5-c32ba9a97dc8",
+          "output_type": "STRING"
+        },
+        "inputs": [
+          {
+            "id": "3981811f-6e33-48b6-b7c5-c32ba9a97dc8",
+            "key": "template",
+            "value": {
+              "rules": [
+                {
+                  "type": "CONSTANT_VALUE",
+                  "data": {
+                    "type": "STRING",
+                    "value": "Hello, world!"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          }
+        ],
+        "display_data": {
+          "position": {
+            "x": 1824.7678784335756,
+            "y": -124.21640253267435
+          },
+          "comment": null,
+          "width": 480.0,
+          "height": 224.0
+        },
+        "definition": null
+      },
+      {
+        "id": "b8b9eb69-4af1-4953-b576-aa59eb138696",
+        "type": "ENTRYPOINT",
+        "data": {
+          "label": "Entrypoint Node",
+          "source_handle_id": "1095ae85-1e2f-4433-aacf-fac30fe12ff3"
+        },
+        "inputs": [],
+        "display_data": {
+          "position": {
+            "x": 1545.0,
+            "y": 330.0
+          },
+          "comment": null,
+          "width": 124.0,
+          "height": 48.0
+        },
+        "definition": null
+      },
+      {
+        "id": "7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842",
+        "type": "TERMINAL",
+        "data": {
+          "label": "Final Output",
+          "name": "final-output",
+          "target_handle_id": "8a2df326-df6a-4a5e-81a3-12da082e468c",
+          "output_id": "8988fa40-5083-4635-a647-bcbbf42c1652",
+          "output_type": "STRING",
+          "node_input_id": "1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c"
+        },
+        "inputs": [
+          {
+            "id": "1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c",
+            "key": "node_input",
+            "value": {
+              "rules": [
+                {
+                  "type": "NODE_OUTPUT",
+                  "data": {
+                    "node_id": "7f7823e9-b97a-4bbe-bfcf-40aed8db24c9",
+                    "output_id": "a18fbec8-4530-4ca9-a265-e9323dc45fc4"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          }
+        ],
+        "display_data": {
+          "position": {
+            "x": 3434.5298476454295,
+            "y": 174.57146814404433
+          },
+          "comment": null,
+          "width": 480.0,
+          "height": 234.0
+        },
+        "definition": null
+      },
+      {
+        "id": "5b7d7b3f-e10d-4334-a217-9099dececd8d",
+        "type": "TEMPLATING",
+        "data": {
+          "label": "Templating Node 2",
+          "output_id": "b96fcdbd-7bd1-4cd1-b91a-49bb50ded865",
+          "error_output_id": null,
+          "source_handle_id": "a5ae5a5c-ad8a-4a19-a726-f3b8ed1fbb1b",
+          "target_handle_id": "f9a55e22-2cbd-4492-8755-36760320f0d9",
+          "template_node_input_id": "6567617f-57e4-4c11-9175-557108fcf07e",
+          "output_type": "STRING"
+        },
+        "inputs": [
+          {
+            "id": "6567617f-57e4-4c11-9175-557108fcf07e",
+            "key": "template",
+            "value": {
+              "rules": [
+                {
+                  "type": "CONSTANT_VALUE",
+                  "data": {
+                    "type": "STRING",
+                    "value": "Goodbye, world!"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          }
+        ],
+        "display_data": {
+          "position": {
+            "x": 1827.1240707957352,
+            "y": 438.20962675410783
+          },
+          "comment": null,
+          "width": 480.0,
+          "height": 224.0
+        },
+        "definition": null
+      }
+    ],
+    "edges": [
+      {
+        "id": "2c4d2583-af8d-4fd8-972b-c850325d4158",
+        "source_node_id": "b8b9eb69-4af1-4953-b576-aa59eb138696",
+        "source_handle_id": "1095ae85-1e2f-4433-aacf-fac30fe12ff3",
+        "target_node_id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
+        "target_handle_id": "2d2c5559-983f-469c-a1d0-c2fe9f8f3639",
+        "type": "DEFAULT"
+      },
+      {
+        "id": "22106f5d-fd97-431d-9615-48278f7a954b",
+        "source_node_id": "b8b9eb69-4af1-4953-b576-aa59eb138696",
+        "source_handle_id": "1095ae85-1e2f-4433-aacf-fac30fe12ff3",
+        "target_node_id": "5b7d7b3f-e10d-4334-a217-9099dececd8d",
+        "target_handle_id": "f9a55e22-2cbd-4492-8755-36760320f0d9",
+        "type": "DEFAULT"
+      },
+      {
+        "id": "20c8d251-bcf1-497e-8d37-668e661ccabc",
+        "source_node_id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
+        "source_handle_id": "e900aa36-b59e-4d13-bb66-21967eb02214",
+        "target_node_id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
+        "target_handle_id": "cf6974a6-1676-43ed-99a0-66bd3eac235f",
+        "type": "DEFAULT"
+      },
+      {
+        "id": "114b1eab-ad2a-4612-b590-35f6ebdd87bc",
+        "source_node_id": "5b7d7b3f-e10d-4334-a217-9099dececd8d",
+        "source_handle_id": "a5ae5a5c-ad8a-4a19-a726-f3b8ed1fbb1b",
+        "target_node_id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
+        "target_handle_id": "dee0633e-0221-40c7-b179-aae1cf67de87",
+        "type": "DEFAULT"
+      },
+      {
+        "id": "fba82107-15bc-4033-9b38-6a8b0094aa7f",
+        "source_node_id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
+        "source_handle_id": "e0e666c4-a90b-4a95-928e-144bab251356",
+        "target_node_id": "7f7823e9-b97a-4bbe-bfcf-40aed8db24c9",
+        "target_handle_id": "2c1e39e0-ce3e-4c2d-8baf-c5d93b244997",
+        "type": "DEFAULT"
+      },
+      {
+        "id": "0c6ddc01-1db6-4b0f-ac7c-8b43ca4cf3c2",
+        "source_node_id": "7f7823e9-b97a-4bbe-bfcf-40aed8db24c9",
+        "source_handle_id": "e51cd1b6-6c1f-4436-aaed-36cb38e7615d",
+        "target_node_id": "7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842",
+        "target_handle_id": "8a2df326-df6a-4a5e-81a3-12da082e468c",
+        "type": "DEFAULT"
+      }
+    ],
+    "display_data": {
+      "viewport": {
+        "x": -799.056805115941,
+        "y": 229.9501405115533,
+        "zoom": 0.5596719538849867
+      }
+    },
+    "definition": null
+  },
+  "input_variables": [],
+  "output_variables": [
+    {
+      "id": "8988fa40-5083-4635-a647-bcbbf42c1652",
+      "key": "final-output",
+      "type": "STRING",
+      "required": null,
+      "default": null,
+      "extensions": null
+    }
+  ],
+  "runner_config": null
+}

--- a/ee/codegen_integration/fixtures/simple_merge_node/display_data/simple_merge_node.json
+++ b/ee/codegen_integration/fixtures/simple_merge_node/display_data/simple_merge_node.json
@@ -2,148 +2,6 @@
   "workflow_raw_data": {
     "nodes": [
       {
-        "id": "7f7823e9-b97a-4bbe-bfcf-40aed8db24c9",
-        "type": "TEMPLATING",
-        "data": {
-          "label": "Templating Node 3",
-          "output_id": "a18fbec8-4530-4ca9-a265-e9323dc45fc4",
-          "error_output_id": null,
-          "source_handle_id": "e51cd1b6-6c1f-4436-aaed-36cb38e7615d",
-          "target_handle_id": "2c1e39e0-ce3e-4c2d-8baf-c5d93b244997",
-          "template_node_input_id": "c1cc89c9-7cb7-498d-9dda-e9e5f36fe556",
-          "output_type": "STRING"
-        },
-        "inputs": [
-          {
-            "id": "56ff5b3f-41e1-492d-80a0-493f170452a1",
-            "key": "input_a",
-            "value": {
-              "rules": [
-                {
-                  "type": "NODE_OUTPUT",
-                  "data": {
-                    "node_id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
-                    "output_id": "6a903b23-d66c-413b-996d-109f6a483056"
-                  }
-                }
-              ],
-              "combinator": "OR"
-            }
-          },
-          {
-            "id": "c1cc89c9-7cb7-498d-9dda-e9e5f36fe556",
-            "key": "template",
-            "value": {
-              "rules": [
-                {
-                  "type": "CONSTANT_VALUE",
-                  "data": {
-                    "type": "STRING",
-                    "value": "{{ input_a }}\n{{ input_b }}"
-                  }
-                }
-              ],
-              "combinator": "OR"
-            }
-          },
-          {
-            "id": "553fe161-a16e-48d1-b07c-b51fe7d10bf3",
-            "key": "input_b",
-            "value": {
-              "rules": [
-                {
-                  "type": "NODE_OUTPUT",
-                  "data": {
-                    "node_id": "5b7d7b3f-e10d-4334-a217-9099dececd8d",
-                    "output_id": "b96fcdbd-7bd1-4cd1-b91a-49bb50ded865"
-                  }
-                }
-              ],
-              "combinator": "OR"
-            }
-          }
-        ],
-        "display_data": {
-          "position": {
-            "x": 2877.183015927978,
-            "y": 185.8336045706372
-          },
-          "comment": null,
-          "width": 480.0,
-          "height": 278.0
-        },
-        "definition": null
-      },
-      {
-        "id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
-        "type": "MERGE",
-        "data": {
-          "label": "Merge Node",
-          "merge_strategy": "AWAIT_ALL",
-          "target_handles": [
-            {
-              "id": "cf6974a6-1676-43ed-99a0-66bd3eac235f"
-            },
-            {
-              "id": "dee0633e-0221-40c7-b179-aae1cf67de87"
-            }
-          ],
-          "source_handle_id": "e0e666c4-a90b-4a95-928e-144bab251356"
-        },
-        "inputs": [],
-        "display_data": {
-          "position": {
-            "x": 2374.2549861495845,
-            "y": 205.20096952908594
-          },
-          "comment": null,
-          "width": 476.0,
-          "height": 180.0
-        },
-        "definition": null
-      },
-      {
-        "id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
-        "type": "TEMPLATING",
-        "data": {
-          "label": "Templating Node 1",
-          "output_id": "6a903b23-d66c-413b-996d-109f6a483056",
-          "error_output_id": null,
-          "source_handle_id": "e900aa36-b59e-4d13-bb66-21967eb02214",
-          "target_handle_id": "2d2c5559-983f-469c-a1d0-c2fe9f8f3639",
-          "template_node_input_id": "3981811f-6e33-48b6-b7c5-c32ba9a97dc8",
-          "output_type": "STRING"
-        },
-        "inputs": [
-          {
-            "id": "3981811f-6e33-48b6-b7c5-c32ba9a97dc8",
-            "key": "template",
-            "value": {
-              "rules": [
-                {
-                  "type": "CONSTANT_VALUE",
-                  "data": {
-                    "type": "STRING",
-                    "value": "Hello, world!"
-                  }
-                }
-              ],
-              "combinator": "OR"
-            }
-          }
-        ],
-        "display_data": {
-          "position": {
-            "x": 1824.7678784335756,
-            "y": -124.21640253267435
-          },
-          "comment": null,
-          "width": 480.0,
-          "height": 224.0
-        },
-        "definition": null
-      },
-      {
         "id": "b8b9eb69-4af1-4953-b576-aa59eb138696",
         "type": "ENTRYPOINT",
         "data": {
@@ -156,51 +14,20 @@
             "x": 1545.0,
             "y": 330.0
           },
-          "comment": null,
-          "width": 124.0,
-          "height": 48.0
+          "width": 124,
+          "height": 48
         },
-        "definition": null
-      },
-      {
-        "id": "7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842",
-        "type": "TERMINAL",
-        "data": {
-          "label": "Final Output",
-          "name": "final-output",
-          "target_handle_id": "8a2df326-df6a-4a5e-81a3-12da082e468c",
-          "output_id": "8988fa40-5083-4635-a647-bcbbf42c1652",
-          "output_type": "STRING",
-          "node_input_id": "1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c"
-        },
-        "inputs": [
-          {
-            "id": "1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c",
-            "key": "node_input",
-            "value": {
-              "rules": [
-                {
-                  "type": "NODE_OUTPUT",
-                  "data": {
-                    "node_id": "7f7823e9-b97a-4bbe-bfcf-40aed8db24c9",
-                    "output_id": "a18fbec8-4530-4ca9-a265-e9323dc45fc4"
-                  }
-                }
-              ],
-              "combinator": "OR"
-            }
-          }
-        ],
-        "display_data": {
-          "position": {
-            "x": 3434.5298476454295,
-            "y": 174.57146814404433
-          },
-          "comment": null,
-          "width": 480.0,
-          "height": 234.0
-        },
-        "definition": null
+        "definition": {
+          "bases": [],
+          "module": [
+            "vellum",
+            "workflows",
+            "nodes",
+            "bases",
+            "base"
+          ],
+          "name": "BaseNode"
+        }
       },
       {
         "id": "5b7d7b3f-e10d-4334-a217-9099dececd8d",
@@ -237,22 +64,306 @@
             "x": 1827.1240707957352,
             "y": 438.20962675410783
           },
-          "comment": null,
-          "width": 480.0,
-          "height": 224.0
+          "width": 480,
+          "height": 224
         },
-        "definition": null
+        "definition": {
+          "bases": [
+            {
+              "module": [
+                "vellum",
+                "workflows",
+                "nodes",
+                "core",
+                "templating_node",
+                "node"
+              ],
+              "name": "TemplatingNode"
+            }
+          ],
+          "module": [
+            "codegen_integration",
+            "fixtures",
+            "simple_merge_node",
+            "code",
+            "nodes",
+            "templating_node_2"
+          ],
+          "name": "TemplatingNode2"
+        }
+      },
+      {
+        "id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
+        "type": "MERGE",
+        "data": {
+          "label": "Merge Node",
+          "merge_strategy": "AWAIT_ALL",
+          "target_handles": [
+            {
+              "id": "cf6974a6-1676-43ed-99a0-66bd3eac235f"
+            },
+            {
+              "id": "dee0633e-0221-40c7-b179-aae1cf67de87"
+            }
+          ],
+          "source_handle_id": "e0e666c4-a90b-4a95-928e-144bab251356"
+        },
+        "inputs": [],
+        "display_data": {
+          "position": {
+            "x": 2374.2549861495845,
+            "y": 205.20096952908594
+          },
+          "width": 476,
+          "height": 180
+        },
+        "definition": {
+          "bases": [
+            {
+              "module": [
+                "vellum",
+                "workflows",
+                "nodes",
+                "displayable",
+                "merge_node",
+                "node"
+              ],
+              "name": "MergeNode"
+            }
+          ],
+          "module": [
+            "codegen_integration",
+            "fixtures",
+            "simple_merge_node",
+            "code",
+            "nodes",
+            "merge_node"
+          ],
+          "name": "MergeNode"
+        }
+      },
+      {
+        "id": "7f7823e9-b97a-4bbe-bfcf-40aed8db24c9",
+        "type": "TEMPLATING",
+        "data": {
+          "label": "Templating Node 3",
+          "output_id": "a18fbec8-4530-4ca9-a265-e9323dc45fc4",
+          "error_output_id": null,
+          "source_handle_id": "e51cd1b6-6c1f-4436-aaed-36cb38e7615d",
+          "target_handle_id": "2c1e39e0-ce3e-4c2d-8baf-c5d93b244997",
+          "template_node_input_id": "c1cc89c9-7cb7-498d-9dda-e9e5f36fe556",
+          "output_type": "STRING"
+        },
+        "inputs": [
+          {
+            "id": "c1cc89c9-7cb7-498d-9dda-e9e5f36fe556",
+            "key": "template",
+            "value": {
+              "rules": [
+                {
+                  "type": "CONSTANT_VALUE",
+                  "data": {
+                    "type": "STRING",
+                    "value": "{{ input_a }}\n{{ input_b }}"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          },
+          {
+            "id": "56ff5b3f-41e1-492d-80a0-493f170452a1",
+            "key": "input_a",
+            "value": {
+              "rules": [
+                {
+                  "type": "NODE_OUTPUT",
+                  "data": {
+                    "node_id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
+                    "output_id": "6a903b23-d66c-413b-996d-109f6a483056"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          },
+          {
+            "id": "553fe161-a16e-48d1-b07c-b51fe7d10bf3",
+            "key": "input_b",
+            "value": {
+              "rules": [
+                {
+                  "type": "NODE_OUTPUT",
+                  "data": {
+                    "node_id": "5b7d7b3f-e10d-4334-a217-9099dececd8d",
+                    "output_id": "b96fcdbd-7bd1-4cd1-b91a-49bb50ded865"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          }
+        ],
+        "display_data": {
+          "position": {
+            "x": 2877.183015927978,
+            "y": 185.8336045706372
+          },
+          "width": 480,
+          "height": 278
+        },
+        "definition": {
+          "bases": [
+            {
+              "module": [
+                "vellum",
+                "workflows",
+                "nodes",
+                "core",
+                "templating_node",
+                "node"
+              ],
+              "name": "TemplatingNode"
+            }
+          ],
+          "module": [
+            "codegen_integration",
+            "fixtures",
+            "simple_merge_node",
+            "code",
+            "nodes",
+            "templating_node_3"
+          ],
+          "name": "TemplatingNode3"
+        }
+      },
+      {
+        "id": "7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842",
+        "type": "TERMINAL",
+        "data": {
+          "label": "Final Output",
+          "name": "final-output",
+          "target_handle_id": "8a2df326-df6a-4a5e-81a3-12da082e468c",
+          "output_id": "8988fa40-5083-4635-a647-bcbbf42c1652",
+          "output_type": "STRING",
+          "node_input_id": "1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c"
+        },
+        "inputs": [
+          {
+            "id": "1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c",
+            "key": "node_input",
+            "value": {
+              "rules": [
+                {
+                  "type": "NODE_OUTPUT",
+                  "data": {
+                    "node_id": "7f7823e9-b97a-4bbe-bfcf-40aed8db24c9",
+                    "output_id": "a18fbec8-4530-4ca9-a265-e9323dc45fc4"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          }
+        ],
+        "display_data": {
+          "position": {
+            "x": 3434.5298476454295,
+            "y": 174.57146814404433
+          },
+          "width": 480,
+          "height": 234
+        },
+        "definition": {
+          "bases": [
+            {
+              "module": [
+                "vellum",
+                "workflows",
+                "nodes",
+                "displayable",
+                "final_output_node",
+                "node"
+              ],
+              "name": "FinalOutputNode"
+            }
+          ],
+          "module": [
+            "codegen_integration",
+            "fixtures",
+            "simple_merge_node",
+            "code",
+            "nodes",
+            "final_output"
+          ],
+          "name": "FinalOutput"
+        }
+      },
+      {
+        "id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
+        "type": "TEMPLATING",
+        "data": {
+          "label": "Templating Node 1",
+          "output_id": "6a903b23-d66c-413b-996d-109f6a483056",
+          "error_output_id": null,
+          "source_handle_id": "e900aa36-b59e-4d13-bb66-21967eb02214",
+          "target_handle_id": "2d2c5559-983f-469c-a1d0-c2fe9f8f3639",
+          "template_node_input_id": "3981811f-6e33-48b6-b7c5-c32ba9a97dc8",
+          "output_type": "STRING"
+        },
+        "inputs": [
+          {
+            "id": "3981811f-6e33-48b6-b7c5-c32ba9a97dc8",
+            "key": "template",
+            "value": {
+              "rules": [
+                {
+                  "type": "CONSTANT_VALUE",
+                  "data": {
+                    "type": "STRING",
+                    "value": "Hello, world!"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          }
+        ],
+        "display_data": {
+          "position": {
+            "x": 1824.7678784335756,
+            "y": -124.21640253267435
+          },
+          "width": 480,
+          "height": 224
+        },
+        "definition": {
+          "bases": [
+            {
+              "module": [
+                "vellum",
+                "workflows",
+                "nodes",
+                "core",
+                "templating_node",
+                "node"
+              ],
+              "name": "TemplatingNode"
+            }
+          ],
+          "module": [
+            "codegen_integration",
+            "fixtures",
+            "simple_merge_node",
+            "code",
+            "nodes",
+            "templating_node_1"
+          ],
+          "name": "TemplatingNode1"
+        }
       }
     ],
     "edges": [
-      {
-        "id": "2c4d2583-af8d-4fd8-972b-c850325d4158",
-        "source_node_id": "b8b9eb69-4af1-4953-b576-aa59eb138696",
-        "source_handle_id": "1095ae85-1e2f-4433-aacf-fac30fe12ff3",
-        "target_node_id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
-        "target_handle_id": "2d2c5559-983f-469c-a1d0-c2fe9f8f3639",
-        "type": "DEFAULT"
-      },
       {
         "id": "22106f5d-fd97-431d-9615-48278f7a954b",
         "source_node_id": "b8b9eb69-4af1-4953-b576-aa59eb138696",
@@ -262,11 +373,11 @@
         "type": "DEFAULT"
       },
       {
-        "id": "20c8d251-bcf1-497e-8d37-668e661ccabc",
-        "source_node_id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
-        "source_handle_id": "e900aa36-b59e-4d13-bb66-21967eb02214",
-        "target_node_id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
-        "target_handle_id": "cf6974a6-1676-43ed-99a0-66bd3eac235f",
+        "id": "2c4d2583-af8d-4fd8-972b-c850325d4158",
+        "source_node_id": "b8b9eb69-4af1-4953-b576-aa59eb138696",
+        "source_handle_id": "1095ae85-1e2f-4433-aacf-fac30fe12ff3",
+        "target_node_id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
+        "target_handle_id": "2d2c5559-983f-469c-a1d0-c2fe9f8f3639",
         "type": "DEFAULT"
       },
       {
@@ -292,6 +403,14 @@
         "target_node_id": "7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842",
         "target_handle_id": "8a2df326-df6a-4a5e-81a3-12da082e468c",
         "type": "DEFAULT"
+      },
+      {
+        "id": "20c8d251-bcf1-497e-8d37-668e661ccabc",
+        "source_node_id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
+        "source_handle_id": "e900aa36-b59e-4d13-bb66-21967eb02214",
+        "target_node_id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
+        "target_handle_id": "cf6974a6-1676-43ed-99a0-66bd3eac235f",
+        "type": "DEFAULT"
       }
     ],
     "display_data": {
@@ -301,18 +420,23 @@
         "zoom": 0.5596719538849867
       }
     },
-    "definition": null
+    "definition": {
+      "name": "Workflow",
+      "module": [
+        "codegen_integration",
+        "fixtures",
+        "simple_merge_node",
+        "code",
+        "workflow"
+      ]
+    }
   },
   "input_variables": [],
   "output_variables": [
     {
       "id": "8988fa40-5083-4635-a647-bcbbf42c1652",
       "key": "final-output",
-      "type": "STRING",
-      "required": null,
-      "default": null,
-      "extensions": null
+      "type": "STRING"
     }
-  ],
-  "runner_config": null
+  ]
 }

--- a/src/vellum/workflows/types/__init__.py
+++ b/src/vellum/workflows/types/__init__.py
@@ -1,0 +1,5 @@
+from .core import MergeBehavior
+
+__all__ = [
+    "MergeBehavior",
+]


### PR DESCRIPTION
This PR:
1. Gets the boilerplate in place for e2e testing of merge nodes based on this Workflow: https://app.vellum.ai/workflow-sandboxes/4d344cd9-e480-464b-8746-f9a4cf7bf183
2. Fixes an import path issue for the `MergeBehavior` enum
3. Updates our test inclusions/exclusions

Note: This test is currently asserting incorrect functionality in at least codegen, but possibly also serialization. My goal is to iterate on getting codegen in a good spot in the next PR, then take stock of what if anything in serialization land needs updating after that.