### PR TITLE
Fix simple merge node test

### DIFF
--- a/ee/codegen_integration/conftest.py
+++ b/ee/codegen_integration/conftest.py
@@ -33,13 +33,11 @@ _fixture_paths = _get_fixtures(
     # TODO: Remove exclusions on all of these fixtures
     # https://app.shortcut.com/vellum/story/4649/remove-fixture-exclusions-for-serialization
     exclude_fixtures={
-        "simple_merge_node",
         "faa_q_and_a_bot",
         # TODO: Remove the bottom three in fast follows
         "simple_inline_subworkflow_node",
         "simple_map_node",
     },
-    include_fixtures={"simple_search_node"},
 )
 _fixture_ids = [os.path.basename(path) for path in _fixture_paths]
 

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/merge_node.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/merge_node.py
@@ -8,7 +8,7 @@ from ...nodes.merge_node import MergeNode
 
 
 class MergeNodeDisplay(BaseMergeNodeDisplay[MergeNode]):
-    target_handle_ids = [UUID("cf6974a6-1676-43ed-99a0-66bd3eac235f"), UUID("dee0633e-0221-40c7-b179-aae1cf67de87")]
+    target_handle_ids = [UUID("dee0633e-0221-40c7-b179-aae1cf67de87"), UUID("cf6974a6-1676-43ed-99a0-66bd3eac235f")]
     node_input_ids_by_name = {}
     port_displays = {MergeNode.Ports.default: PortDisplayOverrides(id=UUID("e0e666c4-a90b-4a95-928e-144bab251356"))}
     display_data = NodeDisplayData(

--- a/ee/codegen_integration/fixtures/simple_merge_node/display_data/simple_merge_node.json
+++ b/ee/codegen_integration/fixtures/simple_merge_node/display_data/simple_merge_node.json
@@ -19,13 +19,7 @@
         },
         "definition": {
           "bases": [],
-          "module": [
-            "vellum",
-            "workflows",
-            "nodes",
-            "bases",
-            "base"
-          ],
+          "module": ["vellum", "workflows", "nodes", "bases", "base"],
           "name": "BaseNode"
         }
       },
@@ -100,10 +94,10 @@
           "merge_strategy": "AWAIT_ALL",
           "target_handles": [
             {
-              "id": "cf6974a6-1676-43ed-99a0-66bd3eac235f"
+              "id": "dee0633e-0221-40c7-b179-aae1cf67de87"
             },
             {
-              "id": "dee0633e-0221-40c7-b179-aae1cf67de87"
+              "id": "cf6974a6-1676-43ed-99a0-66bd3eac235f"
             }
           ],
           "source_handle_id": "e0e666c4-a90b-4a95-928e-144bab251356"

