### PR TITLE
Setup and solve test cases surrounding use of three nodes

### DIFF
--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -24,6 +24,7 @@
     "test": "vitest --run",
     "prepublishOnly": "npm run build && npm run gar-login",
     "test:update": "vitest --run -u",
+    "test:debug": "vitest --run --inspect-brk --no-file-parallelism",
     "types": "tsc --noEmit",
     "start": "node --loader ts-node/esm --experimental-specifier-resolution=node src/index.ts",
     "version:codegen": "node scripts/version.js"

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -53,6 +53,19 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
+exports[`Workflow > write > graph > should be correct for a basic merge node case of multiple nodes 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_3 import TemplatingNode3
+from .nodes.templating_node_2 import TemplatingNode2
+from .nodes.merge_node import MergeNode
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = {TemplatingNode, TemplatingNode2, TemplatingNode3} >> MergeNode,
+"
+`;
+
 exports[`Workflow > write > graph > should be correct for a basic multiple nodes case 1`] = `
 "from vellum.workflows import BaseWorkflow
 from .nodes.templating_node import TemplatingNode

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -56,13 +56,13 @@ class TestWorkflow(BaseWorkflow):
 exports[`Workflow > write > graph > should be correct for a basic merge node case of multiple nodes 1`] = `
 "from vellum.workflows import BaseWorkflow
 from .nodes.templating_node import TemplatingNode
-from .nodes.templating_node_3 import TemplatingNode3
 from .nodes.templating_node_2 import TemplatingNode2
+from .nodes.templating_node_3 import TemplatingNode3
 from .nodes.merge_node import MergeNode
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = {TemplatingNode, TemplatingNode2, TemplatingNode3} >> MergeNode,
+    graph = {TemplatingNode, TemplatingNode2, TemplatingNode3} >> MergeNode
 "
 `;
 
@@ -175,8 +175,8 @@ class TestWorkflow(BaseWorkflow):
 exports[`Workflow > write > graph > should be correct for three nodes 1`] = `
 "from vellum.workflows import BaseWorkflow
 from .nodes.templating_node import TemplatingNode
-from .nodes.templating_node_3 import TemplatingNode3
 from .nodes.templating_node_2 import TemplatingNode2
+from .nodes.templating_node_3 import TemplatingNode3
 
 
 class TestWorkflow(BaseWorkflow):

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -172,6 +172,18 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
+exports[`Workflow > write > graph > should be correct for three nodes 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_3 import TemplatingNode3
+from .nodes.templating_node_2 import TemplatingNode2
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = {TemplatingNode, TemplatingNode2, TemplatingNode3}
+"
+`;
+
 exports[`Workflow > write > should generate correct code when there are input variables 1`] = `
 "from vellum.workflows import BaseWorkflow
 

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -250,6 +250,83 @@ describe("Workflow", () => {
         expect(await writer.toStringFormatted()).toMatchSnapshot();
       });
 
+      it("should be correct for three nodes", async () => {
+        const inputs = codegen.inputs({ workflowContext });
+
+        const templatingNodeData1 = templatingNodeFactory();
+        const templatingNodeContext1 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData1,
+        });
+        workflowContext.addNodeContext(templatingNodeContext1);
+
+        const templatingNodeData2 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+          label: "Templating Node 2",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+        });
+        const templatingNodeContext2 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData2,
+        });
+        workflowContext.addNodeContext(templatingNodeContext2);
+
+        const templatingNodeData3 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
+          label: "Templating Node 3",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
+        });
+        const templatingNodeContext3 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData3,
+        });
+        workflowContext.addNodeContext(templatingNodeContext3);
+
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData1.id,
+            targetHandleId: templatingNodeData1.data.targetHandleId,
+          },
+          {
+            id: "edge-2",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData2.id,
+            targetHandleId: templatingNodeData2.data.targetHandleId,
+          },
+          {
+            id: "edge-3",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData3.id,
+            targetHandleId: templatingNodeData3.data.targetHandleId,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
+
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [
+            templatingNodeData1,
+            templatingNodeData2,
+            templatingNodeData3,
+          ],
+        });
+
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
+
       it("should be correct for a basic single edge case", async () => {
         const inputs = codegen.inputs({ workflowContext });
 

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -384,6 +384,120 @@ describe("Workflow", () => {
         expect(await writer.toStringFormatted()).toMatchSnapshot();
       });
 
+      it("should be correct for a basic merge node case of multiple nodes", async () => {
+        const inputs = codegen.inputs({ workflowContext });
+
+        const templatingNodeData1 = templatingNodeFactory();
+        const templatingNodeContext1 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData1,
+        });
+        workflowContext.addNodeContext(templatingNodeContext1);
+
+        const templatingNodeData2 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+          label: "Templating Node 2",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+        });
+        const templatingNodeContext2 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData2,
+        });
+        workflowContext.addNodeContext(templatingNodeContext2);
+
+        const templatingNodeData3 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
+          label: "Templating Node 3",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
+        });
+        const templatingNodeContext3 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData3,
+        });
+        workflowContext.addNodeContext(templatingNodeContext3);
+
+        const mergeNodeData = mergeNodeDataFactory();
+        const mergeNodeContext = await createNodeContext({
+          workflowContext,
+          nodeData: mergeNodeData,
+        });
+        workflowContext.addNodeContext(mergeNodeContext);
+        const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
+        const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
+        if (!mergeTargetHandle1 || !mergeTargetHandle2) {
+          throw new Error("Handle IDs are required");
+        }
+
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData1.id,
+            targetHandleId: templatingNodeData1.data.targetHandleId,
+          },
+          {
+            id: "edge-2",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData2.id,
+            targetHandleId: templatingNodeData2.data.targetHandleId,
+          },
+          {
+            id: "edge-3",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData3.id,
+            targetHandleId: templatingNodeData3.data.targetHandleId,
+          },
+          {
+            id: "edge-4",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData1.id,
+            sourceHandleId: templatingNodeData1.data.sourceHandleId,
+            targetNodeId: mergeNodeData.id,
+            targetHandleId: mergeTargetHandle1,
+          },
+          {
+            id: "edge-5",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData2.id,
+            sourceHandleId: templatingNodeData2.data.sourceHandleId,
+            targetNodeId: mergeNodeData.id,
+            targetHandleId: mergeTargetHandle2,
+          },
+          {
+            id: "edge-6",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData3.id,
+            sourceHandleId: templatingNodeData3.data.sourceHandleId,
+            targetNodeId: mergeNodeData.id,
+            targetHandleId: mergeTargetHandle2,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
+
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [
+            templatingNodeData1,
+            templatingNodeData2,
+            templatingNodeData3,
+            mergeNodeData,
+          ],
+        });
+
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
+
       it("should be correct for a basic merge node and an additional edge", async () => {
         const inputs = codegen.inputs({ workflowContext });
 

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -216,6 +216,11 @@ export class GraphAttribute extends AstNode {
           }
         } else if (mutableAst.type === "set") {
           const newSet = mutableAst.values.map((subAst) => {
+            const canBeAdded = this.isNodeInBranch(sourceNode, subAst);
+            if (!canBeAdded) {
+              return { edgeAdded: false, value: subAst };
+            }
+
             const newSubAst = addEdgeToGraph(subAst, graphSourceNode);
             if (!newSubAst) {
               return { edgeAdded: false, value: subAst };
@@ -227,7 +232,7 @@ export class GraphAttribute extends AstNode {
               return {
                 type: "set",
                 values: [
-                  mutableAst,
+                  ...mutableAst.values,
                   { type: "node_reference", reference: targetNode },
                 ],
               };
@@ -395,9 +400,12 @@ export class GraphAttribute extends AstNode {
    * Checks if targetNode is in the branch
    */
   private isNodeInBranch(
-    targetNode: BaseNodeContext<WorkflowDataNode>,
+    targetNode: BaseNodeContext<WorkflowDataNode> | null,
     mutableAst: GraphMutableAst
   ): boolean {
+    if (targetNode == null) {
+      return false;
+    }
     if (
       mutableAst.type === "node_reference" &&
       mutableAst.reference === targetNode


### PR DESCRIPTION
Solves both of these test cases, both relevant for deepscribe's graph [generation](https://github.com/vellum-ai/workflows-as-code-runner-prototype/pull/529/files#diff-190954e59737e8c60702ee2c36c5a383d80611a212b71fcaa99f7e8c755335deR19)

`graph = {A, B, C}`

`graph = {A, B, C} >> D`