### PR TITLE
Setup test & implementation for new workflow state snapshot events

### DIFF
--- a/src/vellum/workflows/state/base.py
+++ b/src/vellum/workflows/state/base.py
@@ -192,7 +192,6 @@ class StateMeta(UniversalBaseModel):
     node_outputs: Dict[OutputReference, Any] = field(default_factory=dict)
     node_execution_cache: NodeExecutionCache = field(default_factory=NodeExecutionCache)
     parent: Optional["BaseState"] = None
-    is_terminated: Optional[bool] = None
     __snapshot_callback__: Optional[Callable[[], None]] = field(init=False, default=None)
 
     def model_post_init(self, context: Any) -> None:
@@ -286,7 +285,6 @@ class BaseState(metaclass=_BaseStateMeta):
 {values}
     meta:
         id={self.meta.id}
-        is_terminated={self.meta.is_terminated}
         updated_ts={self.meta.updated_ts}
         node_outputs:{' Empty' if not node_outputs else ''}
 {node_outputs}

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -62,6 +62,8 @@ from vellum.workflows.events.workflow import (
     WorkflowExecutionRejectedEvent,
     WorkflowExecutionResumedBody,
     WorkflowExecutionResumedEvent,
+    WorkflowExecutionSnapshottedBody,
+    WorkflowExecutionSnapshottedEvent,
     WorkflowExecutionStreamingBody,
     WorkflowExecutionStreamingEvent,
 )
@@ -102,6 +104,7 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
         GenericWorkflowEvent,
         WorkflowExecutionInitiatedEvent[WorkflowInputsType],  # type: ignore[valid-type]
         WorkflowExecutionFulfilledEvent[Outputs],
+        WorkflowExecutionSnapshottedEvent[StateType],  # type: ignore[valid-type]
     ]
 
     TerminalWorkflowEvent = Union[
@@ -121,9 +124,7 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
     ):
         self._parent_state = parent_state
         self.emitters = emitters or (self.emitters if hasattr(self, "emitters") else [])
-        self.resolvers = resolvers or (
-            self.resolvers if hasattr(self, "resolvers") else []
-        )
+        self.resolvers = resolvers or (self.resolvers if hasattr(self, "resolvers") else [])
         self._context = context or WorkflowContext()
         self._store = Store()
 
@@ -140,8 +141,7 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
             return [original_graph]
         if isinstance(original_graph, set):
             return [
-                subgraph if isinstance(subgraph, Graph) else Graph.from_node(subgraph)
-                for subgraph in original_graph
+                subgraph if isinstance(subgraph, Graph) else Graph.from_node(subgraph) for subgraph in original_graph
             ]
         if issubclass(original_graph, BaseNode):
             return [Graph.from_node(original_graph)]
@@ -198,15 +198,10 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
             cancel_signal=cancel_signal,
             parent_context=self._context.parent_context,
         ).stream()
-        first_event: Optional[
-            Union[WorkflowExecutionInitiatedEvent, WorkflowExecutionResumedEvent]
-        ] = None
+        first_event: Optional[Union[WorkflowExecutionInitiatedEvent, WorkflowExecutionResumedEvent]] = None
         last_event = None
         for event in events:
-            if (
-                event.name == "workflow.execution.initiated"
-                or event.name == "workflow.execution.resumed"
-            ):
+            if event.name == "workflow.execution.initiated" or event.name == "workflow.execution.resumed":
                 first_event = event
             last_event = event
 
