### PR TITLE
Set up failing test and impl for graph attribute generation for merge nodes

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`Workflow > write > graph > should be correct for a basic merge node case 1`] = `
 "from vellum.workflows import BaseWorkflow
 from .nodes.templating_node import TemplatingNode
-from .nodes.merge_node import MergeNode
 from .nodes.templating_node_2 import TemplatingNode2
+from .nodes.merge_node import MergeNode
 
 
 class TestWorkflow(BaseWorkflow):
@@ -15,7 +15,65 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
+exports[`Workflow > write > graph > should be correct for a basic multiple nodes case 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_2 import TemplatingNode2
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = {TemplatingNode, TemplatingNode2}
+
+    class Outputs(BaseWorkflow.Outputs):
+        pass
+"
+`;
+
+exports[`Workflow > write > graph > should be correct for a basic single edge case 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_2 import TemplatingNode2
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = TemplatingNode >> TemplatingNode2
+
+    class Outputs(BaseWorkflow.Outputs):
+        pass
+"
+`;
+
+exports[`Workflow > write > graph > should be correct for a basic single edge case 2`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_2 import TemplatingNode2
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = TemplatingNode >> TemplatingNode2
+
+    class Outputs(BaseWorkflow.Outputs):
+        pass
+"
+`;
+
 exports[`Workflow > write > graph > should be correct for a basic single node case 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .inputs import Inputs
+from vellum.workflows.state import BaseState
+from .nodes.search_node import SearchNode
+from .nodes.final_output import FinalOutput
+
+
+class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
+    graph = SearchNode
+
+    class Outputs(BaseWorkflow.Outputs):
+        query = FinalOutput.Outputs.value
+"
+`;
+
+exports[`Workflow > write > graph > should be correct for a basic single node case 2`] = `
 "from vellum.workflows import BaseWorkflow
 from .inputs import Inputs
 from vellum.workflows.state import BaseState

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -1,5 +1,20 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Workflow > write > graph > should be correct for a basic merge node case 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+from .nodes.merge_node import MergeNode
+from .nodes.templating_node_2 import TemplatingNode2
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = {TemplatingNode, TemplatingNode2} >> MergeNode
+
+    class Outputs(BaseWorkflow.Outputs):
+        pass
+"
+`;
+
 exports[`Workflow > write > graph > should be correct for a basic single node case 1`] = `
 "from vellum.workflows import BaseWorkflow
 from .inputs import Inputs

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -560,19 +560,27 @@ export function promptDeploymentNodeDataFactory(): PromptNode {
 }
 
 export function templatingNodeFactory({
+  id,
+  label,
+  sourceHandleId,
+  targetHandleId,
   errorOutputId,
 }: {
+  id?: string;
+  label?: string;
+  sourceHandleId?: string;
+  targetHandleId?: string;
   errorOutputId?: string;
 } = {}): TemplatingNode {
   const nodeData: TemplatingNode = {
-    id: "7e09927b-6d6f-4829-92c9-54e66bdcaf80",
+    id: id ?? "7e09927b-6d6f-4829-92c9-54e66bdcaf80",
     type: WorkflowNodeType.TEMPLATING,
     data: {
-      label: "Templating Node",
+      label: label ?? "Templating Node",
       outputId: "2d4f1826-de75-499a-8f84-0a690c8136ad",
       errorOutputId,
-      sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb98",
-      targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2948",
+      sourceHandleId: sourceHandleId ?? "dd8397b1-5a41-4fa0-8c24-e5dffee4fb98",
+      targetHandleId: targetHandleId ?? "3feb7e71-ec63-4d58-82ba-c3df829a2948",
       templateNodeInputId: "7b8af68b-cf60-4fca-9c57-868042b5b616",
       outputType: VellumVariableType.String,
     },

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -245,6 +245,8 @@ describe("Workflow", () => {
           workflowContext,
           inputs,
           nodes: [templatingNodeData1, templatingNodeData2],
+          // This test case fails with the legacy graph generation algorithm
+          // so we don't parameterize over it.
           breadthFirstGraphGeneration: true,
         });
 
@@ -301,8 +303,6 @@ describe("Workflow", () => {
             workflowContext,
             inputs,
             nodes: [templatingNodeData1, templatingNodeData2],
-            // This test case fails with the legacy graph generation algorithm
-            // so we don't parameterize over it.
             breadthFirstGraphGeneration,
           });
 

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -4,7 +4,9 @@ import { workflowContextFactory } from "./helpers";
 import { inputVariableContextFactory } from "./helpers/input-variable-context-factory";
 import {
   entrypointNodeDataFactory,
+  mergeNodeDataFactory,
   searchNodeDataFactory,
+  templatingNodeFactory,
   terminalNodeDataFactory,
 } from "./helpers/node-data-factories";
 
@@ -186,6 +188,87 @@ describe("Workflow", () => {
           workflowContext,
           inputs,
           nodes: [searchNodeData],
+        });
+
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
+
+      it("should be correct for a basic merge node case", async () => {
+        const inputs = codegen.inputs({ workflowContext });
+
+        const templatingNodeData1 = templatingNodeFactory();
+        const templatingNodeContext1 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData1,
+        });
+        workflowContext.addNodeContext(templatingNodeContext1);
+
+        const templatingNodeData2 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+          label: "Templating Node 2",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+        });
+        const templatingNodeContext2 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData2,
+        });
+        workflowContext.addNodeContext(templatingNodeContext2);
+
+        const mergeNodeData = mergeNodeDataFactory();
+        const mergeNodeContext = await createNodeContext({
+          workflowContext,
+          nodeData: mergeNodeData,
+        });
+        workflowContext.addNodeContext(mergeNodeContext);
+        const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
+        const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
+        if (!mergeTargetHandle1 || !mergeTargetHandle2) {
+          throw new Error("Handle IDs are required");
+        }
+
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData1.id,
+            targetHandleId: templatingNodeData1.data.targetHandleId,
+          },
+          {
+            id: "edge-2",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData2.id,
+            targetHandleId: templatingNodeData2.data.targetHandleId,
+          },
+          {
+            id: "edge-3",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData1.id,
+            sourceHandleId: templatingNodeData1.data.sourceHandleId,
+            targetNodeId: mergeNodeData.id,
+            targetHandleId: mergeTargetHandle1,
+          },
+          {
+            id: "edge-4",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData2.id,
+            sourceHandleId: templatingNodeData2.data.sourceHandleId,
+            targetNodeId: mergeNodeData.id,
+            targetHandleId: mergeTargetHandle2,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
+
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [templatingNodeData1, templatingNodeData2, mergeNodeData],
         });
 
         workflow.getWorkflowFile().write(writer);


### PR DESCRIPTION
This PR introduces the early innings of the new graph generation algorithm, which will be a breadth first search across edges, amending the AST as we traverse.

This PR _only_ strives to pass an initial bank of test cases (4), in order to show that the original ticket can be solved. I intend to continue solving the rest over a series of smaller PRs, each with its own test case, taking after what we support in execution land here: https://github.com/vellum-ai/vellum-python-sdks/blob/main/src/vellum/workflows/graph/tests/test_graph.py

So as to not regress what we currently have in the interim, I introduced a "feature flag", so that we could build out graph gen across tests, and then cut over once they're all ready and passing.