### PR TITLE
Add tests for our CLI's `push` command

### DIFF
--- a/ee/vellum_cli/tests/conftest.py
+++ b/ee/vellum_cli/tests/conftest.py
@@ -1,0 +1,40 @@
+import pytest
+import os
+import shutil
+import tempfile
+from uuid import uuid4
+from typing import Any, Callable, Dict, Generator, Tuple
+
+import tomli_w
+
+
+@pytest.fixture
+def mock_module() -> Generator[Tuple[str, str, Callable[[Dict[str, Any]], None]], None, None]:
+    current_dir = os.getcwd()
+    temp_dir = tempfile.mkdtemp()
+    os.chdir(temp_dir)
+    module = "examples.mock"
+
+    def set_pyproject_toml(vellum_config: Dict[str, Any]) -> None:
+        pyproject_toml_path = os.path.join(temp_dir, "pyproject.toml")
+        with open(pyproject_toml_path, "wb") as f:
+            tomli_w.dump(
+                {"tool": {"vellum": vellum_config}},
+                f,
+            )
+
+    set_pyproject_toml(
+        {
+            "workflows": [
+                {
+                    "module": module,
+                    "workflow_sandbox_id": str(uuid4()),
+                }
+            ]
+        }
+    )
+
+    yield temp_dir, module, set_pyproject_toml
+
+    os.chdir(current_dir)
+    shutil.rmtree(temp_dir)

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -1,19 +1,15 @@
-import pytest
 import io
 import os
-import shutil
 import tempfile
 from uuid import uuid4
 import zipfile
-from typing import Any, Callable, Dict, Generator, Tuple
 
 from click.testing import CliRunner
-import tomli_w
 
 from vellum_cli import main as cli_main
 
 
-def zip_file_map(file_map: dict[str, str]) -> bytes:
+def _zip_file_map(file_map: dict[str, str]) -> bytes:
     # Create an in-memory bytes buffer to store the zip
     zip_buffer = io.BytesIO()
 
@@ -29,44 +25,12 @@ def zip_file_map(file_map: dict[str, str]) -> bytes:
     return zip_bytes
 
 
-@pytest.fixture
-def mock_module() -> Generator[Tuple[str, str, Callable[[Dict[str, Any]], None]], None, None]:
-    current_dir = os.getcwd()
-    temp_dir = tempfile.mkdtemp()
-    os.chdir(temp_dir)
-    module = "examples.mock"
-
-    def set_pyproject_toml(vellum_config: Dict[str, Any]) -> None:
-        pyproject_toml_path = os.path.join(temp_dir, "pyproject.toml")
-        with open(pyproject_toml_path, "wb") as f:
-            tomli_w.dump(
-                {"tool": {"vellum": vellum_config}},
-                f,
-            )
-
-    set_pyproject_toml(
-        {
-            "workflows": [
-                {
-                    "module": module,
-                    "workflow_sandbox_id": str(uuid4()),
-                }
-            ]
-        }
-    )
-
-    yield temp_dir, module, set_pyproject_toml
-
-    os.chdir(current_dir)
-    shutil.rmtree(temp_dir)
-
-
 def test_pull(vellum_client, mock_module):
     # GIVEN a module on the user's filesystem
     temp_dir, module, _ = mock_module
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter([zip_file_map({"workflow.py": "print('hello')"})])
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
 
     # WHEN the user runs the pull command
     runner = CliRunner()
