### PR TITLE
Setup test and fix for pulling by id error.

### DIFF
--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -7,8 +7,26 @@ from typing import Optional
 from dotenv import load_dotenv
 
 from vellum.workflows.vellum_client import create_vellum_client
-from vellum_cli.config import WorkflowConfig, load_vellum_cli_config
+from vellum_cli.config import VellumCliConfig, WorkflowConfig, load_vellum_cli_config
 from vellum_cli.logger import load_cli_logger
+
+
+def resolve_workflow_config(
+    config: VellumCliConfig,
+    module: Optional[str] = None,
+    workflow_sandbox_id: Optional[str] = None,
+) -> Optional[WorkflowConfig]:
+    if module:
+        return next((w for w in config.workflows if w.module == module), None)
+    elif workflow_sandbox_id:
+        return WorkflowConfig(
+            workflow_sandbox_id=workflow_sandbox_id,
+            module=f"workflow_{workflow_sandbox_id.split('-')[0]}",
+        )
+    elif config.workflows:
+        return config.workflows[0]
+
+    return None
 
 
 def pull_command(
@@ -21,24 +39,15 @@ def pull_command(
     logger = load_cli_logger()
     config = load_vellum_cli_config()
 
-    workflow_config = (
-        next((w for w in config.workflows if w.module == module), None)
-        if module
-        else (config.workflows[0] if config.workflows else None)
+    workflow_config = resolve_workflow_config(
+        config,
+        module,
+        workflow_sandbox_id,
     )
-    save_lock_file = False
-    if workflow_config is None:
-        if module:
-            raise ValueError(f"No workflow config for '{module}' found in project to pull.")
-        elif workflow_sandbox_id:
-            workflow_config = WorkflowConfig(
-                workflow_sandbox_id=workflow_sandbox_id,
-                module=f"workflow_{workflow_sandbox_id.split('-')[0]}",
-            )
-            config.workflows.append(workflow_config)
-            save_lock_file = True
-        else:
-            raise ValueError("No workflow config found in project to pull from.")
+    save_lock_file = not module
+
+    if not workflow_config:
+        raise ValueError("No workflow config found in project to pull from.")
 
     if not workflow_config.workflow_sandbox_id:
         raise ValueError("No workflow sandbox ID found in project to pull from.")


### PR DESCRIPTION
`vellum pull` had a bug where pulling by id while there was a _different_ workflow configured in the `pyproject.toml` would prefer the latter. We should always prefer cli args over config files