### PR TITLE
Preserve lock file deployments on future vellum pulls

### DIFF
--- a/ee/vellum_cli/tests/conftest.py
+++ b/ee/vellum_cli/tests/conftest.py
@@ -1,19 +1,29 @@
 import pytest
+from dataclasses import dataclass
 import os
 import shutil
 import tempfile
 from uuid import uuid4
-from typing import Any, Callable, Dict, Generator, Tuple
+from typing import Any, Callable, Dict, Generator
 
 import tomli_w
 
 
+@dataclass
+class MockModuleResult:
+    temp_dir: str
+    module: str
+    set_pyproject_toml: Callable[[Dict[str, Any]], None]
+    workflow_sandbox_id: str
+
+
 @pytest.fixture
-def mock_module() -> Generator[Tuple[str, str, Callable[[Dict[str, Any]], None]], None, None]:
+def mock_module() -> Generator[MockModuleResult, None, None]:
     current_dir = os.getcwd()
     temp_dir = tempfile.mkdtemp()
     os.chdir(temp_dir)
     module = "examples.mock"
+    workflow_sandbox_id = str(uuid4())
 
     def set_pyproject_toml(vellum_config: Dict[str, Any]) -> None:
         pyproject_toml_path = os.path.join(temp_dir, "pyproject.toml")
@@ -28,13 +38,18 @@ def mock_module() -> Generator[Tuple[str, str, Callable[[Dict[str, Any]], None]]
             "workflows": [
                 {
                     "module": module,
-                    "workflow_sandbox_id": str(uuid4()),
+                    "workflow_sandbox_id": workflow_sandbox_id,
                 }
             ]
         }
     )
 
-    yield temp_dir, module, set_pyproject_toml
+    yield MockModuleResult(
+        temp_dir=temp_dir,
+        module=module,
+        set_pyproject_toml=set_pyproject_toml,
+        workflow_sandbox_id=workflow_sandbox_id,
+    )
 
     os.chdir(current_dir)
     shutil.rmtree(temp_dir)

--- a/ee/vellum_cli/tests/test_push.py
+++ b/ee/vellum_cli/tests/test_push.py
@@ -29,8 +29,7 @@ def _extract_tar_gz(tar_gz_bytes: bytes) -> dict[str, str]:
 
 def test_push__no_config(mock_module):
     # GIVEN no config file set
-    _, _, set_pyproject_toml = mock_module
-    set_pyproject_toml({"workflows": []})
+    mock_module.set_pyproject_toml({"workflows": []})
 
     # WHEN calling `vellum push`
     runner = CliRunner()
@@ -44,8 +43,7 @@ def test_push__no_config(mock_module):
 
 def test_push__multiple_workflows_configured__no_module_specified(mock_module):
     # GIVEN multiple workflows configured
-    _, _, set_pyproject_toml = mock_module
-    set_pyproject_toml({"workflows": [{"module": "examples.mock"}, {"module": "examples.mock2"}]})
+    mock_module.set_pyproject_toml({"workflows": [{"module": "examples.mock"}, {"module": "examples.mock2"}]})
 
     # WHEN calling `vellum push` without a module specified
     runner = CliRunner()
@@ -62,8 +60,8 @@ def test_push__multiple_workflows_configured__no_module_specified(mock_module):
 
 def test_push__multiple_workflows_configured__not_found_module(mock_module):
     # GIVEN multiple workflows configured
-    _, module, set_pyproject_toml = mock_module
-    set_pyproject_toml({"workflows": [{"module": "examples.mock2"}, {"module": "examples.mock3"}]})
+    module = mock_module.module
+    mock_module.set_pyproject_toml({"workflows": [{"module": "examples.mock2"}, {"module": "examples.mock3"}]})
 
     # WHEN calling `vellum push` with a module that doesn't exist
     runner = CliRunner()
@@ -85,7 +83,8 @@ def test_push__multiple_workflows_configured__not_found_module(mock_module):
 )
 def test_push__happy_path(mock_module, vellum_client, base_command):
     # GIVEN a single workflow configured
-    temp_dir, module, _ = mock_module
+    temp_dir = mock_module.temp_dir
+    module = mock_module.module
 
     # AND a workflow exists in the module successfully
     base_dir = os.path.join(temp_dir, *module.split("."))
@@ -134,7 +133,8 @@ class ExampleWorkflow(BaseWorkflow):
 )
 def test_push__deployment(mock_module, vellum_client, base_command):
     # GIVEN a single workflow configured
-    temp_dir, module, _ = mock_module
+    temp_dir = mock_module.temp_dir
+    module = mock_module.module
 
     # AND a workflow exists in the module successfully
     base_dir = os.path.join(temp_dir, *module.split("."))


### PR DESCRIPTION
If there was a deployment in the vellum lock file, pulls of _other_ workflows would clear it, causing diffs like this: https://github.com/vellum-ai/workflows-as-code-runner-prototype/pull/523/files#r1876411802