### PR TITLE
Remove legacy module option from pull

### DIFF
--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -42,7 +42,6 @@ def push(
 
 @main.command()
 @click.argument("module", required=False)
-@click.option("--legacy-module", is_flag=True, help="Pull the Workflow as a legacy module")
 @click.option(
     "--include-json",
     is_flag=True,
@@ -56,7 +55,6 @@ def push(
 )
 def pull(
     module: Optional[str],
-    legacy_module: Optional[bool],
     include_json: Optional[bool],
     workflow_sandbox_id: Optional[str],
     exclude_code: Optional[bool],
@@ -64,7 +62,6 @@ def pull(
     """Pull Workflow from Vellum"""
     pull_command(
         module=module,
-        legacy_module=legacy_module,
         include_json=include_json,
         workflow_sandbox_id=workflow_sandbox_id,
         exclude_code=exclude_code,

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -14,7 +14,6 @@ from vellum_cli.logger import load_cli_logger
 def pull_command(
     module: Optional[str] = None,
     workflow_sandbox_id: Optional[str] = None,
-    legacy_module: Optional[bool] = None,
     include_json: Optional[bool] = None,
     exclude_code: Optional[bool] = None,
 ) -> None:
@@ -47,8 +46,6 @@ def pull_command(
     logger.info(f"Pulling workflow into {workflow_config.module}")
     client = create_vellum_client()
     query_parameters = {}
-    if legacy_module:
-        query_parameters["legacyModule"] = legacy_module
     if include_json:
         query_parameters["include_json"] = include_json
     if exclude_code:


### PR DESCRIPTION
This option was originally added to support codegen differences between when this repo was in the prototype repo and the cutover to the public sdk. Now that we are fully in sdk land, we could remove the arg