@@ -87,7 +51,7 @@ def test_pull__second_module(vellum_client, mock_module):
     temp_dir, module, set_pyproject_toml = mock_module
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter([zip_file_map({"workflow.py": "print('hello')"})])
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
 
     # AND the module we're about to pull is configured second
     set_pyproject_toml(
@@ -118,7 +82,7 @@ def test_pull__sandbox_id_with_no_config(vellum_client):
     workflow_sandbox_id = "87654321-0000-0000-0000-000000000000"
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter([zip_file_map({"workflow.py": "print('hello')"})])
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
 
     # AND we are currently in a new directory
     current_dir = os.getcwd()
@@ -146,7 +110,7 @@ def test_pull__remove_missing_files(vellum_client, mock_module):
     temp_dir, module, _ = mock_module
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter([zip_file_map({"workflow.py": "print('hello')"})])
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
 
     # AND there is already a different file in the module directory
     other_file_path = os.path.join(temp_dir, *module.split("."), "other_file.py")
@@ -175,7 +139,7 @@ def test_pull__remove_missing_files__ignore_pattern(vellum_client, mock_module):
     temp_dir, module, set_pyproject_toml = mock_module
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter([zip_file_map({"workflow.py": "print('hello')"})])
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
 
     # AND there is already a different file in the module directory
     other_file_path = os.path.join(temp_dir, *module.split("."), "other_file.py")
@@ -227,7 +191,7 @@ def test_pull__include_json(vellum_client, mock_module):
 
     # AND the workflow pull API call returns a zip file
     vellum_client.workflows.pull.return_value = iter(
-        [zip_file_map({"workflow.py": "print('hello')", "workflow.json": "{}"})]
+        [_zip_file_map({"workflow.py": "print('hello')", "workflow.json": "{}"})]
     )
 
     # WHEN the user runs the pull command
@@ -249,7 +213,7 @@ def test_pull__exclude_code(vellum_client, mock_module):
 
     # AND the workflow pull API call returns a zip file
     vellum_client.workflows.pull.return_value = iter(
-        [zip_file_map({"workflow.py": "print('hello')", "workflow.json": "{}"})]
+        [_zip_file_map({"workflow.py": "print('hello')", "workflow.json": "{}"})]
     )
 
     # WHEN the user runs the pull command

--- a/ee/vellum_cli/tests/test_push.py
+++ b/ee/vellum_cli/tests/test_push.py
@@ -1,0 +1,36 @@
+from click.testing import CliRunner
+
+from vellum_cli import main as cli_main
+
+
+def test_push__no_config(mock_module):
+    # GIVEN no config file set
+    _, _, set_pyproject_toml = mock_module
+    set_pyproject_toml({"workflows": []})
+
+    # WHEN calling `vellum push`
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["push"])
+
+    # THEN it should fail
+    assert result.exit_code == 1
+    assert result.exception
+    assert str(result.exception) == "No Workflows found in project to push."
+
+
+def test_push__multiple_workflows_configured__no_module_specified(mock_module):
+    # GIVEN multiple workflows configured
+    _, _, set_pyproject_toml = mock_module
+    set_pyproject_toml({"workflows": [{"module": "examples.mock"}, {"module": "examples.mock2"}]})
+
+    # WHEN calling `vellum push` without a module specified
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["push"])
+
+    # THEN it should fail
+    assert result.exit_code == 1
+    assert result.exception
+    assert (
+        str(result.exception)
+        == "Multiple workflows found in project to push. Pushing only a single workflow is supported."
+    )

--- a/ee/vellum_cli/tests/test_push.py
+++ b/ee/vellum_cli/tests/test_push.py
@@ -34,3 +34,18 @@ def test_push__multiple_workflows_configured__no_module_specified(mock_module):
         str(result.exception)
         == "Multiple workflows found in project to push. Pushing only a single workflow is supported."
     )
+
+
+def test_push__multiple_workflows_configured__not_found_module(mock_module):
+    # GIVEN multiple workflows configured
+    _, module, set_pyproject_toml = mock_module
+    set_pyproject_toml({"workflows": [{"module": "examples.mock2"}, {"module": "examples.mock3"}]})
+
+    # WHEN calling `vellum push` with a module that doesn't exist
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["push", module])
+
+    # THEN it should fail
+    assert result.exit_code == 1
+    assert result.exception
+    assert str(result.exception) == f"No workflow config for '{module}' found in project to push."

