### PR TITLE
[Codegen][SC-5623] Use Workflow Definition to Power Class Name

### DIFF
--- a/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
+++ b/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
@@ -3,7 +3,6 @@ import { WorkflowContext } from "src/context";
 export function workflowContextFactory({
   absolutePathToOutputDirectory,
   moduleName,
-  workflowLabel,
   workflowClassName,
   workflowRawEdges,
 }: Partial<WorkflowContext.Args> = {}): WorkflowContext {
@@ -11,8 +10,7 @@ export function workflowContextFactory({
     absolutePathToOutputDirectory:
       absolutePathToOutputDirectory || "./src/__tests__/",
     moduleName: moduleName || "code",
-    workflowClassName: workflowLabel || "Workflow",
-    workflowLabel: workflowClassName || "Workflow",
+    workflowClassName: workflowClassName || "Workflow",
     vellumApiKey: "<TEST_API_KEY>",
     workflowRawEdges: workflowRawEdges || [],
   });

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -56,7 +56,6 @@ describe("WorkflowProjectGenerator", () => {
 
         const project = new WorkflowProjectGenerator({
           absolutePathToOutputDirectory: tempDir,
-          workflowLabel: "Workflow",
           workflowVersionExecConfigData: displayData,
           moduleName: "code",
           vellumApiKey: "<TEST_API_KEY>",

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -21,7 +21,6 @@ describe("Workflow", () => {
 
   beforeEach(async () => {
     workflowContext = workflowContextFactory({
-      workflowLabel: "TestWorkflow",
       workflowClassName: "TestWorkflow",
     });
     workflowContext.addEntrypointNode(entrypointNode);

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -13,7 +13,6 @@ import {
   WorkflowDataNode,
   WorkflowEdge,
 } from "src/types/vellum";
-import { createPythonClassName } from "src/utils/casing";
 
 type InputVariableContextsById = Map<string, InputVariableContext>;
 
@@ -26,8 +25,7 @@ export declare namespace WorkflowContext {
   export type Args = {
     absolutePathToOutputDirectory: string;
     moduleName: string;
-    workflowLabel?: string;
-    workflowClassName?: string;
+    workflowClassName: string;
     globalInputVariableContextsById?: InputVariableContextsById;
     globalNodeContextsByNodeId?: NodeContextsByNodeId;
     parentNode?: BaseNode<WorkflowDataNode, BaseNodeContext<WorkflowDataNode>>;
@@ -80,7 +78,6 @@ export class WorkflowContext {
   constructor({
     absolutePathToOutputDirectory,
     moduleName,
-    workflowLabel,
     workflowClassName,
     globalInputVariableContextsById,
     globalNodeContextsByNodeId,
@@ -98,9 +95,7 @@ export class WorkflowContext {
           GENERATED_WORKFLOW_MODULE_NAME,
         ]
       : [this.moduleName, GENERATED_WORKFLOW_MODULE_NAME];
-    this.label = workflowLabel || "Workflow";
-    this.workflowClassName =
-      workflowClassName || createPythonClassName(this.label);
+    this.workflowClassName = workflowClassName;
     this.vellumApiKey = vellumApiKey;
 
     this.inputVariableContextsById = new Map();
@@ -120,18 +115,18 @@ export class WorkflowContext {
 
   /* Create a new workflow context for a nested workflow from its parent */
   public createNestedWorkflowContext({
-    workflowLabel,
     parentNode,
+    workflowClassName,
     workflowRawEdges,
   }: {
-    workflowLabel: string;
     parentNode: BaseNode<WorkflowDataNode, BaseNodeContext<WorkflowDataNode>>;
+    workflowClassName: string;
     workflowRawEdges: WorkflowEdge[];
   }) {
     return new WorkflowContext({
       absolutePathToOutputDirectory: this.absolutePathToOutputDirectory,
       moduleName: this.moduleName,
-      workflowLabel,
+      workflowClassName: workflowClassName,
       globalInputVariableContextsById: this.globalInputVariableContextsById,
       globalNodeContextsByNodeId: this.globalNodeContextsByNodeId,
       parentNode,

--- a/ee/codegen/src/generators/nodes/bases/nested-workflow-base.ts
+++ b/ee/codegen/src/generators/nodes/bases/nested-workflow-base.ts
@@ -4,6 +4,7 @@ import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
 import { WorkflowProjectGenerator } from "src/project";
 import { WorkflowDataNode, WorkflowRawData } from "src/types/vellum";
+import { createPythonClassName } from "src/utils/casing";
 
 export abstract class BaseNestedWorkflowNode<
   T extends WorkflowDataNode,
@@ -62,13 +63,14 @@ export abstract class BaseNestedWorkflowNode<
 
   protected generateNestedWorkflowContexts(): Map<string, WorkflowContext> {
     const nestedWorkflowLabel = `${this.nodeContext.getNodeLabel()} Workflow`;
+    const nestedWorkflowClassName = createPythonClassName(nestedWorkflowLabel);
 
     const innerWorkflowData = this.getInnerWorkflowData();
 
     const nestedWorkflowContext =
       this.workflowContext.createNestedWorkflowContext({
-        workflowLabel: nestedWorkflowLabel,
         parentNode: this,
+        workflowClassName: nestedWorkflowClassName,
         workflowRawEdges: innerWorkflowData.edges,
       });
 

--- a/ee/codegen/src/generators/nodes/inline-subworkflow-node.ts
+++ b/ee/codegen/src/generators/nodes/inline-subworkflow-node.ts
@@ -180,6 +180,7 @@ export class InlineSubworkflowNode extends BaseNestedWorkflowNode<
         inputVariables: inlineSubworkflowNodeData.inputVariables,
         outputVariables: inlineSubworkflowNodeData.outputVariables,
       },
+      moduleName: nestedWorkflowContext.moduleName,
       workflowContext: nestedWorkflowContext,
     });
   }

--- a/ee/codegen/src/generators/nodes/map-node.ts
+++ b/ee/codegen/src/generators/nodes/map-node.ts
@@ -151,6 +151,7 @@ export class MapNode extends BaseNestedWorkflowNode<
         inputVariables: mapNodeData.inputVariables,
         outputVariables: mapNodeData.outputVariables,
       },
+      moduleName: nestedWorkflowContext.moduleName,
       workflowContext: nestedWorkflowContext,
     });
   }

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -134,8 +134,9 @@ ${errors.slice(0, 3).map((err) => {
       this.workflowVersionExecConfig = workflowVersionExecConfigResult.value;
       const rawEdges = this.workflowVersionExecConfig.workflowRawData.edges;
 
-      // TODO: Drive from definition
-      const workflowClassName = "Workflow";
+      const workflowClassName =
+        this.workflowVersionExecConfig.workflowRawData.definition?.name ||
+        "Workflow";
 
       this.workflowContext = new WorkflowContext({
         workflowsSdkModulePath: rest.workflowsSdkModulePath,

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -62,7 +62,6 @@ import {
   WorkflowNodeType as WorkflowNodeTypeEnum,
   WorkflowVersionExecConfig,
 } from "src/types/vellum";
-import { toSnakeCase } from "src/utils/casing";
 import { getNodeId } from "src/utils/nodes";
 import { assertUnreachable } from "src/utils/typing";
 
@@ -72,9 +71,7 @@ export class ProjectSerializationError extends Error {
 
 export declare namespace WorkflowProjectGenerator {
   interface BaseArgs {
-    workflowLabel?: string;
-    moduleName?: string;
-    workflowClassName?: string;
+    moduleName: string;
   }
 
   interface BaseProject extends BaseArgs {
@@ -96,12 +93,7 @@ export class WorkflowProjectGenerator {
   public readonly workflowVersionExecConfig: WorkflowVersionExecConfig;
   private readonly workflowContext: WorkflowContext;
 
-  constructor({
-    workflowLabel = "Workflow",
-    moduleName,
-    workflowClassName,
-    ...rest
-  }: WorkflowProjectGenerator.Args) {
+  constructor({ moduleName, ...rest }: WorkflowProjectGenerator.Args) {
     if ("workflowContext" in rest) {
       this.workflowContext = rest.workflowContext;
       this.workflowVersionExecConfig = rest.workflowVersionExecConfig;
@@ -141,11 +133,14 @@ ${errors.slice(0, 3).map((err) => {
 
       this.workflowVersionExecConfig = workflowVersionExecConfigResult.value;
       const rawEdges = this.workflowVersionExecConfig.workflowRawData.edges;
+
+      // TODO: Drive from definition
+      const workflowClassName = "Workflow";
+
       this.workflowContext = new WorkflowContext({
         workflowsSdkModulePath: rest.workflowsSdkModulePath,
         absolutePathToOutputDirectory: rest.absolutePathToOutputDirectory,
-        moduleName: moduleName || toSnakeCase(workflowLabel),
-        workflowLabel,
+        moduleName,
         workflowClassName,
         vellumApiKey,
         workflowRawEdges: rawEdges,


### PR DESCRIPTION
If a Workflow has a definition, we should use its name as the generated Workflow's class name. Only if there isn't one should we fall back to the name "Workflow"