### PR TITLE
Remove new graph gen feature flag

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -18,24 +18,6 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
-exports[`Workflow > write > graph > should be correct for a basic conditional node case 2`] = `
-"from vellum.workflows import BaseWorkflow
-from .nodes.conditional_node import ConditionalNode
-from .nodes.templating_node import TemplatingNode
-from .nodes.templating_node_2 import TemplatingNode2
-
-
-class TestWorkflow(BaseWorkflow):
-    graph = {
-        ConditionalNode.Ports.branch_1 >> TemplatingNode,
-        ConditionalNode.Ports.branch_2 >> TemplatingNode2,
-    }
-
-    class Outputs(BaseWorkflow.Outputs):
-        pass
-"
-`;
-
 exports[`Workflow > write > graph > should be correct for a basic merge node and an additional edge 1`] = `
 "from vellum.workflows import BaseWorkflow
 from .nodes.templating_node import TemplatingNode
@@ -95,37 +77,7 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
-exports[`Workflow > write > graph > should be correct for a basic single edge case 2`] = `
-"from vellum.workflows import BaseWorkflow
-from .nodes.templating_node import TemplatingNode
-from .nodes.templating_node_2 import TemplatingNode2
-
-
-class TestWorkflow(BaseWorkflow):
-    graph = TemplatingNode >> TemplatingNode2
-
-    class Outputs(BaseWorkflow.Outputs):
-        pass
-"
-`;
-
 exports[`Workflow > write > graph > should be correct for a basic single node case 1`] = `
-"from vellum.workflows import BaseWorkflow
-from .inputs import Inputs
-from vellum.workflows.state import BaseState
-from .nodes.search_node import SearchNode
-from .nodes.final_output import FinalOutput
-
-
-class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
-    graph = SearchNode
-
-    class Outputs(BaseWorkflow.Outputs):
-        query = FinalOutput.Outputs.value
-"
-`;
-
-exports[`Workflow > write > graph > should be correct for a basic single node case 2`] = `
 "from vellum.workflows import BaseWorkflow
 from .inputs import Inputs
 from vellum.workflows.state import BaseState
