### PR TITLE
[Codegen] Prepare for Returning Mapping Between Node ID & Node Definition

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ApiNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "APINode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "api_node",
+  ],
+  "name": "APINode",
+}
+`;
+
 exports[`ApiNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseAPINodeDisplay
 from ...nodes.api_node import APINode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ConditionalNode > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "ConditionalNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "conditional_node",
+  ],
+  "name": "ConditionalNode",
+}
+`;
+
 exports[`ConditionalNode > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from ...nodes.conditional_node import ConditionalNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ErrorNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "ErrorNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "error_node",
+  ],
+  "name": "ErrorNode",
+}
+`;
+
 exports[`ErrorNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
 from ...nodes.error_node import ErrorNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`FinalOutputNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "FinalOutputNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "final_output_node",
+  ],
+  "name": "FinalOutputNode",
+}
+`;
+
 exports[`FinalOutputNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from ...nodes.final_output_node import FinalOutputNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/generic-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`GenericNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "BaseNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "my_custom_node",
+  ],
+  "name": "MyCustomNode",
+}
+`;
+
 exports[`GenericNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseNodeDisplay
 from ...nodes.my_custom_node import MyCustomNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`GuardrailNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "GuardrailNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "guardrail_node",
+  ],
+  "name": "GuardrailNode",
+}
+`;
+
 exports[`GuardrailNode > basic > getNodeDisplayFile - multiple output variables 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseGuardrailNodeDisplay
 from ...nodes.guardrail_node import GuardrailNode
@@ -112,10 +134,7 @@ exports[`GuardrailNode > reject on error enabled > getNodeDisplayFile 1`] = `
 )
 from uuid import UUID
 from ...nodes.guardrail_node import GuardrailNode
-from vellum_ee.workflows.display.nodes.types import (
-    NodeOutputDisplay,
-    PortDisplayOverrides,
-)
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 
@@ -135,14 +154,7 @@ class GuardrailNodeDisplay(BaseGuardrailNodeDisplay[GuardrailNode]):
         "expected": UUID("3f917af8-03a4-4ca4-8d40-fa662417fe9c"),
         "actual": UUID("bed55ada-923e-46ef-8340-1a5b0b563dc1"),
     }
-    output_display = {
-        GuardrailNode.Outputs.score1: NodeOutputDisplay(
-            id=UUID("mocked-input-id-1"), name="score1"
-        ),
-        GuardrailNode.Outputs.score2: NodeOutputDisplay(
-            id=UUID("mocked-input-id-2"), name="score2"
-        ),
-    }
+    output_display = {}
     port_displays = {
         GuardrailNode.Ports.default: PortDisplayOverrides(
             id=UUID("92aafe31-101b-47d3-86f2-e261c7747c16")

--- a/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
@@ -134,7 +134,10 @@ exports[`GuardrailNode > reject on error enabled > getNodeDisplayFile 1`] = `
 )
 from uuid import UUID
 from ...nodes.guardrail_node import GuardrailNode
-from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 
@@ -154,7 +157,14 @@ class GuardrailNodeDisplay(BaseGuardrailNodeDisplay[GuardrailNode]):
         "expected": UUID("3f917af8-03a4-4ca4-8d40-fa662417fe9c"),
         "actual": UUID("bed55ada-923e-46ef-8340-1a5b0b563dc1"),
     }
-    output_display = {}
+    output_display = {
+        GuardrailNode.Outputs.score1: NodeOutputDisplay(
+            id=UUID("mocked-input-id-1"), name="score1"
+        ),
+        GuardrailNode.Outputs.score2: NodeOutputDisplay(
+            id=UUID("mocked-input-id-2"), name="score2"
+        ),
+    }
     port_displays = {
         GuardrailNode.Ports.default: PortDisplayOverrides(
             id=UUID("92aafe31-101b-47d3-86f2-e261c7747c16")

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`InlinePromptNode > CHAT_MESSAGE block type > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "InlinePromptNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "prompt_node",
+  ],
+  "name": "PromptNode",
+}
+`;
+
 exports[`InlinePromptNode > CHAT_MESSAGE block type > basic > getNodeDisplayFile for CHAT_MESSAGE block type 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from ...nodes.prompt_node import PromptNode
