### PR TITLE
Include sdk version in vellum push

### DIFF
--- a/ee/vellum_cli/push.py
+++ b/ee/vellum_cli/push.py
@@ -3,6 +3,7 @@ import json
 import os
 import sys
 import tarfile
+from importlib import metadata
 from uuid import UUID
 from typing import List, Optional
 
@@ -50,6 +51,9 @@ def push_command(
     workflow = BaseWorkflow.load_from_module(workflow_config.module)
     workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=workflow)
     exec_config = workflow_display.serialize()
+    exec_config["runner_config"] = {
+        "sdk_version": metadata.version("vellum-ai"),
+    }
 
     label = snake_to_title_case(workflow_config.module.split(".")[-1])
 


### PR DESCRIPTION
I thought about putting this in workflow_display but in the actual push call seemed more appropriate since I think push will also grab the container image from the toml in the future