### PR TITLE
[Codegen][SC-5648] Stabilize Templating Node Output IDs

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -44,6 +44,7 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
         "additional_header_key_3": UUID("13c2dd5e-cdd0-431b-aa91-46ad8da1cb51"),
         "additional_header_value_3": UUID("408c2b3d-7c30-4e01-a2e3-276753beadbc"),
     }
+    output_display = {}
     port_displays = {
         APINode.Ports.default: PortDisplayOverrides(
             id=UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e")
@@ -114,6 +115,7 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
         "additional_header_key_3": UUID("13c2dd5e-cdd0-431b-aa91-46ad8da1cb51"),
         "additional_header_value_3": UUID("408c2b3d-7c30-4e01-a2e3-276753beadbc"),
     }
+    output_display = {}
     port_displays = {
         APINode.Ports.default: PortDisplayOverrides(
             id=UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e")

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -14,7 +14,6 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
-    output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
     template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
@@ -66,7 +65,6 @@ class TryNodeDisplay(BaseTryNodeDisplay):
 class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
-    output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
     template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -4,7 +4,10 @@ exports[`TemplatingNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from ...nodes.templating_node import TemplatingNode
 from uuid import UUID
-from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 
@@ -15,6 +18,11 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
     template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
+    output_display = {
+        TemplatingNode.Outputs.result: NodeOutputDisplay(
+            id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="result"
+        )
+    }
     port_displays = {
         TemplatingNode.Ports.default: PortDisplayOverrides(
             id=UUID("dd8397b1-5a41-4fa0-8c24-e5dffee4fb98")
@@ -44,7 +52,10 @@ exports[`TemplatingNode > reject on error enabled > getNodeDisplayFile 1`] = `
 )
 from uuid import UUID
 from ...nodes.templating_node import TemplatingNode
-from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 
@@ -59,6 +70,11 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
     template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
+    output_display = {
+        TemplatingNode.Outputs.result: NodeOutputDisplay(
+            id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="result"
+        )
+    }
     port_displays = {
         TemplatingNode.Ports.default: PortDisplayOverrides(
             id=UUID("dd8397b1-5a41-4fa0-8c24-e5dffee4fb98")

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -194,6 +194,17 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
     return statements;
   }
 
+  protected getOutputDisplay(): python.Field {
+    return python.field({
+      name: "output_display",
+      initializer: python.TypeInstantiation.dict(
+        // TODO: Specify output displays
+        //    https://app.shortcut.com/vellum/story/5640
+        []
+      ),
+    });
+  }
+
   getErrorOutputId(): string | undefined {
     return this.nodeData.data.errorOutputId;
   }

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -47,9 +47,7 @@ export abstract class BaseNode<
   protected abstract getNodeDisplayClassBodyStatements(): AstNode[];
 
   // Override to specify a custom output display
-  protected getOutputDisplay(): python.Field | undefined {
-    return undefined;
-  }
+  protected abstract getOutputDisplay(): python.Field | undefined;
 
   // If the node supports the Reject on Error toggle, then implement this to return
   // the error_output_id from this.nodeData. If returned, a @TryNode decorator will be

--- a/ee/codegen/src/generators/nodes/conditional-node.ts
+++ b/ee/codegen/src/generators/nodes/conditional-node.ts
@@ -1,4 +1,5 @@
 import { python } from "@fern-api/python-ast";
+import { Field } from "@fern-api/python-ast/Field";
 import { Reference } from "@fern-api/python-ast/Reference";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { VellumValue } from "vellum-ai/api/types";
@@ -145,6 +146,10 @@ export class ConditionalNode extends BaseSingleFileNode<
     );
 
     return statements;
+  }
+
+  protected getOutputDisplay(): Field | undefined {
+    return undefined;
   }
 
   private createConditionIdList(

--- a/ee/codegen/src/generators/nodes/error-node.ts
+++ b/ee/codegen/src/generators/nodes/error-node.ts
@@ -1,3 +1,4 @@
+import { Field } from "@fern-api/python-ast/Field";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 
 import { ErrorNodeContext } from "src/context/node-context/error-node";
@@ -19,6 +20,10 @@ export class ErrorNode extends BaseSingleFileNode<
   getNodeDisplayClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
     return statements;
+  }
+
+  protected getOutputDisplay(): Field | undefined {
+    return undefined;
   }
 
   getErrorOutputId(): string | undefined {

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -1,3 +1,4 @@
+import { Field } from "@fern-api/python-ast/Field";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 
 import { GenericNodeContext } from "src/context/node-context/generic-node";
@@ -19,6 +20,10 @@ export class GenericNode extends BaseSingleFileNode<
   getNodeDisplayClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
     return statements;
+  }
+
+  protected getOutputDisplay(): Field | undefined {
+    return undefined;
   }
 
   protected getErrorOutputId(): string | undefined {

--- a/ee/codegen/src/generators/nodes/merge-node.ts
+++ b/ee/codegen/src/generators/nodes/merge-node.ts
@@ -1,4 +1,5 @@
 import { python } from "@fern-api/python-ast";
+import { Field } from "@fern-api/python-ast/Field";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 
 import { MergeNodeContext } from "src/context/node-context/merge-node";
@@ -61,7 +62,11 @@ export class MergeNode extends BaseSingleFileNode<
     return statements;
   }
 
+  protected getOutputDisplay(): Field | undefined {
+    return undefined;
+  }
+
   getErrorOutputId(): string | undefined {
-    return;
+    return undefined;
   }
 }

--- a/ee/codegen/src/generators/nodes/note-node.ts
+++ b/ee/codegen/src/generators/nodes/note-node.ts
@@ -1,4 +1,5 @@
 import { python } from "@fern-api/python-ast";
+import { Field } from "@fern-api/python-ast/Field";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 
 import { NoteNodeContext } from "src/context/node-context/note-node";
@@ -42,6 +43,10 @@ export class NoteNode extends BaseSingleFileNode<
     );
 
     return statements;
