### PR TITLE
Setup test for and Implement function compilation for all parameter types

### DIFF
--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Callable
 
 from vellum.client.types.function_definition import FunctionDefinition
@@ -7,7 +8,29 @@ def compile_function_definition(function: Callable) -> FunctionDefinition:
     """
     Converts a Python function into our Vellum-native FunctionDefinition type.
     """
+    type_map = {
+        str: "string",
+        int: "integer",
+        float: "number",
+        bool: "boolean",
+        list: "array",
+        dict: "object",
+        type(None): "null",
+    }
+
+    try:
+        signature = inspect.signature(function)
+    except ValueError as e:
+        raise ValueError(f"Failed to get signature for function {function.__name__}: {str(e)}")
+
+    properties = {}
+    for param in signature.parameters.values():
+        property_type = type_map[param.annotation]
+        properties[param.name] = {"type": property_type}
+
+    required = [param.name for param in signature.parameters.values() if param.default is inspect.Parameter.empty]
 
     return FunctionDefinition(
         name=function.__name__,
+        parameters={"type": "object", "properties": properties, "required": required},
     )

--- a/src/vellum/workflows/utils/tests/test_functions.py
+++ b/src/vellum/workflows/utils/tests/test_functions.py
@@ -13,4 +13,31 @@ def test_compile_function_definition__just_name():
     # THEN it should return the compiled function definition
     assert compiled_function == FunctionDefinition(
         name="my_function",
+        parameters={"type": "object", "properties": {}, "required": []},
+    )
+
+
+def test_compile_function_definition__all_args():
+    # GIVEN a function with args of all base types
+    def my_function(a: str, b: int, c: float, d: bool, e: list, f: dict):
+        pass
+
+    # WHEN compiling the function
+    compiled_function = compile_function_definition(my_function)
+
+    # THEN it should return the compiled function definition
+    assert compiled_function == FunctionDefinition(
+        name="my_function",
+        parameters={
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "integer"},
+                "c": {"type": "number"},
+                "d": {"type": "boolean"},
+                "e": {"type": "array"},
+                "f": {"type": "object"},
+            },
+            "required": ["a", "b", "c", "d", "e", "f"],
+        },
     )


### PR DESCRIPTION
With just these two tests, we now support everything that [openai swarm does](https://github.com/openai/swarm/blob/main/swarm/util.py#L31-L87)

However we can't stop here. We still need to do unions, parameterized lists & dicts, dataclasses, optionals, etc etc