### PR TITLE
Start injecting custom errors in response to orphaned node output id

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -15,6 +15,7 @@ import {
   SubworkflowNode,
   NoteNode,
   ErrorNode,
+  NodeInputValuePointerRule,
   PromptTemplateBlock,
 } from "src/types/vellum";
 
@@ -565,12 +566,14 @@ export function templatingNodeFactory({
   sourceHandleId,
   targetHandleId,
   errorOutputId,
+  inputRules,
 }: {
   id?: string;
   label?: string;
   sourceHandleId?: string;
   targetHandleId?: string;
   errorOutputId?: string;
+  inputRules?: NodeInputValuePointerRule[];
 } = {}): TemplatingNode {
   const nodeData: TemplatingNode = {
     id: id ?? "7e09927b-6d6f-4829-92c9-54e66bdcaf80",
@@ -589,7 +592,7 @@ export function templatingNodeFactory({
         id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
         key: "text",
         value: {
-          rules: [
+          rules: inputRules ?? [
             {
               type: "CONSTANT_VALUE",
               data: {

--- a/ee/codegen/src/__test__/nodes/base-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/base-node.test.ts
@@ -1,0 +1,42 @@
+import { workflowContextFactory } from "src/__test__/helpers";
+import { templatingNodeFactory } from "src/__test__/helpers/node-data-factories";
+import { createNodeContext } from "src/context";
+import { TemplatingNodeContext } from "src/context/node-context/templating-node";
+import { NodeAttributeGenerationError } from "src/generators/errors";
+import { TemplatingNode } from "src/generators/nodes/templating-node";
+
+describe("BaseNode", () => {
+  describe("failures", () => {
+    it("should throw the expected error when a input references an invalid node", async () => {
+      const workflowContext = workflowContextFactory();
+
+      const templatingNodeData = templatingNodeFactory({
+        inputRules: [
+          {
+            type: "NODE_OUTPUT",
+            data: {
+              nodeId: "12345678-1234-5678-1234-567812345678",
+              outputId: "90abcdef-90ab-cdef-90ab-cdef90abcdef",
+            },
+          },
+        ],
+      });
+      const templatingNodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData: templatingNodeData,
+      })) as TemplatingNodeContext;
+      workflowContext.addNodeContext(templatingNodeContext);
+
+      expect(() => {
+        new TemplatingNode({
+          workflowContext,
+          nodeContext: templatingNodeContext,
+        });
+      }).toThrow(
+        new NodeAttributeGenerationError(
+          "Failed to generate attribute 'TemplatingNode.inputs.text': Failed to find node with id '12345678-1234-5678-1234-567812345678'"
+        )
+      );
+    });
+  });
+});

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -7,6 +7,7 @@ import { PortContext } from "src/context/port-context";
 import { generateSdkModulePaths } from "src/context/workflow-context/sdk-module-paths";
 import { SDK_MODULE_PATHS } from "src/context/workflow-context/types";
 import { WorkflowOutputContext } from "src/context/workflow-output-context";
+import { NodeNotFoundError } from "src/generators/errors";
 import { BaseNode } from "src/generators/nodes/bases";
 import {
   EntrypointNode,
@@ -208,7 +209,7 @@ export class WorkflowContext {
     const nodeContext = this.nodeContextsByNodeId.get(nodeId);
 
     if (!nodeContext) {
-      throw new Error(`Node context not found for node ID: ${nodeId}`);
+      throw new NodeNotFoundError(`Failed to find node with id '${nodeId}'`);
     }
 
     return nodeContext as BaseNodeContext<T>;
@@ -235,8 +236,9 @@ export class WorkflowContext {
   }
 
   public async getMLModelNameById(mlModelId: string): Promise<string> {
-    if (this.mlModelNamesById[mlModelId]) {
-      return this.mlModelNamesById[mlModelId];
+    const mlModelName = this.mlModelNamesById[mlModelId];
+    if (mlModelName) {
+      return mlModelName;
     }
 
     const mlModel = await new MlModels({ apiKey: this.vellumApiKey }).retrieve(

--- a/ee/codegen/src/generators/errors.ts
+++ b/ee/codegen/src/generators/errors.ts
@@ -1,0 +1,30 @@
+export type CodegenErrorCode =
+  | "PROJECT_SERIALIZATION_ERROR"
+  | "NODE_ATTRIBUTE_GENERATION_ERROR"
+  | "NODE_NOT_FOUND_ERROR";
+
+export abstract class BaseCodegenError extends Error {
+  abstract code: CodegenErrorCode;
+}
+
+/**
+ * An error that raises when deserializing the request to codegen
+ * into a valid Workflow project.
+ */
+export class ProjectSerializationError extends BaseCodegenError {
+  code = "PROJECT_SERIALIZATION_ERROR" as const;
+}
+
+/**
+ * An error that raises when generating a node attribute fails.
+ */
+export class NodeAttributeGenerationError extends BaseCodegenError {
+  code = "NODE_ATTRIBUTE_GENERATION_ERROR" as const;
+}
+
+/**
+ * An error that raises when a node is not found.
+ */
+export class NodeNotFoundError extends BaseCodegenError {
+  code = "NODE_NOT_FOUND_ERROR" as const;
+}

--- a/ee/codegen/src/generators/nodes/templating-node.ts
+++ b/ee/codegen/src/generators/nodes/templating-node.ts
@@ -4,7 +4,6 @@ import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { OUTPUTS_CLASS_NAME } from "src/constants";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import { BaseState } from "src/generators/base-state";
-import { NodeInputValuePointer } from "src/generators/node-inputs/node-input-value-pointer";
 import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base";
 import { TemplatingNode as TemplatingNodeType } from "src/types/vellum";
 import { getVellumVariablePrimitiveType } from "src/utils/vellum-variables";
@@ -31,8 +30,9 @@ export class TemplatingNode extends BaseSingleFileNode<
   protected getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 
-    const otherInputs = this.nodeData.inputs.filter(
-      (input) => input.id !== this.nodeData.data.templateNodeInputId
+    const otherInputs = Array.from(this.nodeInputsByKey.values()).filter(
+      (nodeInput) =>
+        nodeInput.nodeInputData.id !== this.nodeData.data.templateNodeInputId
     );
 
     statements.push(
@@ -46,12 +46,9 @@ export class TemplatingNode extends BaseSingleFileNode<
       python.field({
         name: "inputs",
         initializer: python.TypeInstantiation.dict(
-          otherInputs.map((input) => ({
-            key: python.TypeInstantiation.str(input.key),
-            value: new NodeInputValuePointer({
-              workflowContext: this.workflowContext,
-              nodeInputValuePointerData: input.value,
-            }),
+          otherInputs.map((codeInput) => ({
+            key: python.TypeInstantiation.str(codeInput.nodeInputData.key),
+            value: codeInput,
           }))
         ),
       })

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -17,6 +17,7 @@ import {
 import { createNodeContext, WorkflowContext } from "./context";
 import { InputVariableContext } from "./context/input-variable-context";
 import { InitFile, Inputs, Workflow } from "./generators";
+import { ProjectSerializationError } from "./generators/errors";
 import { BaseNode } from "./generators/nodes/bases";
 import { GuardrailNode } from "./generators/nodes/guardrail-node";
 import { InlineSubworkflowNode } from "./generators/nodes/inline-subworkflow-node";
@@ -64,10 +65,6 @@ import {
 } from "src/types/vellum";
 import { getNodeId } from "src/utils/nodes";
 import { assertUnreachable } from "src/utils/typing";
-
-export class ProjectSerializationError extends Error {
-  isProjectSerializationError = true;
-}
 
 export declare namespace WorkflowProjectGenerator {
   interface BaseArgs {


### PR DESCRIPTION
I first started by triaging this sentry error: https://vellum.sentry.io/issues/6114814120/?project=4508362703634432&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=7d&stream_index=0

I then realized I wanted to use this as an opportunity to start bubbling up custom errors that eventually results in a list of warnings for the user. 

This PR simply adds a test that replicates the situation posed by the sentry error, adding in some custom error classes. In a future PR, will then use this to parlay into codegen warnings so that we generate as much as possible