### PR TITLE
Graph Gen - Solving case with a set of an edge and a node

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -158,8 +158,8 @@ class TestWorkflow(BaseWorkflow):
 exports[`Workflow > write > graph > should be correct for set of a branch and a node 1`] = `
 "from vellum.workflows import BaseWorkflow
 from .nodes.templating_node import TemplatingNode
-from .nodes.templating_node_3 import TemplatingNode3
 from .nodes.templating_node_2 import TemplatingNode2
+from .nodes.templating_node_3 import TemplatingNode3
 
 
 class TestWorkflow(BaseWorkflow):

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -155,6 +155,21 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
+exports[`Workflow > write > graph > should be correct for set of a branch and a node 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_3 import TemplatingNode3
+from .nodes.templating_node_2 import TemplatingNode2
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = {TemplatingNode >> TemplatingNode2, TemplatingNode3}
+
+    class Outputs(BaseWorkflow.Outputs):
+        pass
+"
+`;
+
 exports[`Workflow > write > should generate correct code when there are input variables 1`] = `
 "from vellum.workflows import BaseWorkflow
 

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -559,6 +559,86 @@ describe("Workflow", () => {
           expect(await writer.toStringFormatted()).toMatchSnapshot();
         }
       );
+
+      it("should be correct for set of a branch and a node", async () => {
+        const inputs = codegen.inputs({ workflowContext });
+
+        const templatingNodeData1 = templatingNodeFactory();
+        const templatingNodeContext1 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData1,
+        });
+        workflowContext.addNodeContext(templatingNodeContext1);
+
+        const templatingNodeData2 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+          label: "Templating Node 2",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+        });
+        const templatingNodeContext2 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData2,
+        });
+        workflowContext.addNodeContext(templatingNodeContext2);
+
+        const templatingNodeData3 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
+          label: "Templating Node 3",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
+        });
+        const templatingNodeContext3 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData3,
+        });
+        workflowContext.addNodeContext(templatingNodeContext3);
+
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData1.id,
+            targetHandleId: templatingNodeData1.data.targetHandleId,
+          },
+          {
+            id: "edge-2",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData1.id,
+            sourceHandleId: templatingNodeData1.data.sourceHandleId,
+            targetNodeId: templatingNodeData2.id,
+            targetHandleId: templatingNodeData2.data.targetHandleId,
+          },
+          {
+            id: "edge-3",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData3.id,
+            targetHandleId: templatingNodeData3.data.targetHandleId,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
+
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [
+            templatingNodeData1,
+            templatingNodeData2,
+            templatingNodeData3,
+          ],
+          // This test case fails with the legacy graph generation algorithm
+          // so we don't parameterize over it.
+          breadthFirstGraphGeneration: true,
+        });
+
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
     });
   });
 });


### PR DESCRIPTION
`graph = {A >> B, C}`

This test case finally pushed us over the edge into recursion. I would review by commit:
- first commit lays out the test case we want to solve
- The second commit is a logicless refactor to format our existing graph manipulation logic into a callable function
- The third commit uses recursion to solve the new test case