### PR TITLE
Setup Test Case and implementation fix for adding an edge to a non-terminal node within a set

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -145,16 +145,17 @@ exports[`Workflow > write > graph > should be correct for set of a branch and a 
 from .nodes.templating_node import TemplatingNode
 from .nodes.templating_node_3 import TemplatingNode3
 from .nodes.templating_node_4 import TemplatingNode4
-from .nodes.merge_node import MergeNode
 from .nodes.templating_node_2 import TemplatingNode2
+from .nodes.merge_node import MergeNode
 from .nodes.templating_node_5 import TemplatingNode5
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = {
-        TemplatingNode >> TemplatingNode3 >> TemplatingNode4,
-        TemplatingNode2,
-    } >> MergeNode >> TemplatingNode5
+    graph = (
+        {TemplatingNode >> TemplatingNode3 >> TemplatingNode4, TemplatingNode2}
+        >> MergeNode
+        >> TemplatingNode5
+    )
 "
 `;
 

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -140,6 +140,24 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
+exports[`Workflow > write > graph > should be correct for set of a branch and a node to a node 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_3 import TemplatingNode3
+from .nodes.templating_node_4 import TemplatingNode4
+from .nodes.merge_node import MergeNode
+from .nodes.templating_node_2 import TemplatingNode2
+from .nodes.templating_node_5 import TemplatingNode5
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = {
+        TemplatingNode >> TemplatingNode3 >> TemplatingNode4,
+        TemplatingNode2,
+    } >> MergeNode >> TemplatingNode5
+"
+`;
+
 exports[`Workflow > write > should generate correct code when there are input variables 1`] = `
 "from vellum.workflows import BaseWorkflow
 

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -1009,6 +1009,154 @@ describe("Workflow", () => {
         workflow.getWorkflowFile().write(writer);
         expect(await writer.toStringFormatted()).toMatchSnapshot();
       });
+
+      it("should be correct for set of a branch and a node to a node", async () => {
+        const inputs = codegen.inputs({ workflowContext });
+
+        const templatingNodeData1 = templatingNodeFactory();
+        const templatingNodeContext1 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData1,
+        });
+        workflowContext.addNodeContext(templatingNodeContext1);
+
+        const templatingNodeData2 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+          label: "Templating Node 2",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+        });
+        const templatingNodeContext2 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData2,
+        });
+        workflowContext.addNodeContext(templatingNodeContext2);
+
+        const templatingNodeData3 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
+          label: "Templating Node 3",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
+        });
+        const templatingNodeContext3 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData3,
+        });
+        workflowContext.addNodeContext(templatingNodeContext3);
+
+        const templatingNodeData4 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf83",
+          label: "Templating Node 4",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9b",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294b",
+        });
+        const templatingNodeContext4 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData4,
+        });
+        workflowContext.addNodeContext(templatingNodeContext4);
+
+        const templatingNodeData5 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf84",
+          label: "Templating Node 5",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9c",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294c",
+        });
+        const templatingNodeContext5 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData5,
+        });
+        workflowContext.addNodeContext(templatingNodeContext5);
+
+        const mergeNodeData = mergeNodeDataFactory();
+        const mergeNodeContext = await createNodeContext({
+          workflowContext,
+          nodeData: mergeNodeData,
+        });
+        workflowContext.addNodeContext(mergeNodeContext);
+        const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
+        const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
+        if (!mergeTargetHandle1 || !mergeTargetHandle2) {
+          throw new Error("Handle IDs are required");
+        }
+
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData1.id,
+            targetHandleId: templatingNodeData1.data.targetHandleId,
+          },
+          {
+            id: "edge-2",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData2.id,
+            targetHandleId: templatingNodeData2.data.targetHandleId,
+          },
+          {
+            id: "edge-3",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData1.id,
+            sourceHandleId: templatingNodeData1.data.sourceHandleId,
+            targetNodeId: templatingNodeData3.id,
+            targetHandleId: templatingNodeData3.data.targetHandleId,
+          },
+          {
+            id: "edge-4",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData3.id,
+            sourceHandleId: templatingNodeData3.data.sourceHandleId,
+            targetNodeId: templatingNodeData4.id,
+            targetHandleId: templatingNodeData4.data.targetHandleId,
+          },
+          {
+            id: "edge-5",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData4.id,
+            sourceHandleId: templatingNodeData4.data.sourceHandleId,
+            targetNodeId: mergeNodeData.id,
+            targetHandleId: mergeTargetHandle1,
+          },
+          {
+            id: "edge-6",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData2.id,
+            sourceHandleId: templatingNodeData2.data.sourceHandleId,
+            targetNodeId: mergeNodeData.id,
+            targetHandleId: mergeTargetHandle2,
+          },
+          {
+            id: "edge-7",
+            type: "DEFAULT",
+            sourceNodeId: mergeNodeData.id,
+            sourceHandleId: mergeNodeData.data.sourceHandleId,
+            targetNodeId: templatingNodeData5.id,
+            targetHandleId: templatingNodeData5.data.targetHandleId,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
+
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [
+            templatingNodeData1,
+            templatingNodeData2,
+            templatingNodeData3,
+            templatingNodeData4,
+            templatingNodeData5,
+            mergeNodeData,
+          ],
+        });
+
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
     });
   });
 });


### PR DESCRIPTION
```
graph = {
    A >> B >> C,
    D
} >> E >> F
```

The tricky thing about this edge case is that near the end, we have this graph:

```
graph = {
    A >> B >> C,
    D >> E >> F
}
```

When this graph then comes across the `C >> E` edge, it fails to locate `E` on the bottom to simplify, so the graph stays as two edges instead of simplifying into the merge node `E`. This PR tackles this problem, while starting to take some of our helper methods out of the main function and out into the GraphAttribute class