### PR TITLE
Use core module definitions for core nodes

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
@@ -8,7 +8,7 @@ exports[`ErrorNode > basic > getNodeDefinition 1`] = `
         "vellum",
         "workflows",
         "nodes",
-        "displayable",
+        "core",
       ],
       "name": "ErrorNode",
     },

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -8,7 +8,7 @@ exports[`TemplatingNode > basic > getNodeDefinition 1`] = `
         "vellum",
         "workflows",
         "nodes",
-        "displayable",
+        "core",
       ],
       "name": "TemplatingNode",
     },

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -29,6 +29,7 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
   public abstract readonly baseNodeClassName: string;
   public abstract readonly baseNodeDisplayClassName: string;
 
+  protected isCore = false;
   public readonly baseNodeClassModulePath: readonly string[];
   public readonly baseNodeDisplayClassModulePath: readonly string[];
 
@@ -96,7 +97,12 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
       bases: [
         {
           name: this.baseNodeClassName,
-          module: [...this.baseNodeClassModulePath],
+          module: [
+            ...(this.isCore
+              ? this.workflowContext.sdkModulePathNames.CORE_NODES_MODULE_PATH
+              : this.workflowContext.sdkModulePathNames
+                  .DISPLAYABLE_NODES_MODULE_PATH),
+          ],
         },
       ],
     };

--- a/ee/codegen/src/context/node-context/error-node.ts
+++ b/ee/codegen/src/context/node-context/error-node.ts
@@ -6,6 +6,7 @@ import { ErrorNode } from "src/types/vellum";
 export class ErrorNodeContext extends BaseNodeContext<ErrorNode> {
   baseNodeClassName = "ErrorNode";
   baseNodeDisplayClassName = "BaseErrorNodeDisplay";
+  isCore = true;
 
   getNodeOutputNamesById(): Record<string, string> {
     return {

--- a/ee/codegen/src/context/node-context/inline-subworkflow-node.ts
+++ b/ee/codegen/src/context/node-context/inline-subworkflow-node.ts
@@ -6,6 +6,7 @@ import { SubworkflowNode as SubworkflowNodeType } from "src/types/vellum";
 export class InlineSubworkflowNodeContext extends BaseNodeContext<SubworkflowNodeType> {
   baseNodeClassName = "InlineSubworkflowNode";
   baseNodeDisplayClassName = "BaseInlineSubworkflowNodeDisplay";
+  isCore = true;
 
   getNodeOutputNamesById(): Record<string, string> {
     const subworkflowNodeData = this.nodeData.data;

--- a/ee/codegen/src/context/node-context/map-node.ts
+++ b/ee/codegen/src/context/node-context/map-node.ts
@@ -6,6 +6,8 @@ import { MapNode as MapNodeType } from "src/types/vellum";
 export class MapNodeContext extends BaseNodeContext<MapNodeType> {
   baseNodeClassName = "MapNode";
   baseNodeDisplayClassName = "BaseMapNodeDisplay";
+  isCore = true;
+
   getNodeOutputNamesById(): Record<string, string> {
     const subworkflowNodeData = this.nodeData.data;
     if (subworkflowNodeData.variant !== "INLINE") {

--- a/ee/codegen/src/context/node-context/templating-node.ts
+++ b/ee/codegen/src/context/node-context/templating-node.ts
@@ -5,6 +5,7 @@ import { TemplatingNode } from "src/types/vellum";
 export class TemplatingNodeContext extends BaseNodeContext<TemplatingNode> {
   baseNodeClassName = "TemplatingNode";
   baseNodeDisplayClassName = "BaseTemplatingNodeDisplay";
+  isCore = true;
 
   protected getNodeOutputNamesById(): Record<string, string> {
     return {


### PR DESCRIPTION
[These](https://github.com/vellum-ai/vellum-python-sdks/blob/main/src/vellum/workflows/nodes/displayable/__init__.py#L1-L4) four nodes will actually emit `module` paths in their events with `core` instead of `displayable`, bc that's where they actually live. This means there's a difference between the _import module_ and the _definition module_. This PR attempts to address this disparity