### PR TITLE
[Codegen][SC-5803] Handle Numeric Values at Start of Python Statements

### DIFF
--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.test.ts
@@ -41,7 +41,7 @@ describe("NodeInputValuePointerRule", () => {
     vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
-      getNodeOutputNameById: vi.fn().mockReturnValue("my-output"),
+      getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),
     } as unknown as BaseNodeContext<WorkflowDataNode>);
 
     const nodeOutputPointer: NodeInputValuePointerRuleType = {

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-output-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-output-pointer.test.ts
@@ -21,7 +21,7 @@ describe("NodeOutputPointer", () => {
     vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
-      getNodeOutputNameById: vi.fn().mockReturnValue("my-output"),
+      getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),
     } as unknown as BaseNodeContext<WorkflowDataNode>);
 
     const nodeOutputPointer = new NodeOutputPointerRule({

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer.test.ts
@@ -47,7 +47,7 @@ describe("NodeInputValuePointer", () => {
     vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
-      getNodeOutputNameById: vi.fn().mockReturnValue("my-output"),
+      getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),
     } as unknown as BaseNodeContext<WorkflowDataNode>);
 
     const nodeInputValuePointerData: NodeInputValuePointerType = {
@@ -91,7 +91,7 @@ describe("NodeInputValuePointer", () => {
     vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
-      getNodeOutputNameById: vi.fn().mockReturnValue("my-output"),
+      getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),
     } as unknown as BaseNodeContext<WorkflowDataNode>);
 
     const nodeInputValuePointerData: NodeInputValuePointerType = {
@@ -135,7 +135,7 @@ describe("NodeInputValuePointer", () => {
     vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
-      getNodeOutputNameById: vi.fn().mockReturnValue("my-output"),
+      getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),
     } as unknown as BaseNodeContext<WorkflowDataNode>);
 
     const nodeInputValuePointerData: NodeInputValuePointerType = {

--- a/ee/codegen/src/__test__/utils/cases.test.ts
+++ b/ee/codegen/src/__test__/utils/cases.test.ts
@@ -1,7 +1,7 @@
 import {
   createPythonClassName,
   toKebabCase,
-  toSnakeCase,
+  toPythonSafeSnakeCase,
 } from "src/utils/casing";
 
 describe("Casing utility functions", () => {
@@ -54,19 +54,55 @@ describe("Casing utility functions", () => {
     );
   });
 
-  describe("toSnakeCase", () => {
+  describe("toPythonSafeSnakeCase", () => {
     const testCases = [
-      { input: "hello-world", expected: "hello_world" },
-      { input: "HelloWorld", expected: "hello_world" },
-      { input: "hello world", expected: "hello_world" },
-      { input: "Hello-World_Example 123", expected: "hello_world_example_123" },
-      { input: "$hello*World", expected: "hello_world" },
+      {
+        input: "hello-world",
+        safetyPrefix: undefined,
+        expected: "hello_world",
+      },
+      { input: "HelloWorld", safetyPrefix: undefined, expected: "hello_world" },
+      {
+        input: "hello world",
+        safetyPrefix: undefined,
+        expected: "hello_world",
+      },
+      {
+        input: "Hello-World_Example 123",
+        safetyPrefix: undefined,
+        expected: "hello_world_example_123",
+      },
+      {
+        input: "$hello*World",
+        safetyPrefix: undefined,
+        expected: "hello_world",
+      },
+      {
+        input: "$1hello*World",
+        safetyPrefix: undefined,
+        expected: "_1hello_world",
+      },
+      {
+        input: "$1hello*World",
+        safetyPrefix: "module",
+        expected: "module_1hello_world",
+      },
+      {
+        input: "$1hello*World",
+        safetyPrefix: "attr",
+        expected: "attr_1hello_world",
+      },
+      {
+        input: "$1hello*World",
+        safetyPrefix: "attr_",
+        expected: "attr_1hello_world",
+      },
     ];
 
     it.each(testCases)(
       "should convert '$input' to '$expected'",
-      ({ input, expected }) => {
-        expect(toSnakeCase(input)).toBe(expected);
+      ({ input, safetyPrefix, expected }) => {
+        expect(toPythonSafeSnakeCase(input, safetyPrefix)).toBe(expected);
       }
     );
   });

--- a/ee/codegen/src/context/input-variable-context.ts
+++ b/ee/codegen/src/context/input-variable-context.ts
@@ -44,7 +44,7 @@ export class InputVariableContext {
 
     const initialInputVariableName =
       !isNil(rawInputVariableName) && !isEmpty(rawInputVariableName)
-        ? toPythonSafeSnakeCase(rawInputVariableName)
+        ? toPythonSafeSnakeCase(rawInputVariableName, "input")
         : defaultName;
 
     // Deduplicate the input variable name if it's already in use

--- a/ee/codegen/src/context/input-variable-context.ts
+++ b/ee/codegen/src/context/input-variable-context.ts
@@ -2,7 +2,7 @@ import { isEmpty, isNil } from "lodash";
 import { VellumVariable } from "vellum-ai/api/types";
 
 import { WorkflowContext } from "src/context/workflow-context";
-import { toSnakeCase } from "src/utils/casing";
+import { toPythonSafeSnakeCase } from "src/utils/casing";
 import { getGeneratedInputsModulePath } from "src/utils/paths";
 
 export declare namespace InputVariableContext {
@@ -44,7 +44,7 @@ export class InputVariableContext {
 
     const initialInputVariableName =
       !isNil(rawInputVariableName) && !isEmpty(rawInputVariableName)
-        ? toSnakeCase(rawInputVariableName)
+        ? toPythonSafeSnakeCase(rawInputVariableName)
         : defaultName;
 
     // Deduplicate the input variable name if it's already in use

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -1,6 +1,7 @@
 import { WorkflowContext } from "src/context";
 import { PortContext } from "src/context/port-context";
 import { WorkflowDataNode, WorkflowNodeDefinition } from "src/types/vellum";
+import { toPythonSafeSnakeCase } from "src/utils/casing";
 import { getNodeId, getNodeLabel } from "src/utils/nodes";
 import {
   getGeneratedNodeDisplayModulePath,
@@ -120,6 +121,6 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
       throw new Error(`Node output name not found for output ID: ${outputId}`);
     }
 
-    return nodeOutputName;
+    return toPythonSafeSnakeCase(nodeOutputName, "output");
   }
 }

--- a/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
@@ -28,7 +28,7 @@ export class SubworkflowDeploymentNodeContext extends BaseNodeContext<Subworkflo
     return this.workflowDeploymentHistoryItem.outputVariables.reduce<
       Record<string, string>
     >((acc, output) => {
-      acc[output.id] = toPythonSafeSnakeCase(output.key);
+      acc[output.id] = toPythonSafeSnakeCase(output.key, "output");
       return acc;
     }, {});
   }

--- a/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
@@ -4,7 +4,7 @@ import { BaseNodeContext } from "./base";
 
 import { PortContext } from "src/context/port-context";
 import { SubworkflowNode as SubworkflowNodeType } from "src/types/vellum";
-import { toSnakeCase } from "src/utils/casing";
+import { toPythonSafeSnakeCase } from "src/utils/casing";
 
 export declare namespace SubworkflowDeploymentNodeContext {
   interface Args extends BaseNodeContext.Args<SubworkflowNodeType> {
@@ -28,7 +28,7 @@ export class SubworkflowDeploymentNodeContext extends BaseNodeContext<Subworkflo
     return this.workflowDeploymentHistoryItem.outputVariables.reduce<
       Record<string, string>
     >((acc, output) => {
-      acc[output.id] = toSnakeCase(output.key);
+      acc[output.id] = toPythonSafeSnakeCase(output.key);
       return acc;
     }, {});
   }

--- a/ee/codegen/src/context/workflow-output-context.ts
+++ b/ee/codegen/src/context/workflow-output-context.ts
@@ -2,7 +2,7 @@ import { isEmpty, isNil } from "lodash";
 
 import { WorkflowContext } from "src/context/workflow-context";
 import { FinalOutputNode as FinalOutputNodeType } from "src/types/vellum";
-import { toSnakeCase } from "src/utils/casing";
+import { toPythonSafeSnakeCase } from "src/utils/casing";
 
 export declare namespace WorkflowOutputContext {
   export type Args = {
@@ -39,7 +39,7 @@ export class WorkflowOutputContext {
 
     const initialOutputVariableName =
       !isNil(rawOutputVariableName) && !isEmpty(rawOutputVariableName)
-        ? toSnakeCase(rawOutputVariableName)
+        ? toPythonSafeSnakeCase(rawOutputVariableName)
         : defaultName;
 
     // Deduplicate the output variable name if it's already in use

--- a/ee/codegen/src/context/workflow-output-context.ts
+++ b/ee/codegen/src/context/workflow-output-context.ts
@@ -39,7 +39,7 @@ export class WorkflowOutputContext {
 
     const initialOutputVariableName =
       !isNil(rawOutputVariableName) && !isEmpty(rawOutputVariableName)
-        ? toPythonSafeSnakeCase(rawOutputVariableName)
+        ? toPythonSafeSnakeCase(rawOutputVariableName, "output")
         : defaultName;
 
     // Deduplicate the output variable name if it's already in use

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
@@ -4,7 +4,6 @@ import { BaseNodeInputValuePointerRule } from "./base";
 
 import { OUTPUTS_CLASS_NAME } from "src/constants";
 import { NodeOutputPointer } from "src/types/vellum";
-import { toPythonSafeSnakeCase } from "src/utils/casing";
 
 export class NodeOutputPointerRule extends BaseNodeInputValuePointerRule<NodeOutputPointer> {
   getAstNode(): python.Reference {
@@ -27,7 +26,7 @@ export class NodeOutputPointerRule extends BaseNodeInputValuePointerRule<NodeOut
     return python.reference({
       name: nodeContext.nodeClassName,
       modulePath: nodeContext.nodeModulePath,
-      attribute: [OUTPUTS_CLASS_NAME, toPythonSafeSnakeCase(nodeOutputName)],
+      attribute: [OUTPUTS_CLASS_NAME, nodeOutputName],
     });
   }
 }

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
@@ -4,7 +4,7 @@ import { BaseNodeInputValuePointerRule } from "./base";
 
 import { OUTPUTS_CLASS_NAME } from "src/constants";
 import { NodeOutputPointer } from "src/types/vellum";
-import { toSnakeCase } from "src/utils/casing";
+import { toPythonSafeSnakeCase } from "src/utils/casing";
 
 export class NodeOutputPointerRule extends BaseNodeInputValuePointerRule<NodeOutputPointer> {
   getAstNode(): python.Reference {
@@ -27,7 +27,7 @@ export class NodeOutputPointerRule extends BaseNodeInputValuePointerRule<NodeOut
     return python.reference({
       name: nodeContext.nodeClassName,
       modulePath: nodeContext.nodeModulePath,
-      attribute: [OUTPUTS_CLASS_NAME, toSnakeCase(nodeOutputName)],
+      attribute: [OUTPUTS_CLASS_NAME, toPythonSafeSnakeCase(nodeOutputName)],
     });
   }
 }

--- a/ee/codegen/src/utils/casing.ts
+++ b/ee/codegen/src/utils/casing.ts
@@ -64,11 +64,26 @@ export function createPythonClassName(input: string): string {
     .join("");
 }
 
-export function toSnakeCase(str: string): string {
-  return str
-    .replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, "") // Remove leading/trailing non-alphanumeric characters first
+export function toPythonSafeSnakeCase(
+  str: string,
+  safetyPrefix: string = "_"
+): string {
+  // Strip special characters from start of string
+  const cleanedStr = str.replace(/^[^a-zA-Z0-9_]+/, "");
+
+  // Check if cleaned string starts with a number
+  const startsWithUnsafe = /^\d/.test(cleanedStr);
+
+  const snakeCase = cleanedStr
     .replace(/([a-z])([A-Z])/g, "$1_$2") // Insert underscore between lower and upper case
     .replace(/[^a-zA-Z0-9]+/g, "_") // Replace any non-alphanumeric characters with underscore
     .replace(/^_+|_+$/g, "") // Remove any leading/trailing underscores
     .toLowerCase(); // Convert to lowercase
+
+  // Add underscore prefix if cleaned string started with unsafe chars
+  const cleanedSafetyPrefix =
+    safetyPrefix === "_"
+      ? "_"
+      : `${safetyPrefix}${safetyPrefix.endsWith("_") ? "" : "_"}`;
+  return startsWithUnsafe ? cleanedSafetyPrefix + snakeCase : snakeCase;
 }

--- a/ee/codegen/src/utils/paths.ts
+++ b/ee/codegen/src/utils/paths.ts
@@ -5,7 +5,7 @@ import {
 } from "src/constants";
 import { WorkflowContext } from "src/context";
 import { WorkflowNodeDefinition } from "src/types/vellum";
-import { createPythonClassName, toSnakeCase } from "src/utils/casing";
+import { createPythonClassName, toPythonSafeSnakeCase } from "src/utils/casing";
 
 export function getGeneratedInputsModulePath(
   workflowContext: WorkflowContext
@@ -61,13 +61,13 @@ export function getGeneratedNodeModuleInfo({
   if (modulePathLeaf && modulePathLeaf === "<adornment>") {
     rawModuleName =
       nodeDefinition?.module?.[nodeDefinition.module.length - 3] ??
-      toSnakeCase(nodeLabel);
+      toPythonSafeSnakeCase(nodeLabel);
 
     nodeClassName =
       nodeDefinition?.module?.[nodeDefinition.module.length - 2] ??
       createPythonClassName(nodeLabel);
   } else {
-    rawModuleName = modulePathLeaf ?? toSnakeCase(nodeLabel);
+    rawModuleName = modulePathLeaf ?? toPythonSafeSnakeCase(nodeLabel);
 
     nodeClassName = nodeDefinition?.name ?? createPythonClassName(nodeLabel);
   }

--- a/ee/codegen/src/utils/paths.ts
+++ b/ee/codegen/src/utils/paths.ts
@@ -61,13 +61,13 @@ export function getGeneratedNodeModuleInfo({
   if (modulePathLeaf && modulePathLeaf === "<adornment>") {
     rawModuleName =
       nodeDefinition?.module?.[nodeDefinition.module.length - 3] ??
-      toPythonSafeSnakeCase(nodeLabel);
+      toPythonSafeSnakeCase(nodeLabel, "node");
 
     nodeClassName =
       nodeDefinition?.module?.[nodeDefinition.module.length - 2] ??
       createPythonClassName(nodeLabel);
   } else {
-    rawModuleName = modulePathLeaf ?? toPythonSafeSnakeCase(nodeLabel);
+    rawModuleName = modulePathLeaf ?? toPythonSafeSnakeCase(nodeLabel, "node");
 
     nodeClassName = nodeDefinition?.name ?? createPythonClassName(nodeLabel);
   }


### PR DESCRIPTION
If a user uses a number at the start of a node label, input name, or output name, we currently include that number at the start of the generated python statement, resulting in invalid python.

This PR fixes this by cleaning the names that we generate.