### PR TITLE
[Codegen] Handle Duplicative Nodes Class Names

### DIFF
--- a/ee/codegen/README.md
+++ b/ee/codegen/README.md
@@ -118,12 +118,12 @@ changes in the workflow codegen package locally, follow these steps:
 2. Update the `"@fern-api/python-ast"` dependency in `package.json` to point to the local fern repository.
    It should be the relative file path to the `ast` directory in this repository.
    ```json
-   "@fern-api/python-ast": "file:../../../fern-api/fern/generators/python-v2/ast/lib",
+   "@fern-api/python-ast": "file:../../../../fern-api/fern/generators/python-v2/ast/lib",
    ```
 3. Run `npm install` to install the updated dependency.
 4. Navigate to the `fern` repo and be sure to pull the `vargas/publish-python-ast` branch.
 5. Make changes to the fern python ast package.
-6. After making changes, run `pnpm dist` within `fern/generators/python-v2/ast` to compile the changes.
+6. After making changes, run `pnpm compile` within `fern/generators/python-v2/ast` to compile the changes.
 7. Navigate back to this repo and make use of these changes
 8. Open a PR of the commit in its own branch (separate from the `vargas/publish-python-ast` branch) in the fern repository to merge your changes.
 9. Work with a Vellum Admin to cut a new release of the package as we'll need to rebase the `vargas/publish-python-ast`

--- a/ee/codegen/package-lock.json
+++ b/ee/codegen/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@vellum-ai/vellum-codegen",
       "version": "0.11.1-post1",
       "dependencies": {
-        "@fern-api/python-ast": "^0.0.14",
+        "@fern-api/python-ast": "^0.0.17",
         "@fern-fern/generator-cli-sdk": "file:./stubs/generator-cli-sdk",
         "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
         "lodash": "^4.17.21",
@@ -691,9 +691,9 @@
       }
     },
     "node_modules/@fern-api/python-ast": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.14.tgz",
-      "integrity": "sha512-i56Q5wz/o9mi7/Ete0WZjkXFHdlyZx54GLKsTIlcaEKtVy2o/20dcc1lXVsHaxfQhqiuHuBDaG2mvHL4G1Pj3w==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.17.tgz",
+      "integrity": "sha512-vfwgWVOYcV9Ll46BQEbESh1j+/l77tn7vWLWWu1JBcttZxAJrKLxqdtHgRzEe4eFDCW65MpvQG7nOkY0nYilrQ==",
       "dependencies": {
         "@fern-api/base-generator": "0.0.6",
         "@fern-api/core-utils": "^0.15.0-rc63",
@@ -6557,9 +6557,9 @@
       }
     },
     "@fern-api/python-ast": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.14.tgz",
-      "integrity": "sha512-i56Q5wz/o9mi7/Ete0WZjkXFHdlyZx54GLKsTIlcaEKtVy2o/20dcc1lXVsHaxfQhqiuHuBDaG2mvHL4G1Pj3w==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.17.tgz",
+      "integrity": "sha512-vfwgWVOYcV9Ll46BQEbESh1j+/l77tn7vWLWWu1JBcttZxAJrKLxqdtHgRzEe4eFDCW65MpvQG7nOkY0nYilrQ==",
       "requires": {
         "@fern-api/base-generator": "0.0.6",
         "@fern-api/core-utils": "^0.15.0-rc63",

--- a/ee/codegen/package-lock.json
+++ b/ee/codegen/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@vellum-ai/vellum-codegen",
       "version": "0.11.1-post1",
       "dependencies": {
-        "@fern-api/python-ast": "^0.0.17",
+        "@fern-api/python-ast": "^0.0.18",
         "@fern-fern/generator-cli-sdk": "file:./stubs/generator-cli-sdk",
         "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
         "lodash": "^4.17.21",
@@ -691,9 +691,9 @@
       }
     },
     "node_modules/@fern-api/python-ast": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.17.tgz",