@@ -257,9 +252,7 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
 
     def stream(
         self,
-        event_filter: Optional[
-            Callable[[Type["BaseWorkflow"], WorkflowEvent], bool]
-        ] = None,
+        event_filter: Optional[Callable[[Type["BaseWorkflow"], WorkflowEvent], bool]] = None,
         inputs: Optional[WorkflowInputsType] = None,
         state: Optional[StateType] = None,
         entrypoint_nodes: Optional[RunFromNodeArg] = None,
@@ -302,14 +295,10 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
             state_type = BaseState
 
         if not issubclass(inputs_type, BaseInputs):
-            raise ValueError(
-                f"Expected first type to be a subclass of BaseInputs, was: {inputs_type}"
-            )
+            raise ValueError(f"Expected first type to be a subclass of BaseInputs, was: {inputs_type}")
 
         if not issubclass(state_type, BaseState):
-            raise ValueError(
-                f"Expected second type to be a subclass of BaseState, was: {state_type}"
-            )
+            raise ValueError(f"Expected second type to be a subclass of BaseState, was: {state_type}")
 
         return (inputs_type, state_type)
 
@@ -324,9 +313,7 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
     def get_default_inputs(self) -> WorkflowInputsType:
         return self.get_inputs_class()()
 
-    def get_default_state(
-        self, workflow_inputs: Optional[WorkflowInputsType] = None
-    ) -> StateType:
+    def get_default_state(self, workflow_inputs: Optional[WorkflowInputsType] = None) -> StateType:
         return self.get_state_class()(
             meta=StateMeta(
                 parent=self._parent_state,
@@ -337,10 +324,7 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
     def get_state_at_node(self, node: Type[BaseNode]) -> StateType:
         event_ts = datetime.min
         for event in self._store.events:
-            if (
-                event.name == "node.execution.initiated"
-                and event.node_definition == node
-            ):
+            if event.name == "node.execution.initiated" and event.node_definition == node:
                 event_ts = event.timestamp
 
         most_recent_state_snapshot: Optional[StateType] = None
@@ -362,9 +346,7 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
             next_state = cast(StateType, snapshot)
             if not most_recent_state_snapshot:
                 most_recent_state_snapshot = next_state
-            elif (
-                next_state.meta.updated_ts >= most_recent_state_snapshot.meta.updated_ts
-            ):
+            elif next_state.meta.updated_ts >= most_recent_state_snapshot.meta.updated_ts:
                 most_recent_state_snapshot = next_state
 
         if not most_recent_state_snapshot:
@@ -402,6 +384,7 @@ WorkflowExecutionRejectedBody.model_rebuild()
 WorkflowExecutionPausedBody.model_rebuild()
 WorkflowExecutionResumedBody.model_rebuild()
 WorkflowExecutionStreamingBody.model_rebuild()
+WorkflowExecutionSnapshottedBody.model_rebuild()
 
 NodeExecutionInitiatedBody.model_rebuild()
 NodeExecutionFulfilledBody.model_rebuild()
@@ -416,6 +399,7 @@ WorkflowExecutionRejectedEvent.model_rebuild()
 WorkflowExecutionPausedEvent.model_rebuild()
 WorkflowExecutionResumedEvent.model_rebuild()
 WorkflowExecutionStreamingEvent.model_rebuild()
+WorkflowExecutionSnapshottedEvent.model_rebuild()
 
 NodeExecutionInitiatedEvent.model_rebuild()
 NodeExecutionFulfilledEvent.model_rebuild()

--- a/tests/workflows/basic_emitter_workflow/workflow.py
+++ b/tests/workflows/basic_emitter_workflow/workflow.py
@@ -1,5 +1,4 @@
 import json
-import time
 from typing import Iterator, List
 
 from vellum.workflows import BaseWorkflow

--- a/tests/workflows/basic_emitter_workflow/workflow.py
+++ b/tests/workflows/basic_emitter_workflow/workflow.py
@@ -1,4 +1,5 @@
 import json
+import time
 from typing import Iterator, List
 
 from vellum.workflows import BaseWorkflow

--- a/tests/workflows/basic_node_streaming/tests/test_workflow.py
+++ b/tests/workflows/basic_node_streaming/tests/test_workflow.py
@@ -20,7 +20,7 @@ def test_run_workflow__happy_path():
     # - A node is made up of one or more outputs, each of which emit initiated/streaming/fulfilled/rejected states
     #
     # This allows end users to have the option to either use values as they stream available or use just the end result.
-    assert len(events) == 14
+    assert len(events) == 16
 
     # AND each event should have the expected data
     assert events[0].name == "workflow.execution.initiated"
@@ -29,72 +29,75 @@ def test_run_workflow__happy_path():
     assert events[1].name == "node.execution.initiated"
     assert events[1].inputs == {StreamingNode.foo: "Hello"}
 
-    assert events[2].name == "node.execution.streaming"
-    assert events[2].output.is_initiated
-    assert events[2].output.name == "stream"
+    assert events[2].name == "workflow.execution.snapshotted"
 
-    assert events[3].name == "workflow.execution.streaming"
+    assert events[3].name == "node.execution.streaming"
     assert events[3].output.is_initiated
-    assert events[3].output.name == "outer_stream"
+    assert events[3].output.name == "stream"
 
-    assert events[4].name == "node.execution.streaming"
-    assert events[4].output.is_streaming
-    assert events[4].output.name == "stream"
-    assert events[4].output.delta == "Hello, world! 0"
+    assert events[4].name == "workflow.execution.streaming"
+    assert events[4].output.is_initiated
+    assert events[4].output.name == "outer_stream"
 
-    assert events[5].name == "workflow.execution.streaming"
+    assert events[5].name == "node.execution.streaming"
     assert events[5].output.is_streaming
-    assert events[5].output.name == "outer_stream"
+    assert events[5].output.name == "stream"
     assert events[5].output.delta == "Hello, world! 0"
 
-    assert events[6].name == "node.execution.streaming"
+    assert events[6].name == "workflow.execution.streaming"
     assert events[6].output.is_streaming
-    assert events[6].output.name == "stream"
-    assert events[6].output.delta == "Hello, world! 1"
+    assert events[6].output.name == "outer_stream"
+    assert events[6].output.delta == "Hello, world! 0"
 
-    assert events[7].name == "workflow.execution.streaming"
+    assert events[7].name == "node.execution.streaming"
     assert events[7].output.is_streaming
-    assert events[7].output.name == "outer_stream"
+    assert events[7].output.name == "stream"
     assert events[7].output.delta == "Hello, world! 1"
 
-    assert events[8].name == "node.execution.streaming"
+    assert events[8].name == "workflow.execution.streaming"
     assert events[8].output.is_streaming
-    assert events[8].output.name == "stream"
-    assert events[8].output.delta == "Hello, world! 2"
+    assert events[8].output.name == "outer_stream"
+    assert events[8].output.delta == "Hello, world! 1"
 
-    assert events[9].name == "workflow.execution.streaming"
+    assert events[9].name == "node.execution.streaming"
     assert events[9].output.is_streaming
-    assert events[9].output.name == "outer_stream"
+    assert events[9].output.name == "stream"
     assert events[9].output.delta == "Hello, world! 2"
 
-    assert events[10].name == "node.execution.streaming"
-    assert events[10].output.is_fulfilled
-    assert events[10].output.name == "stream"
-    assert events[10].output.value == [
-        "Hello, world! 0",
-        "Hello, world! 1",
-        "Hello, world! 2",
-    ]
+    assert events[10].name == "workflow.execution.streaming"
+    assert events[10].output.is_streaming
+    assert events[10].output.name == "outer_stream"
+    assert events[10].output.delta == "Hello, world! 2"
 
-    assert events[11].name == "workflow.execution.streaming"
+    assert events[11].name == "node.execution.streaming"
     assert events[11].output.is_fulfilled
-    assert events[11].output.name == "outer_stream"
+    assert events[11].output.name == "stream"
     assert events[11].output.value == [
         "Hello, world! 0",
         "Hello, world! 1",
         "Hello, world! 2",
     ]
 
-    assert events[12].name == "node.execution.fulfilled"
-    # https://app.shortcut.com/vellum/story/3985
-    assert events[12].outputs.stream == [
+    assert events[12].name == "workflow.execution.streaming"
+    assert events[12].output.is_fulfilled
+    assert events[12].output.name == "outer_stream"
+    assert events[12].output.value == [
         "Hello, world! 0",
         "Hello, world! 1",
         "Hello, world! 2",
     ]
 
-    assert events[13].name == "workflow.execution.fulfilled"
-    assert events[13].outputs.outer_stream == [
+    assert events[13].name == "workflow.execution.snapshotted"
+
+    assert events[14].name == "node.execution.fulfilled"
+    assert events[14].outputs.stream == [
+        "Hello, world! 0",
+        "Hello, world! 1",
+        "Hello, world! 2",
+    ]
+
+    assert events[15].name == "workflow.execution.fulfilled"
+    assert events[15].outputs.outer_stream == [
         "Hello, world! 0",
         "Hello, world! 1",
         "Hello, world! 2",

--- a/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
+++ b/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
@@ -26,9 +26,7 @@ def test_workflow_stream__happy_path():
     WrappedNode = InnerNode.__wrapped_node__
 
     # workflow initiated events
-    workflow_initiated_events = [
-        e for e in events if e.name == "workflow.execution.initiated"
-    ]
+    workflow_initiated_events = [e for e in events if e.name == "workflow.execution.initiated"]
     assert workflow_initiated_events[0].workflow_definition == StreamingTryExample
     assert workflow_initiated_events[0].parent is None
     assert workflow_initiated_events[1].workflow_definition == InnerWorkflow
@@ -42,9 +40,7 @@ def test_workflow_stream__happy_path():
     # node initiated events
     node_initiated_events = [e for e in events if e.name == "node.execution.initiated"]
     assert node_initiated_events[0].node_definition == InnerNode
-    assert node_initiated_events[0].model_dump(mode="json")["body"][
-        "node_definition"
-    ] == {
+    assert node_initiated_events[0].model_dump(mode="json")["body"]["node_definition"] == {
         "name": "TryNode",
         "module": [
             "tests",
@@ -57,22 +53,16 @@ def test_workflow_stream__happy_path():
     }
     assert node_initiated_events[0].parent is not None
     assert node_initiated_events[0].parent.type == "WORKFLOW"
-    assert node_initiated_events[
-        0
-    ].parent.workflow_definition == CodeResourceDefinition.encode(StreamingTryExample)
+    assert node_initiated_events[0].parent.workflow_definition == CodeResourceDefinition.encode(StreamingTryExample)
     assert node_initiated_events[1].node_definition == WrappedNode
     assert node_initiated_events[1].parent is not None
     assert node_initiated_events[1].parent.type == "WORKFLOW"
-    assert node_initiated_events[
-        1
-    ].parent.workflow_definition == CodeResourceDefinition.encode(InnerWorkflow)
+    assert node_initiated_events[1].parent.workflow_definition == CodeResourceDefinition.encode(InnerWorkflow)
     assert len(node_initiated_events) == 2
 
     # inner node streaming events
     inner_node_streaming_events = [
-        e
-        for e in events
-        if e.name == "node.execution.streaming" and e.node_definition == WrappedNode
+        e for e in events if e.name == "node.execution.streaming" and e.node_definition == WrappedNode
     ]
     assert inner_node_streaming_events[0].output.name == "processed"
     assert inner_node_streaming_events[0].output.is_initiated
@@ -88,10 +78,7 @@ def test_workflow_stream__happy_path():
 
     # inner workflow streaming events
     inner_workflow_streaming_events = [
-        e
-        for e in events
-        if e.name == "workflow.execution.streaming"
-        and e.workflow_definition == InnerWorkflow
+        e for e in events if e.name == "workflow.execution.streaming" and e.workflow_definition == InnerWorkflow
     ]
     assert inner_workflow_streaming_events[0].output.name == "processed"
     assert inner_workflow_streaming_events[0].output.is_initiated
@@ -107,9 +94,7 @@ def test_workflow_stream__happy_path():
 
     # outer node streaming events
     outer_node_streaming_events = [
-        e
-        for e in events
-        if e.name == "node.execution.streaming" and e.node_definition == InnerNode
+        e for e in events if e.name == "node.execution.streaming" and e.node_definition == InnerNode
     ]
     assert outer_node_streaming_events[0].output.name == "processed"
     assert outer_node_streaming_events[0].output.is_initiated
@@ -125,10 +110,7 @@ def test_workflow_stream__happy_path():
 
     # outer workflow streaming events
     outer_workflow_streaming_events = [
-        e
-        for e in events
-        if e.name == "workflow.execution.streaming"
-        and e.workflow_definition == StreamingTryExample
+        e for e in events if e.name == "workflow.execution.streaming" and e.workflow_definition == StreamingTryExample
     ]
     assert outer_workflow_streaming_events[0].output.name == "final_value"
     assert outer_workflow_streaming_events[0].output.is_initiated
@@ -159,13 +141,9 @@ def test_workflow_stream__happy_path():
     assert len(node_fulfilled_events) == 2
 
     # workflow fulfilled events
-    workflow_fulfilled_events = [
-        e for e in events if e.name == "workflow.execution.fulfilled"
-    ]
+    workflow_fulfilled_events = [e for e in events if e.name == "workflow.execution.fulfilled"]
     assert workflow_fulfilled_events[0].workflow_definition == InnerWorkflow
-    assert workflow_fulfilled_events[0].outputs == {
-        "processed": ["apple apple", "banana banana", "cherry cherry"]
-    }
+    assert workflow_fulfilled_events[0].outputs == {"processed": ["apple apple", "banana banana", "cherry cherry"]}
     assert workflow_fulfilled_events[1].workflow_definition == StreamingTryExample
     assert workflow_fulfilled_events[1].outputs.final_value == [
         "apple apple",
@@ -174,4 +152,9 @@ def test_workflow_stream__happy_path():
     ]
     assert len(workflow_fulfilled_events) == 2
 
-    assert len(events) == 28
+    # workflow snapshotted events
+    workflow_snapshotted_events = [e for e in events if e.name == "workflow.execution.snapshotted"]
+    assert len(workflow_snapshotted_events) == 4
+
+    # AND the total number of events is correct
+    assert len(events) == 32


### PR DESCRIPTION
This PR introduces `workflow.execution.snapshotted` events. They are responsible for emitting to the user what the state was at that moment in time. They will contain in its body the full state and are emitted whenever the state is updated. Some opinionated stances that were made and seeking feedback on:
- It will be the only `workflow.*` level event not emitted to the user by default
- adding the new status `snapshotted` as part of our `entity.action.status` spec.
- getting rid of the `meta.is_terminated` field within state. We first introduced this to make resume from node slightly easier, but have since found a workaround, and we are trying to keep all state updates to come from a node thread instead of a workflow thread.