### PR TITLE
[Codegen] Use Discriminated Unions

### DIFF
--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -611,7 +611,7 @@ export declare namespace EntrypointNodeSerializer {
 
 export const InlineSubworkflowNodeDataSerializer: ObjectSchema<
   InlineSubworkflowNodeDataSerializer.Raw,
-  InlineSubworkflowNodeData
+  Omit<InlineSubworkflowNodeData, "variant">
 > = objectSchema({
   workflowRawData: propertySchema(
     "workflow_raw_data",
@@ -629,7 +629,6 @@ export const InlineSubworkflowNodeDataSerializer: ObjectSchema<
   sourceHandleId: propertySchema("source_handle_id", stringSchema()),
   targetHandleId: propertySchema("target_handle_id", stringSchema()),
   errorOutputId: propertySchema("error_output_id", stringSchema().optional()),
-  variant: stringLiteralSchema("INLINE"),
 });
 
 export declare namespace InlineSubworkflowNodeDataSerializer {
@@ -641,19 +640,17 @@ export declare namespace InlineSubworkflowNodeDataSerializer {
     source_handle_id: string;
     target_handle_id: string;
     error_output_id?: string | null;
-    variant: "INLINE";
   }
 }
 
 export const DeploymentSubworkflowNodeDataSerializer: ObjectSchema<
   DeploymentSubworkflowNodeDataSerializer.Raw,
-  DeploymentSubworkflowNodeData
+  Omit<DeploymentSubworkflowNodeData, "variant">
 > = objectSchema({
   label: stringSchema(),
   sourceHandleId: propertySchema("source_handle_id", stringSchema()),
   targetHandleId: propertySchema("target_handle_id", stringSchema()),
   errorOutputId: propertySchema("error_output_id", stringSchema().optional()),
-  variant: stringLiteralSchema("DEPLOYMENT"),
   workflowDeploymentId: propertySchema(
     "workflow_deployment_id",
     stringSchema()
@@ -667,16 +664,15 @@ export declare namespace DeploymentSubworkflowNodeDataSerializer {
     source_handle_id: string;
     target_handle_id: string;
     error_output_id?: string | null;
-    variant: "DEPLOYMENT";
     workflow_deployment_id: string;
     release_tag: string;
   }
 }
 
-export const SubworkflowNodeDataSerializer = undiscriminatedUnionSchema([
-  InlineSubworkflowNodeDataSerializer,
-  DeploymentSubworkflowNodeDataSerializer,
-]);
+export const SubworkflowNodeDataSerializer = union("variant", {
+  INLINE: InlineSubworkflowNodeDataSerializer,
+  DEPLOYMENT: DeploymentSubworkflowNodeDataSerializer,
+});
 
 export declare namespace SubworkflowNodeDataSerializer {
   type Raw =

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -300,9 +300,8 @@ const PromptTemplateBlockSerializer = undiscriminatedUnionSchema([
 
 export const NodeOutputPointerSerializer: ObjectSchema<
   NodeOutputPointerSerializer.Raw,
-  NodeOutputPointer
+  Omit<NodeOutputPointer, "type">
 > = objectSchema({
-  type: stringLiteralSchema("NODE_OUTPUT"),
   data: objectSchema({
     nodeId: propertySchema("node_id", stringSchema()),
     outputId: propertySchema("output_id", stringSchema()),
@@ -311,7 +310,6 @@ export const NodeOutputPointerSerializer: ObjectSchema<
 
 export declare namespace NodeOutputPointerSerializer {
   interface Raw {
-    type: "NODE_OUTPUT";
     data: {
       node_id: string;
     };
@@ -320,9 +318,8 @@ export declare namespace NodeOutputPointerSerializer {
 
 export const InputVariablePointerSerializer: ObjectSchema<
   InputVariablePointerSerializer.Raw,
-  InputVariablePointer
+  Omit<InputVariablePointer, "type">
 > = objectSchema({
-  type: stringLiteralSchema("INPUT_VARIABLE"),
   data: objectSchema({
     inputVariableId: propertySchema("input_variable_id", stringSchema()),
   }),
@@ -330,7 +327,6 @@ export const InputVariablePointerSerializer: ObjectSchema<
 
 export declare namespace InputVariablePointerSerializer {
   interface Raw {
-    type: "INPUT_VARIABLE";
     data: {
       input_variable_id: string;
     };
@@ -339,24 +335,21 @@ export declare namespace InputVariablePointerSerializer {
 
 export const ConstantValuePointerSerializer: ObjectSchema<
   ConstantValuePointerSerializer.Raw,
-  ConstantValuePointer
+  Omit<ConstantValuePointer, "type">
 > = objectSchema({
-  type: stringLiteralSchema("CONSTANT_VALUE"),
   data: VellumValueSerializer,
 });
 
 export declare namespace ConstantValuePointerSerializer {
   interface Raw {
-    type: "CONSTANT_VALUE";
     data: VellumValueSerializer.Raw;
   }
 }
 
 export const WorkspaceSecretPointerSerializer: ObjectSchema<
   WorkspaceSecretPointerSerializer.Raw,
-  WorkspaceSecretPointer
+  Omit<WorkspaceSecretPointer, "type">
 > = objectSchema({
-  type: stringLiteralSchema("WORKSPACE_SECRET"),
   data: objectSchema({
     type: stringLiteralSchema("STRING"),
     workspaceSecretId: propertySchema(
@@ -368,7 +361,6 @@ export const WorkspaceSecretPointerSerializer: ObjectSchema<
 
 export declare namespace WorkspaceSecretPointerSerializer {
   interface Raw {
-    type: "WORKSPACE_SECRET";
     data: {
       type: "STRING";
       workspace_secret_id?: string | null | undefined;
@@ -378,9 +370,8 @@ export declare namespace WorkspaceSecretPointerSerializer {
 
 export const ExecutionCounterPointerSerializer: ObjectSchema<
   ExecutionCounterPointerSerializer.Raw,
-  ExecutionCounterPointer
+  Omit<ExecutionCounterPointer, "type">
 > = objectSchema({
-  type: stringLiteralSchema("EXECUTION_COUNTER"),
   data: objectSchema({
     nodeId: propertySchema("node_id", stringSchema()),
   }),
@@ -388,7 +379,6 @@ export const ExecutionCounterPointerSerializer: ObjectSchema<
 
 export declare namespace ExecutionCounterPointerSerializer {
   interface Raw {
-    type: "EXECUTION_COUNTER";
     data: {
       node_id: string;
     };
@@ -398,13 +388,13 @@ export declare namespace ExecutionCounterPointerSerializer {
 export const NodeInputValuePointerRuleSerializer: Schema<
   NodeInputValuePointerRuleSerializer.Raw,
   NodeInputValuePointerRule
-> = undiscriminatedUnionSchema([
-  NodeOutputPointerSerializer,
-  InputVariablePointerSerializer,
-  ConstantValuePointerSerializer,
-  WorkspaceSecretPointerSerializer,
-  ExecutionCounterPointerSerializer,
-]);
+> = union("type", {
+  NODE_OUTPUT: NodeOutputPointerSerializer,
+  INPUT_VARIABLE: InputVariablePointerSerializer,
+  CONSTANT_VALUE: ConstantValuePointerSerializer,
+  WORKSPACE_SECRET: WorkspaceSecretPointerSerializer,
+  EXECUTION_COUNTER: ExecutionCounterPointerSerializer,
+});
 
 export declare namespace NodeInputValuePointerRuleSerializer {
   type Raw =

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -9,12 +9,12 @@ import {
   any as anySchema,
   boolean as booleanSchema,
   ObjectSchema,
-  lazy,
+  lazy as lazySchema,
   property as propertySchema,
   Schema,
   record as recordSchema,
   unknown as unknownSchema,
-  union,
+  union as unionSchema,
 } from "vellum-ai/core/schemas";
 import {
   ChatMessageRole as ChatMessageRoleSerializer,
@@ -143,7 +143,7 @@ export const ChatMessagePromptTemplateBlockSerializer: ObjectSchema<
     blocks: propertySchema(
       "blocks",
       listSchema(
-        lazy(() => {
+        lazySchema(() => {
           return PromptTemplateBlockSerializer as unknown as Schema<
             PromptTemplateBlockSerializer.Raw,
             PromptTemplateBlock
@@ -214,7 +214,7 @@ export const RichTextPromptTemplateBlockSerializer: ObjectSchema<
   state: propertySchema("state", PromptBlockStateSerializer),
   cacheConfig: propertySchema("cache_config", CacheConfigSerializer.optional()),
   blocks: listSchema(
-    union(
+    unionSchema(
       {
         parsedDiscriminant: "blockType",
         rawDiscriminant: "block_type",
@@ -295,7 +295,7 @@ export declare namespace PromptTemplateBlockSerializer {
     | FunctionDefinitionPromptTemplateBlockSerializer.Raw;
 }
 
-const PromptTemplateBlockSerializer = union(
+const PromptTemplateBlockSerializer = unionSchema(
   { parsedDiscriminant: "blockType", rawDiscriminant: "block_type" },
   {
     JINJA: JinjaPromptTemplateBlockSerializer,
@@ -396,7 +396,7 @@ export declare namespace ExecutionCounterPointerSerializer {
 export const NodeInputValuePointerRuleSerializer: Schema<
   NodeInputValuePointerRuleSerializer.Raw,
   NodeInputValuePointerRule
-> = union("type", {
+> = unionSchema("type", {
   NODE_OUTPUT: NodeOutputPointerSerializer,
   INPUT_VARIABLE: InputVariablePointerSerializer,
   CONSTANT_VALUE: ConstantValuePointerSerializer,
@@ -621,7 +621,7 @@ export const InlineSubworkflowNodeDataSerializer: ObjectSchema<
 > = objectSchema({
   workflowRawData: propertySchema(
     "workflow_raw_data",
-    lazy(() => WorkflowRawDataSerializer)
+    lazySchema(() => WorkflowRawDataSerializer)
   ),
   inputVariables: propertySchema(
     "input_variables",
@@ -675,7 +675,7 @@ export declare namespace DeploymentSubworkflowNodeDataSerializer {
   }
 }
 
-export const SubworkflowNodeDataSerializer = union("variant", {
+export const SubworkflowNodeDataSerializer = unionSchema("variant", {
   INLINE: InlineSubworkflowNodeDataSerializer,
   DEPLOYMENT: DeploymentSubworkflowNodeDataSerializer,
 });
@@ -869,7 +869,7 @@ export declare namespace LegacyPromptNodeDataSerializer {
 export const PromptNodeDataSerializer: Schema<
   PromptNodeDataSerializer.Raw,
   PromptNodeData
-> = union("variant", {
+> = unionSchema("variant", {
   INLINE: InlinePromptNodeDataSerializer,
   DEPLOYMENT: DeploymentPromptNodeDataSerializer,
   LEGACY: LegacyPromptNodeDataSerializer,
@@ -942,7 +942,7 @@ export const InlineMapNodeDataSerializer: ObjectSchema<
 > = objectSchema({
   workflowRawData: propertySchema(
     "workflow_raw_data",
-    lazy(() => WorkflowRawDataSerializer)
+    lazySchema(() => WorkflowRawDataSerializer)
   ),
   inputVariables: propertySchema(
     "input_variables",
@@ -981,7 +981,7 @@ export declare namespace InlineMapNodeDataSerializer {
 export const MapNodeDataSerializer: Schema<
   MapNodeDataSerializer.Raw,
   MapNodeData
-> = union("variant", {
+> = unionSchema("variant", {
   INLINE: InlineMapNodeDataSerializer,
   DEPLOYMENT: DeploymentMapNodeDataSerializer,
 });
@@ -1191,7 +1191,7 @@ export const ConditionalRuleDataSerializer: ObjectSchema<
   ConditionalRuleData
 > = objectSchema({
   id: stringSchema(),
-  rules: listSchema(lazy(() => ConditionalRuleDataSerializer)).optional(),
+  rules: listSchema(lazySchema(() => ConditionalRuleDataSerializer)).optional(),
   combinator: stringSchema().optional(),
   negated: booleanSchema().optional(),
   fieldNodeInputId: propertySchema(
@@ -1582,7 +1582,7 @@ export declare namespace GenericNodeSerializer {
 export const WorkflowNodeSerializer: Schema<
   WorkflowNodeSerializer.Raw,
   WorkflowNode
-> = union("type", {
+> = unionSchema("type", {
   ENTRYPOINT: EntrypointNodeSerializer,
   PROMPT: PromptNodeSerializer,
   SEARCH: SearchNodeSerializer,

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -692,10 +692,9 @@ export declare namespace SubworkflowNodeSerializer {
 
 export const InlinePromptNodeDataSerializer: ObjectSchema<
   InlinePromptNodeDataSerializer.Raw,
-  InlinePromptNodeData
+  Omit<InlinePromptNodeData, "variant">
 > = objectSchema({
   label: stringSchema(),
-  variant: stringLiteralSchema("INLINE"),
   outputId: propertySchema("output_id", stringSchema()),
   errorOutputId: propertySchema("error_output_id", stringSchema().optional()),
   arrayOutputId: propertySchema("array_output_id", stringSchema()),
@@ -713,7 +712,6 @@ export declare namespace InlinePromptNodeDataSerializer {
     array_output_id: string;
     source_handle_id: string;
     target_handle_id: string;
-    variant: "INLINE";
     exec_config: PromptVersionExecConfigSerializer.Raw;
     ml_model_name: string;
   }
@@ -721,10 +719,9 @@ export declare namespace InlinePromptNodeDataSerializer {
 
 export const DeploymentPromptNodeDataSerializer: ObjectSchema<
   DeploymentPromptNodeDataSerializer.Raw,
-  DeploymentPromptNodeData
+  Omit<DeploymentPromptNodeData, "variant">
 > = objectSchema({
   label: stringSchema(),
-  variant: stringLiteralSchema("DEPLOYMENT"),
   promptDeploymentId: propertySchema("prompt_deployment_id", stringSchema()),
   releaseTag: propertySchema("release_tag", stringSchema()),
   outputId: propertySchema("output_id", stringSchema()),
@@ -736,7 +733,6 @@ export const DeploymentPromptNodeDataSerializer: ObjectSchema<
 
 export declare namespace DeploymentPromptNodeDataSerializer {
   interface Raw {
-    variant: "DEPLOYMENT";
     prompt_deployment_id: string;
     release_tag: string;
     label: string;
@@ -821,10 +817,9 @@ export declare namespace PromptNodeDeploymentSerializer {
 
 export const LegacyPromptNodeDataSerializer: ObjectSchema<
   LegacyPromptNodeDataSerializer.Raw,
-  LegacyPromptNodeData
+  Omit<LegacyPromptNodeData, "variant">
 > = objectSchema({
   label: stringSchema(),
-  variant: stringLiteralSchema("LEGACY"),
   outputId: propertySchema("output_id", stringSchema()),
   errorOutputId: propertySchema("error_output_id", stringSchema().optional()),
   arrayOutputId: propertySchema("array_output_id", stringSchema()),
@@ -844,7 +839,6 @@ export const LegacyPromptNodeDataSerializer: ObjectSchema<
 export declare namespace LegacyPromptNodeDataSerializer {
   interface Raw {
     label: string;
-    variant: "LEGACY";
     output_id: string;
     error_output_id?: string | null;
     array_output_id: string;
@@ -859,11 +853,11 @@ export declare namespace LegacyPromptNodeDataSerializer {
 export const PromptNodeDataSerializer: Schema<
   PromptNodeDataSerializer.Raw,
   PromptNodeData
-> = undiscriminatedUnionSchema([
-  InlinePromptNodeDataSerializer,
-  DeploymentPromptNodeDataSerializer,
-  LegacyPromptNodeDataSerializer,
-]);
+> = union("variant", {
+  INLINE: InlinePromptNodeDataSerializer,
+  DEPLOYMENT: DeploymentPromptNodeDataSerializer,
+  LEGACY: LegacyPromptNodeDataSerializer,
+});
 
 export declare namespace PromptNodeDataSerializer {
   type Raw =

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -908,9 +908,8 @@ export declare namespace PromptNodeSerializer {
 
 export const DeploymentMapNodeDataSerializer: ObjectSchema<
   DeploymentMapNodeDataSerializer.Raw,
-  DeploymentMapNodeData
+  Omit<DeploymentMapNodeData, "variant">
 > = objectSchema({
-  variant: stringLiteralSchema("DEPLOYMENT"),
   concurrency: numberSchema().optional(),
   label: stringSchema(),
   sourceHandleId: propertySchema("source_handle_id", stringSchema()),
@@ -928,7 +927,6 @@ export const DeploymentMapNodeDataSerializer: ObjectSchema<
 
 export declare namespace DeploymentMapNodeDataSerializer {
   interface Raw {
-    variant: "DEPLOYMENT";
     concurrency?: number | null;
     label: string;
     source_handle_id: string;
@@ -944,9 +942,8 @@ export declare namespace DeploymentMapNodeDataSerializer {
 
 export const InlineMapNodeDataSerializer: ObjectSchema<
   InlineMapNodeDataSerializer.Raw,
-  InlineMapNodeData
+  Omit<InlineMapNodeData, "variant">
 > = objectSchema({
-  variant: stringLiteralSchema("INLINE"),
   workflowRawData: propertySchema(
     "workflow_raw_data",
     lazy(() => WorkflowRawDataSerializer)
@@ -971,7 +968,6 @@ export const InlineMapNodeDataSerializer: ObjectSchema<
 
 export declare namespace InlineMapNodeDataSerializer {
   interface Raw {
-    variant: "INLINE";
     workflow_raw_data: WorkflowRawDataSerializer.Raw;
     input_variables: VellumVariableSerializer.Raw[];
     output_variables: VellumVariableSerializer.Raw[];
@@ -989,10 +985,10 @@ export declare namespace InlineMapNodeDataSerializer {
 export const MapNodeDataSerializer: Schema<
   MapNodeDataSerializer.Raw,
   MapNodeData
-> = undiscriminatedUnionSchema([
-  InlineMapNodeDataSerializer,
-  DeploymentMapNodeDataSerializer,
-]);
+> = union("variant", {
+  INLINE: InlineMapNodeDataSerializer,
+  DEPLOYMENT: DeploymentMapNodeDataSerializer,
+});
 
 export declare namespace MapNodeDataSerializer {
   type Raw =


### PR DESCRIPTION
We previously were using undiscriminated unions in our serializers, making serialization errors verbose and hard to debug. The hope is that by using discriminated unions, we get more direct error messages.