### PR TITLE
[Codegen] De-Dupe Output Names & Clean Up Input Variables

### DIFF
--- a/ee/codegen/src/__test__/helpers/workflow-output-context-factory.ts
+++ b/ee/codegen/src/__test__/helpers/workflow-output-context-factory.ts
@@ -1,13 +1,17 @@
 import { terminalNodeDataFactory } from "src/__test__/helpers/node-data-factories";
+import { WorkflowContext } from "src/context";
 import { WorkflowOutputContext } from "src/context/workflow-output-context";
 import { FinalOutputNode as FinalOutputNodeType } from "src/types/vellum";
 
 export function workflowOutputContextFactory({
   terminalNodeData,
+  workflowContext,
 }: {
   terminalNodeData?: FinalOutputNodeType;
-} = {}): WorkflowOutputContext {
+  workflowContext: WorkflowContext;
+}): WorkflowOutputContext {
   return new WorkflowOutputContext({
     terminalNodeData: terminalNodeData ?? terminalNodeDataFactory(),
+    workflowContext,
   });
 }

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -80,7 +80,9 @@ describe("Workflow", () => {
 
       const inputs = codegen.inputs({ workflowContext });
 
-      workflowContext.addWorkflowOutputContext(workflowOutputContextFactory());
+      workflowContext.addWorkflowOutputContext(
+        workflowOutputContextFactory({ workflowContext })
+      );
 
       const workflow = codegen.workflow({
         moduleName,
@@ -162,7 +164,7 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         workflowContext.addWorkflowOutputContext(
-          workflowOutputContextFactory()
+          workflowOutputContextFactory({ workflowContext })
         );
 
         const searchNodeData = searchNodeDataFactory();

--- a/ee/codegen/src/context/input-variable-context.ts
+++ b/ee/codegen/src/context/input-variable-context.ts
@@ -44,10 +44,10 @@ export class InputVariableContext {
 
     const initialInputVariableName =
       !isNil(rawInputVariableName) && !isEmpty(rawInputVariableName)
-        ? toSnakeCase(this.inputVariableData.key)
+        ? toSnakeCase(rawInputVariableName)
         : defaultName;
 
-    // Deduplicate the module name if it's already in use
+    // Deduplicate the input variable name if it's already in use
     let sanitizedName = initialInputVariableName;
     let numRenameAttempts = 0;
     while (this.workflowContext.isInputVariableNameUsed(sanitizedName)) {

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -51,7 +51,7 @@ export class WorkflowContext {
 
   // Track what input variables names are used within this workflow so that we can ensure name uniqueness when adding
   // new input variables.
-  public readonly inputVariableNames: Set<string> = new Set();
+  private readonly inputVariableNames: Set<string> = new Set();
 
   // Maps node IDs to a mapping of output IDs to output names.
   // Tracks local and global contexts in the case of nested workflows.
@@ -60,7 +60,7 @@ export class WorkflowContext {
 
   // Track what node module names are used within this workflow so that we can ensure name uniqueness when adding
   // new nodes.
-  public readonly nodeModuleNames: Set<string> = new Set();
+  private readonly nodeModuleNames: Set<string> = new Set();
 
   // A list of all outputs this workflow produces
   public readonly workflowOutputContexts: WorkflowOutputContext[] = [];
@@ -83,12 +83,6 @@ export class WorkflowContext {
   private readonly mlModelNamesById: Record<string, string> = {};
 
   public readonly workflowRawEdges: WorkflowEdge[];
-
-  // This is used to track the workflow input variable names for the workflow keyed by input variable id
-  public readonly inputNamesById: Map<string, string>;
-
-  // This is used to track the original input names before being sanitized
-  public readonly sanitizedInputNamesMapping: Map<string, string>;
 
   constructor({
     absolutePathToOutputDirectory,
@@ -126,8 +120,6 @@ export class WorkflowContext {
 
     this.sdkModulePathNames = generateSdkModulePaths(workflowsSdkModulePath);
     this.workflowRawEdges = workflowRawEdges;
-    this.inputNamesById = new Map<string, string>();
-    this.sanitizedInputNamesMapping = new Map<string, string>();
   }
 
   /* Create a new workflow context for a nested workflow from its parent */

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -65,6 +65,10 @@ export class WorkflowContext {
   // A list of all outputs this workflow produces
   public readonly workflowOutputContexts: WorkflowOutputContext[] = [];
 
+  // Track what output variables names are used within this workflow so that we can ensure name uniqueness when adding
+  // new output variables.
+  private readonly outputVariableNames: Set<string> = new Set();
+
   // If this workflow is a nested workflow belonging to a node, track that node's context here.
   public readonly parentNode?: BaseNode<
     WorkflowDataNode,
@@ -203,10 +207,19 @@ export class WorkflowContext {
     return inputVariableContext;
   }
 
+  public isOutputVariableNameUsed(outputVariableName: string): boolean {
+    return this.outputVariableNames.has(outputVariableName);
+  }
+
+  private addUsedOutputVariableName(outputVariableName: string): void {
+    this.outputVariableNames.add(outputVariableName);
+  }
+
   public addWorkflowOutputContext(
     workflowOutputContext: WorkflowOutputContext
   ): void {
     this.workflowOutputContexts.push(workflowOutputContext);
+    this.addUsedOutputVariableName(workflowOutputContext.name);
   }
 
   public isNodeModuleNameUsed(nodeModuleName: string): boolean {

--- a/ee/codegen/src/context/workflow-output-context.ts
+++ b/ee/codegen/src/context/workflow-output-context.ts
@@ -1,17 +1,28 @@
+import { isEmpty, isNil } from "lodash";
+
+import { WorkflowContext } from "src/context/workflow-context";
 import { FinalOutputNode as FinalOutputNodeType } from "src/types/vellum";
 import { toSnakeCase } from "src/utils/casing";
 
 export declare namespace WorkflowOutputContext {
   export type Args = {
+    workflowContext: WorkflowContext;
     terminalNodeData: FinalOutputNodeType;
   };
 }
 
 export class WorkflowOutputContext {
+  private readonly workflowContext: WorkflowContext;
   private readonly terminalNodeData: FinalOutputNodeType;
+  public readonly name: string;
 
-  constructor({ terminalNodeData }: WorkflowOutputContext.Args) {
+  constructor({
+    terminalNodeData,
+    workflowContext,
+  }: WorkflowOutputContext.Args) {
+    this.workflowContext = workflowContext;
     this.terminalNodeData = terminalNodeData;
+    this.name = this.generateSanitizedOutputVariableName();
   }
 
   public getFinalOutputNodeId(): string {
@@ -22,7 +33,25 @@ export class WorkflowOutputContext {
     return this.terminalNodeData;
   }
 
-  public getOutputName(): string {
-    return toSnakeCase(this.terminalNodeData.data.name);
+  private generateSanitizedOutputVariableName(): string {
+    const defaultName = "output_";
+    const rawOutputVariableName = this.terminalNodeData.data.name;
+
+    const initialOutputVariableName =
+      !isNil(rawOutputVariableName) && !isEmpty(rawOutputVariableName)
+        ? toSnakeCase(rawOutputVariableName)
+        : defaultName;
+
+    // Deduplicate the output variable name if it's already in use
+    let sanitizedName = initialOutputVariableName;
+    let numRenameAttempts = 0;
+    while (this.workflowContext.isOutputVariableNameUsed(sanitizedName)) {
+      sanitizedName = `${initialOutputVariableName}${
+        initialOutputVariableName.endsWith("_") ? "" : "_"
+      }${numRenameAttempts + 1}`;
+      numRenameAttempts += 1;
+    }
+
+    return sanitizedName;
   }
 }

--- a/ee/codegen/src/generators/inputs.ts
+++ b/ee/codegen/src/generators/inputs.ts
@@ -76,11 +76,12 @@ export class Inputs extends BasePersistedFile {
       const vellumVariableField = codegen.vellumVariable({
         variable: {
           id: inputVariableData.id,
+          // Use the sanitized name from the input variable context to ensure it's a valid
+          // attribute name (as opposed to the raw name from hte input variable data).
           name: inputVariableName,
           type: inputVariableData.type,
           required: inputVariableData.required,
           default: inputVariableData.default,
-          extensions: inputVariableData.extensions,
         },
       });
 

--- a/ee/codegen/src/generators/nodes/inline-subworkflow-node.ts
+++ b/ee/codegen/src/generators/nodes/inline-subworkflow-node.ts
@@ -99,7 +99,7 @@ export class InlineSubworkflowNode extends BaseNestedWorkflowNode<
     );
 
     nestedWorkflowContext.workflowOutputContexts.forEach((outputContext) => {
-      const outputName = outputContext.getOutputName();
+      const outputName = outputContext.name;
       const outputField = python.field({
         name: outputName,
         initializer: python.reference({
@@ -124,7 +124,7 @@ export class InlineSubworkflowNode extends BaseNestedWorkflowNode<
       name: "output_display",
       initializer: python.TypeInstantiation.dict(
         nestedWorkflowContext.workflowOutputContexts.map((outputContext) => {
-          const outputName = outputContext.getOutputName();
+          const outputName = outputContext.name;
           const terminalNodeData = outputContext.getFinalOutputNodeData().data;
 
           return {

--- a/ee/codegen/src/generators/nodes/map-node.ts
+++ b/ee/codegen/src/generators/nodes/map-node.ts
@@ -114,7 +114,7 @@ export class MapNode extends BaseNestedWorkflowNode<
     );
 
     nestedWorkflowContext.workflowOutputContexts.forEach((outputContext) => {
-      const outputName = outputContext.getOutputName();
+      const outputName = outputContext.name;
       const outputField = python.field({
         name: outputName,
         initializer: python.reference({

--- a/ee/codegen/src/generators/vellum-variable.ts
+++ b/ee/codegen/src/generators/vellum-variable.ts
@@ -2,7 +2,6 @@ import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
 import { VellumValue as VellumValueType } from "vellum-ai/api/types";
-import { VellumVariableExtensions } from "vellum-ai/api/types/VellumVariableExtensions";
 
 import { VellumValue } from "src/generators/vellum-variable-value";
 import { getVellumVariablePrimitiveType } from "src/utils/vellum-variables";
@@ -15,7 +14,6 @@ type VellumVariableWithName = (
     id: string;
     required?: boolean | null;
     default?: VellumValueType | null;
-    extensions?: VellumVariableExtensions | null;
   };
 
 export declare namespace VellumVariable {
@@ -26,11 +24,9 @@ export declare namespace VellumVariable {
 
 export class VellumVariable extends AstNode {
   private readonly field: python.Field;
-  private readonly variable: VellumVariableWithName;
 
   constructor({ variable }: VellumVariable.Args) {
     super();
-    this.variable = variable;
     this.field = python.field({
       name: variable.name ?? variable.key,
       type: getVellumVariablePrimitiveType(variable.type),

--- a/ee/codegen/src/generators/workflow-output.ts
+++ b/ee/codegen/src/generators/workflow-output.ts
@@ -6,7 +6,6 @@ import { Writer } from "@fern-api/python-ast/core/Writer";
 import { OUTPUTS_CLASS_NAME } from "src/constants";
 import { WorkflowContext } from "src/context";
 import { WorkflowOutputContext } from "src/context/workflow-output-context";
-import { toSnakeCase } from "src/utils/casing";
 
 export declare namespace WorkflowOutput {
   export interface Args {
@@ -35,7 +34,7 @@ export class WorkflowOutput extends AstNode {
       this.workflowContext.getNodeContext(terminalNodeId);
 
     const workflowOutput = python.field({
-      name: toSnakeCase(this.workflowOutputContext.getOutputName()),
+      name: this.workflowOutputContext.name,
       initializer: python.reference({
         name: terminalNodeContext.nodeClassName,
         modulePath: terminalNodeContext.nodeModulePath,

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -491,10 +491,7 @@ export class Workflow {
                 key: python.reference({
                   name: this.workflowContext.workflowClassName,
                   modulePath: this.workflowContext.modulePath,
-                  attribute: [
-                    OUTPUTS_CLASS_NAME,
-                    workflowOutputContext.getOutputName(),
-                  ],
+                  attribute: [OUTPUTS_CLASS_NAME, workflowOutputContext.name],
                 }),
                 value: python.instantiateClass({
                   classReference: python.reference({

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -308,7 +308,9 @@ export class Workflow {
                 python.methodArgument({
                   name: "name",
                   value: python.TypeInstantiation.str(
-                    inputVariableContext.name
+                    // Intentionally use the raw name from the input variable data
+                    // rather than the sanitized name from the input variable context
+                    inputVariableContext.getInputVariableData().key
                   ),
                 })
               );
@@ -521,6 +523,8 @@ export class Workflow {
                     python.methodArgument({
                       name: "name",
                       value: python.TypeInstantiation.str(
+                        // Intentionally use the raw name from the terminal node
+                        // Rather than the sanitized name from the output context
                         terminalNodeData.data.name
                       ),
                     }),

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -304,6 +304,7 @@ ${errors.slice(0, 3).map((err) => {
           if (nodeData.type === "TERMINAL") {
             this.workflowContext.addWorkflowOutputContext(
               new WorkflowOutputContext({
+                workflowContext: this.workflowContext,
                 terminalNodeData: nodeData,
               })
             );

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -117,8 +117,6 @@ class WorkflowOutputVellumDisplayOverrides(WorkflowOutputDisplay, WorkflowOutput
     target_handle_id: UUID
     display_data: NodeDisplayData
     edge_id: UUID
-    # source_node_id: Optional[UUID]
-    # source_handle_id: Optional[UUID]
 
 
 @dataclass


### PR DESCRIPTION
This repeats the pattern introduced for Input Variables in https://github.com/vellum-ai/vellum-python-sdks/pull/380, but applies it to Output Variables.

It also cleans up some input-variable related code along the way.