### PR TITLE
Introduce function compilation

### DIFF
--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -1,0 +1,13 @@
+from typing import Callable
+
+from vellum.client.types.function_definition import FunctionDefinition
+
+
+def compile_function_definition(function: Callable) -> FunctionDefinition:
+    """
+    Converts a Python function into our Vellum-native FunctionDefinition type.
+    """
+
+    return FunctionDefinition(
+        name=function.__name__,
+    )

--- a/src/vellum/workflows/utils/tests/test_functions.py
+++ b/src/vellum/workflows/utils/tests/test_functions.py
@@ -1,0 +1,16 @@
+from vellum.client.types.function_definition import FunctionDefinition
+from vellum.workflows.utils.functions import compile_function_definition
+
+
+def test_compile_function_definition__just_name():
+    # GIVEN a function with just a name
+    def my_function():
+        pass
+
+    # WHEN compiling the function
+    compiled_function = compile_function_definition(my_function)
+
+    # THEN it should return the compiled function definition
+    assert compiled_function == FunctionDefinition(
+        name="my_function",
+    )


### PR DESCRIPTION
This PR introduces the utility for function compilation into our Vellum-native `FunctionDefinition` class. We simply solve the base case, and will be rolling out each test case per PR. We eventually (the last PR) will use this utility within our inline prompt nodes to allow users to pass in arbitrary functions defined locally as arguments.