@@ -285,6 +307,28 @@ class PromptNode(InlinePromptNode):
 "
 `;
 
+exports[`InlinePromptNode > FUNCTION_DEFINITION block type > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "InlinePromptNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "prompt_node",
+  ],
+  "name": "PromptNode",
+}
+`;
+
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > basic > getNodeDisplayFile for FUNCTION_DEFINITION block type 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from ...nodes.prompt_node import PromptNode
@@ -487,6 +531,28 @@ class PromptNode(InlinePromptNode):
         FunctionDefinition(name="functionTest", description="This is a test function")
     ]
 "
+`;
+
+exports[`InlinePromptNode > JINJA block type > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "InlinePromptNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "prompt_node",
+  ],
+  "name": "PromptNode",
+}
 `;
 
 exports[`InlinePromptNode > JINJA block type > basic > getNodeDisplayFile for JINJA block type 1`] = `
@@ -700,6 +766,28 @@ class PromptNode(InlinePromptNode):
     )
     prompt_inputs = {"text": Inputs.text}
 "
+`;
+
+exports[`InlinePromptNode > RICH_TEXT block type > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "InlinePromptNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "prompt_node",
+  ],
+  "name": "PromptNode",
+}
 `;
 
 exports[`InlinePromptNode > RICH_TEXT block type > basic > getNodeDisplayFile for RICH_TEXT block type 1`] = `
@@ -925,6 +1013,28 @@ class PromptNode(InlinePromptNode):
     )
     prompt_inputs = {"text": Inputs.text}
 "
+`;
+
+exports[`InlinePromptNode > VARIABLE block type > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "InlinePromptNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "prompt_node",
+  ],
+  "name": "PromptNode",
+}
 `;
 
 exports[`InlinePromptNode > VARIABLE block type > basic > getNodeDisplayFile for VARIABLE block type 1`] = `

--- a/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`MergeNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "MergeNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "merge_node",
+  ],
+  "name": "MergeNode",
+}
+`;
+
 exports[`MergeNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseMergeNodeDisplay
 from ...nodes.merge_node import MergeNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`NoteNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "NoteNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "note_node",
+  ],
+  "name": "NoteNode",
+}
+`;
+
 exports[`NoteNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseNoteNodeDisplay
 from ...nodes.note_node import NoteNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`PromptDeploymentNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "PromptDeploymentNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "prompt_deployment_node",
+  ],
+  "name": "PromptDeploymentNode",
+}
+`;
+
 exports[`PromptDeploymentNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BasePromptDeploymentNodeDisplay
 from ...nodes.prompt_deployment_node import PromptDeploymentNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`TextSearchNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "SearchNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "search_node",
+  ],
+  "name": "SearchNode",
+}
+`;
+
 exports[`TextSearchNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from ...nodes.search_node import SearchNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`SubworkflowDeploymentNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "SubworkflowDeploymentNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "subworkflow_node",
+  ],
+  "name": "SubworkflowNode",
+}
+`;
+
 exports[`SubworkflowDeploymentNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
 from ...nodes.subworkflow_node import SubworkflowNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`TemplatingNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "TemplatingNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "templating_node",
+  ],
+  "name": "TemplatingNode",
+}
+`;
+
 exports[`TemplatingNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from ...nodes.templating_node import TemplatingNode

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -64,6 +64,10 @@ describe("ApiNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("getNodeDefinition", () => {
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
   });
 
   describe("reject on error enabled", () => {

--- a/ee/codegen/src/__test__/nodes/conditional-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/conditional-node.test.ts
@@ -51,4 +51,8 @@ describe("ConditionalNode", () => {
     node.getNodeDisplayFile().write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
   });
+
+  it("getNodeDefinition", () => {
+    expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+  });
 });

--- a/ee/codegen/src/__test__/nodes/error-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/error-node.test.ts
@@ -42,5 +42,9 @@ describe("ErrorNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("getNodeDefinition", () => {
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/final-output-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/final-output-node.test.ts
@@ -42,5 +42,9 @@ describe("FinalOutputNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("getNodeDefinition", () => {
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/generic-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-node.test.ts
@@ -42,5 +42,9 @@ describe("GenericNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("getNodeDefinition", () => {
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
@@ -128,6 +128,12 @@ describe("GuardrailNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("getNodeDefinition", async () => {
+      const node = await createNode([]);
+
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
   });
 
   describe("reject on error enabled", () => {

--- a/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
@@ -13,7 +13,6 @@ import { GuardrailNode } from "src/generators/nodes/guardrail-node";
 describe("GuardrailNode", () => {
   let workflowContext: WorkflowContext;
   let writer: Writer;
-  let node: GuardrailNode;
 
   beforeEach(() => {
     workflowContext = workflowContextFactory();
@@ -53,44 +52,46 @@ describe("GuardrailNode", () => {
     );
   });
 
-  describe("basic", () => {
-    const mockMetricDefinition = (
-      outputVariables: { id: string; key: string; type: string }[]
-    ) => ({
-      id: "mocked-metric-output-id",
-      label: "mocked-metric-output-label",
-      name: "mocked-metric-output-name",
-      description: "mocked-metric-output-description",
-      outputVariables,
+  const mockMetricDefinition = (
+    outputVariables: { id: string; key: string; type: string }[]
+  ) => ({
+    id: "mocked-metric-output-id",
+    label: "mocked-metric-output-label",
+    name: "mocked-metric-output-name",
+    description: "mocked-metric-output-description",
+    outputVariables,
+  });
+
+  const createNode = async ({
+    errorOutputId,
+    outputVariables,
+  }: {
+    errorOutputId?: string;
+    outputVariables: { id: string; key: string; type: string }[];
+  }) => {
+    vi.spyOn(
+      MetricDefinitionsClient.prototype,
+      "metricDefinitionHistoryItemRetrieve"
+    ).mockResolvedValue(
+      mockMetricDefinition(
+        outputVariables
+      ) as unknown as MetricDefinitionHistoryItem
+    );
+    const nodeData = guardrailNodeDataFactory({ errorOutputId });
+
+    const nodeContext = (await createNodeContext({
+      workflowContext,
+      nodeData,
+    })) as GuardrailNodeContext;
+    workflowContext.addNodeContext(nodeContext);
+
+    return new GuardrailNode({
+      workflowContext: workflowContext,
+      nodeContext,
     });
+  };
 
-    const createNode = async (
-      outputVariables: { id: string; key: string; type: string }[]
-    ) => {
-      vi.spyOn(
-        MetricDefinitionsClient.prototype,
-        "metricDefinitionHistoryItemRetrieve"
-      ).mockResolvedValue(
-        mockMetricDefinition(
-          outputVariables
-        ) as unknown as MetricDefinitionHistoryItem
-      );
-      const nodeData = guardrailNodeDataFactory();
-
-      const nodeContext = (await createNodeContext({
-        workflowContext,
-        nodeData,
-      })) as GuardrailNodeContext;
-      workflowContext.addNodeContext(nodeContext);
-
-      return new GuardrailNode({
-        workflowContext: workflowContext,
-        nodeContext,
-      });
-    };
-
-    beforeEach(async () => {});
-
+  describe("basic", () => {
     it.each([
       [
         "single output variable",
@@ -104,7 +105,7 @@ describe("GuardrailNode", () => {
         ],
       ],
     ])("getNodeFile - %s", async (_, outputVariables) => {
-      const node = await createNode(outputVariables);
+      const node = await createNode({ outputVariables });
 
       node.getNodeFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -123,43 +124,42 @@ describe("GuardrailNode", () => {
         ],
       ],
     ])("getNodeDisplayFile - %s", async (_, outputVariables) => {
-      const node = await createNode(outputVariables);
+      const node = await createNode({ outputVariables });
 
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
 
     it("getNodeDefinition", async () => {
-      const node = await createNode([]);
+      const node = await createNode({ outputVariables: [] });
 
       expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
     });
   });
 
   describe("reject on error enabled", () => {
-    beforeEach(async () => {
-      const nodeData = guardrailNodeDataFactory({
-        errorOutputId: "38361ff1-c826-49b8-aa8d-28179c3684cc",
-      });
-
-      const nodeContext = (await createNodeContext({
-        workflowContext,
-        nodeData,
-      })) as GuardrailNodeContext;
-      workflowContext.addNodeContext(nodeContext);
-
-      node = new GuardrailNode({
-        workflowContext: workflowContext,
-        nodeContext,
-      });
-    });
-
     it("getNodeFile", async () => {
+      const node = await createNode({
+        errorOutputId: "38361ff1-c826-49b8-aa8d-28179c3684cc",
+        outputVariables: [
+          { id: "mocked-input-id-1", key: "score1", type: "NUMBER" },
+          { id: "mocked-input-id-2", key: "score2", type: "NUMBER" },
+        ],
+      });
+
       node.getNodeFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
 
     it("getNodeDisplayFile", async () => {
+      const node = await createNode({
+        errorOutputId: "38361ff1-c826-49b8-aa8d-28179c3684cc",
+        outputVariables: [
+          { id: "mocked-input-id-1", key: "score1", type: "NUMBER" },
+          { id: "mocked-input-id-2", key: "score2", type: "NUMBER" },
+        ],
+      });
+
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -69,6 +69,10 @@ describe("InlinePromptNode", () => {
         node.getNodeDisplayFile().write(writer);
         expect(await writer.toStringFormatted()).toMatchSnapshot();
       });
+
+      it("getNodeDefinition", () => {
+        expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+      });
     });
 
     describe("reject on error enabled", () => {

--- a/ee/codegen/src/__test__/nodes/merge-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/merge-node.test.ts
@@ -42,5 +42,9 @@ describe("MergeNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("getNodeDefinition", () => {
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/note-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/note-node.test.ts
@@ -42,5 +42,9 @@ describe("NoteNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("getNodeDefinition", () => {
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
@@ -42,5 +42,9 @@ describe("PromptDeploymentNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("getNodeDefinition", () => {
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -54,6 +54,10 @@ describe("TextSearchNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("getNodeDefinition", () => {
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
   });
 
   describe("reject on error enabled", () => {

--- a/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
@@ -55,5 +55,9 @@ describe("SubworkflowDeploymentNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("getNodeDefinition", () => {
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/templating-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/templating-node.test.ts
@@ -54,6 +54,10 @@ describe("TemplatingNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("getNodeDefinition", () => {
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
   });
 
   describe("reject on error enabled", () => {

--- a/ee/codegen/src/context/node-context/api-node.ts
+++ b/ee/codegen/src/context/node-context/api-node.ts
@@ -3,6 +3,9 @@ import { PortContext } from "src/context/port-context";
 import { ApiNode as ApiNodeType } from "src/types/vellum";
 
 export class ApiNodeContext extends BaseNodeContext<ApiNodeType> {
+  baseNodeClassName = "APINode";
+  baseNodeDisplayClassName = "BaseAPINodeDisplay";
+
   getNodeOutputNamesById(): Record<string, string> {
     return {
       [this.nodeData.data.jsonOutputId]: "json",

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -1,6 +1,6 @@
 import { WorkflowContext } from "src/context";
 import { PortContext } from "src/context/port-context";
-import { WorkflowDataNode } from "src/types/vellum";
+import { WorkflowDataNode, WorkflowNodeDefinition } from "src/types/vellum";
 import { getNodeId, getNodeLabel } from "src/utils/nodes";
 import {
   getGeneratedNodeDisplayModulePath,
@@ -87,6 +87,19 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
 
   public getNodeLabel(): string {
     return getNodeLabel(this.nodeData);
+  }
+
+  public getNodeDefinition(): WorkflowNodeDefinition {
+    return {
+      name: this.nodeClassName,
+      module: this.nodeModulePath,
+      bases: [
+        {
+          name: this.baseNodeClassName,
+          module: [...this.baseNodeClassModulePath],
+        },
+      ],
+    };
   }
 
   public getNodeOutputNameById(outputId: string): string {

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -26,6 +26,11 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
   public readonly nodeDisplayClassName: string;
 
   public nodeData: T;
+  public abstract readonly baseNodeClassName: string;
+  public abstract readonly baseNodeDisplayClassName: string;
+
+  public readonly baseNodeClassModulePath: readonly string[];
+  public readonly baseNodeDisplayClassModulePath: readonly string[];
 
   private nodeOutputNamesById: Record<string, string> | undefined;
   public readonly portContextsById: Map<string, PortContext>;
@@ -34,6 +39,11 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
   constructor(args: BaseNodeContext.Args<T>) {
     this.workflowContext = args.workflowContext;
     this.nodeData = args.nodeData;
+
+    this.baseNodeClassModulePath =
+      this.workflowContext.sdkModulePathNames.DISPLAYABLE_NODES_MODULE_PATH;
+    this.baseNodeDisplayClassModulePath =
+      this.workflowContext.sdkModulePathNames.NODE_DISPLAY_MODULE_PATH;
 
     const { moduleName, nodeClassName, modulePath } =
       getGeneratedNodeModuleInfo({
@@ -77,6 +87,10 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
 
   public getNodeLabel(): string {
     return getNodeLabel(this.nodeData);
+  }
+
+  public getNodeDefinition() {
+    return {};
   }
 
   public getNodeOutputNameById(outputId: string): string {

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -89,10 +89,6 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
     return getNodeLabel(this.nodeData);
   }
 
-  public getNodeDefinition() {
-    return {};
-  }
-
   public getNodeOutputNameById(outputId: string): string {
     // Lazily load node output names
     if (!this.nodeOutputNamesById) {

--- a/ee/codegen/src/context/node-context/code-execution-node.ts
+++ b/ee/codegen/src/context/node-context/code-execution-node.ts
@@ -4,6 +4,9 @@ import { PortContext } from "src/context/port-context";
 import { CodeExecutionNode as CodeExecutionNodeType } from "src/types/vellum";
 
 export class CodeExecutionContext extends BaseNodeContext<CodeExecutionNodeType> {
+  baseNodeClassName = "CodeExecutionNode";
+  baseNodeDisplayClassName = "BaseCodeExecutionNodeDisplay";
+
   public readonly filepath: string;
 
   constructor(args: BaseNodeContext.Args<CodeExecutionNodeType>) {

--- a/ee/codegen/src/context/node-context/conditional-node.ts
+++ b/ee/codegen/src/context/node-context/conditional-node.ts
@@ -3,6 +3,9 @@ import { PortContext } from "src/context/port-context";
 import { ConditionalNode } from "src/types/vellum";
 
 export class ConditionalNodeContext extends BaseNodeContext<ConditionalNode> {
+  baseNodeClassName = "ConditionalNode";
+  baseNodeDisplayClassName = "BaseConditionalNodeDisplay";
+
   protected getNodeOutputNamesById(): Record<string, string> {
     return {};
   }

--- a/ee/codegen/src/context/node-context/error-node.ts
+++ b/ee/codegen/src/context/node-context/error-node.ts
@@ -4,6 +4,9 @@ import { PortContext } from "src/context/port-context";
 import { ErrorNode } from "src/types/vellum";
 
 export class ErrorNodeContext extends BaseNodeContext<ErrorNode> {
+  baseNodeClassName = "ErrorNode";
+  baseNodeDisplayClassName = "BaseErrorNodeDisplay";
+
   getNodeOutputNamesById(): Record<string, string> {
     return {
       [this.nodeData.data.errorOutputId]: "error",

--- a/ee/codegen/src/context/node-context/final-output-node.ts
+++ b/ee/codegen/src/context/node-context/final-output-node.ts
@@ -3,6 +3,9 @@ import { PortContext } from "src/context/port-context";
 import { FinalOutputNode } from "src/types/vellum";
 
 export class FinalOutputNodeContext extends BaseNodeContext<FinalOutputNode> {
+  baseNodeClassName = "FinalOutputNode";
+  baseNodeDisplayClassName = "BaseFinalOutputNodeDisplay";
+
   protected getNodeOutputNamesById(): Record<string, string> {
     return {
       [this.nodeData.data.outputId]: "value",

--- a/ee/codegen/src/context/node-context/generic-node.ts
+++ b/ee/codegen/src/context/node-context/generic-node.ts
@@ -3,6 +3,9 @@ import { PortContext } from "src/context/port-context";
 import { GenericNode as GenericNodeType } from "src/types/vellum";
 
 export class GenericNodeContext extends BaseNodeContext<GenericNodeType> {
+  baseNodeClassName = "BaseNode";
+  baseNodeDisplayClassName = "BaseNodeDisplay";
+
   getNodeOutputNamesById(): Record<string, string> {
     return {};
   }

--- a/ee/codegen/src/context/node-context/guardrail-node.ts
+++ b/ee/codegen/src/context/node-context/guardrail-node.ts
@@ -12,6 +12,9 @@ export declare namespace GuardrailNodeContext {
 }
 
 export class GuardrailNodeContext extends BaseNodeContext<GuardrailNodeType> {
+  baseNodeClassName = "GuardrailNode";
+  baseNodeDisplayClassName = "BaseGuardrailNodeDisplay";
+
   public readonly metricDefinitionsHistoryItem: MetricDefinitionHistoryItem;
 
   constructor(args: GuardrailNodeContext.Args) {

--- a/ee/codegen/src/context/node-context/inline-prompt-node.ts
+++ b/ee/codegen/src/context/node-context/inline-prompt-node.ts
@@ -3,6 +3,9 @@ import { PortContext } from "src/context/port-context";
 import { InlinePromptNode as InlinePromptNodeType } from "src/types/vellum";
 
 export class InlinePromptNodeContext extends BaseNodeContext<InlinePromptNodeType> {
+  baseNodeClassName = "InlinePromptNode";
+  baseNodeDisplayClassName = "BaseInlinePromptNodeDisplay";
+
   protected getNodeOutputNamesById(): Record<string, string> {
     return {
       [this.nodeData.data.outputId]: "text",

--- a/ee/codegen/src/context/node-context/inline-subworkflow-node.ts
+++ b/ee/codegen/src/context/node-context/inline-subworkflow-node.ts
@@ -4,6 +4,9 @@ import { PortContext } from "src/context/port-context";
 import { SubworkflowNode as SubworkflowNodeType } from "src/types/vellum";
 
 export class InlineSubworkflowNodeContext extends BaseNodeContext<SubworkflowNodeType> {
+  baseNodeClassName = "InlineSubworkflowNode";
+  baseNodeDisplayClassName = "BaseInlineSubworkflowNodeDisplay";
+
   getNodeOutputNamesById(): Record<string, string> {
     const subworkflowNodeData = this.nodeData.data;
     if (subworkflowNodeData.variant !== "INLINE") {

--- a/ee/codegen/src/context/node-context/map-node.ts
+++ b/ee/codegen/src/context/node-context/map-node.ts
@@ -4,6 +4,8 @@ import { PortContext } from "src/context/port-context";
 import { MapNode as MapNodeType } from "src/types/vellum";
 
 export class MapNodeContext extends BaseNodeContext<MapNodeType> {
+  baseNodeClassName = "MapNode";
+  baseNodeDisplayClassName = "BaseMapNodeDisplay";
   getNodeOutputNamesById(): Record<string, string> {
     const subworkflowNodeData = this.nodeData.data;
     if (subworkflowNodeData.variant !== "INLINE") {

--- a/ee/codegen/src/context/node-context/merge-node.ts
+++ b/ee/codegen/src/context/node-context/merge-node.ts
@@ -4,6 +4,9 @@ import { PortContext } from "src/context/port-context";
 import { MergeNode } from "src/types/vellum";
 
 export class MergeNodeContext extends BaseNodeContext<MergeNode> {
+  baseNodeClassName = "MergeNode";
+  baseNodeDisplayClassName = "BaseMergeNodeDisplay";
+
   getNodeOutputNamesById(): Record<string, string> {
     return {};
   }

--- a/ee/codegen/src/context/node-context/note-node.ts
+++ b/ee/codegen/src/context/node-context/note-node.ts
@@ -4,6 +4,9 @@ import { PortContext } from "src/context/port-context";
 import { NoteNode } from "src/types/vellum";
 
 export class NoteNodeContext extends BaseNodeContext<NoteNode> {
+  baseNodeClassName = "NoteNode";
+  baseNodeDisplayClassName = "BaseNoteNodeDisplay";
+
   getNodeOutputNamesById(): Record<string, string> {
     return {};
   }

--- a/ee/codegen/src/context/node-context/prompt-deployment-node.ts
+++ b/ee/codegen/src/context/node-context/prompt-deployment-node.ts
@@ -3,6 +3,9 @@ import { PortContext } from "src/context/port-context";
 import { PromptNode } from "src/types/vellum";
 
 export class PromptDeploymentNodeContext extends BaseNodeContext<PromptNode> {
+  baseNodeClassName = "PromptDeploymentNode";
+  baseNodeDisplayClassName = "BasePromptDeploymentNodeDisplay";
+
   protected getNodeOutputNamesById(): Record<string, string> {
     return {
       [this.nodeData.data.outputId]: "text",

--- a/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
@@ -13,6 +13,9 @@ export declare namespace SubworkflowDeploymentNodeContext {
 }
 
 export class SubworkflowDeploymentNodeContext extends BaseNodeContext<SubworkflowNodeType> {
+  baseNodeClassName = "SubworkflowDeploymentNode";
+  baseNodeDisplayClassName = "BaseSubworkflowDeploymentNodeDisplay";
+
   public workflowDeploymentHistoryItem: WorkflowDeploymentHistoryItem;
 
   constructor(args: SubworkflowDeploymentNodeContext.Args) {

--- a/ee/codegen/src/context/node-context/templating-node.ts
+++ b/ee/codegen/src/context/node-context/templating-node.ts
@@ -3,6 +3,9 @@ import { PortContext } from "src/context/port-context";
 import { TemplatingNode } from "src/types/vellum";
 
 export class TemplatingNodeContext extends BaseNodeContext<TemplatingNode> {
+  baseNodeClassName = "TemplatingNode";
+  baseNodeDisplayClassName = "BaseTemplatingNodeDisplay";
+
   protected getNodeOutputNamesById(): Record<string, string> {
     return {
       [this.nodeData.data.outputId]: "result",

--- a/ee/codegen/src/context/node-context/text-search-node.ts
+++ b/ee/codegen/src/context/node-context/text-search-node.ts
@@ -4,6 +4,9 @@ import { PortContext } from "src/context/port-context";
 import { SearchNode } from "src/types/vellum";
 
 export class TextSearchNodeContext extends BaseNodeContext<SearchNode> {
+  baseNodeClassName = "SearchNode";
+  baseNodeDisplayClassName = "BaseSearchNodeDisplay";
+
   getNodeOutputNamesById(): Record<string, string> {
     return {
       [this.nodeData.data.resultsOutputId]: "results",

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -9,9 +9,6 @@ import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base"
 import { ApiNode as ApiNodeType, ConstantValuePointer } from "src/types/vellum";
 
 export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
-  baseNodeClassName = "APINode";
-  baseNodeDisplayClassName = "BaseAPINodeDisplay";
-
   getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -31,8 +31,6 @@ export abstract class BaseNode<
 
   protected readonly nodeInputsByKey: Map<string, NodeInput>;
 
-  protected abstract readonly baseNodeClassName: string;
-  protected abstract readonly baseNodeDisplayClassName: string;
   private readonly errorOutputId: string | undefined;
 
   constructor({ workflowContext, nodeContext }: BaseNode.Args<T, V>) {
@@ -65,16 +63,15 @@ export abstract class BaseNode<
 
   protected getNodeBaseClass(): python.Reference {
     const baseNodeClassNameAlias =
-      this.baseNodeClassName === this.nodeContext.nodeClassName
-        ? `Base${this.baseNodeClassName}`
+      this.nodeContext.baseNodeClassName === this.nodeContext.nodeClassName
+        ? `Base${this.nodeContext.baseNodeClassName}`
         : undefined;
 
     const baseNodeGenericTypes = this.getNodeBaseGenericTypes();
 
     return python.reference({
-      name: this.baseNodeClassName,
-      modulePath:
-        this.workflowContext.sdkModulePathNames.DISPLAYABLE_NODES_MODULE_PATH,
+      name: this.nodeContext.baseNodeClassName,
+      modulePath: this.nodeContext.baseNodeClassModulePath,
       genericTypes: baseNodeGenericTypes,
       alias: baseNodeClassNameAlias,
     });
@@ -82,9 +79,8 @@ export abstract class BaseNode<
 
   protected getNodeDisplayBaseClass(): python.Reference {
     return python.reference({
-      name: this.baseNodeDisplayClassName,
-      modulePath:
-        this.workflowContext.sdkModulePathNames.NODE_DISPLAY_MODULE_PATH,
+      name: this.nodeContext.baseNodeDisplayClassName,
+      modulePath: this.nodeContext.baseNodeDisplayClassModulePath,
       genericTypes: [
         python.reference({
           name: this.nodeContext.nodeClassName,

--- a/ee/codegen/src/generators/nodes/code-execution-node.ts
+++ b/ee/codegen/src/generators/nodes/code-execution-node.ts
@@ -18,9 +18,6 @@ export class CodeExecutionNode extends BaseSingleFileNode<
 > {
   public declare readonly nodeContext: CodeExecutionContext;
 
-  baseNodeClassName = "CodeExecutionNode";
-  baseNodeDisplayClassName = "BaseCodeExecutionNodeDisplay";
-
   // Override
   public async persist(): Promise<void> {
     const nodeInitFile = new InitFile({

--- a/ee/codegen/src/generators/nodes/conditional-node.ts
+++ b/ee/codegen/src/generators/nodes/conditional-node.ts
@@ -18,9 +18,6 @@ export class ConditionalNode extends BaseSingleFileNode<
   ConditionalNodeType,
   ConditionalNodeContext
 > {
-  baseNodeClassName = "ConditionalNode";
-  baseNodeDisplayClassName = "BaseConditionalNodeDisplay";
-
   protected getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 

--- a/ee/codegen/src/generators/nodes/error-node.ts
+++ b/ee/codegen/src/generators/nodes/error-node.ts
@@ -10,9 +10,6 @@ export class ErrorNode extends BaseSingleFileNode<
   ErrorNodeType,
   ErrorNodeContext
 > {
-  baseNodeClassName = "ErrorNode";
-  baseNodeDisplayClassName = "BaseErrorNodeDisplay";
-
   getNodeClassBodyStatements(): AstNode[] {
     const bodyStatements: AstNode[] = [];
     bodyStatements.push(

--- a/ee/codegen/src/generators/nodes/final-output-node.ts
+++ b/ee/codegen/src/generators/nodes/final-output-node.ts
@@ -12,9 +12,6 @@ export class FinalOutputNode extends BaseSingleFileNode<
   FinalOutputNodeType,
   FinalOutputNodeContext
 > {
-  baseNodeClassName = "FinalOutputNode";
-  baseNodeDisplayClassName = "BaseFinalOutputNodeDisplay";
-
   protected getNodeBaseGenericTypes(): AstNode[] {
     const baseStateClassReference = new BaseState({
       workflowContext: this.workflowContext,

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -9,9 +9,6 @@ export class GenericNode extends BaseSingleFileNode<
   GenericNodeType,
   GenericNodeContext
 > {
-  baseNodeClassName = "BaseNode";
-  baseNodeDisplayClassName = "BaseNodeDisplay";
-
   getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
     return statements;

--- a/ee/codegen/src/generators/nodes/guardrail-node.ts
+++ b/ee/codegen/src/generators/nodes/guardrail-node.ts
@@ -10,9 +10,6 @@ export class GuardrailNode extends BaseSingleFileNode<
   GuardrailNodeType,
   GuardrailNodeContext
 > {
-  baseNodeClassName = "GuardrailNode";
-  baseNodeDisplayClassName = "BaseGuardrailNodeDisplay";
-
   getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 

--- a/ee/codegen/src/generators/nodes/inline-prompt-node.ts
+++ b/ee/codegen/src/generators/nodes/inline-prompt-node.ts
@@ -18,9 +18,6 @@ export class InlinePromptNode extends BaseSingleFileNode<
   InlinePromptNodeType,
   InlinePromptNodeContext
 > {
-  baseNodeClassName = "InlinePromptNode";
-  baseNodeDisplayClassName = "BaseInlinePromptNodeDisplay";
-
   protected getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 

--- a/ee/codegen/src/generators/nodes/inline-subworkflow-node.ts
+++ b/ee/codegen/src/generators/nodes/inline-subworkflow-node.ts
@@ -14,9 +14,6 @@ export class InlineSubworkflowNode extends BaseNestedWorkflowNode<
   SubworkflowNodeType,
   InlineSubworkflowNodeContext
 > {
-  baseNodeClassName = "InlineSubworkflowNode";
-  baseNodeDisplayClassName = "BaseInlineSubworkflowNodeDisplay";
-
   getInnerWorkflowData(): WorkflowRawData {
     if (this.nodeData.data.variant !== "INLINE") {
       throw new Error(

--- a/ee/codegen/src/generators/nodes/map-node.ts
+++ b/ee/codegen/src/generators/nodes/map-node.ts
@@ -16,9 +16,6 @@ export class MapNode extends BaseNestedWorkflowNode<
   MapNodeType,
   MapNodeContext
 > {
-  baseNodeClassName = "MapNode";
-  baseNodeDisplayClassName = "BaseMapNodeDisplay";
-
   getInnerWorkflowData(): WorkflowRawData {
     if (this.nodeData.data.variant !== "INLINE") {
       throw new Error(

--- a/ee/codegen/src/generators/nodes/merge-node.ts
+++ b/ee/codegen/src/generators/nodes/merge-node.ts
@@ -10,9 +10,6 @@ export class MergeNode extends BaseSingleFileNode<
   MergeNodeType,
   MergeNodeContext
 > {
-  baseNodeClassName = "MergeNode";
-  baseNodeDisplayClassName = "BaseMergeNodeDisplay";
-
   getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 

--- a/ee/codegen/src/generators/nodes/note-node.ts
+++ b/ee/codegen/src/generators/nodes/note-node.ts
@@ -11,9 +11,6 @@ export class NoteNode extends BaseSingleFileNode<
   NoteNodeType,
   NoteNodeContext
 > {
-  baseNodeClassName = "NoteNode";
-  baseNodeDisplayClassName = "BaseNoteNodeDisplay";
-
   getNodeClassBodyStatements(): AstNode[] {
     // Note Nodes intentionally have no body statements.
     return [];

--- a/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
@@ -10,9 +10,6 @@ export class PromptDeploymentNode extends BaseSingleFileNode<
   PromptNode,
   PromptDeploymentNodeContext
 > {
-  baseNodeClassName = "PromptDeploymentNode";
-  baseNodeDisplayClassName = "BasePromptDeploymentNodeDisplay";
-
   protected getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 

--- a/ee/codegen/src/generators/nodes/search-node.ts
+++ b/ee/codegen/src/generators/nodes/search-node.ts
@@ -11,9 +11,6 @@ export class SearchNode extends BaseSingleFileNode<
   SearchNodeType,
   TextSearchNodeContext
 > {
-  baseNodeClassName = "SearchNode";
-  baseNodeDisplayClassName = "BaseSearchNodeDisplay";
-
   getNodeClassBodyStatements(): AstNode[] {
     const bodyStatements: AstNode[] = [];
 

--- a/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
@@ -11,9 +11,6 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
   SubworkflowNodeType,
   SubworkflowDeploymentNodeContext
 > {
-  baseNodeClassName = "SubworkflowDeploymentNode";
-  baseNodeDisplayClassName = "BaseSubworkflowDeploymentNodeDisplay";
-
   getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 

--- a/ee/codegen/src/generators/nodes/templating-node.ts
+++ b/ee/codegen/src/generators/nodes/templating-node.ts
@@ -12,9 +12,6 @@ export class TemplatingNode extends BaseSingleFileNode<
   TemplatingNodeType,
   TemplatingNodeContext
 > {
-  baseNodeClassName = "TemplatingNode";
-  baseNodeDisplayClassName = "BaseTemplatingNodeDisplay";
-
   protected getNodeBaseGenericTypes(): AstNode[] {
     const baseStateClassReference = new BaseState({
       workflowContext: this.workflowContext,

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -88,7 +88,7 @@ export declare namespace WorkflowProjectGenerator {
 
 export class WorkflowProjectGenerator {
   public readonly workflowVersionExecConfig: WorkflowVersionExecConfig;
-  private readonly workflowContext: WorkflowContext;
+  public readonly workflowContext: WorkflowContext;
 
   constructor({ moduleName, ...rest }: WorkflowProjectGenerator.Args) {
     if ("workflowContext" in rest) {


### PR DESCRIPTION
Codegen service will need to return not only the generated files, but also a mapping between Node IDs and Node Definitions.

This PR adds everything needed for codegen service to be able to do this. Specifically:
1. Make `workflowContext` publicly accessible
2. Move info about node base classes to node context and out of the ast node
3. Create a helper on node context to get the definition

I'll get a PR up in codegen service next that makes use of a new release of the package.