### PR TITLE
Setup branch and start testing codegen private registry publishing

### DIFF
--- a/.github/workflows/ci-codegen.yaml
+++ b/.github/workflows/ci-codegen.yaml
@@ -1,6 +1,9 @@
 name: ci-codegen
 
-on: [push]
+on:
+  push:
+    branches:
+      - vargas/fix-codegen-publish
 
 jobs:
   compile:
@@ -60,7 +63,7 @@ jobs:
       id-token: "write"
 
     needs: [compile, test]
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    # if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
@@ -92,7 +95,7 @@ jobs:
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
         run: |
-          npm config set @vellum-ai:registry https://us-central1-npm.pkg.dev/vocify-prod/vellum-private-npm
+          npm config set @vellum-ai:registry https://us-central1-npm.pkg.dev/vocify-prod/vellum-private-npm/
           npm run gar-login
           npm publish
         working-directory: ee/codegen

--- a/.github/workflows/ci-codegen.yaml
+++ b/.github/workflows/ci-codegen.yaml
@@ -1,9 +1,6 @@
 name: ci-codegen
 
-on:
-  push:
-    branches:
-      - vargas/fix-codegen-publish
+on: [push]
 
 jobs:
   compile:
@@ -63,7 +60,7 @@ jobs:
       id-token: "write"
 
     needs: [compile, test]
-    # if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo

--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -11,7 +11,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "registry": "https://us-central1-npm.pkg.dev/vocify-prod/vellum-private-npm"
+    "registry": "https://us-central1-npm.pkg.dev/vocify-prod/vellum-private-npm/"
   },
   "scripts": {
     "gar-login": "npx google-artifactregistry-auth",


### PR DESCRIPTION
This PR looks to get npm private publishing working on GHA CI

In the first commit, we ran the publish script on this branch since 0.11.4. And we confirmed that the fix worked! https://github.com/vellum-ai/vellum-python-sdks/actions/runs/12342564193/job/34442545225?pr=396