### PR TITLE
Creating a `workflows` subcommand for vellum push

### DIFF
--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -21,7 +21,7 @@ class PushGroup(ClickAliasedGroup):
         if cmd is not None:
             return cmd
 
-        # If no command found, treat the command name as a module
+        # If no command found, call our catch-all
         return push_module
 
 
@@ -30,7 +30,7 @@ class PushGroup(ClickAliasedGroup):
 def push(
     ctx: click.Context,
 ) -> None:
-    """Push to Vellum"""
+    """Push Resources to Vellum"""
 
     if ctx.invoked_subcommand is None:
         push_command()
@@ -38,12 +38,12 @@ def push(
 
 @push.command(name="workflows")
 @click.argument("module", required=False)
-@click.option("--deploy", is_flag=True, help="Deploy the workflow after pushing it to Vellum")
-@click.option("--deployment-label", type=str, help="Label to use for the deployment")
-@click.option("--deployment-name", type=str, help="Unique name for the deployment")
-@click.option("--deployment-description", type=str, help="Description for the deployment")
-@click.option("--release-tag", type=list, help="Release tag for the deployment", multiple=True)
-def push_workflow(
+@click.option("--deploy", is_flag=True, help="Deploy the Workflow after pushing it to Vellum")
+@click.option("--deployment-label", type=str, help="Label to use for the Deployment")
+@click.option("--deployment-name", type=str, help="Unique name for the Deployment")
+@click.option("--deployment-description", type=str, help="Description for the Deployment")
+@click.option("--release-tag", type=list, help="Release Tag for the Deployment", multiple=True)
+def push_workflows(
     module: Optional[str],
     deploy: Optional[bool],
     deployment_label: Optional[str],
@@ -51,6 +51,11 @@ def push_workflow(
     deployment_description: Optional[str],
     release_tag: Optional[List[str]],
 ) -> None:
+    """
+    Push Workflows to Vellum. If a module is provided, only the Workflow for that module will be pushed.
+    If no module is provided, the first configured Workflow will be pushed.
+    """
+
     push_command(
         module=module,
         deploy=deploy,
@@ -63,11 +68,11 @@ def push_workflow(
 
 @push.command(name="*", hidden=True)
 @click.pass_context
-@click.option("--deploy", is_flag=True, help="Deploy the workflow after pushing it to Vellum")
-@click.option("--deployment-label", type=str, help="Label to use for the deployment")
-@click.option("--deployment-name", type=str, help="Unique name for the deployment")
-@click.option("--deployment-description", type=str, help="Description for the deployment")
-@click.option("--release-tag", type=list, help="Release tag for the deployment", multiple=True)
+@click.option("--deploy", is_flag=True, help="Deploy the Resource after pushing it to Vellum")
+@click.option("--deployment-label", type=str, help="Label to use for the Deployment")
+@click.option("--deployment-name", type=str, help="Unique name for the Deployment")
+@click.option("--deployment-description", type=str, help="Description for the Deployment")
+@click.option("--release-tag", type=list, help="Release Tag for the Deployment", multiple=True)
 def push_module(
     ctx: click.Context,
     deploy: Optional[bool],
@@ -76,7 +81,8 @@ def push_module(
     deployment_description: Optional[str],
     release_tag: Optional[List[str]],
 ) -> None:
-    """Push any arbitrary module defined locally to Vellum"""
+    """Push a specific module to Vellum"""
+
     if ctx.parent:
         push_command(
             module=ctx.parent.invoked_subcommand,
@@ -118,7 +124,7 @@ def pull(
     include_json: Optional[bool],
     exclude_code: Optional[bool],
 ) -> None:
-    """Pull the first configured Resource from Vellum"""
+    """Pull Resources from Vellum"""
 
     if ctx.invoked_subcommand is None:
         pull_command(

--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -25,9 +25,9 @@ class PushGroup(ClickAliasedGroup):
         return push_module
 
 
-@main.group(name="push", invoke_without_command=True, cls=PushGroup)
+@main.group(invoke_without_command=True, cls=PushGroup)
 @click.pass_context
-def push_group(
+def push(
     ctx: click.Context,
 ) -> None:
     """Push to Vellum"""
@@ -36,7 +36,7 @@ def push_group(
         push_command()
 
 
-@push_group.command(name="workflow")
+@push.command(name="workflows")
 @click.argument("module", required=False)
 @click.option("--deploy", is_flag=True, help="Deploy the workflow after pushing it to Vellum")
 @click.option("--deployment-label", type=str, help="Label to use for the deployment")
@@ -61,7 +61,7 @@ def push_workflow(
     )
 
 
-@push_group.command(name="*", hidden=True)
+@push.command(name="*", hidden=True)
 @click.pass_context
 @click.option("--deploy", is_flag=True, help="Deploy the workflow after pushing it to Vellum")
 @click.option("--deployment-label", type=str, help="Label to use for the deployment")
@@ -77,14 +77,15 @@ def push_module(
     release_tag: Optional[List[str]],
 ) -> None:
     """Push any arbitrary module defined locally to Vellum"""
-    push_command(
-        module=ctx.invoked_subcommand,
-        deploy=deploy,
-        deployment_label=deployment_label,
-        deployment_name=deployment_name,
-        deployment_description=deployment_description,
-        release_tags=release_tag,
-    )
+    if ctx.parent:
+        push_command(
+            module=ctx.parent.invoked_subcommand,
+            deploy=deploy,
+            deployment_label=deployment_label,
+            deployment_name=deployment_name,
+            deployment_description=deployment_description,
+            release_tags=release_tag,
+        )
 
 
 class PullGroup(ClickAliasedGroup):

--- a/ee/vellum_cli/push.py
+++ b/ee/vellum_cli/push.py
@@ -20,12 +20,12 @@ from vellum_ee.workflows.display.workflows.vellum_workflow_display import Vellum
 
 
 def push_command(
-    module: Optional[str],
-    deploy: Optional[bool],
-    deployment_label: Optional[str],
-    deployment_name: Optional[str],
-    deployment_description: Optional[str],
-    release_tags: Optional[List[str]],
+    module: Optional[str] = None,
+    deploy: Optional[bool] = None,
+    deployment_label: Optional[str] = None,
+    deployment_name: Optional[str] = None,
+    deployment_description: Optional[str] = None,
+    release_tags: Optional[List[str]] = None,
 ) -> None:
     load_dotenv()
     logger = load_cli_logger()

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -1,3 +1,4 @@
+import pytest
 import io
 import os
 import tempfile
@@ -25,7 +26,15 @@ def _zip_file_map(file_map: dict[str, str]) -> bytes:
     return zip_bytes
 
 
-def test_pull(vellum_client, mock_module):
+@pytest.mark.parametrize(
+    "base_command",
+    [
+        ["pull"],
+        ["pull", "workflows"],
+    ],
+    ids=["pull", "pull_workflows"],
+)
+def test_pull(vellum_client, mock_module, base_command):
     # GIVEN a module on the user's filesystem
     temp_dir, module, _ = mock_module
 
@@ -34,7 +43,7 @@ def test_pull(vellum_client, mock_module):
 
     # WHEN the user runs the pull command
     runner = CliRunner()
-    result = runner.invoke(cli_main, ["pull", module])
+    result = runner.invoke(cli_main, base_command + [module])
 
     # THEN the command returns successfully
     assert result.exit_code == 0

--- a/ee/vellum_cli/tests/test_push.py
+++ b/ee/vellum_cli/tests/test_push.py
@@ -1,3 +1,4 @@
+import pytest
 import io
 import json
 import os
@@ -74,7 +75,15 @@ def test_push__multiple_workflows_configured__not_found_module(mock_module):
     assert str(result.exception) == f"No workflow config for '{module}' found in project to push."
 
 
-def test_push__happy_path(mock_module, vellum_client):
+@pytest.mark.parametrize(
+    "base_command",
+    [
+        ["push"],
+        ["push", "workflows"],
+    ],
+    ids=["push", "push_workflows"],
+)
+def test_push__happy_path(mock_module, vellum_client, base_command):
     # GIVEN a single workflow configured
     temp_dir, module, _ = mock_module
 
@@ -97,7 +106,7 @@ class ExampleWorkflow(BaseWorkflow):
 
     # WHEN calling `vellum push`
     runner = CliRunner()
-    result = runner.invoke(cli_main, ["push", module])
+    result = runner.invoke(cli_main, base_command + [module])
 
     # THEN it should succeed
     assert result.exit_code == 0
@@ -115,7 +124,15 @@ class ExampleWorkflow(BaseWorkflow):
     assert extracted_files["workflow.py"] == workflow_py_file_content
 
 
-def test_push__deployment(mock_module, vellum_client):
+@pytest.mark.parametrize(
+    "base_command",
+    [
+        ["push"],
+        ["push", "workflows"],
+    ],
+    ids=["push", "push_workflows"],
+)
+def test_push__deployment(mock_module, vellum_client, base_command):
     # GIVEN a single workflow configured
     temp_dir, module, _ = mock_module
 
@@ -138,7 +155,7 @@ class ExampleWorkflow(BaseWorkflow):
 
     # WHEN calling `vellum push`
     runner = CliRunner()
-    result = runner.invoke(cli_main, ["push", module, "--deploy"])
+    result = runner.invoke(cli_main, base_command + [module, "--deploy"])
 
     # THEN it should succeed
     assert result.exit_code == 0


### PR DESCRIPTION
This PR introduces support for:
- `vellum push workflows [module]` - push a specific workflow, as defined in config
- `vellum push [module]` - push a specific resource, as defined in config

In the near future, we plan to support:
- `vellum push` - push all of the resources
- `vellum push workflows` - push all of the workflows