### PR TITLE
remove exclusions from map and subworkflow nodes

### DIFF
--- a/ee/codegen_integration/conftest.py
+++ b/ee/codegen_integration/conftest.py
@@ -34,9 +34,6 @@ _fixture_paths = _get_fixtures(
     # https://app.shortcut.com/vellum/story/4649/remove-fixture-exclusions-for-serialization
     exclude_fixtures={
         "faa_q_and_a_bot",
-        # TODO: Remove the bottom three in fast follows
-        "simple_inline_subworkflow_node",
-        "simple_map_node",
     },
 )
 _fixture_ids = [os.path.basename(path) for path in _fixture_paths]


### PR DESCRIPTION
Quick PR: These were originally excluded due to duplicate output/input vars errors