### PR TITLE
Resolve function block serialization

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1,10 +1,4 @@
-import {
-  ChatMessagePromptBlock,
-  JinjaPromptBlock,
-  RichTextPromptBlock,
-  VellumVariableType,
-} from "vellum-ai/api";
-import { VariablePromptBlock } from "vellum-ai/api/types/VariablePromptBlock";
+import { VellumVariableType } from "vellum-ai/api";
 
 import {
   EntrypointNode,
@@ -20,6 +14,7 @@ import {
   GenericNode,
   SubworkflowNode,
   NoteNode,
+  PromptTemplateBlock,
 } from "src/types/vellum";
 
 export function entrypointNodeDataFactory(): EntrypointNode {
@@ -314,60 +309,76 @@ export function guardrailNodeDataFactory({
   return nodeData;
 }
 
-const generateBlockGivenType = (
-  blockType: string
-):
-  | JinjaPromptBlock
-  | ChatMessagePromptBlock
-  | VariablePromptBlock
-  | RichTextPromptBlock => {
+const generateBlockGivenType = (blockType: string): PromptTemplateBlock => {
   if (blockType === "JINJA") {
     return {
+      id: "block-id",
       blockType: "JINJA",
-      template: "Summarize what this means {{ INPUT_VARIABLE }}",
+      properties: {
+        template: "Summarize what this means {{ INPUT_VARIABLE }}",
+      },
       state: "ENABLED",
     };
   } else if (blockType === "CHAT_MESSAGE") {
     return {
+      id: "block-id",
       blockType: "CHAT_MESSAGE",
-      blocks: [
-        {
-          blockType: "RICH_TEXT",
-          blocks: [
-            {
-              blockType: "PLAIN_TEXT",
-              text: "Summarize the following text:\n\n",
-              state: "ENABLED",
-            },
-            {
-              blockType: "VARIABLE",
-              state: "ENABLED",
-              inputVariable: "text",
-            },
-          ],
-          state: "ENABLED",
-        },
-      ],
-      chatRole: "SYSTEM",
-      chatMessageUnterminated: false,
+      properties: {
+        blocks: [
+          {
+            id: "block-id",
+            blockType: "RICH_TEXT",
+            blocks: [
+              {
+                id: "block-id",
+                blockType: "PLAIN_TEXT",
+                text: "Summarize the following text:\n\n",
+                state: "ENABLED",
+              },
+              {
+                id: "block-id",
+                blockType: "VARIABLE",
+                state: "ENABLED",
+                inputVariableId: "text",
+              },
+            ],
+            state: "ENABLED",
+          },
+        ],
+        chatRole: "SYSTEM",
+        chatMessageUnterminated: false,
+      },
       state: "ENABLED",
     };
   } else if (blockType === "VARIABLE") {
     return {
+      id: "block-id",
       blockType: "VARIABLE",
       state: "ENABLED",
-      inputVariable: "text",
+      inputVariableId: "text",
     };
   } else if (blockType === "RICH_TEXT") {
     return {
+      id: "block-id",
       blockType: "RICH_TEXT",
       blocks: [
         {
+          id: "block-id",
           blockType: "PLAIN_TEXT",
           text: "Hello World!",
           state: "ENABLED",
         },
       ],
+      state: "ENABLED",
+    };
+  } else if (blockType === "FUNCTION_DEFINITION") {
+    return {
+      id: "block-id",
+      blockType: "FUNCTION_DEFINITION",
+      properties: {
+        functionName: "functionTest",
+        functionDescription: "This is a test function",
+      },
       state: "ENABLED",
     };
   } else {

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -285,6 +285,210 @@ class PromptNode(InlinePromptNode):
 "
 `;
 
+exports[`InlinePromptNode > FUNCTION_DEFINITION block type > basic > getNodeDisplayFile for FUNCTION_DEFINITION block type 1`] = `
+"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
+from ...nodes.prompt_node import PromptNode
+from uuid import UUID
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
+    label = "Prompt Node"
+    node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
+    output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
+    array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
+    target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
+    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
+    node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
+    output_display = {
+        PromptNode.Outputs.text: NodeOutputDisplay(
+            id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="text"
+        ),
+        PromptNode.Outputs.results: NodeOutputDisplay(
+            id=UUID("771c6fba-5b4a-4092-9d52-693242d7b92c"), name="results"
+        ),
+    }
+    port_displays = {
+        PromptNode.Ports.default: PortDisplayOverrides(
+            id=UUID("dd8397b1-5a41-4fa0-8c24-e5dffee4fb98")
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=0, y=0), width=None, height=None
+    )
+"
+`;
+
+exports[`InlinePromptNode > FUNCTION_DEFINITION block type > basic > getNodeFile for FUNCTION_DEFINITION block type 1`] = `
+"from vellum.workflows.nodes.displayable import InlinePromptNode
+from vellum import PromptParameters, FunctionDefinition
+from ..inputs import Inputs
+
+
+class PromptNode(InlinePromptNode):
+    ml_model = "gpt-4o-mini"
+    blocks = []
+    parameters = PromptParameters(
+        stop=None,
+        temperature=0,
+        max_tokens=1000,
+        top_p=1,
+        top_k=0,
+        frequency_penalty=0,
+        presence_penalty=0,
+        logit_bias={},
+        custom_parameters={},
+    )
+    prompt_inputs = {"text": Inputs.text}
+    functions = [
+        FunctionDefinition(name="functionTest", description="This is a test function")
+    ]
+"
+`;
+
+exports[`InlinePromptNode > FUNCTION_DEFINITION block type > legacy prompt variant > getNodeDisplayFile for FUNCTION_DEFINITION block type 1`] = `
+"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
+from ...nodes.prompt_node import PromptNode
+from uuid import UUID
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
+    label = "Prompt Node"
+    node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
+    output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
+    array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
+    target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
+    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
+    node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
+    output_display = {
+        PromptNode.Outputs.text: NodeOutputDisplay(
+            id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="text"
+        ),
+        PromptNode.Outputs.results: NodeOutputDisplay(
+            id=UUID("771c6fba-5b4a-4092-9d52-693242d7b92c"), name="results"
+        ),
+    }
+    port_displays = {
+        PromptNode.Ports.default: PortDisplayOverrides(
+            id=UUID("dd8397b1-5a41-4fa0-8c24-e5dffee4fb98")
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=0, y=0), width=None, height=None
+    )
+"
+`;
+
+exports[`InlinePromptNode > FUNCTION_DEFINITION block type > legacy prompt variant > getNodeFile for FUNCTION_DEFINITION block type 1`] = `
+"from vellum.workflows.nodes.displayable import InlinePromptNode
+from vellum import PromptParameters, FunctionDefinition
+from ..inputs import Inputs
+
+
+class PromptNode(InlinePromptNode):
+    ml_model = "gpt-4o-mini"
+    blocks = []
+    parameters = PromptParameters(
+        stop=None,
+        temperature=0,
+        max_tokens=1000,
+        top_p=1,
+        top_k=0,
+        frequency_penalty=0,
+        presence_penalty=0,
+        logit_bias={},
+        custom_parameters={},
+    )
+    prompt_inputs = {"text": Inputs.text}
+    functions = [
+        FunctionDefinition(name="functionTest", description="This is a test function")
+    ]
+"
+`;
+
+exports[`InlinePromptNode > FUNCTION_DEFINITION block type > reject on error enabled > getNodeDisplayFile for FUNCTION_DEFINITION block type 1`] = `
+"from vellum_ee.workflows.display.nodes import (
+    BaseTryNodeDisplay,
+    BaseInlinePromptNodeDisplay,
+)
+from uuid import UUID
+from ...nodes.prompt_node import PromptNode
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class TryNodeDisplay(BaseTryNodeDisplay):
+    error_output_id = UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f")
+
+
+class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
+    label = "Prompt Node"
+    node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
+    output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
+    array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
+    target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
+    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
+    node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
+    output_display = {
+        PromptNode.Outputs.text: NodeOutputDisplay(
+            id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="text"
+        ),
+        PromptNode.Outputs.results: NodeOutputDisplay(
+            id=UUID("771c6fba-5b4a-4092-9d52-693242d7b92c"), name="results"
+        ),
+    }
+    port_displays = {
+        PromptNode.Ports.default: PortDisplayOverrides(
+            id=UUID("dd8397b1-5a41-4fa0-8c24-e5dffee4fb98")
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=0, y=0), width=None, height=None
+    )
+"
+`;
+
+exports[`InlinePromptNode > FUNCTION_DEFINITION block type > reject on error enabled > getNodeFile for FUNCTION_DEFINITION block type 1`] = `
+"from vellum.workflows.nodes.displayable import InlinePromptNode
+from vellum.workflows.nodes.core import TryNode
+from vellum import PromptParameters, FunctionDefinition
+from ..inputs import Inputs
+
+
+@TryNode.wrap()
+class PromptNode(InlinePromptNode):
+    ml_model = "gpt-4o-mini"
+    blocks = []
+    parameters = PromptParameters(
+        stop=None,
+        temperature=0,
+        max_tokens=1000,
+        top_p=1,
+        top_k=0,
+        frequency_penalty=0,
+        presence_penalty=0,
+        logit_bias={},
+        custom_parameters={},
+    )
+    prompt_inputs = {"text": Inputs.text}
+    functions = [
+        FunctionDefinition(name="functionTest", description="This is a test function")
+    ]
+"
+`;
+
 exports[`InlinePromptNode > JINJA block type > basic > getNodeDisplayFile for JINJA block type 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from ...nodes.prompt_node import PromptNode

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -1,5 +1,4 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
-import { PromptBlock } from "vellum-ai/api";
 import { beforeEach } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
@@ -32,12 +31,13 @@ describe("InlinePromptNode", () => {
     );
   });
 
-  const promptInputBlockTypes: PromptBlock["blockType"][] = [
+  const promptInputBlockTypes = [
     "JINJA",
     "CHAT_MESSAGE",
+    "FUNCTION_DEFINITION",
     "VARIABLE",
     "RICH_TEXT",
-  ];
+  ] as const;
 
   describe.each(promptInputBlockTypes)("%s block type", (blockType) => {
     let node: InlinePromptNode;

--- a/ee/codegen/src/context/node-context/create-node-context.ts
+++ b/ee/codegen/src/context/node-context/create-node-context.ts
@@ -19,6 +19,7 @@ import { PromptDeploymentNodeContext } from "src/context/node-context/prompt-dep
 import { SubworkflowDeploymentNodeContext } from "src/context/node-context/subworkflow-deployment-node";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import {
+  InlinePromptNode,
   InlinePromptNodeData,
   LegacyPromptNodeData,
   WorkflowDataNode,
@@ -107,7 +108,7 @@ export async function createNodeContext(
         case "INLINE": {
           return new InlinePromptNodeContext({
             ...args,
-            nodeData: promptNodeData,
+            nodeData: promptNodeData as InlinePromptNode,
           });
         }
         case "LEGACY": {

--- a/ee/codegen/src/context/node-context/inline-prompt-node.ts
+++ b/ee/codegen/src/context/node-context/inline-prompt-node.ts
@@ -1,8 +1,8 @@
 import { BaseNodeContext } from "src/context/node-context/base";
 import { PortContext } from "src/context/port-context";
-import { PromptNode } from "src/types/vellum";
+import { InlinePromptNode as InlinePromptNodeType } from "src/types/vellum";
 
-export class InlinePromptNodeContext extends BaseNodeContext<PromptNode> {
+export class InlinePromptNodeContext extends BaseNodeContext<InlinePromptNodeType> {
   protected getNodeOutputNamesById(): Record<string, string> {
     return {
       [this.nodeData.data.outputId]: "text",

--- a/ee/codegen/src/generators/base-prompt-block.ts
+++ b/ee/codegen/src/generators/base-prompt-block.ts
@@ -3,24 +3,35 @@ import { ClassInstantiation } from "@fern-api/python-ast/ClassInstantiation";
 import { MethodArgument } from "@fern-api/python-ast/MethodArgument";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
+
 import {
-  PromptBlock as PromptBlockType,
-  FunctionDefinition as FunctionDefinitionType,
-} from "vellum-ai/api";
+  FunctionDefinitionPromptTemplateBlock,
+  PromptTemplateBlock,
+} from "src/types/vellum";
+
+export type PromptTemplateBlockExcludingFunctionDefinition = Exclude<
+  PromptTemplateBlock,
+  FunctionDefinitionPromptTemplateBlock
+>;
 
 export declare namespace BasePromptBlock {
-  interface Args<T extends PromptBlockType | FunctionDefinitionType> {
+  interface Args<T extends PromptTemplateBlockExcludingFunctionDefinition> {
     promptBlock: T;
+    inputVariableNameById: Record<string, string>;
   }
 }
 
 export abstract class BasePromptBlock<
-  T extends PromptBlockType | FunctionDefinitionType
+  T extends PromptTemplateBlockExcludingFunctionDefinition
 > extends AstNode {
   private astNode: python.ClassInstantiation;
-
-  public constructor({ promptBlock }: BasePromptBlock.Args<T>) {
+  protected inputVariableNameById: Record<string, string>;
+  public constructor({
+    promptBlock,
+    inputVariableNameById,
+  }: BasePromptBlock.Args<T>) {
     super();
+    this.inputVariableNameById = inputVariableNameById;
     this.astNode = this.generateAstNode(promptBlock);
   }
 

--- a/ee/codegen/src/generators/function-definition.ts
+++ b/ee/codegen/src/generators/function-definition.ts
@@ -1,61 +1,81 @@
 import { python } from "@fern-api/python-ast";
 import { MethodArgument } from "@fern-api/python-ast/MethodArgument";
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { AstNode } from "@fern-api/python-ast/python";
 import { isNil } from "lodash";
-import { FunctionDefinition as FunctionDefinitionType } from "vellum-ai/api";
 
 import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
-import { BasePromptBlock } from "src/generators/base-prompt-block";
 import { Json } from "src/generators/json";
+import { FunctionDefinitionPromptTemplateBlock } from "src/types/vellum";
 
-export class FunctionDefinition extends BasePromptBlock<FunctionDefinitionType> {
+export declare namespace FunctionDefinition {
+  interface Args {
+    functionDefinition: FunctionDefinitionPromptTemplateBlock;
+  }
+}
+
+export class FunctionDefinition extends AstNode {
+  private astNode: python.ClassInstantiation;
+
+  public constructor({ functionDefinition }: FunctionDefinition.Args) {
+    super();
+    this.astNode = this.generateAstNode(functionDefinition);
+  }
+
   protected generateAstNode(
-    functionDefinition: FunctionDefinitionType
+    functionDefinition: FunctionDefinitionPromptTemplateBlock
   ): python.ClassInstantiation {
-    const classArgs: MethodArgument[] = [
-      ...this.constructCommonClassArguments(functionDefinition),
-    ];
+    const classArgs: MethodArgument[] = [];
 
-    if (!isNil(functionDefinition.name)) {
+    if (!isNil(functionDefinition.properties.functionName)) {
       classArgs.push(
         new MethodArgument({
           name: "name",
-          value: python.TypeInstantiation.str(functionDefinition.name),
+          value: python.TypeInstantiation.str(
+            functionDefinition.properties.functionName
+          ),
         })
       );
     }
 
-    if (!isNil(functionDefinition.description)) {
+    if (!isNil(functionDefinition.properties.functionDescription)) {
       classArgs.push(
         new MethodArgument({
           name: "description",
-          value: python.TypeInstantiation.str(functionDefinition.description),
+          value: python.TypeInstantiation.str(
+            functionDefinition.properties.functionDescription
+          ),
         })
       );
     }
 
-    if (!isNil(functionDefinition.parameters)) {
+    if (!isNil(functionDefinition.properties.functionParameters)) {
       classArgs.push(
         new MethodArgument({
           name: "parameters",
-          value: new Json(functionDefinition.parameters),
+          value: new Json(functionDefinition.properties.functionParameters),
         })
       );
     }
 
-    if (!isNil(functionDefinition.forced)) {
+    if (!isNil(functionDefinition.properties.functionForced)) {
       classArgs.push(
         new MethodArgument({
           name: "function_forced",
-          value: python.TypeInstantiation.bool(functionDefinition.forced),
+          value: python.TypeInstantiation.bool(
+            functionDefinition.properties.functionForced
+          ),
         })
       );
     }
 
-    if (!isNil(functionDefinition.strict)) {
+    if (!isNil(functionDefinition.properties.functionStrict)) {
       classArgs.push(
         new MethodArgument({
           name: "function_strict",
-          value: python.TypeInstantiation.bool(functionDefinition.strict),
+          value: python.TypeInstantiation.bool(
+            functionDefinition.properties.functionStrict
+          ),
         })
       );
     }
@@ -70,5 +90,9 @@ export class FunctionDefinition extends BasePromptBlock<FunctionDefinitionType> 
 
     this.inheritReferences(functionDefinitionClass);
     return functionDefinitionClass;
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
   }
 }

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -494,36 +494,6 @@ export declare namespace PromptSettingsSerializer {
   }
 }
 
-// const fixVariableBlock = <B extends PromptBlock | RichTextChildBlock>(
-//   block: B,
-//   inputVariableNameById: Record<string, string>
-// ): B => {
-//   if (block.blockType === "VARIABLE") {
-//     return {
-//       ...block,
-//       inputVariable:
-//         inputVariableNameById[block.inputVariable] ?? block.inputVariable,
-//     };
-//   }
-//   if (block.blockType === "CHAT_MESSAGE") {
-//     return {
-//       ...block,
-//       blocks: block.blocks.map((b) =>
-//         fixVariableBlock(b, inputVariableNameById)
-//       ),
-//     };
-//   }
-//   if (block.blockType === "RICH_TEXT") {
-//     return {
-//       ...block,
-//       blocks: block.blocks.map((b) =>
-//         fixVariableBlock(b, inputVariableNameById)
-//       ),
-//     };
-//   }
-//   return block;
-// };
-
 export const PromptVersionExecConfigSerializer: Schema<
   PromptVersionExecConfigSerializer.Raw,
   PromptVersionExecConfig

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -1,14 +1,4 @@
-import {
-  ChatMessagePromptBlock,
-  ChatMessageRole,
-  JinjaPromptBlock,
-  PlainTextPromptBlock,
-  PromptBlock,
-  PromptBlockState,
-  RichTextChildBlock,
-  RichTextPromptBlock,
-  VariablePromptBlock,
-} from "vellum-ai/api";
+import { ChatMessageRole, PromptBlockState } from "vellum-ai/api";
 import {
   object as objectSchema,
   list as listSchema,
@@ -22,6 +12,8 @@ import {
   lazy,
   property as propertySchema,
   Schema,
+  record as recordSchema,
+  unknown as unknownSchema,
 } from "vellum-ai/core/schemas";
 import {
   ChatMessageRole as ChatMessageRoleSerializer,
@@ -64,7 +56,6 @@ import {
   PromptNode,
   PromptNodeData,
   PromptSettings,
-  PromptTemplateBlockData,
   PromptVersionExecConfig,
   SearchNode,
   SearchNodeData,
@@ -91,6 +82,12 @@ import {
   GenericNode,
   ExecutionCounterPointer,
   GenericNodeDisplayData,
+  JinjaPromptTemplateBlock,
+  VariablePromptTemplateBlock,
+  ChatMessagePromptTemplateBlock,
+  RichTextPromptTemplateBlock,
+  PlainTextPromptTemplateBlock,
+  FunctionDefinitionPromptTemplateBlock,
 } from "src/types/vellum";
 
 const CacheConfigSerializer = objectSchema({
@@ -99,7 +96,7 @@ const CacheConfigSerializer = objectSchema({
 
 export const JinjaPromptTemplateBlockSerializer: ObjectSchema<
   JinjaPromptTemplateBlockSerializer.Raw,
-  JinjaPromptBlock
+  JinjaPromptTemplateBlock
 > = objectSchema({
   id: stringSchema(),
   blockType: propertySchema("block_type", stringLiteralSchema("JINJA")),
@@ -107,24 +104,12 @@ export const JinjaPromptTemplateBlockSerializer: ObjectSchema<
   cacheConfig: propertySchema("cache_config", CacheConfigSerializer.optional()),
   properties: objectSchema({
     template: stringSchema(),
-    templateType: propertySchema("template_type", stringSchema().optional()),
+    templateType: propertySchema(
+      "template_type",
+      VellumVariableTypeSerializer.optional()
+    ),
   }),
-}).transform({
-  transform: (block) =>
-    ({
-      blockType: block.blockType,
-      state: block.state,
-      cacheConfig: block.cacheConfig,
-      template: block.properties.template,
-    } as JinjaPromptBlock),
-  untransform: (block) => ({
-    id: block.id,
-    blockType: block.blockType,
-    state: block.state,
-    cacheConfig: block.cacheConfig,
-    properties: { template: block.template, templateType: "STRING" },
-  }),
-}) as ObjectSchema<JinjaPromptTemplateBlockSerializer.Raw, JinjaPromptBlock>;
+});
 
 export declare namespace JinjaPromptTemplateBlockSerializer {
   interface Raw {
@@ -141,7 +126,7 @@ export declare namespace JinjaPromptTemplateBlockSerializer {
 
 export const ChatMessagePromptTemplateBlockSerializer: ObjectSchema<
   ChatMessagePromptTemplateBlockSerializer.Raw,
-  ChatMessagePromptBlock
+  ChatMessagePromptTemplateBlock
 > = objectSchema({
   id: stringSchema(),
   blockType: propertySchema("block_type", stringLiteralSchema("CHAT_MESSAGE")),
@@ -159,33 +144,7 @@ export const ChatMessagePromptTemplateBlockSerializer: ObjectSchema<
       listSchema(lazy(() => PromptTemplateBlockSerializer))
     ),
   }),
-}).transform({
-  transform: (block) =>
-    ({
-      blockType: block.blockType,
-      state: block.state,
-      cacheConfig: block.cacheConfig,
-      chatRole: block.properties.chatRole,
-      chatSource: block.properties.chatSource,
-      chatMessageUnterminated: block.properties.chatMessageUnterminated,
-      blocks: block.properties.blocks,
-    } as ChatMessagePromptBlock),
-  untransform: (block) => ({
-    id: block.id,
-    blockType: block.blockType,
-    state: block.state,
-    cacheConfig: block.cacheConfig,
-    properties: {
-      chatRole: block.chatRole,
-      chatSource: block.chatSource,
-      chatMessageUnterminated: block.chatMessageUnterminated,
-      blocks: block.blocks,
-    },
-  }),
-}) as ObjectSchema<
-  ChatMessagePromptTemplateBlockSerializer.Raw,
-  ChatMessagePromptBlock
->;
+});
 
 export declare namespace ChatMessagePromptTemplateBlockSerializer {
   interface Raw {
@@ -204,32 +163,14 @@ export declare namespace ChatMessagePromptTemplateBlockSerializer {
 
 export const VariablePromptTemplateBlockSerializer: ObjectSchema<
   VariablePromptTemplateBlockSerializer.Raw,
-  VariablePromptBlock
+  VariablePromptTemplateBlock
 > = objectSchema({
   id: stringSchema(),
   blockType: propertySchema("block_type", stringLiteralSchema("VARIABLE")),
   state: propertySchema("state", PromptBlockStateSerializer),
   cacheConfig: propertySchema("cache_config", CacheConfigSerializer.optional()),
   inputVariableId: propertySchema("input_variable_id", stringSchema()),
-}).transform({
-  transform: (block) =>
-    ({
-      blockType: block.blockType,
-      state: block.state,
-      cacheConfig: block.cacheConfig,
-      inputVariable: block.inputVariableId,
-    } as VariablePromptBlock),
-  untransform: (block) => ({
-    id: block.id,
-    blockType: block.blockType,
-    state: block.state,
-    cacheConfig: block.cacheConfig,
-    inputVariableId: block.inputVariable,
-  }),
-}) as ObjectSchema<
-  VariablePromptTemplateBlockSerializer.Raw,
-  VariablePromptBlock
->;
+});
 
 export declare namespace VariablePromptTemplateBlockSerializer {
   interface Raw {
@@ -243,32 +184,14 @@ export declare namespace VariablePromptTemplateBlockSerializer {
 
 export const PlainTextPromptTemplateBlockSerializer: ObjectSchema<
   PlainTextPromptTemplateBlockSerializer.Raw,
-  PlainTextPromptBlock
+  PlainTextPromptTemplateBlock
 > = objectSchema({
   id: stringSchema(),
   blockType: propertySchema("block_type", stringLiteralSchema("PLAIN_TEXT")),
   state: propertySchema("state", PromptBlockStateSerializer),
   cacheConfig: propertySchema("cache_config", CacheConfigSerializer.optional()),
   text: stringSchema(),
-}).transform({
-  transform: (block) =>
-    ({
-      blockType: block.blockType,
-      state: block.state,
-      cacheConfig: block.cacheConfig,
-      text: block.text,
-    } as PlainTextPromptBlock),
-  untransform: (block) => ({
-    id: block.id,
-    blockType: block.blockType,
-    state: block.state,
-    cacheConfig: block.cacheConfig,
-    text: block.text,
-  }),
-}) as ObjectSchema<
-  PlainTextPromptTemplateBlockSerializer.Raw,
-  PlainTextPromptBlock
->;
+});
 
 export declare namespace PlainTextPromptTemplateBlockSerializer {
   interface Raw {
@@ -282,7 +205,7 @@ export declare namespace PlainTextPromptTemplateBlockSerializer {
 
 export const RichTextPromptTemplateBlockSerializer: ObjectSchema<
   RichTextPromptTemplateBlockSerializer.Raw,
-  RichTextPromptBlock
+  RichTextPromptTemplateBlock
 > = objectSchema({
   id: stringSchema(),
   blockType: propertySchema("block_type", stringLiteralSchema("RICH_TEXT")),
@@ -294,25 +217,7 @@ export const RichTextPromptTemplateBlockSerializer: ObjectSchema<
       VariablePromptTemplateBlockSerializer,
     ])
   ),
-}).transform({
-  transform: (block) =>
-    ({
-      blockType: block.blockType,
-      state: block.state,
-      cacheConfig: block.cacheConfig,
-      blocks: block.blocks,
-    } as RichTextPromptBlock),
-  untransform: (block) => ({
-    id: block.id,
-    blockType: block.blockType,
-    state: block.state,
-    cacheConfig: block.cacheConfig,
-    blocks: block.blocks,
-  }),
-}) as ObjectSchema<
-  RichTextPromptTemplateBlockSerializer.Raw,
-  RichTextPromptBlock
->;
+});
 
 export declare namespace RichTextPromptTemplateBlockSerializer {
   interface Raw {
@@ -327,12 +232,61 @@ export declare namespace RichTextPromptTemplateBlockSerializer {
   }
 }
 
+export const FunctionDefinitionPromptTemplateBlockSerializer: ObjectSchema<
+  FunctionDefinitionPromptTemplateBlockSerializer.Raw,
+  FunctionDefinitionPromptTemplateBlock
+> = objectSchema({
+  id: stringSchema(),
+  blockType: propertySchema(
+    "block_type",
+    stringLiteralSchema("FUNCTION_DEFINITION")
+  ),
+  state: propertySchema("state", PromptBlockStateSerializer),
+  cacheConfig: propertySchema("cache_config", CacheConfigSerializer.optional()),
+  properties: objectSchema({
+    functionName: propertySchema("function_name", stringSchema().optional()),
+    functionDescription: propertySchema(
+      "function_description",
+      stringSchema().optional()
+    ),
+    functionParameters: propertySchema(
+      "function_parameters",
+      recordSchema(stringSchema(), unknownSchema()).optional()
+    ),
+    functionForced: propertySchema(
+      "function_forced",
+      booleanSchema().optional()
+    ),
+    functionStrict: propertySchema(
+      "function_strict",
+      booleanSchema().optional()
+    ),
+  }),
+});
+
+export declare namespace FunctionDefinitionPromptTemplateBlockSerializer {
+  interface Raw {
+    id: string;
+    block_type: "FUNCTION_DEFINITION";
+    state: PromptBlockState;
+    cache_config?: { type: "EPHEMERAL" } | null;
+    properties: {
+      function_name?: string | null;
+      function_description?: string | null;
+      function_parameters?: Record<string, unknown> | null;
+      function_forced?: boolean | null;
+      function_strict?: boolean | null;
+    };
+  }
+}
+
 export declare namespace PromptTemplateBlockSerializer {
   type Raw =
     | JinjaPromptTemplateBlockSerializer.Raw
     | ChatMessagePromptTemplateBlockSerializer.Raw
     | VariablePromptTemplateBlockSerializer.Raw
-    | RichTextPromptTemplateBlockSerializer.Raw;
+    | RichTextPromptTemplateBlockSerializer.Raw
+    | FunctionDefinitionPromptTemplateBlockSerializer.Raw;
 }
 
 const PromptTemplateBlockSerializer = undiscriminatedUnionSchema([
@@ -340,6 +294,7 @@ const PromptTemplateBlockSerializer = undiscriminatedUnionSchema([
   ChatMessagePromptTemplateBlockSerializer,
   VariablePromptTemplateBlockSerializer,
   RichTextPromptTemplateBlockSerializer,
+  FunctionDefinitionPromptTemplateBlockSerializer,
 ]);
 
 export const NodeOutputPointerSerializer: ObjectSchema<
@@ -517,13 +472,7 @@ export declare namespace WorkflowNodeDefinitionSerializer {
 export const PromptTemplateBlockDataSerializer = objectSchema({
   version: numberSchema(),
   blocks: listSchema(PromptTemplateBlockSerializer),
-}).transform({
-  transform: (data) => data as PromptTemplateBlockData,
-  untransform: (data) => data,
-}) as ObjectSchema<
-  PromptTemplateBlockDataSerializer.Raw,
-  PromptTemplateBlockData
->;
+});
 
 export declare namespace PromptTemplateBlockDataSerializer {
   interface Raw {
@@ -545,35 +494,35 @@ export declare namespace PromptSettingsSerializer {
   }
 }
 
-const fixVariableBlock = <B extends PromptBlock | RichTextChildBlock>(
-  block: B,
-  inputVariableNameById: Record<string, string>
-): B => {
-  if (block.blockType === "VARIABLE") {
-    return {
-      ...block,
-      inputVariable:
-        inputVariableNameById[block.inputVariable] ?? block.inputVariable,
-    };
-  }
-  if (block.blockType === "CHAT_MESSAGE") {
-    return {
-      ...block,
-      blocks: block.blocks.map((b) =>
-        fixVariableBlock(b, inputVariableNameById)
-      ),
-    };
-  }
-  if (block.blockType === "RICH_TEXT") {
-    return {
-      ...block,
-      blocks: block.blocks.map((b) =>
-        fixVariableBlock(b, inputVariableNameById)
-      ),
-    };
-  }
-  return block;
-};
+// const fixVariableBlock = <B extends PromptBlock | RichTextChildBlock>(
+//   block: B,
+//   inputVariableNameById: Record<string, string>
+// ): B => {
+//   if (block.blockType === "VARIABLE") {
+//     return {
+//       ...block,
+//       inputVariable:
+//         inputVariableNameById[block.inputVariable] ?? block.inputVariable,
+//     };
+//   }
+//   if (block.blockType === "CHAT_MESSAGE") {
+//     return {
+//       ...block,
+//       blocks: block.blocks.map((b) =>
+//         fixVariableBlock(b, inputVariableNameById)
+//       ),
+//     };
+//   }
+//   if (block.blockType === "RICH_TEXT") {
+//     return {
+//       ...block,
+//       blocks: block.blocks.map((b) =>
+//         fixVariableBlock(b, inputVariableNameById)
+//       ),
+//     };
+//   }
+//   return block;
+// };
 
 export const PromptVersionExecConfigSerializer: Schema<
   PromptVersionExecConfigSerializer.Raw,
@@ -589,28 +538,6 @@ export const PromptVersionExecConfigSerializer: Schema<
     PromptTemplateBlockDataSerializer
   ),
   settings: PromptSettingsSerializer.optional(),
-}).transform({
-  transform: (config) =>
-    ({
-      parameters: config.parameters,
-      inputVariables: config.inputVariables,
-      promptTemplateBlockData: {
-        version: 1,
-        blocks: config.promptTemplateBlockData.blocks.map((block) =>
-          fixVariableBlock(
-            block,
-            Object.fromEntries(config.inputVariables.map((v) => [v.id, v.key]))
-          )
-        ),
-      },
-      settings: config.settings,
-    } as PromptVersionExecConfig),
-  untransform: (config) => ({
-    parameters: config.parameters,
-    inputVariables: config.inputVariables,
-    promptTemplateBlockData: config.promptTemplateBlockData,
-    settings: config.settings,
-  }),
 });
 
 export declare namespace PromptVersionExecConfigSerializer {

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -1,6 +1,8 @@
-import { ChatMessage, PromptBlock } from "vellum-ai/api";
+import { ChatMessage } from "vellum-ai/api";
 import {
   ChatMessageRequest,
+  ChatMessageRole,
+  PromptBlockState,
   PromptParameters,
   SearchResult,
   SearchResultRequest,
@@ -170,9 +172,86 @@ export interface EntrypointNode extends BaseDisplayableWorkflowNode {
   data: EntrypointNodeData;
 }
 
+export interface CacheConfig {
+  type: "EPHEMERAL";
+}
+
+export interface JinjaPromptTemplateBlock {
+  id: string;
+  blockType: "JINJA";
+  state: PromptBlockState;
+  cacheConfig?: CacheConfig;
+  properties: {
+    template: string;
+    templateType?: VellumVariableType;
+  };
+}
+
+export interface ChatMessagePromptTemplateBlock {
+  id: string;
+  blockType: "CHAT_MESSAGE";
+  state: PromptBlockState;
+  cacheConfig?: CacheConfig;
+  properties: {
+    chatRole: ChatMessageRole;
+    chatSource?: string;
+    chatMessageUnterminated: boolean;
+    blocks: PromptTemplateBlock[];
+  };
+}
+
+export interface VariablePromptTemplateBlock {
+  id: string;
+  blockType: "VARIABLE";
+  state: PromptBlockState;
+  cacheConfig?: CacheConfig;
+  inputVariableId: string;
+}
+
+export interface PlainTextPromptTemplateBlock {
+  id: string;
+  blockType: "PLAIN_TEXT";
+  state: PromptBlockState;
+  cacheConfig?: CacheConfig;
+  text: string;
+}
+
+export type RichTextChildPromptTemplateBlock =
+  | PlainTextPromptTemplateBlock
+  | VariablePromptTemplateBlock;
+
+export interface RichTextPromptTemplateBlock {
+  id: string;
+  blockType: "RICH_TEXT";
+  state: PromptBlockState;
+  cacheConfig?: CacheConfig;
+  blocks: RichTextChildPromptTemplateBlock[];
+}
+
+export interface FunctionDefinitionPromptTemplateBlock {
+  id: string;
+  blockType: "FUNCTION_DEFINITION";
+  state: PromptBlockState;
+  cacheConfig?: CacheConfig;
+  properties: {
+    functionName?: string;
+    functionDescription?: string;
+    functionParameters?: Record<string, unknown>;
+    functionForced?: boolean;
+    functionStrict?: boolean;
+  };
+}
+
+export type PromptTemplateBlock =
+  | JinjaPromptTemplateBlock
+  | ChatMessagePromptTemplateBlock
+  | VariablePromptTemplateBlock
+  | RichTextPromptTemplateBlock
+  | FunctionDefinitionPromptTemplateBlock;
+
 export interface PromptTemplateBlockData {
   version: number;
-  blocks: PromptBlock[];
+  blocks: PromptTemplateBlock[];
 }
 
 export interface PromptSettings {
@@ -239,6 +318,11 @@ export type PromptNodeData =
   | InlinePromptNodeData
   | DeploymentPromptNodeData
   | LegacyPromptNodeData;
+
+export interface InlinePromptNode extends BaseDisplayableWorkflowNode {
+  type: "PROMPT";
+  data: InlinePromptNodeData;
+}
 
 export interface PromptNode extends BaseDisplayableWorkflowNode {
   type: "PROMPT";


### PR DESCRIPTION
Function blocks needed to be split from the rest of the blocks during codegen.

Instead of handling this from within serialization, this PR simplified serialization to be just `old types(snake_case) -> old types(camelCase)`, and our codegen ast nodes purely operate on `old types(camelCase) -> new generated types`, removing the need for intermediate "new types" 