### PR TITLE
[SC-5780] Fix duplicate variable assignments for workflows that have the same name for terminal nodes

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -171,6 +171,22 @@ class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
 "
 `;
 
+exports[`Workflow > write > should generate correct code with multiple terminal nodes with the same name 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .inputs import Inputs
+from vellum.workflows.state import BaseState
+from .nodes.final_output import FinalOutput
+
+
+class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
+    graph = None
+
+    class Outputs(BaseWorkflow.Outputs):
+        query = FinalOutput.Outputs.value
+        query_1 = FinalOutput.Outputs.value
+"
+`;
+
 exports[`Workflow > write > should handle edges pointing to non-existent nodes 1`] = `
 "from vellum.workflows import BaseWorkflow
 from .inputs import Inputs

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -87,7 +87,7 @@ class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
     graph = SearchNode
 
     class Outputs(BaseWorkflow.Outputs):
-        query = FinalOutput.Outputs.value
+        query_1 = FinalOutput.Outputs.value
 "
 `;
 
@@ -167,7 +167,7 @@ from .nodes.final_output import FinalOutput
 
 class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
     class Outputs(BaseWorkflow.Outputs):
-        query = FinalOutput.Outputs.value
+        query_1 = FinalOutput.Outputs.value
 "
 `;
 
@@ -182,7 +182,7 @@ class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
     graph = None
 
     class Outputs(BaseWorkflow.Outputs):
-        query = FinalOutput.Outputs.value
+        query_1 = FinalOutput.Outputs.value
         query_2 = FinalOutput.Outputs.value
 "
 `;

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -183,7 +183,7 @@ class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
 
     class Outputs(BaseWorkflow.Outputs):
         query = FinalOutput.Outputs.value
-        query_1 = FinalOutput.Outputs.value
+        query_2 = FinalOutput.Outputs.value
 "
 `;
 

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -28,9 +28,9 @@ export function entrypointNodeDataFactory(): EntrypointNode {
   };
 }
 
