### PR TITLE
Flip push/pull order with workflows

### DIFF
--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -36,14 +36,20 @@ def push(
         push_command()
 
 
-@push.command(name="workflows")
+@main.group()
+def workflows():
+    """Operations related to Vellum Workflows"""
+    pass
+
+
+@workflows.command(name="push")
 @click.argument("module", required=False)
 @click.option("--deploy", is_flag=True, help="Deploy the Workflow after pushing it to Vellum")
 @click.option("--deployment-label", type=str, help="Label to use for the Deployment")
 @click.option("--deployment-name", type=str, help="Unique name for the Deployment")
 @click.option("--deployment-description", type=str, help="Description for the Deployment")
 @click.option("--release-tag", type=list, help="Release Tag for the Deployment", multiple=True)
-def push_workflows(
+def workflows_push(
     module: Optional[str],
     deploy: Optional[bool],
     deployment_label: Optional[str],
@@ -133,7 +139,7 @@ def pull(
         )
 
 
-@pull.command(name="workflows")
+@workflows.command(name="pull")
 @click.argument("module", required=False)
 @click.option(
     "--include-json",
@@ -148,7 +154,7 @@ Should only be used for debugging purposes.""",
     help="""Exclude the code definition of the Workflow from the pull response. \
 Should only be used for debugging purposes.""",
 )
-def pull_workflows(
+def workflows_pull(
     module: Optional[str],
     include_json: Optional[bool],
     workflow_sandbox_id: Optional[str],

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -30,9 +30,9 @@ def _zip_file_map(file_map: dict[str, str]) -> bytes:
     "base_command",
     [
         ["pull"],
-        ["pull", "workflows"],
+        ["workflows", "pull"],
     ],
-    ids=["pull", "pull_workflows"],
+    ids=["pull", "workflows_pull"],
 )
 def test_pull(vellum_client, mock_module, base_command):
     # GIVEN a module on the user's filesystem
@@ -100,7 +100,7 @@ def test_pull__sandbox_id_with_no_config(vellum_client):
 
     # WHEN the user runs the pull command with the workflow sandbox id and no module
     runner = CliRunner()
-    result = runner.invoke(cli_main, ["pull", "workflows", "--workflow-sandbox-id", workflow_sandbox_id])
+    result = runner.invoke(cli_main, ["workflows", "pull", "--workflow-sandbox-id", workflow_sandbox_id])
     os.chdir(current_dir)
 
     # THEN the command returns successfully
@@ -126,7 +126,7 @@ def test_pull__sandbox_id_with_other_workflow_configured(vellum_client, mock_mod
 
     # WHEN the user runs the pull command with the new workflow sandbox id
     runner = CliRunner()
-    result = runner.invoke(cli_main, ["pull", "workflows", "--workflow-sandbox-id", workflow_sandbox_id])
+    result = runner.invoke(cli_main, ["workflows", "pull", "--workflow-sandbox-id", workflow_sandbox_id])
 
     # THEN the command returns successfully
     assert result.exit_code == 0

--- a/ee/vellum_cli/tests/test_push.py
+++ b/ee/vellum_cli/tests/test_push.py
@@ -79,9 +79,9 @@ def test_push__multiple_workflows_configured__not_found_module(mock_module):
     "base_command",
     [
         ["push"],
-        ["push", "workflows"],
+        ["workflows", "push"],
     ],
-    ids=["push", "push_workflows"],
+    ids=["push", "workflows_push"],
 )
 def test_push__happy_path(mock_module, vellum_client, base_command):
     # GIVEN a single workflow configured
@@ -128,9 +128,9 @@ class ExampleWorkflow(BaseWorkflow):
     "base_command",
     [
         ["push"],
-        ["push", "workflows"],
+        ["workflows", "push"],
     ],
-    ids=["push", "push_workflows"],
+    ids=["push", "workflows_push"],
 )
 def test_push__deployment(mock_module, vellum_client, base_command):
     # GIVEN a single workflow configured


### PR DESCRIPTION
Synced on CLI stuff with @noanflaherty this morning and we decided that:
- Instead of `vellum push workflows ...`, we'd do `vellum workflows push ...`
- Instead of `vellum pull workflows ...`, we'd do `vellum workflows pull ...`

This PR performs this swap. I also noticed that this makes us consistent with the `vellum images push` and `vellum images pull` commands that @m-abboud introduced a few weeks back