### PR TITLE
Introduce the event filter param into workflow streaming to replace

### DIFF
--- a/src/vellum/workflows/events/__init__.py
+++ b/src/vellum/workflows/events/__init__.py
@@ -5,7 +5,6 @@ from .node import (
     NodeExecutionRejectedEvent,
     NodeExecutionStreamingEvent,
 )
-from .types import WorkflowEventType
 from .workflow import (
     WorkflowEvent,
     WorkflowEventStream,
@@ -27,5 +26,4 @@ __all__ = [
     "WorkflowExecutionStreamingEvent",
     "WorkflowEvent",
     "WorkflowEventStream",
-    "WorkflowEventType",
 ]

--- a/src/vellum/workflows/events/types.py
+++ b/src/vellum/workflows/events/types.py
@@ -15,11 +15,6 @@ if TYPE_CHECKING:
     from vellum.workflows.workflows.base import BaseWorkflow
 
 
-class WorkflowEventType(Enum):
-    NODE = "NODE"
-    WORKFLOW = "WORKFLOW"
-
-
 def default_datetime_factory() -> datetime:
     """
     Makes it possible to mock the datetime factory for testing.
@@ -49,7 +44,7 @@ def default_serializer(obj: Any) -> Any:
 
 class BaseParentContext(UniversalBaseModel):
     span_id: UUID
-    parent: Optional['ParentContext'] = None
+    parent: Optional["ParentContext"] = None
 
 
 class BaseDeploymentParentContext(BaseParentContext):
@@ -73,7 +68,7 @@ class PromptDeploymentParentContext(BaseDeploymentParentContext):
 
 class NodeParentContext(BaseParentContext):
     type: Literal["WORKFLOW_NODE"] = "WORKFLOW_NODE"
-    node_definition: Type['BaseNode']
+    node_definition: Type["BaseNode"]
 
     @field_serializer("node_definition")
     def serialize_node_definition(self, definition: Type, _info: Any) -> Dict[str, Any]:
@@ -82,7 +77,7 @@ class NodeParentContext(BaseParentContext):
 
 class WorkflowParentContext(BaseParentContext):
     type: Literal["WORKFLOW"] = "WORKFLOW"
-    workflow_definition: Type['BaseWorkflow']
+    workflow_definition: Type["BaseWorkflow"]
 
     @field_serializer("workflow_definition")
     def serialize_workflow_definition(self, definition: Type, _info: Any) -> Dict[str, Any]:

--- a/src/vellum/workflows/events/workflow.py
+++ b/src/vellum/workflows/events/workflow.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, Generic, Iterable, Liter
 from pydantic import field_serializer
 
 from vellum.core.pydantic_utilities import UniversalBaseModel
-
 from vellum.workflows.errors import VellumError
 from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.references import ExternalInputReference
@@ -31,6 +30,14 @@ class _BaseWorkflowExecutionBody(UniversalBaseModel):
         return serialize_type_encoder(workflow_definition)
 
 
+class _BaseWorkflowEvent(BaseEvent):
+    body: _BaseWorkflowExecutionBody
+
+    @property
+    def workflow_definition(self) -> Type["BaseWorkflow"]:
+        return self.body.workflow_definition
+
+
 class WorkflowExecutionInitiatedBody(_BaseWorkflowExecutionBody, Generic[WorkflowInputsType]):
     inputs: WorkflowInputsType
 
@@ -39,7 +46,7 @@ class WorkflowExecutionInitiatedBody(_BaseWorkflowExecutionBody, Generic[Workflo
         return default_serializer(inputs)
 
 
-class WorkflowExecutionInitiatedEvent(BaseEvent, Generic[WorkflowInputsType]):
+class WorkflowExecutionInitiatedEvent(_BaseWorkflowEvent, Generic[WorkflowInputsType]):
     name: Literal["workflow.execution.initiated"] = "workflow.execution.initiated"
     body: WorkflowExecutionInitiatedBody[WorkflowInputsType]
 
@@ -56,7 +63,7 @@ class WorkflowExecutionStreamingBody(_BaseWorkflowExecutionBody):
         return default_serializer(output)
 
 
-class WorkflowExecutionStreamingEvent(BaseEvent):
+class WorkflowExecutionStreamingEvent(_BaseWorkflowEvent):
     name: Literal["workflow.execution.streaming"] = "workflow.execution.streaming"
     body: WorkflowExecutionStreamingBody
 
@@ -73,7 +80,7 @@ class WorkflowExecutionFulfilledBody(_BaseWorkflowExecutionBody, Generic[Outputs
         return default_serializer(outputs)
 
 
-class WorkflowExecutionFulfilledEvent(BaseEvent, Generic[OutputsType]):
+class WorkflowExecutionFulfilledEvent(_BaseWorkflowEvent, Generic[OutputsType]):
     name: Literal["workflow.execution.fulfilled"] = "workflow.execution.fulfilled"
     body: WorkflowExecutionFulfilledBody[OutputsType]
 
@@ -86,7 +93,7 @@ class WorkflowExecutionRejectedBody(_BaseWorkflowExecutionBody):
     error: VellumError
 
 
-class WorkflowExecutionRejectedEvent(BaseEvent):
+class WorkflowExecutionRejectedEvent(_BaseWorkflowEvent):
     name: Literal["workflow.execution.rejected"] = "workflow.execution.rejected"
     body: WorkflowExecutionRejectedBody
 
@@ -99,7 +106,7 @@ class WorkflowExecutionPausedBody(_BaseWorkflowExecutionBody):
     external_inputs: Iterable[ExternalInputReference]
 
 
-class WorkflowExecutionPausedEvent(BaseEvent):
+class WorkflowExecutionPausedEvent(_BaseWorkflowEvent):
     name: Literal["workflow.execution.paused"] = "workflow.execution.paused"
     body: WorkflowExecutionPausedBody
 
@@ -112,7 +119,7 @@ class WorkflowExecutionResumedBody(_BaseWorkflowExecutionBody):
     pass
 
 
-class WorkflowExecutionResumedEvent(BaseEvent):
+class WorkflowExecutionResumedEvent(_BaseWorkflowEvent):
     name: Literal["workflow.execution.resumed"] = "workflow.execution.resumed"
     body: WorkflowExecutionResumedBody
 

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -48,7 +48,6 @@ from vellum.workflows.events.node import (
     NodeExecutionStreamingBody,
     NodeExecutionStreamingEvent,
 )
-from vellum.workflows.events.types import WorkflowEventType
 from vellum.workflows.events.workflow import (
     GenericWorkflowEvent,
     WorkflowExecutionFulfilledBody,

--- a/src/vellum/workflows/workflows/event_filters.py
+++ b/src/vellum/workflows/workflows/event_filters.py
@@ -1,0 +1,48 @@
+from typing import TYPE_CHECKING, Type
+
+from vellum.workflows.events.workflow import WorkflowEvent
+
+if TYPE_CHECKING:
+    from vellum.workflows.workflows.base import BaseWorkflow
+
+
+def workflow_event_filter(workflow_definition: Type["BaseWorkflow"], event: WorkflowEvent) -> bool:
+    """
+    Filters for only Workflow events that were emitted by the `workflow_definition` parameter.
+    """
+
+    if (
+        event.name == "workflow.execution.initiated"
+        or event.name == "workflow.execution.resumed"
+        or event.name == "workflow.execution.fulfilled"
+        or event.name == "workflow.execution.rejected"
+        or event.name == "workflow.execution.paused"
+        or event.name == "workflow.execution.streaming"
+    ):
+        return event.workflow_definition == workflow_definition
+
+    return False
+
+
+def root_workflow_event_filter(workflow_definition: Type["BaseWorkflow"], event: WorkflowEvent) -> bool:
+    """
+    Filters for Workflow and Node events that were emitted by the `workflow_definition` parameter.
+    """
+
+    if (
+        event.name == "workflow.execution.initiated"
+        or event.name == "workflow.execution.resumed"
+        or event.name == "workflow.execution.fulfilled"
+        or event.name == "workflow.execution.rejected"
+        or event.name == "workflow.execution.paused"
+        or event.name == "workflow.execution.streaming"
+    ):
+        return event.workflow_definition == workflow_definition
+
+    if not event.parent:
+        return False
+
+    if event.parent.type != "WORKFLOW":
+        return False
+
+    return event.parent.workflow_definition == workflow_definition

--- a/tests/workflows/basic_conditional_branch/tests/test_workflow.py
+++ b/tests/workflows/basic_conditional_branch/tests/test_workflow.py
@@ -54,7 +54,7 @@ def test_stream_workflow__verify_invoked_ports():
     # WHEN we stream the Workflow
     stream = workflow.stream(
         inputs=Inputs(value=True),
-        event_types={WorkflowEventType.WORKFLOW, WorkflowEventType.NODE},
+        event_filter=workflow.ROOT_EVENT_FILTER,
     )
     events = list(stream)
 

--- a/tests/workflows/basic_conditional_branch/tests/test_workflow.py
+++ b/tests/workflows/basic_conditional_branch/tests/test_workflow.py
@@ -1,4 +1,5 @@
 from vellum.workflows.constants import UNDEF
+from vellum.workflows.workflows.event_filters import root_workflow_event_filter
 
 from tests.workflows.basic_conditional_branch.workflow import (
     BasicConditionalBranchWorkflow,
@@ -53,7 +54,7 @@ def test_stream_workflow__verify_invoked_ports():
     # WHEN we stream the Workflow
     stream = workflow.stream(
         inputs=Inputs(value=True),
-        event_filter=workflow.ROOT_EVENT_FILTER,
+        event_filter=root_workflow_event_filter,
     )
     events = list(stream)
 

--- a/tests/workflows/basic_conditional_branch/tests/test_workflow.py
+++ b/tests/workflows/basic_conditional_branch/tests/test_workflow.py
@@ -1,5 +1,4 @@
 from vellum.workflows.constants import UNDEF
-from vellum.workflows.events.types import WorkflowEventType
 
 from tests.workflows.basic_conditional_branch.workflow import (
     BasicConditionalBranchWorkflow,

--- a/tests/workflows/basic_node_streaming/tests/test_workflow.py
+++ b/tests/workflows/basic_node_streaming/tests/test_workflow.py
@@ -1,5 +1,3 @@
-from vellum.workflows.events.types import WorkflowEventType
-
 from tests.workflows.basic_node_streaming.workflow import BasicNodeStreaming, Inputs, StreamingNode
 
 

--- a/tests/workflows/basic_node_streaming/tests/test_workflow.py
+++ b/tests/workflows/basic_node_streaming/tests/test_workflow.py
@@ -1,5 +1,6 @@
-from tests.workflows.basic_node_streaming.workflow import BasicNodeStreaming, Inputs, StreamingNode
 from vellum.workflows.events.types import WorkflowEventType
+
+from tests.workflows.basic_node_streaming.workflow import BasicNodeStreaming, Inputs, StreamingNode
 
 
 def test_run_workflow__happy_path():
@@ -8,7 +9,7 @@ def test_run_workflow__happy_path():
 
     # WHEN the workflow is run
     inputs = Inputs(foo="Hello")
-    events = list(workflow.stream(event_types={WorkflowEventType.WORKFLOW, WorkflowEventType.NODE}, inputs=inputs))
+    events = list(workflow.stream(event_filter=workflow.ROOT_EVENT_FILTER, inputs=inputs))
 
     # THEN the workflow should have emitted 14 events
     #

--- a/tests/workflows/basic_node_streaming/tests/test_workflow.py
+++ b/tests/workflows/basic_node_streaming/tests/test_workflow.py
@@ -1,3 +1,5 @@
+from vellum.workflows.workflows.event_filters import root_workflow_event_filter
+
 from tests.workflows.basic_node_streaming.workflow import BasicNodeStreaming, Inputs, StreamingNode
 
 
@@ -7,7 +9,7 @@ def test_run_workflow__happy_path():
 
     # WHEN the workflow is run
     inputs = Inputs(foo="Hello")
-    events = list(workflow.stream(event_filter=workflow.ROOT_EVENT_FILTER, inputs=inputs))
+    events = list(workflow.stream(event_filter=root_workflow_event_filter, inputs=inputs))
 
     # THEN the workflow should have emitted 14 events
     #

--- a/tests/workflows/basic_parent_context/tests/test_basic_parent_context_workflow_runner.py
+++ b/tests/workflows/basic_parent_context/tests/test_basic_parent_context_workflow_runner.py
@@ -1,3 +1,5 @@
+from vellum.workflows.workflows.event_filters import root_workflow_event_filter
+
 from tests.workflows.basic_parent_context.basic_workflow import TrivialWorkflow
 
 
@@ -11,7 +13,7 @@ def test_run_workflow__happy_path():
 
 def test_stream_workflow__happy_path():
     workflow = TrivialWorkflow()
-    events = list(workflow.stream(event_filter=workflow.ROOT_EVENT_FILTER))
+    events = list(workflow.stream(event_filter=root_workflow_event_filter))
 
     assert len(events) == 4
 

--- a/tests/workflows/basic_parent_context/tests/test_basic_parent_context_workflow_runner.py
+++ b/tests/workflows/basic_parent_context/tests/test_basic_parent_context_workflow_runner.py
@@ -14,7 +14,7 @@ def test_run_workflow__happy_path():
 
 def test_stream_workflow__happy_path():
     workflow = TrivialWorkflow()
-    events = list(workflow.stream(event_types={WorkflowEventType.WORKFLOW, WorkflowEventType.NODE}))
+    events = list(workflow.stream(event_filter=workflow.ROOT_EVENT_FILTER))
 
     assert len(events) == 4
 
@@ -23,9 +23,9 @@ def test_stream_workflow__happy_path():
 
     assert events[1].name == "node.execution.initiated"
     parent_context = events[1].parent.model_dump() if events[1].parent else {}
-    assert parent_context.get('type') == 'WORKFLOW'
-    assert parent_context.get('parent') is None
-    assert parent_context.get('workflow_definition') is not None
+    assert parent_context.get("type") == "WORKFLOW"
+    assert parent_context.get("parent") is None
+    assert parent_context.get("workflow_definition") is not None
 
     assert events[-1].name == "workflow.execution.fulfilled"
     assert events[-1].parent is None

--- a/tests/workflows/basic_parent_context/tests/test_basic_parent_context_workflow_runner.py
+++ b/tests/workflows/basic_parent_context/tests/test_basic_parent_context_workflow_runner.py
@@ -1,6 +1,3 @@
-from vellum.workflows.events import WorkflowEventType
-from vellum.workflows.events.types import WorkflowParentContext
-
 from tests.workflows.basic_parent_context.basic_workflow import TrivialWorkflow
 
 

--- a/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
+++ b/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
@@ -1,4 +1,3 @@
-from vellum.workflows.events.types import WorkflowEventType
 from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
 
 from tests.workflows.stream_try_node_annotation.workflow import InnerNode, Inputs, StreamingTryExample

--- a/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
+++ b/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
@@ -1,4 +1,5 @@
 from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
+from vellum.workflows.workflows.event_filters import root_workflow_event_filter
 
 from tests.workflows.stream_try_node_annotation.workflow import InnerNode, Inputs, StreamingTryExample
 
@@ -15,7 +16,7 @@ def test_workflow_stream__happy_path():
     # WHEN we stream the events of the Workflow
     stream = workflow.stream(
         inputs=Inputs(items=["apple", "banana", "cherry"]),
-        event_filter=workflow.ROOT_EVENT_FILTER,
+        event_filter=root_workflow_event_filter,
     )
     events = list(stream)
 

--- a/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
+++ b/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
@@ -16,7 +16,7 @@ def test_workflow_stream__happy_path():
     # WHEN we stream the events of the Workflow
     stream = workflow.stream(
         inputs=Inputs(items=["apple", "banana", "cherry"]),
-        event_types={WorkflowEventType.NODE, WorkflowEventType.WORKFLOW},
+        event_filter=workflow.ROOT_EVENT_FILTER,
     )
     events = list(stream)
 


### PR DESCRIPTION
Workflows never needed to return subworkflow events as part of the API before because we had new emitters initialized within the node to capture events.

Now that everything runs in Vembda, we need to support the need for emitting events from inner subworkflows as part of the API. Before doing so (we started exploring it [here](https://github.com/vellum-ai/vellum-python-sdks/pull/294/files#diff-bf147bd0bb4a35ee966635944c240b29aeac1162f4f1e17c9d663b3ebda65559R34-R39)), we need to make our event filter more expressive so that our default behaviors still don't emit all of those events.

This PR focuses on replacing our param for listening to events from `event_types` to `event_filter`, so that we can say by default, we only return root workflow events