+  }
+
+  protected getOutputDisplay(): Field | undefined {
+    return undefined;
   }
 
   getErrorOutputId(): string | undefined {

--- a/ee/codegen/src/generators/nodes/templating-node.ts
+++ b/ee/codegen/src/generators/nodes/templating-node.ts
@@ -1,6 +1,7 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 
+import { OUTPUTS_CLASS_NAME } from "src/constants";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import { BaseState } from "src/generators/base-state";
 import { NodeInputValuePointer } from "src/generators/node-inputs/node-input-value-pointer";
@@ -126,6 +127,41 @@ export class TemplatingNode extends BaseSingleFileNode<
     }
 
     return python.TypeInstantiation.str(templateRule.data.value);
+  }
+
+  protected getOutputDisplay(): python.Field {
+    return python.field({
+      name: "output_display",
+      initializer: python.TypeInstantiation.dict([
+        {
+          key: python.reference({
+            name: this.nodeContext.nodeClassName,
+            modulePath: this.nodeContext.nodeModulePath,
+            attribute: [OUTPUTS_CLASS_NAME, "result"],
+          }),
+          value: python.instantiateClass({
+            classReference: python.reference({
+              name: "NodeOutputDisplay",
+              modulePath:
+                this.workflowContext.sdkModulePathNames
+                  .NODE_DISPLAY_TYPES_MODULE_PATH,
+            }),
+            arguments_: [
+              python.methodArgument({
+                name: "id",
+                value: python.TypeInstantiation.uuid(
+                  this.nodeData.data.outputId
+                ),
+              }),
+              python.methodArgument({
+                name: "name",
+                value: python.TypeInstantiation.str("result"),
+              }),
+            ],
+          }),
+        },
+      ]),
+    });
   }
 
   protected getErrorOutputId(): string | undefined {

--- a/ee/codegen/src/generators/nodes/templating-node.ts
+++ b/ee/codegen/src/generators/nodes/templating-node.ts
@@ -79,10 +79,6 @@ export class TemplatingNode extends BaseSingleFileNode<
 
     statements.push(
       python.field({
-        name: "output_id",
-        initializer: python.TypeInstantiation.uuid(this.nodeData.data.outputId),
-      }),
-      python.field({
         name: "target_handle_id",
         initializer: python.TypeInstantiation.uuid(
           this.nodeData.data.targetHandleId

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/templating_node.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
-from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node import TemplatingNode
@@ -14,6 +14,9 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     target_handle_id = UUID("3522e32d-6735-499b-8d45-c0c6488ae92f")
     template_input_id = UUID("5d2f0f48-4504-4979-8e24-92a8c08c23a4")
     node_input_ids_by_name = {"template": UUID("5d2f0f48-4504-4979-8e24-92a8c08c23a4")}
+    output_display = {
+        TemplatingNode.Outputs.result: NodeOutputDisplay(id=UUID("4d39036a-fd6d-4a51-b410-7c0623375ebd"), name="result")
+    }
     port_displays = {
         TemplatingNode.Ports.default: PortDisplayOverrides(id=UUID("9bce9d0a-3b0e-478e-8a97-f0510715a5a0"))
     }

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/templating_node.py
@@ -10,7 +10,6 @@ from ...nodes.templating_node import TemplatingNode
 class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("7dffcbb1-0a5c-4149-a6e9-f83095b0a871")
-    output_id = UUID("4d39036a-fd6d-4a51-b410-7c0623375ebd")
     target_handle_id = UUID("3522e32d-6735-499b-8d45-c0c6488ae92f")
     template_input_id = UUID("5d2f0f48-4504-4979-8e24-92a8c08c23a4")
     node_input_ids_by_name = {"template": UUID("5d2f0f48-4504-4979-8e24-92a8c08c23a4")}


### PR DESCRIPTION
We weren't using output displays in Templating Nodes to ensure a stable ID reference. This is because `getOutputDisplay` wasn't made abstract and so children weren't forced to implement it, just optionally override it, and so it's easily missed.

This PR makes it abstract and then implements it for all children classes.