-export function terminalNodeDataFactory(): FinalOutputNode {
+export function terminalNodeDataFactory(id?: string): FinalOutputNode {
   return {
-    id: "terminal-node-1",
+    id: id ? id : "terminal-node-1",
     type: WorkflowNodeType.TERMINAL,
     inputs: [
       {

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -28,7 +28,9 @@ export function entrypointNodeDataFactory(): EntrypointNode {
   };
 }
 
-export function terminalNodeDataFactory(id?: string): FinalOutputNode {
+export function terminalNodeDataFactory({
+  id,
+}: { id?: string } = {}): FinalOutputNode {
   return {
     id: id ? id : "terminal-node-1",
     type: WorkflowNodeType.TERMINAL,

--- a/ee/codegen/src/__test__/helpers/workflow-output-context-factory.ts
+++ b/ee/codegen/src/__test__/helpers/workflow-output-context-factory.ts
@@ -1,13 +1,17 @@
 import { terminalNodeDataFactory } from "src/__test__/helpers/node-data-factories";
+import { WorkflowContext } from "src/context";
 import { WorkflowOutputContext } from "src/context/workflow-output-context";
 import { FinalOutputNode as FinalOutputNodeType } from "src/types/vellum";
 
 export function workflowOutputContextFactory({
   terminalNodeData,
+  workflowContext,
 }: {
   terminalNodeData?: FinalOutputNodeType;
-} = {}): WorkflowOutputContext {
+  workflowContext: WorkflowContext;
+}): WorkflowOutputContext {
   return new WorkflowOutputContext({
     terminalNodeData: terminalNodeData ?? terminalNodeDataFactory(),
+    workflowContext,
   });
 }

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -160,8 +160,9 @@ describe("Workflow", () => {
         })
       );
 
-      const anotherTerminalNodeData =
-        terminalNodeDataFactory("terminal-node-2");
+      const anotherTerminalNodeData = terminalNodeDataFactory({
+        id: "terminal-node-2",
+      });
 
       workflowContext.addNodeContext(
         await createNodeContext({

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -76,6 +76,8 @@ export class WorkflowContext {
 
   public readonly workflowRawEdges: WorkflowEdge[];
 
+  public readonly outputNamesById: Map<string, string>;
+
   constructor({
     absolutePathToOutputDirectory,
     moduleName,
@@ -112,6 +114,7 @@ export class WorkflowContext {
 
     this.sdkModulePathNames = generateSdkModulePaths(workflowsSdkModulePath);
     this.workflowRawEdges = workflowRawEdges;
+    this.outputNamesById = new Map<string, string>();
   }
 
   /* Create a new workflow context for a nested workflow from its parent */
@@ -251,5 +254,13 @@ export class WorkflowContext {
 
   public addWorkflowEdges(edges: WorkflowEdge[]): void {
     this.workflowRawEdges.push(...edges);
+  }
+
+  public getOutputName(terminalNodeId: string): string | undefined {
+    return this.outputNamesById.get(terminalNodeId);
+  }
+
+  public addOutputName(terminalNodeId: string, outputName: string): void {
+    this.outputNamesById.set(terminalNodeId, outputName);
   }
 }

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -267,7 +267,7 @@ export class WorkflowContext {
     this.outputNamesById.set(terminalNodeId, outputName);
   }
 
-  public generateUniqueFinalOutputName(
+  private generateUniqueFinalOutputName(
     workflowOutputContext: WorkflowOutputContext
   ): string {
     const node: FinalOutputNode =
@@ -276,15 +276,15 @@ export class WorkflowContext {
     if (value !== undefined) {
       return value;
     } else {
-      let counter = 2;
+      let counter = 1;
       const names = new Set(this.outputNamesById.values());
 
-      const originalName = node.data.name;
-      let uniqueName = originalName;
+      const originalName = `${node.data.name}-`;
+      let uniqueName = `${originalName}${counter}`;
 
       while (names.has(uniqueName)) {
-        uniqueName = `${originalName}-${counter}`;
         counter++;
+        uniqueName = `${originalName}${counter}`;
       }
       this.addOutputName(node.id, uniqueName);
       return uniqueName;

--- a/ee/codegen/src/context/workflow-output-context.ts
+++ b/ee/codegen/src/context/workflow-output-context.ts
@@ -30,27 +30,12 @@ export class WorkflowOutputContext {
   }
 
   public getOutputName(): string {
-    const name = this.generateUniqueFinalOutputName();
-    return toSnakeCase(name);
-  }
-
-  private generateUniqueFinalOutputName(): string {
-    const value = this.workflowContext.getOutputName(this.terminalNodeData.id);
-    if (value !== undefined) {
-      return value;
-    } else {
-      let counter = 1;
-      const names = new Set(this.workflowContext.outputNamesById.values());
-
-      const originalName = this.terminalNodeData.data.name;
-      let uniqueName = originalName;
-
-      while (names.has(uniqueName)) {
-        uniqueName = `${originalName}-${counter}`;
-        counter++;
-      }
-      this.workflowContext.addOutputName(this.terminalNodeData.id, uniqueName);
-      return uniqueName;
+    const name = this.workflowContext.getOutputName(this.terminalNodeData.id);
+    if (!name) {
+      throw new Error(
+        `No final output name found for output names in workflow context given id ${this.terminalNodeData.id}`
+      );
     }
+    return toSnakeCase(name);
   }
 }

--- a/ee/codegen/src/generators/workflow-output.ts
+++ b/ee/codegen/src/generators/workflow-output.ts
@@ -20,14 +20,12 @@ export class WorkflowOutput extends AstNode {
   private workflowContext: WorkflowContext;
   private workflowOutputContext: WorkflowOutputContext;
   private workflowOutput: Field;
-  private outputNamesById: Map<string, string>;
 
   public constructor(args: WorkflowOutput.Args) {
     super();
 
     this.workflowContext = args.workflowContext;
     this.workflowOutputContext = args.workflowOutputContext;
-    this.outputNamesById = args.outputNamesById;
 
     this.workflowOutput = this.generateWorkflowOutput();
   }

--- a/ee/codegen/src/generators/workflow-output.ts
+++ b/ee/codegen/src/generators/workflow-output.ts
@@ -12,6 +12,7 @@ export declare namespace WorkflowOutput {
   export interface Args {
     workflowContext: WorkflowContext;
     workflowOutputContext: WorkflowOutputContext;
+    outputNamesById: Map<string, string>;
   }
 }
 
@@ -19,12 +20,14 @@ export class WorkflowOutput extends AstNode {
   private workflowContext: WorkflowContext;
   private workflowOutputContext: WorkflowOutputContext;
   private workflowOutput: Field;
+  private outputNamesById: Map<string, string>;
 
   public constructor(args: WorkflowOutput.Args) {
     super();
 
     this.workflowContext = args.workflowContext;
     this.workflowOutputContext = args.workflowOutputContext;
+    this.outputNamesById = args.outputNamesById;
 
     this.workflowOutput = this.generateWorkflowOutput();
   }

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -48,6 +48,7 @@ export class Workflow {
   private readonly entrypointNodeEdges: WorkflowEdge[];
   private readonly displayData: WorkflowDisplayData | undefined;
   private readonly entrypointNodeId: string;
+
   constructor({ workflowContext, inputs, nodes, displayData }: Workflow.Args) {
     this.workflowContext = workflowContext;
     this.inputs = inputs;
@@ -152,6 +153,7 @@ export class Workflow {
           new WorkflowOutput({
             workflowContext: this.workflowContext,
             workflowOutputContext,
+            outputNamesById: this.workflowContext.outputNamesById,
           })
         );
       }

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -305,6 +305,7 @@ ${errors.slice(0, 3).map((err) => {
             this.workflowContext.addWorkflowOutputContext(
               new WorkflowOutputContext({
                 terminalNodeData: nodeData,
+                workflowContext: this.workflowContext,
               })
             );
           } else if (nodeData.type === "ENTRYPOINT") {

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -41,7 +41,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        Workflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62"),
             node_id=UUID("dad01b99-c0b4-4904-a75e-066fa947d256"),
             node_input_id=UUID("bc3e4cad-e6b6-4f3d-b0d8-ee7099fe6352"),

--- a/ee/codegen_integration/fixtures/simple_api_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/workflow.py
@@ -10,4 +10,4 @@ class Workflow(BaseWorkflow[Inputs, BaseState]):
     graph = ApiNode >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -43,7 +43,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        Workflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("87760362-25b9-4dcb-8034-b49dc9e033ab"),
             node_id=UUID("5bb10d67-efc7-4bd4-9452-4ec2ffbc031d"),
             node_input_id=UUID("d3b9060a-40b5-492c-a628-f2d3c912cf44"),

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/workflow.py
@@ -10,4 +10,4 @@ class Workflow(BaseWorkflow[Inputs, BaseState]):
     graph = CodeExecutionNode >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -44,7 +44,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        Workflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("d8381526-1225-4843-8c22-eec7747445e4"),
             node_id=UUID("b0d2bd58-fa00-4eea-98fb-bc09ee1427dd"),
             node_input_id=UUID("8a2dbefa-0722-4989-8cb7-f2eb526b3247"),

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/workflow.py
@@ -10,4 +10,4 @@ class Workflow(BaseWorkflow[Inputs, BaseState]):
     graph = ConditionalNode.Ports.branch_1 >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -44,7 +44,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        Workflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("493cfa4b-5235-4b71-99ef-270955f35fcb"),
             node_id=UUID("a9455dc7-85f5-43a9-8be7-f131bc5f08e2"),
             node_input_id=UUID("ff856e07-ed9a-47fa-8cec-76ebd8795cdb"),

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/workflow.py
@@ -10,4 +10,4 @@ class Workflow(BaseWorkflow[Inputs, BaseState]):
     graph = GuardrailNode >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
@@ -18,7 +18,7 @@ class SubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[SubworkflowNode]):
     workflow_input_ids_by_name = {}
     node_input_ids_by_name = {}
     output_display = {
-        SubworkflowNode.Outputs.final_output: NodeOutputDisplay(
+        SubworkflowNode.Outputs.final_output_1: NodeOutputDisplay(
             id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -39,7 +39,7 @@ class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkfl
         )
     }
     output_displays = {
-        SubworkflowNodeWorkflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        SubworkflowNodeWorkflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"),
             node_id=UUID("f3fe1e6e-5a4a-42d8-9cfe-9ecbcb935f72"),
             node_input_id=UUID("8e8c6182-4898-47de-be8f-769edad990ed"),

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -43,7 +43,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        Workflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6"),
             node_id=UUID("075932b7-c6ba-4c3a-8c8f-d6b043f8fe48"),
             node_input_id=UUID("e4585fda-2016-40fb-8ceb-6553a73f0311"),

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/nodes/subworkflow_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/nodes/subworkflow_node/__init__.py
@@ -7,4 +7,4 @@ class SubworkflowNode(InlineSubworkflowNode):
     subworkflow = SubworkflowNodeWorkflow
 
     class Outputs(InlineSubworkflowNode.Outputs):
-        final_output = SubworkflowNodeWorkflow.Outputs.final_output
+        final_output_1 = SubworkflowNodeWorkflow.Outputs.final_output_1

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/nodes/subworkflow_node/workflow.py
@@ -8,4 +8,4 @@ class SubworkflowNodeWorkflow(BaseWorkflow):
     graph = SearchNode >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/workflow.py
@@ -10,4 +10,4 @@ class Workflow(BaseWorkflow[Inputs, BaseState]):
     graph = SubworkflowNode >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -45,7 +45,7 @@ class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
         )
     }
     output_displays = {
-        MapNodeWorkflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        MapNodeWorkflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("bffc4749-00b8-44db-90ee-db655cbc7e62"),
             node_id=UUID("d9d29911-dd45-45d5-9ac8-1a06bb596c2f"),
             node_input_id=UUID("18dddbce-025b-461c-aa7a-ab2561739521"),

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -43,7 +43,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        Workflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("d9269719-a7a2-4388-9b85-73e329a78d16"),
             node_id=UUID("fa0d5829-f259-4db8-a11a-b12fd7237ea5"),
             node_input_id=UUID("ca8f8a34-24d3-4941-893f-73c5e3bbb66c"),

--- a/ee/codegen_integration/fixtures/simple_map_node/code/nodes/map_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/nodes/map_node/__init__.py
@@ -10,4 +10,4 @@ class MapNode(BaseMapNode):
     concurrency = 4
 
     class Outputs(BaseMapNode.Outputs):
-        final_output = MapNodeWorkflow.Outputs.final_output
+        final_output_1 = MapNodeWorkflow.Outputs.final_output_1

--- a/ee/codegen_integration/fixtures/simple_map_node/code/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/nodes/map_node/workflow.py
@@ -10,4 +10,4 @@ class MapNodeWorkflow(BaseWorkflow[Inputs, BaseState]):
     graph = SearchNode >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_map_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/workflow.py
@@ -10,4 +10,4 @@ class Workflow(BaseWorkflow[Inputs, BaseState]):
     graph = MapNode >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -55,7 +55,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         ),
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        Workflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"),
             node_id=UUID("7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842"),
             node_input_id=UUID("1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c"),

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/workflow.py
@@ -11,4 +11,4 @@ class Workflow(BaseWorkflow):
     graph = {TemplatingNode2, TemplatingNode1} >> MergeNode >> TemplatingNode3 >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -43,7 +43,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        Workflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("aed7279d-59cd-4c15-b82c-21de48129ba3"),
             node_id=UUID("e39c8f13-d59b-49fc-8c59-03ee7997b9b6"),
             node_input_id=UUID("cfed56e1-bdf8-4e17-a0f9-ff1bb8ca4221"),

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/workflow.py
@@ -10,4 +10,4 @@ class Workflow(BaseWorkflow[Inputs, BaseState]):
     graph = PromptNode >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -43,7 +43,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        Workflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("43e128f4-24fe-4484-9d08-948a4a390707"),
             node_id=UUID("ed688426-1976-4d0c-9f3a-2a0b0fae161a"),
             node_input_id=UUID("097798e5-9330-46a4-b8ec-e93532668d37"),

--- a/ee/codegen_integration/fixtures/simple_search_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/workflow.py
@@ -10,4 +10,4 @@ class Workflow(BaseWorkflow[Inputs, BaseState]):
     graph = SearchNode >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -39,7 +39,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+        Workflow.Outputs.final_output_1: WorkflowOutputVellumDisplayOverrides(
             id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"),
             node_id=UUID("f0347fdc-1611-446c-b1da-408511d4181b"),
             node_input_id=UUID("bb465fa1-defb-493c-8284-7156cd680fb3"),

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/workflow.py
@@ -8,4 +8,4 @@ class Workflow(BaseWorkflow):
     graph = TemplatingNode >> FinalOutput
 
     class Outputs(BaseWorkflow.Outputs):
-        final_output = FinalOutput.Outputs.value
+        final_output_1 = FinalOutput.Outputs.value


### PR DESCRIPTION
This was discovered during customer workflows pulling. It would pull and codegen workflows like the one below:
```
class Workflow(BaseWorkflow[Inputs, BaseState]):
    graph = CampaignStrategy >> {Summary, CampaignTactics}

    class Outputs(BaseWorkflow.Outputs):
        final_output_11 = FinalOutput11.Outputs.value
        final_output_9 = FinalOutput9.Outputs.value
        final_output = FinalOutput.Outputs.value
        final_output_10 = Tactics.Outputs.value
        final_output = Summary.Outputs.value
```

        
`final_output` has two assignments which technically isn't incorrect in python standards but when looking at the json, it has the following:

```
{
        "id": "05531472-903d-4c03-bafa-08510a80ff27",
        "type": "TERMINAL",
        "data": {
          "label": "Summary",
          "name": "final-output",
          "target_handle_id": "8016e648-7434-424d-b7f6-d324f88e23ad",
          "output_id": "7ef20c0c-6b68-4109-a990-604c218b8340",
          "output_type": "STRING",
          "node_input_id": "db4d7102-6ba1-49fe-8925-965d95351b56"
        }
```
        
        
and
        
        
```
        {
        "id": "31aa4dce-6c17-4eef-b059-50af89ca3d38",
        "type": "TERMINAL",
        "data": {
          "label": "Final Output",
          "name": "final-output",
          "target_handle_id": "6c489c7c-ca64-474b-86ac-16bab42f52d9",
          "output_id": "d3716282-7fc7-4364-a38b-2141bbe851c4",
          "output_type": "STRING",
          "node_input_id": "17934e2e-8174-4852-9872-8d93591cb983"
        }
```
        
        
Therefore, the workflow is trying to convey two terminal node outputs for this but the name is the one we key on when codegening this field