### PR TITLE
[SC-5655] Fast follow - fix logic for required and default values

### DIFF
--- a/ee/codegen_integration/conftest.py
+++ b/ee/codegen_integration/conftest.py
@@ -29,8 +29,14 @@ def _get_fixture_paths(root: str) -> Tuple[str, str]:
 _fixture_paths = _get_fixtures(
     # TODO: Remove exclusions on all of these fixtures
     # https://app.shortcut.com/vellum/story/4649/remove-fixture-exclusions-for-serialization
-    exclude_fixtures={"simple_merge_node"},
-    include_fixtures={"simple_error_node"},
+    exclude_fixtures={
+        "simple_merge_node",
+        "faa_q_and_a_bot",
+        # TODO: Remove the bottom three in fast follows
+        "simple_inline_subworkflow_node",
+        "simple_map_node",
+        "simple_api_node",
+    }
 )
 _fixture_ids = [os.path.basename(path) for path in _fixture_paths]
 

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -57,12 +57,12 @@ class VellumWorkflowDisplay(
     def serialize(self, raise_errors: bool = True) -> JsonObject:
         input_variables: JsonArray = []
         for workflow_input, workflow_input_display in self.display_context.workflow_input_displays.items():
-            default = (
-                primitive_to_vellum_value(raise_if_descriptor(workflow_input.instance))
-                if workflow_input.instance
-                else None
+            default = primitive_to_vellum_value(workflow_input.instance) if workflow_input.instance else None
+            required = (
+                workflow_input_display.required
+                if workflow_input_display.required is not None
+                else type(None) not in workflow_input.types
             )
-            required = type(None) not in workflow_input.types
 
             input_variables.append(
                 {
@@ -270,12 +270,16 @@ class VellumWorkflowDisplay(
         self, workflow_input: WorkflowInputReference, overrides: Optional[WorkflowInputsVellumDisplayOverrides] = None
     ) -> WorkflowInputsVellumDisplay:
         workflow_input_id: UUID
+        required = None
+        color = None
         if overrides:
             workflow_input_id = overrides.id
+            required = overrides.required
+            color = overrides.color
         else:
             workflow_input_id = uuid4_from_hash(f"{self.workflow_id}|inputs|id|{workflow_input.name}")
 
-        return WorkflowInputsVellumDisplay(id=workflow_input_id)
+        return WorkflowInputsVellumDisplay(id=workflow_input_id, required=required, color=color)
 
     def _generate_entrypoint_display(
         self,

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -14,7 +14,6 @@ from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplay
-from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.utils.vellum import infer_vellum_variable_type, primitive_to_vellum_value


### PR DESCRIPTION
This fixes the input variable changes I did with required and false.

More detail in the comment below but this is one of a couple of fast follows to address the changes I made before. TLDR: the failures in main were not caught by tests because they were hidden. There were 4 failing tests in main: search node, api node, map node, and subworkflow node. This one fixes search node. Api node works fine as is and map node/subworkflow node are the same error that relate to my duplicate output name handling PR