--- a/ee/codegen_integration/fixtures/simple_merge_node/display_data/simple_merge_node.json
+++ b/ee/codegen_integration/fixtures/simple_merge_node/display_data/simple_merge_node.json
@@ -93,7 +93,7 @@
         }
       },
       {
-        "id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
+        "id": "7426f273-a43d-4448-a2d2-76d0ee0d069c",
         "type": "MERGE",
         "data": {
           "label": "Merge Node",
@@ -384,13 +384,13 @@
         "id": "114b1eab-ad2a-4612-b590-35f6ebdd87bc",
         "source_node_id": "5b7d7b3f-e10d-4334-a217-9099dececd8d",
         "source_handle_id": "a5ae5a5c-ad8a-4a19-a726-f3b8ed1fbb1b",
-        "target_node_id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
+        "target_node_id": "7426f273-a43d-4448-a2d2-76d0ee0d069c",
         "target_handle_id": "dee0633e-0221-40c7-b179-aae1cf67de87",
         "type": "DEFAULT"
       },
       {
         "id": "fba82107-15bc-4033-9b38-6a8b0094aa7f",
-        "source_node_id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
+        "source_node_id": "7426f273-a43d-4448-a2d2-76d0ee0d069c",
         "source_handle_id": "e0e666c4-a90b-4a95-928e-144bab251356",
         "target_node_id": "7f7823e9-b97a-4bbe-bfcf-40aed8db24c9",
         "target_handle_id": "2c1e39e0-ce3e-4c2d-8baf-c5d93b244997",
@@ -408,7 +408,7 @@
         "id": "20c8d251-bcf1-497e-8d37-668e661ccabc",
         "source_node_id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
         "source_handle_id": "e900aa36-b59e-4d13-bb66-21967eb02214",
-        "target_node_id": "f2f5e81f-6ffe-4b0b-9116-a39f24001483",
+        "target_node_id": "7426f273-a43d-4448-a2d2-76d0ee0d069c",
         "target_handle_id": "cf6974a6-1676-43ed-99a0-66bd3eac235f",
         "type": "DEFAULT"
       }

--- a/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
@@ -30,6 +30,9 @@ class BaseNodeVellumDisplay(BaseNodeDisplay[NodeType]):
     def get_target_handle_id(self) -> UUID:
         return self._get_node_display_uuid("target_handle_id")
 
+    def get_target_handle_id_by_source_node_id(self, source_node_id: UUID) -> UUID:
+        return self.get_target_handle_id()
+
     def get_source_handle_id(self, port_displays: Dict[Port, PortDisplay]) -> UUID:
         default_port = self._node.Ports.default
         default_port_display = port_displays[default_port]

--- a/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
@@ -30,9 +30,6 @@ class BaseNodeVellumDisplay(BaseNodeDisplay[NodeType]):
     def get_target_handle_id(self) -> UUID:
         return self._get_node_display_uuid("target_handle_id")
 
-    def get_target_handle_id_by_source_node_id(self, source_node_id: UUID) -> UUID:
-        return self.get_target_handle_id()
-
     def get_source_handle_id(self, port_displays: Dict[Port, PortDisplay]) -> UUID:
         default_port = self._node.Ports.default
         default_port_display = port_displays[default_port]

--- a/ee/vellum_ee/workflows/display/nodes/vellum/merge_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/merge_node.py
@@ -51,11 +51,16 @@ class BaseMergeNodeDisplay(BaseNodeVellumDisplay[_MergeNodeType], Generic[_Merge
     def get_target_handle_ids(self) -> Optional[List[UUID]]:
         return self._get_explicit_node_display_attr("target_handle_ids", List[UUID])
 
-    def get_target_handle_id(self) -> UUID:
+    def get_target_handle_id_by_source_node_id(self, source_node_id: UUID) -> UUID:
+        target_handle_ids = self.get_target_handle_ids()
+        if target_handle_ids is None:
+            return uuid4_from_hash(f"{self.node_id}|target_handle|{source_node_id}")
+
         # Edges call this method to know which handle to connect to
         # We use the order of the edges to determine the handle id. This is quite brittle to the order of the
-        # edges, and we should look into a longer term solution, or cutover Merge Nodes to Generic Nodes soon
-        target_handle_id = self.target_handle_ids[self._target_handle_iterator]
+        # edges matching the order of the Merge Node's data.target_handles attribute. We should look into a
+        # longer term solution, or cutover Merge Nodes to Generic Nodes soon
+        target_handle_id = target_handle_ids[self._target_handle_iterator]
         self._target_handle_iterator += 1
         if self._target_handle_iterator >= len(self.target_handle_ids):
             self._target_handle_iterator = 0

--- a/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
@@ -27,7 +27,11 @@ class BaseTemplatingNodeDisplay(BaseNodeVellumDisplay[_TemplatingNodeType], Gene
             input_name="template",
             value=node.template,
             display_context=display_context,
-            input_id=self.template_input_id,
+            input_id=self.template_input_id
+            or next(
+                (input_id for input_name, input_id in self.node_input_ids_by_name.items() if input_name == "template"),
+                None,
+            ),
         )
         template_node_inputs = raise_if_descriptor(node.inputs)
         template_inputs = [
@@ -36,9 +40,10 @@ class BaseTemplatingNodeDisplay(BaseNodeVellumDisplay[_TemplatingNodeType], Gene
                 input_name=variable_name,
                 value=variable_value,
                 display_context=display_context,
-                input_id=self.input_ids_by_name.get("template"),
+                input_id=self.input_ids_by_name.get(variable_name) or self.node_input_ids_by_name.get(variable_name),
             )
             for variable_name, variable_value in template_node_inputs.items()
+            if variable_name != "template"
         ]
         node_inputs = [template_node_input, *template_inputs]
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_merge_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_merge_node_serialization.py
@@ -218,7 +218,7 @@ def test_serialize_workflow__await_all():
                 "source_node_id": "59243c65-053f-4ea6-9157-3f3edb1477bf",
                 "source_handle_id": "b9c5f52b-b714-46e8-a09c-38b4e770dd36",
                 "target_node_id": "37c10e8a-771b-432b-a767-31f5007851f0",
-                "target_handle_id": "0efd256f-f5f6-45fe-9adb-651780f5e63d",
+                "target_handle_id": "42eeb66c-9792-4609-8c71-3a56f668f4dc",
                 "type": "DEFAULT",
             },
             {
@@ -226,7 +226,7 @@ def test_serialize_workflow__await_all():
                 "source_node_id": "127ef456-91bc-43c6-bd8b-1772db5e3cb5",
                 "source_handle_id": "b0bd17f3-4ce6-4232-9666-ec8afa161bf2",
                 "target_node_id": "37c10e8a-771b-432b-a767-31f5007851f0",
-                "target_handle_id": "0efd256f-f5f6-45fe-9adb-651780f5e63d",
+                "target_handle_id": "f40ff7fb-de1b-4aa4-ba3c-7630f7357cbf",
                 "type": "DEFAULT",
             },
             {

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -12,6 +12,7 @@ from vellum.workflows.references import WorkflowInputReference
 from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
+from vellum_ee.workflows.display.nodes import BaseMergeNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
@@ -366,7 +367,12 @@ class VellumWorkflowDisplay(
 
         target_node_display = node_displays[target_node]
         target_node_id = target_node_display.node_id
-        target_handle_id = target_node_display.get_target_handle_id_by_source_node_id(source_node_id)
+
+        target_handle_id: UUID
+        if isinstance(target_node_display, BaseMergeNodeDisplay):
+            target_handle_id = target_node_display.get_target_handle_id_by_source_node_id(source_node_id)
+        else:
+            target_handle_id = target_node_display.get_target_handle_id()
 
         return self._generate_edge_display_from_source(
             source_node_id, source_handle_id, target_node_id, target_handle_id, overrides

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -366,7 +366,7 @@ class VellumWorkflowDisplay(
 
         target_node_display = node_displays[target_node]
         target_node_id = target_node_display.node_id
-        target_handle_id = target_node_display.get_target_handle_id()
+        target_handle_id = target_node_display.get_target_handle_id_by_source_node_id(source_node_id)
 
         return self._generate_edge_display_from_source(
             source_node_id, source_handle_id, target_node_id, target_handle_id, overrides


### PR DESCRIPTION
DeepScribe's simple workflow was blocked on edges to merge nodes having the proper target handle ids:
<img width="1346" alt="Screenshot 2024-12-11 at 5 42 13 PM" src="https://github.com/user-attachments/assets/28726a21-3083-4b41-add6-c7508bf1f0ec" />

The solution I came to was pretty brittle, and believe would require passing something about the old set of edges data as context. Happy to do something like that with guidance as part of this PR, or hand off to codegen/serialization crew as part of a followup. My end goal with this PR was to:
- uncomment and reinclude tests related to merge nodes as soon as possible
- unblock the workflow screenshotted above