-      "integrity": "sha512-vfwgWVOYcV9Ll46BQEbESh1j+/l77tn7vWLWWu1JBcttZxAJrKLxqdtHgRzEe4eFDCW65MpvQG7nOkY0nYilrQ==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.18.tgz",
+      "integrity": "sha512-x4yHafL2h6BIA/TN63oZZjKPTwNgpjBAeBT+I3pGNy2SgHo1thE54NSHGDlmWRTokboDiitwSirpQ6uJeOIPQw==",
       "dependencies": {
         "@fern-api/base-generator": "0.0.6",
         "@fern-api/core-utils": "^0.15.0-rc63",
@@ -6557,9 +6557,9 @@
       }
     },
     "@fern-api/python-ast": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.17.tgz",
-      "integrity": "sha512-vfwgWVOYcV9Ll46BQEbESh1j+/l77tn7vWLWWu1JBcttZxAJrKLxqdtHgRzEe4eFDCW65MpvQG7nOkY0nYilrQ==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.18.tgz",
+      "integrity": "sha512-x4yHafL2h6BIA/TN63oZZjKPTwNgpjBAeBT+I3pGNy2SgHo1thE54NSHGDlmWRTokboDiitwSirpQ6uJeOIPQw==",
       "requires": {
         "@fern-api/base-generator": "0.0.6",
         "@fern-api/core-utils": "^0.15.0-rc63",

--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -29,7 +29,7 @@
     "version:codegen": "node scripts/version.js"
   },
   "dependencies": {
-    "@fern-api/python-ast": "^0.0.17",
+    "@fern-api/python-ast": "^0.0.18",
     "@fern-fern/generator-cli-sdk": "file:./stubs/generator-cli-sdk",
     "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
     "lodash": "^4.17.21",

--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -29,7 +29,7 @@
     "version:codegen": "node scripts/version.js"
   },
   "dependencies": {
-    "@fern-api/python-ast": "^0.0.14",
+    "@fern-api/python-ast": "^0.0.17",
     "@fern-fern/generator-cli-sdk": "file:./stubs/generator-cli-sdk",
     "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
     "lodash": "^4.17.21",

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -201,3 +201,14 @@ class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
     graph = SearchNode
 "
 `;
+
+exports[`Workflow > write > should handle the case of multiple nodes with the same label 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_1 import TemplatingNode as TemplatingNode1TemplatingNode
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = TemplatingNode >> TemplatingNode1TemplatingNode
+"
+`;

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -146,6 +146,65 @@ describe("Workflow", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
 
+    it("should handle the case of multiple nodes with the same label", async () => {
+      const templatingNodeData1 = templatingNodeFactory({
+        id: "7e09927b-6d6f-4829-92c9-54e66bdcaf80",
+        label: "Templating Node",
+        sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb98",
+        targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2948",
+      });
+      workflowContext.addNodeContext(
+        await createNodeContext({
+          workflowContext: workflowContext,
+          nodeData: templatingNodeData1,
+        })
+      );
+
+      const templatingNodeData2 = templatingNodeFactory({
+        id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+        label: "Templating Node",
+        sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+        targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+      });
+      workflowContext.addNodeContext(
+        await createNodeContext({
+          workflowContext: workflowContext,
+          nodeData: templatingNodeData2,
+        })
+      );
+
+      const edges: WorkflowEdge[] = [
+        {
+          id: "edge-1",
+          type: "DEFAULT",
+          sourceNodeId: entrypointNode.id,
+          sourceHandleId: entrypointNode.data.sourceHandleId,
+          targetNodeId: templatingNodeData1.id,
+          targetHandleId: templatingNodeData1.data.targetHandleId,
+        },
+        {
+          id: "edge-2",
+          type: "DEFAULT",
+          sourceNodeId: templatingNodeData1.id,
+          sourceHandleId: templatingNodeData1.data.sourceHandleId,
+          targetNodeId: templatingNodeData2.id,
+          targetHandleId: templatingNodeData2.data.targetHandleId,
+        },
+      ];
+      workflowContext.addWorkflowEdges(edges);
+
+      const inputs = codegen.inputs({ workflowContext });
+      const workflow = codegen.workflow({
+        moduleName,
+        workflowContext,
+        inputs,
+        nodes: [templatingNodeData1, templatingNodeData2],
+      });
+
+      workflow.getWorkflowFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    }, 1000000);
+
     describe("graph", () => {
       it("should be correct for a basic single node case", async () => {
         workflowContext.addInputVariableContext(

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_1.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_1.py
@@ -8,7 +8,7 @@ from ...nodes.templating_node_1 import TemplatingNode1
 
 
 class TemplatingNode1Display(BaseTemplatingNodeDisplay[TemplatingNode1]):
-    label = "Templating Node 1"
+    label = "Templating Node"
     node_id = UUID("6c5017d1-9aa3-4f34-9a6a-fbe2f7029473")
     target_handle_id = UUID("2d2c5559-983f-469c-a1d0-c2fe9f8f3639")
     template_input_id = UUID("3981811f-6e33-48b6-b7c5-c32ba9a97dc8")

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_2.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_2.py
@@ -8,7 +8,7 @@ from ...nodes.templating_node_2 import TemplatingNode2
 
 
 class TemplatingNode2Display(BaseTemplatingNodeDisplay[TemplatingNode2]):
-    label = "Templating Node 2"
+    label = "Templating Node"
     node_id = UUID("5b7d7b3f-e10d-4334-a217-9099dececd8d")
     target_handle_id = UUID("f9a55e22-2cbd-4492-8755-36760320f0d9")
     template_input_id = UUID("6567617f-57e4-4c11-9175-557108fcf07e")

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_3.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_3.py
@@ -8,7 +8,7 @@ from ...nodes.templating_node_3 import TemplatingNode3
 
 
 class TemplatingNode3Display(BaseTemplatingNodeDisplay[TemplatingNode3]):
-    label = "Templating Node 3"
+    label = "Templating Node"
     node_id = UUID("7f7823e9-b97a-4bbe-bfcf-40aed8db24c9")
     target_handle_id = UUID("2c1e39e0-ce3e-4c2d-8baf-c5d93b244997")
     template_input_id = UUID("c1cc89c9-7cb7-498d-9dda-e9e5f36fe556")

--- a/ee/codegen_integration/fixtures/simple_merge_node/display_data/simple_merge_node.json
+++ b/ee/codegen_integration/fixtures/simple_merge_node/display_data/simple_merge_node.json
@@ -27,7 +27,7 @@
         "id": "5b7d7b3f-e10d-4334-a217-9099dececd8d",
         "type": "TEMPLATING",
         "data": {
-          "label": "Templating Node 2",
+          "label": "Templating Node",
           "output_id": "b96fcdbd-7bd1-4cd1-b91a-49bb50ded865",
           "error_output_id": null,
           "source_handle_id": "a5ae5a5c-ad8a-4a19-a726-f3b8ed1fbb1b",
@@ -140,7 +140,7 @@
         "id": "7f7823e9-b97a-4bbe-bfcf-40aed8db24c9",
         "type": "TEMPLATING",
         "data": {
-          "label": "Templating Node 3",
+          "label": "Templating Node",
           "output_id": "a18fbec8-4530-4ca9-a265-e9323dc45fc4",
           "error_output_id": null,
           "source_handle_id": "e51cd1b6-6c1f-4436-aaed-36cb38e7615d",
@@ -297,7 +297,7 @@
         "id": "6c5017d1-9aa3-4f34-9a6a-fbe2f7029473",
         "type": "TEMPLATING",
         "data": {
-          "label": "Templating Node 1",
+          "label": "Templating Node",
           "output_id": "6a903b23-d66c-413b-996d-109f6a483056",
           "error_output_id": null,
           "source_handle_id": "e900aa36-b59e-4d13-bb66-21967eb02214",


### PR DESCRIPTION
We need to ensure that we generate unique node class names during codegen.

This PR does that by upgrading the version of the fern python ast module where fixes have been implemented to support just this.