@@ -156,37 +108,7 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
-exports[`Workflow > write > graph > should be correct for a longer branch 2`] = `
-"from vellum.workflows import BaseWorkflow
-from .nodes.templating_node import TemplatingNode
-from .nodes.templating_node_2 import TemplatingNode2
-from .nodes.templating_node_3 import TemplatingNode3
-
-
-class TestWorkflow(BaseWorkflow):
-    graph = TemplatingNode >> TemplatingNode2 >> TemplatingNode3
-
-    class Outputs(BaseWorkflow.Outputs):
-        pass
-"
-`;
-
 exports[`Workflow > write > graph > should be correct for set a node to a set 1`] = `
-"from vellum.workflows import BaseWorkflow
-from .nodes.templating_node import TemplatingNode
-from .nodes.templating_node_2 import TemplatingNode2
-from .nodes.templating_node_3 import TemplatingNode3
-
-
-class TestWorkflow(BaseWorkflow):
-    graph = TemplatingNode >> {TemplatingNode2, TemplatingNode3}
-
-    class Outputs(BaseWorkflow.Outputs):
-        pass
-"
-`;
-
-exports[`Workflow > write > graph > should be correct for set a node to a set 2`] = `
 "from vellum.workflows import BaseWorkflow
 from .nodes.templating_node import TemplatingNode
 from .nodes.templating_node_2 import TemplatingNode2

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -45,9 +45,7 @@ describe("WorkflowProjectGenerator", () => {
           "simple_conditional_node",
           "simple_templating_node",
           "simple_error_node",
-          // TODO: Get Merge Node graph codegen working
-          //    https://app.shortcut.com/vellum/story/5588
-          // "simple_merge_node",
+          "simple_merge_node",
         ],
         fixtureMocks: fixtureMocks,
       })

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -147,57 +147,53 @@ describe("Workflow", () => {
     });
 
     describe("graph", () => {
-      it.each([[true], [false]])(
-        "should be correct for a basic single node case",
-        async (breadthFirstGraphGeneration) => {
-          workflowContext.addInputVariableContext(
-            inputVariableContextFactory({
-              inputVariableData: {
-                id: "input-variable-id",
-                key: "query",
-                type: "STRING",
-              },
-              workflowContext,
-            })
-          );
-
-          const inputs = codegen.inputs({ workflowContext });
-
-          workflowContext.addWorkflowOutputContext(
-            workflowOutputContextFactory()
-          );
-
-          const searchNodeData = searchNodeDataFactory();
-          const searchNodeContext = await createNodeContext({
-            workflowContext: workflowContext,
-            nodeData: searchNodeData,
-          });
-          workflowContext.addNodeContext(searchNodeContext);
-
-          const edges: WorkflowEdge[] = [
-            {
-              id: "edge-1",
-              type: "DEFAULT",
-              sourceNodeId: entrypointNode.id,
-              sourceHandleId: entrypointNode.data.sourceHandleId,
-              targetNodeId: searchNodeData.id,
-              targetHandleId: searchNodeData.data.sourceHandleId,
+      it("should be correct for a basic single node case", async () => {
+        workflowContext.addInputVariableContext(
+          inputVariableContextFactory({
+            inputVariableData: {
+              id: "input-variable-id",
+              key: "query",
+              type: "STRING",
             },
-          ];
-          workflowContext.addWorkflowEdges(edges);
-
-          const workflow = codegen.workflow({
-            moduleName,
             workflowContext,
-            inputs,
-            nodes: [searchNodeData],
-            breadthFirstGraphGeneration,
-          });
+          })
+        );
 
-          workflow.getWorkflowFile().write(writer);
-          expect(await writer.toStringFormatted()).toMatchSnapshot();
-        }
-      );
+        const inputs = codegen.inputs({ workflowContext });
+
+        workflowContext.addWorkflowOutputContext(
+          workflowOutputContextFactory()
+        );
+
+        const searchNodeData = searchNodeDataFactory();
+        const searchNodeContext = await createNodeContext({
+          workflowContext: workflowContext,
+          nodeData: searchNodeData,
+        });
+        workflowContext.addNodeContext(searchNodeContext);
+
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: searchNodeData.id,
+            targetHandleId: searchNodeData.data.sourceHandleId,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
+
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [searchNodeData],
+        });
+
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
 
       it("should be correct for a basic multiple nodes case", async () => {
         const inputs = codegen.inputs({ workflowContext });
@@ -246,71 +242,64 @@ describe("Workflow", () => {
           workflowContext,
           inputs,
           nodes: [templatingNodeData1, templatingNodeData2],
-          // This test case fails with the legacy graph generation algorithm
-          // so we don't parameterize over it.
-          breadthFirstGraphGeneration: true,
         });
 
         workflow.getWorkflowFile().write(writer);
         expect(await writer.toStringFormatted()).toMatchSnapshot();
       });
 
-      it.each([[true], [false]])(
-        "should be correct for a basic single edge case",
-        async (breadthFirstGraphGeneration) => {
-          const inputs = codegen.inputs({ workflowContext });
+      it("should be correct for a basic single edge case", async () => {
+        const inputs = codegen.inputs({ workflowContext });
 
-          const templatingNodeData1 = templatingNodeFactory();
-          const templatingNodeContext1 = await createNodeContext({
-            workflowContext,
-            nodeData: templatingNodeData1,
-          });
-          workflowContext.addNodeContext(templatingNodeContext1);
+        const templatingNodeData1 = templatingNodeFactory();
+        const templatingNodeContext1 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData1,
+        });
+        workflowContext.addNodeContext(templatingNodeContext1);
 
-          const templatingNodeData2 = templatingNodeFactory({
-            id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
-            label: "Templating Node 2",
-            sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
-            targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
-          });
-          const templatingNodeContext2 = await createNodeContext({
-            workflowContext,
-            nodeData: templatingNodeData2,
-          });
-          workflowContext.addNodeContext(templatingNodeContext2);
+        const templatingNodeData2 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+          label: "Templating Node 2",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+        });
+        const templatingNodeContext2 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData2,
+        });
+        workflowContext.addNodeContext(templatingNodeContext2);
 
-          const edges: WorkflowEdge[] = [
-            {
-              id: "edge-1",
-              type: "DEFAULT",
-              sourceNodeId: entrypointNode.id,
-              sourceHandleId: entrypointNode.data.sourceHandleId,
-              targetNodeId: templatingNodeData1.id,
-              targetHandleId: templatingNodeData1.data.targetHandleId,
-            },
-            {
-              id: "edge-2",
-              type: "DEFAULT",
-              sourceNodeId: templatingNodeData1.id,
-              sourceHandleId: templatingNodeData1.data.sourceHandleId,
-              targetNodeId: templatingNodeData2.id,
-              targetHandleId: templatingNodeData2.data.targetHandleId,
-            },
-          ];
-          workflowContext.addWorkflowEdges(edges);
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData1.id,
+            targetHandleId: templatingNodeData1.data.targetHandleId,
+          },
+          {
+            id: "edge-2",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData1.id,
+            sourceHandleId: templatingNodeData1.data.sourceHandleId,
+            targetNodeId: templatingNodeData2.id,
+            targetHandleId: templatingNodeData2.data.targetHandleId,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
 
-          const workflow = codegen.workflow({
-            moduleName,
-            workflowContext,
-            inputs,
-            nodes: [templatingNodeData1, templatingNodeData2],
-            breadthFirstGraphGeneration,
-          });
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [templatingNodeData1, templatingNodeData2],
+        });
 
-          workflow.getWorkflowFile().write(writer);
-          expect(await writer.toStringFormatted()).toMatchSnapshot();
-        }
-      );
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
 
       it("should be correct for a basic merge node case", async () => {
         const inputs = codegen.inputs({ workflowContext });
@@ -387,9 +376,6 @@ describe("Workflow", () => {
           workflowContext,
           inputs,
           nodes: [templatingNodeData1, templatingNodeData2, mergeNodeData],
-          // This test case fails with the legacy graph generation algorithm
-          // so we don't parameterize over it.
-          breadthFirstGraphGeneration: true,
         });
 
         workflow.getWorkflowFile().write(writer);
@@ -496,178 +482,167 @@ describe("Workflow", () => {
             mergeNodeData,
             templatingNodeData3,
           ],
-          // This test case fails with the legacy graph generation algorithm
-          // so we don't parameterize over it.
-          breadthFirstGraphGeneration: true,
         });
 
         workflow.getWorkflowFile().write(writer);
         expect(await writer.toStringFormatted()).toMatchSnapshot();
       });
 
-      it.each([[true], [false]])(
-        "should be correct for a basic conditional node case",
-        async (breadthFirstGraphGeneration) => {
-          const inputs = codegen.inputs({ workflowContext });
+      it("should be correct for a basic conditional node case", async () => {
+        const inputs = codegen.inputs({ workflowContext });
 
-          const templatingNodeData1 = templatingNodeFactory();
-          const templatingNodeContext1 = await createNodeContext({
-            workflowContext,
-            nodeData: templatingNodeData1,
-          });
-          workflowContext.addNodeContext(templatingNodeContext1);
+        const templatingNodeData1 = templatingNodeFactory();
+        const templatingNodeContext1 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData1,
+        });
+        workflowContext.addNodeContext(templatingNodeContext1);
 
-          const templatingNodeData2 = templatingNodeFactory({
-            id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
-            label: "Templating Node 2",
-            sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
-            targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
-          });
-          const templatingNodeContext2 = await createNodeContext({
-            workflowContext,
-            nodeData: templatingNodeData2,
-          });
-          workflowContext.addNodeContext(templatingNodeContext2);
+        const templatingNodeData2 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+          label: "Templating Node 2",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+        });
+        const templatingNodeContext2 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData2,
+        });
+        workflowContext.addNodeContext(templatingNodeContext2);
 
-          const conditionalNodeData = conditionalNodeFactory();
-          const conditionalNodeContext = await createNodeContext({
-            workflowContext,
-            nodeData: conditionalNodeData,
-          });
-          workflowContext.addNodeContext(conditionalNodeContext);
-          const conditionalSourceHandle1 =
-            conditionalNodeData.data.conditions[0]?.sourceHandleId;
-          const conditionalSourceHandle2 =
-            conditionalNodeData.data.conditions[1]?.sourceHandleId;
-          if (!conditionalSourceHandle1 || !conditionalSourceHandle2) {
-            throw new Error("Handle IDs are required");
-          }
-
-          const edges: WorkflowEdge[] = [
-            {
-              id: "edge-1",
-              type: "DEFAULT",
-              sourceNodeId: entrypointNode.id,
-              sourceHandleId: entrypointNode.data.sourceHandleId,
-              targetNodeId: conditionalNodeData.id,
-              targetHandleId: conditionalNodeData.data.targetHandleId,
-            },
-            {
-              id: "edge-2",
-              type: "DEFAULT",
-              sourceNodeId: conditionalNodeData.id,
-              sourceHandleId: conditionalSourceHandle1,
-              targetNodeId: templatingNodeData1.id,
-              targetHandleId: templatingNodeData1.data.targetHandleId,
-            },
-            {
-              id: "edge-3",
-              type: "DEFAULT",
-              sourceNodeId: conditionalNodeData.id,
-              sourceHandleId: conditionalSourceHandle2,
-              targetNodeId: templatingNodeData2.id,
-              targetHandleId: templatingNodeData2.data.targetHandleId,
-            },
-          ];
-          workflowContext.addWorkflowEdges(edges);
-
-          const workflow = codegen.workflow({
-            moduleName,
-            workflowContext,
-            inputs,
-            nodes: [
-              conditionalNodeData,
-              templatingNodeData1,
-              templatingNodeData2,
-            ],
-            breadthFirstGraphGeneration,
-          });
-
-          workflow.getWorkflowFile().write(writer);
-          expect(await writer.toStringFormatted()).toMatchSnapshot();
+        const conditionalNodeData = conditionalNodeFactory();
+        const conditionalNodeContext = await createNodeContext({
+          workflowContext,
+          nodeData: conditionalNodeData,
+        });
+        workflowContext.addNodeContext(conditionalNodeContext);
+        const conditionalSourceHandle1 =
+          conditionalNodeData.data.conditions[0]?.sourceHandleId;
+        const conditionalSourceHandle2 =
+          conditionalNodeData.data.conditions[1]?.sourceHandleId;
+        if (!conditionalSourceHandle1 || !conditionalSourceHandle2) {
+          throw new Error("Handle IDs are required");
         }
-      );
 
-      it.each([[true], [false]])(
-        "should be correct for a longer branch",
-        async (breadthFirstGraphGeneration) => {
-          const inputs = codegen.inputs({ workflowContext });
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: conditionalNodeData.id,
+            targetHandleId: conditionalNodeData.data.targetHandleId,
+          },
+          {
+            id: "edge-2",
+            type: "DEFAULT",
+            sourceNodeId: conditionalNodeData.id,
+            sourceHandleId: conditionalSourceHandle1,
+            targetNodeId: templatingNodeData1.id,
+            targetHandleId: templatingNodeData1.data.targetHandleId,
+          },
+          {
+            id: "edge-3",
+            type: "DEFAULT",
+            sourceNodeId: conditionalNodeData.id,
+            sourceHandleId: conditionalSourceHandle2,
+            targetNodeId: templatingNodeData2.id,
+            targetHandleId: templatingNodeData2.data.targetHandleId,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
 
-          const templatingNodeData1 = templatingNodeFactory();
-          const templatingNodeContext1 = await createNodeContext({
-            workflowContext,
-            nodeData: templatingNodeData1,
-          });
-          workflowContext.addNodeContext(templatingNodeContext1);
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [
+            conditionalNodeData,
+            templatingNodeData1,
+            templatingNodeData2,
+          ],
+        });
 
-          const templatingNodeData2 = templatingNodeFactory({
-            id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
-            label: "Templating Node 2",
-            sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
-            targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
-          });
-          const templatingNodeContext2 = await createNodeContext({
-            workflowContext,
-            nodeData: templatingNodeData2,
-          });
-          workflowContext.addNodeContext(templatingNodeContext2);
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
 
-          const templatingNodeData3 = templatingNodeFactory({
-            id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
-            label: "Templating Node 3",
-            sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
-            targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
-          });
-          const templatingNodeContext3 = await createNodeContext({
-            workflowContext,
-            nodeData: templatingNodeData3,
-          });
-          workflowContext.addNodeContext(templatingNodeContext3);
+      it("should be correct for a longer branch", async () => {
+        const inputs = codegen.inputs({ workflowContext });
 
-          const edges: WorkflowEdge[] = [
-            {
-              id: "edge-1",
-              type: "DEFAULT",
-              sourceNodeId: entrypointNode.id,
-              sourceHandleId: entrypointNode.data.sourceHandleId,
-              targetNodeId: templatingNodeData1.id,
-              targetHandleId: templatingNodeData1.data.targetHandleId,
-            },
-            {
-              id: "edge-2",
-              type: "DEFAULT",
-              sourceNodeId: templatingNodeData1.id,
-              sourceHandleId: templatingNodeData1.data.sourceHandleId,
-              targetNodeId: templatingNodeData2.id,
-              targetHandleId: templatingNodeData2.data.targetHandleId,
-            },
-            {
-              id: "edge-3",
-              type: "DEFAULT",
-              sourceNodeId: templatingNodeData2.id,
-              sourceHandleId: templatingNodeData2.data.sourceHandleId,
-              targetNodeId: templatingNodeData3.id,
-              targetHandleId: templatingNodeData3.data.targetHandleId,
-            },
-          ];
-          workflowContext.addWorkflowEdges(edges);
+        const templatingNodeData1 = templatingNodeFactory();
+        const templatingNodeContext1 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData1,
+        });
+        workflowContext.addNodeContext(templatingNodeContext1);
 
-          const workflow = codegen.workflow({
-            moduleName,
-            workflowContext,
-            inputs,
-            nodes: [
-              templatingNodeData1,
-              templatingNodeData2,
-              templatingNodeData3,
-            ],
-            breadthFirstGraphGeneration,
-          });
+        const templatingNodeData2 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+          label: "Templating Node 2",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+        });
+        const templatingNodeContext2 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData2,
+        });
+        workflowContext.addNodeContext(templatingNodeContext2);
 
-          workflow.getWorkflowFile().write(writer);
-          expect(await writer.toStringFormatted()).toMatchSnapshot();
-        }
-      );
+        const templatingNodeData3 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
+          label: "Templating Node 3",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
+        });
+        const templatingNodeContext3 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData3,
+        });
+        workflowContext.addNodeContext(templatingNodeContext3);
+
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData1.id,
+            targetHandleId: templatingNodeData1.data.targetHandleId,
+          },
+          {
+            id: "edge-2",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData1.id,
+            sourceHandleId: templatingNodeData1.data.sourceHandleId,
+            targetNodeId: templatingNodeData2.id,
+            targetHandleId: templatingNodeData2.data.targetHandleId,
+          },
+          {
+            id: "edge-3",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData2.id,
+            sourceHandleId: templatingNodeData2.data.sourceHandleId,
+            targetNodeId: templatingNodeData3.id,
+            targetHandleId: templatingNodeData3.data.targetHandleId,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
+
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [
+            templatingNodeData1,
+            templatingNodeData2,
+            templatingNodeData3,
+          ],
+        });
+
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
 
       it("should be correct for set of a branch and a node", async () => {
         const inputs = codegen.inputs({ workflowContext });
@@ -740,95 +715,88 @@ describe("Workflow", () => {
             templatingNodeData2,
             templatingNodeData3,
           ],
-          // This test case fails with the legacy graph generation algorithm
-          // so we don't parameterize over it.
-          breadthFirstGraphGeneration: true,
         });
 
         workflow.getWorkflowFile().write(writer);
         expect(await writer.toStringFormatted()).toMatchSnapshot();
       });
 
-      it.each([[true], [false]])(
-        "should be correct for set a node to a set",
-        async (breadthFirstGraphGeneration) => {
-          const inputs = codegen.inputs({ workflowContext });
+      it("should be correct for set a node to a set", async () => {
+        const inputs = codegen.inputs({ workflowContext });
 
-          const templatingNodeData1 = templatingNodeFactory();
-          const templatingNodeContext1 = await createNodeContext({
-            workflowContext,
-            nodeData: templatingNodeData1,
-          });
-          workflowContext.addNodeContext(templatingNodeContext1);
+        const templatingNodeData1 = templatingNodeFactory();
+        const templatingNodeContext1 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData1,
+        });
+        workflowContext.addNodeContext(templatingNodeContext1);
 
-          const templatingNodeData2 = templatingNodeFactory({
-            id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
-            label: "Templating Node 2",
-            sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
-            targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
-          });
-          const templatingNodeContext2 = await createNodeContext({
-            workflowContext,
-            nodeData: templatingNodeData2,
-          });
-          workflowContext.addNodeContext(templatingNodeContext2);
+        const templatingNodeData2 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+          label: "Templating Node 2",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+        });
+        const templatingNodeContext2 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData2,
+        });
+        workflowContext.addNodeContext(templatingNodeContext2);
 
-          const templatingNodeData3 = templatingNodeFactory({
-            id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
-            label: "Templating Node 3",
-            sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
-            targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
-          });
-          const templatingNodeContext3 = await createNodeContext({
-            workflowContext,
-            nodeData: templatingNodeData3,
-          });
-          workflowContext.addNodeContext(templatingNodeContext3);
+        const templatingNodeData3 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
+          label: "Templating Node 3",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
+        });
+        const templatingNodeContext3 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData3,
+        });
+        workflowContext.addNodeContext(templatingNodeContext3);
 
-          const edges: WorkflowEdge[] = [
-            {
-              id: "edge-1",
-              type: "DEFAULT",
-              sourceNodeId: entrypointNode.id,
-              sourceHandleId: entrypointNode.data.sourceHandleId,
-              targetNodeId: templatingNodeData1.id,
-              targetHandleId: templatingNodeData1.data.targetHandleId,
-            },
-            {
-              id: "edge-2",
-              type: "DEFAULT",
-              sourceNodeId: templatingNodeData1.id,
-              sourceHandleId: templatingNodeData1.data.sourceHandleId,
-              targetNodeId: templatingNodeData2.id,
-              targetHandleId: templatingNodeData2.data.targetHandleId,
-            },
-            {
-              id: "edge-3",
-              type: "DEFAULT",
-              sourceNodeId: templatingNodeData1.id,
-              sourceHandleId: templatingNodeData1.data.sourceHandleId,
-              targetNodeId: templatingNodeData3.id,
-              targetHandleId: templatingNodeData3.data.targetHandleId,
-            },
-          ];
-          workflowContext.addWorkflowEdges(edges);
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData1.id,
+            targetHandleId: templatingNodeData1.data.targetHandleId,
+          },
+          {
+            id: "edge-2",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData1.id,
+            sourceHandleId: templatingNodeData1.data.sourceHandleId,
+            targetNodeId: templatingNodeData2.id,
+            targetHandleId: templatingNodeData2.data.targetHandleId,
+          },
+          {
+            id: "edge-3",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData1.id,
+            sourceHandleId: templatingNodeData1.data.sourceHandleId,
+            targetNodeId: templatingNodeData3.id,
+            targetHandleId: templatingNodeData3.data.targetHandleId,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
 
-          const workflow = codegen.workflow({
-            moduleName,
-            workflowContext,
-            inputs,
-            nodes: [
-              templatingNodeData1,
-              templatingNodeData2,
-              templatingNodeData3,
-            ],
-            breadthFirstGraphGeneration,
-          });
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [
+            templatingNodeData1,
+            templatingNodeData2,
+            templatingNodeData3,
+          ],
+        });
 
-          workflow.getWorkflowFile().write(writer);
-          expect(await writer.toStringFormatted()).toMatchSnapshot();
-        }
-      );
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
     });
   });
 });

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/workflow.py
@@ -8,10 +8,7 @@ from .nodes.templating_node_3 import TemplatingNode3
 
 
 class Workflow(BaseWorkflow):
-    graph = {
-        TemplatingNode2 >> MergeNode >> TemplatingNode3 >> FinalOutput,
-        TemplatingNode1 >> MergeNode >> TemplatingNode3 >> FinalOutput,
-    }
+    graph = {TemplatingNode2, TemplatingNode1} >> MergeNode >> TemplatingNode3 >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
         final_output = FinalOutput.Outputs.value


### PR DESCRIPTION
Removes the Graph gen feature flag to cut over to the new algo.

Note that we are not yet guaranteeing that we could generate _all_ graphs. just that we are now at least a superset of the old algo. Will leave this one up for review while I continue bashing more test cases and productionizing in parallel