### PR TITLE
Fix mypy errors when setting TemplatingNode.inputs[key] to a descriptor of an int

### DIFF
--- a/src/vellum/workflows/descriptors/base.py
+++ b/src/vellum/workflows/descriptors/base.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from vellum.workflows.nodes.bases import BaseNode
     from vellum.workflows.state.base import BaseState
 
-_T = TypeVar("_T")
+_T = TypeVar("_T", covariant=True)
 _O = TypeVar("_O")
 _O2 = TypeVar("_O2")
 

--- a/src/vellum/workflows/nodes/bases/tests/test_base_node.py
+++ b/src/vellum/workflows/nodes/bases/tests/test_base_node.py
@@ -25,7 +25,7 @@ def test_base_node__node_resolution__unset_pydantic_fields():
     assert node.data.dict() == my_data.dict()
 
 
-def test_base_node__node_resolution__descriptor_in_dict():
+def test_base_node__node_resolution__descriptors_in_dict():
     # GIVEN an Input and State class
     class Inputs(BaseInputs):
         hello: str

--- a/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
@@ -1,5 +1,6 @@
 import json
 
+from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.templating_node.node import TemplatingNode
 
 
@@ -19,3 +20,23 @@ def test_templating_node__dict_output():
 
     # THEN the output is json serializable
     assert json.loads(outputs.result) == {"key": "value"}
+
+
+def test_templating_node__execution_count_reference():
+    # GIVEN a random node
+    class OtherNode(BaseNode):
+        pass
+
+    # AND a templating node that references the execution count of the random node
+    class TemplateNode(TemplatingNode):
+        template = "{{ total }}"
+        inputs = {
+            "total": OtherNode.Execution.count,
+        }
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN the output is just the total
+    assert outputs.result == "0"


### PR DESCRIPTION
The first commit setups up a test that shows the mypy error we were seeing in some pulled workflows. The second commit is the one line fix. For more information on covariants and contravariants, see this explanation from cursor:
<img width="1021" alt="Screenshot 2024-12-12 at 4 24 09 PM" src="https://github.com/user-attachments/assets/54497591-67b8-484a-a9fd-ccc816d35b75" />

Based on what I read above, Descriptors are always meant to be a container type that should "go with", which is why I landed on covariant.