### PR TITLE
Support emitting of subworkflow events

### DIFF
--- a/src/vellum/workflows/events/utils.py
+++ b/src/vellum/workflows/events/utils.py
@@ -1,5 +1,0 @@
-from vellum.workflows.events.workflow import WorkflowEvent
-
-
-def is_terminal_event(event: WorkflowEvent) -> bool:
-    return event.name in {"workflow.execution.fulfilled", "workflow.execution.rejected", "workflow.execution.paused"}

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -29,7 +29,6 @@ from vellum.workflows.events.node import (
     NodeExecutionStreamingBody,
 )
 from vellum.workflows.events.types import BaseEvent, ParentContext, WorkflowParentContext
-from vellum.workflows.events.utils import is_terminal_event
 from vellum.workflows.events.workflow import (
     WorkflowExecutionFulfilledBody,
     WorkflowExecutionInitiatedBody,
@@ -123,6 +122,7 @@ class WorkflowRunner(Generic[StateType]):
             "__snapshot_callback__",
             lambda s: self._snapshot_state(s),
         )
+        self.workflow.context._register_event_queue(self._workflow_event_queue)
 
     def _snapshot_state(self, state: StateType) -> StateType:
         self.workflow._store.append_state_snapshot(state)
@@ -588,6 +588,15 @@ class WorkflowRunner(Generic[StateType]):
             )
         )
 
+    def _is_terminal_event(self, event: WorkflowEvent) -> bool:
+        if (
+            event.name == "workflow.execution.fulfilled"
+            or event.name == "workflow.execution.rejected"
+            or event.name == "workflow.execution.paused"
+        ):
+            return event.workflow_definition == self.workflow.__class__
+        return False
+
     def stream(self) -> WorkflowEventStream:
         background_thread = Thread(
             target=self._run_background_thread, name=f"{self.workflow.__class__.__name__}.background_thread"
@@ -621,7 +630,7 @@ class WorkflowRunner(Generic[StateType]):
 
             yield self._emit_event(event)
 
-            if is_terminal_event(event):
+            if self._is_terminal_event(event):
                 break
 
         try:
@@ -630,7 +639,7 @@ class WorkflowRunner(Generic[StateType]):
         except Empty:
             pass
 
-        if not is_terminal_event(event):
+        if not self._is_terminal_event(event):
             yield self._reject_workflow_event(
                 VellumError(
                     code=VellumErrorCode.INTERNAL_ERROR,

--- a/src/vellum/workflows/state/context.py
+++ b/src/vellum/workflows/state/context.py
@@ -1,14 +1,18 @@
 from functools import cached_property
-from typing import Optional
+from queue import Queue
+from typing import TYPE_CHECKING, Optional
 
 from vellum import Vellum
-
 from vellum.workflows.vellum_client import create_vellum_client
+
+if TYPE_CHECKING:
+    from vellum.workflows.events.workflow import WorkflowEvent
 
 
 class WorkflowContext:
     def __init__(self, _vellum_client: Optional[Vellum] = None):
         self._vellum_client = _vellum_client
+        self._event_queue: Optional[Queue["WorkflowEvent"]] = None
 
     @cached_property
     def vellum_client(self) -> Vellum:
@@ -16,3 +20,10 @@ class WorkflowContext:
             return self._vellum_client
 
         return create_vellum_client()
+
+    def _emit_subworkflow_event(self, event: "WorkflowEvent") -> None:
+        if self._event_queue:
+            self._event_queue.put(event)
+
+    def _register_event_queue(self, event_queue: Queue["WorkflowEvent"]) -> None:
+        self._event_queue = event_queue

--- a/src/vellum/workflows/workflows/event_filters.py
+++ b/src/vellum/workflows/workflows/event_filters.py
@@ -1,12 +1,11 @@
 from typing import TYPE_CHECKING, Type
 
-from vellum.workflows.events.workflow import WorkflowEvent
-
 if TYPE_CHECKING:
+    from vellum.workflows.events.workflow import WorkflowEvent
     from vellum.workflows.workflows.base import BaseWorkflow
 
 
-def workflow_event_filter(workflow_definition: Type["BaseWorkflow"], event: WorkflowEvent) -> bool:
+def workflow_event_filter(workflow_definition: Type["BaseWorkflow"], event: "WorkflowEvent") -> bool:
     """
     Filters for only Workflow events that were emitted by the `workflow_definition` parameter.
     """
@@ -24,7 +23,7 @@ def workflow_event_filter(workflow_definition: Type["BaseWorkflow"], event: Work
     return False
 
 
-def root_workflow_event_filter(workflow_definition: Type["BaseWorkflow"], event: WorkflowEvent) -> bool:
+def root_workflow_event_filter(workflow_definition: Type["BaseWorkflow"], event: "WorkflowEvent") -> bool:
     """
     Filters for Workflow and Node events that were emitted by the `workflow_definition` parameter.
     """
@@ -46,3 +45,7 @@ def root_workflow_event_filter(workflow_definition: Type["BaseWorkflow"], event:
         return False
 
     return event.parent.workflow_definition == workflow_definition
+
+
+def all_workflow_event_filter(workflow_definition: Type["BaseWorkflow"], event: "WorkflowEvent") -> bool:
+    return True

--- a/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
+++ b/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
@@ -22,6 +22,7 @@ def test_workflow_stream__happy_path():
 
     # THEN we see the expected events in the correct order
     assert events[0].name == "workflow.execution.initiated"
+    assert events[0].workflow_definition == StreamingTryExample
 
     assert events[1].name == "node.execution.initiated"
     assert events[1].node_definition == InnerNode
@@ -30,9 +31,12 @@ def test_workflow_stream__happy_path():
         "module": ["tests", "workflows", "stream_try_node_annotation", "workflow", "InnerNode", ADORNMENT_MODULE_NAME],
     }
 
-    assert events[2].name == "node.execution.streaming"
-    assert events[2].output.name == "processed"
-    assert events[2].output.is_initiated
+    assert events[2].name == "workflow.execution.initiated"
+    assert events[2].workflow_definition == InnerNode.subworkflow
+
+    assert events[3].name == "node.execution.streaming"
+    assert events[3].output.name == "processed"
+    assert events[3].output.is_initiated
 
     assert events[3].name == "workflow.execution.streaming"
     assert events[3].output.name == "final_value"


### PR DESCRIPTION
This PR makes it such that events emitted by inline subworkflows (in this case, _specifically_ try nodes) can be emitted back through the `stream` API. This is something we _don't_ support in workflows today, because A) it's noisy and B) we are able to initialize the inline workflow emitter as part of the node.

We don't have access to B in Vembda, so we'll need to emit them out of Vembda and back to vellum in order to be A) stored in clickhouse and B) sent to the UI for display purposes. We solve the noisy problem in a separate PR where we introduced event filters - Vembda will need to use the `all_workflow_event_filter ` filter to allow them all to pass through