### PR TITLE
Support exclude code and workflow sandbox id cli args

### DIFF
--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -42,17 +42,17 @@ def push(
 
 @main.command()
 @click.argument("module", required=False)
-@click.option("--legacy-module", is_flag=True, help="Pull the workflow as a legacy module")
+@click.option("--legacy-module", is_flag=True, help="Pull the Workflow as a legacy module")
 @click.option(
     "--include-json",
     is_flag=True,
     help="Include the JSON representation of the Workflow in the pull response. Should only be used for debugging purposes.",
 )
-@click.option("--workflow-sandbox-id", type=str, help="Pull the workflow from a specific sandbox ID")
+@click.option("--workflow-sandbox-id", type=str, help="Pull the Workflow from a specific Sandbox ID")
 @click.option(
     "--exclude-code",
     is_flag=True,
-    help="Exclude the code from the pull response. Should only be used for debugging purposes.",
+    help="Exclude the code definition of the Workflow from the pull response. Should only be used for debugging purposes.",
 )
 def pull(
     module: Optional[str],

--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -43,10 +43,32 @@ def push(
 @main.command()
 @click.argument("module", required=False)
 @click.option("--legacy-module", is_flag=True, help="Pull the workflow as a legacy module")
-@click.option("--include-json", is_flag=True, help="Include the JSON representation of the Workflow in the pull response. Should only be used for debugging purposes.")
-def pull(module: Optional[str], legacy_module: Optional[bool], include_json: Optional[bool]) -> None:
+@click.option(
+    "--include-json",
+    is_flag=True,
+    help="Include the JSON representation of the Workflow in the pull response. Should only be used for debugging purposes.",
+)
+@click.option("--workflow-sandbox-id", type=str, help="Pull the workflow from a specific sandbox ID")
+@click.option(
+    "--exclude-code",
+    is_flag=True,
+    help="Exclude the code from the pull response. Should only be used for debugging purposes.",
+)
+def pull(
+    module: Optional[str],
+    legacy_module: Optional[bool],
+    include_json: Optional[bool],
+    workflow_sandbox_id: Optional[str],
+    exclude_code: Optional[bool],
+) -> None:
     """Pull Workflow from Vellum"""
-    pull_command(module, legacy_module, include_json)
+    pull_command(
+        module=module,
+        legacy_module=legacy_module,
+        include_json=include_json,
+        workflow_sandbox_id=workflow_sandbox_id,
+        exclude_code=exclude_code,
+    )
 
 
 @main.group(aliases=["images", "image"])

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -30,7 +30,7 @@ def pull_command(
     save_lock_file = False
     if workflow_config is None:
         if module:
-            raise ValueError(f"No workflow config for '{module}' found in project to push.")
+            raise ValueError(f"No workflow config for '{module}' found in project to pull.")
         elif workflow_sandbox_id:
             workflow_config = WorkflowConfig(
                 workflow_sandbox_id=workflow_sandbox_id,


### PR DESCRIPTION
Sibling PR: https://github.com/vellum-ai/vellum/pull/6520

Adds two new cli options to `vellum pull`:
- exclude code - for contributors that simply want to pull _just_ the json down
- workflow sandbox id - allows users to pull down workflows without specifying a module. Default local file location is atm based on the uuid of the workflow sandbox id due to the endpoint being a file download and not having access to fern's response headers atm