--- a/ee/vellum_ee/workflows/display/tests/test_vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/tests/test_vellum_workflow_display.py
@@ -1,0 +1,45 @@
+from vellum.workflows.workflows.base import BaseWorkflow
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+
+
+def test_vellum_workflow_display__serialize_empty_workflow():
+    # GIVEN an empty workflow
+    class ExampleWorkflow(BaseWorkflow):
+        pass
+
+    display = get_workflow_display(
+        base_display_class=VellumWorkflowDisplay,
+        workflow_class=ExampleWorkflow,
+    )
+
+    # WHEN serializing the workflow
+    exec_config = display.serialize()
+
+    # THEN it should return the expected config
+    assert exec_config == {
+        "input_variables": [],
+        "output_variables": [],
+        "workflow_raw_data": {
+            "definition": {
+                "module": ["vellum_ee", "workflows", "display", "tests", "test_vellum_workflow_display"],
+                "name": "ExampleWorkflow",
+            },
+            "display_data": {"viewport": {"x": 0.0, "y": 0.0, "zoom": 1.0}},
+            "edges": [],
+            "nodes": [
+                {
+                    "data": {"label": "Entrypoint Node", "source_handle_id": "508b8b82-3517-4672-a155-18c9c7b9c545"},
+                    "definition": {
+                        "bases": [],
+                        "module": ["vellum", "workflows", "nodes", "bases", "base"],
+                        "name": "BaseNode",
+                    },
+                    "display_data": {"position": {"x": 0.0, "y": 0.0}},
+                    "id": "9eef0c18-f322-4d56-aa89-f088d3e53f6a",
+                    "inputs": [],
+                    "type": "ENTRYPOINT",
+                }
+            ],
+        },
+    }

--- a/src/vellum/workflows/events/node.py
+++ b/src/vellum/workflows/events/node.py
@@ -1,11 +1,10 @@
-from typing import Any, Dict, Generic, List, Literal, Optional, Set, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Generic, List, Literal, Optional, Set, Type, Union
 
 from pydantic import SerializerFunctionWrapHandler, field_serializer, model_serializer
 
 from vellum.core.pydantic_utilities import UniversalBaseModel
 from vellum.workflows.errors import VellumError
 from vellum.workflows.expressions.accessor import AccessorExpression
-from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.ports.port import Port
 from vellum.workflows.references.node import NodeReference
@@ -13,9 +12,12 @@ from vellum.workflows.types.generics import OutputsType
 
 from .types import BaseEvent, default_serializer, serialize_type_encoder
 
+if TYPE_CHECKING:
+    from vellum.workflows.nodes.bases import BaseNode
+
 
 class _BaseNodeExecutionBody(UniversalBaseModel):
-    node_definition: Type[BaseNode]
+    node_definition: Type["BaseNode"]
 
     @field_serializer("node_definition")
     def serialize_node_definition(self, node_definition: Type, _info: Any) -> Dict[str, Any]:
@@ -35,7 +37,7 @@ class _BaseNodeEvent(BaseEvent):
     body: _BaseNodeExecutionBody
 
     @property
-    def node_definition(self) -> Type[BaseNode]:
+    def node_definition(self) -> Type["BaseNode"]:
         return self.body.node_definition
 
 

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -4,7 +4,6 @@ import importlib
 import inspect
 
 from vellum.plugins.utils import load_runtime_plugins
-from vellum.workflows.events.types import CodeResourceDefinition
 from vellum.workflows.workflows.event_filters import workflow_event_filter
 
 load_runtime_plugins()
@@ -84,7 +83,7 @@ from vellum.workflows.types.utils import get_original_base
 class _BaseWorkflowMeta(type):
     def __new__(mcs, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
         if "graph" not in dct:
-            dct["graph"] = []
+            dct["graph"] = set()
 
         return super().__new__(mcs, name, bases, dct)
 
@@ -412,6 +411,9 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
 
         workflows: List[Type[BaseWorkflow]] = []
         for name in dir(module):
+            if name.startswith("__"):
+                continue
+
             attr = getattr(module, name)
             if (
                 inspect.isclass(attr)

--- a/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
+++ b/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
@@ -1,10 +1,8 @@
 import pytest
 from datetime import datetime
-import json
 import time
 
 from vellum.workflows.events.types import default_serializer
-from vellum.workflows.state.encoder import DefaultStateEncoder
 
 from tests.workflows.basic_emitter_workflow.workflow import BasicEmitterWorkflow, ExampleEmitter, NextNode, StartNode
 


### PR DESCRIPTION
In a future PR, we are going to be adding the `workflows` subcommand, similar to how we recently added it to push. This PR simply adds tests to what we have so far so that we could be explicit about the new commands and breaking changes being introduced on the next one