### PR TITLE
Allow ports to be valid edge targets

### DIFF
--- a/src/vellum/workflows/graph/tests/test_graph.py
+++ b/src/vellum/workflows/graph/tests/test_graph.py
@@ -435,3 +435,28 @@ def test_graph__set_to_node():
 
     # AND two edges
     assert len(list(graph.edges)) == 2
+
+
+def test_graph__node_to_port():
+    # GIVEN two nodes, one with a port
+    class SourceNode(BaseNode):
+        pass
+
+    class MiddleNode(BaseNode):
+        class Ports(BaseNode.Ports):
+            custom = Port.on_else()
+
+    class TargetNode(BaseNode):
+        pass
+
+    # WHEN we create a graph from the source node to the target node
+    graph = SourceNode >> MiddleNode.Ports.custom >> TargetNode
+
+    # THEN the graph has the source node as the entrypoint
+    assert set(graph.entrypoints) == {SourceNode}
+
+    # AND three nodes
+    assert len(list(graph.nodes)) == 3
+
+    # AND two edges
+    assert len(list(graph.edges)) == 2

--- a/src/vellum/workflows/ports/port.py
+++ b/src/vellum/workflows/ports/port.py
@@ -52,6 +52,9 @@ class Port:
         if isinstance(other, set) or isinstance(other, Graph):
             return Graph.from_port(self) >> other
 
+        if isinstance(other, Port):
+            return Graph.from_port(self) >> Graph.from_port(other)
+
         edge = Edge(from_port=self, to_node=other)
         if edge not in self._edges:
             self._edges.append(edge)


### PR DESCRIPTION
Follows up on the graph discovered here: https://github.com/vellum-ai/workflows-as-code-runner-prototype/pull/530

Allows Ports to be used as graph targets and set elements