### PR TITLE
Setup test and impl for compiling dataclasses

### DIFF
--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -1,3 +1,4 @@
+import dataclasses
 import inspect
 from typing import Any, Callable, Union, get_args, get_origin
 
@@ -15,17 +16,30 @@ type_map = {
 }
 
 
-def _compile_annotation(annotation: Any) -> dict:
+def _compile_annotation(annotation: Any, defs: dict[str, Any]) -> dict:
     if get_origin(annotation) is Union:
-        return {"anyOf": [_compile_annotation(a) for a in get_args(annotation)]}
+        return {"anyOf": [_compile_annotation(a, defs) for a in get_args(annotation)]}
 
     if get_origin(annotation) is dict:
         _, value_type = get_args(annotation)
-        return {"type": "object", "additionalProperties": _compile_annotation(value_type)}
+        return {"type": "object", "additionalProperties": _compile_annotation(value_type, defs)}
 
     if get_origin(annotation) is list:
         item_type = get_args(annotation)[0]
-        return {"type": "array", "items": _compile_annotation(item_type)}
+        return {"type": "array", "items": _compile_annotation(item_type, defs)}
+
+    if dataclasses.is_dataclass(annotation):
+        if annotation.__name__ not in defs:
+            properties = {}
+            required = []
+            for field in dataclasses.fields(annotation):
+                properties[field.name] = _compile_annotation(field.type, defs)
+                if field.default is dataclasses.MISSING:
+                    required.append(field.name)
+                else:
+                    properties[field.name]["default"] = field.default
+            defs[annotation.__name__] = {"type": "object", "properties": properties, "required": required}
+        return {"$ref": f"#/$defs/{annotation.__name__}"}
 
     return {"type": type_map[annotation]}
 
@@ -42,14 +56,19 @@ def compile_function_definition(function: Callable) -> FunctionDefinition:
 
     properties = {}
     required = []
+    defs: dict[str, Any] = {}
     for param in signature.parameters.values():
-        properties[param.name] = _compile_annotation(param.annotation)
+        properties[param.name] = _compile_annotation(param.annotation, defs)
         if param.default is inspect.Parameter.empty:
             required.append(param.name)
         else:
             properties[param.name]["default"] = param.default
 
+    parameters = {"type": "object", "properties": properties, "required": required}
+    if defs:
+        parameters["$defs"] = defs
+
     return FunctionDefinition(
         name=function.__name__,
-        parameters={"type": "object", "properties": properties, "required": required},
+        parameters=parameters,
     )

--- a/src/vellum/workflows/utils/tests/test_functions.py
+++ b/src/vellum/workflows/utils/tests/test_functions.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
 from vellum.client.types.function_definition import FunctionDefinition
@@ -135,5 +136,36 @@ def test_compile_function_definition__parameterized_lists():
                 "a": {"type": "array", "items": {"type": "integer"}},
             },
             "required": ["a"],
+        },
+    )
+
+
+def test_compile_function_definition__dataclasses():
+    # GIVEN a function with a dataclass
+    @dataclass
+    class MyDataClass:
+        a: int
+        b: str
+
+    def my_function(c: MyDataClass):
+        pass
+
+    # WHEN compiling the function
+    compiled_function = compile_function_definition(my_function)
+
+    # THEN it should return the compiled function definition
+    assert compiled_function == FunctionDefinition(
+        name="my_function",
+        parameters={
+            "type": "object",
+            "properties": {"c": {"$ref": "#/$defs/MyDataClass"}},
+            "required": ["c"],
+            "$defs": {
+                "MyDataClass": {
+                    "type": "object",
+                    "properties": {"a": {"type": "integer"}, "b": {"type": "string"}},
+                    "required": ["a", "b"],
+                }
+            },
         },
     )


### PR DESCRIPTION
Took an opinionated stance here to say that _all_ dataclasses will be pushed to a `$defs` schema. I contemplated only doing this on the second reference of a dataclass, but that's slightly more complex and this is at least more consistent.