### PR TITLE
Ignore non py files in push

### DIFF
--- a/ee/vellum_cli/push.py
+++ b/ee/vellum_cli/push.py
@@ -1,8 +1,8 @@
-import re
 from importlib import metadata
 import io
 import json
 import os
+import re
 import sys
 import tarfile
 from uuid import UUID

--- a/ee/vellum_cli/push.py
+++ b/ee/vellum_cli/push.py
@@ -2,7 +2,6 @@ from importlib import metadata
 import io
 import json
 import os
-import re
 import sys
 import tarfile
 from uuid import UUID
@@ -19,10 +18,6 @@ from vellum_cli.config import WorkflowDeploymentConfig, load_vellum_cli_config
 from vellum_cli.logger import load_cli_logger
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
-
-_IGNORE_DIRECTORIES = [r".*__pycache__"]
-
-_IGNORE_FILES = [r"\.DS_Store"]
 
 
 def push_command(
@@ -84,11 +79,8 @@ def push_command(
     with tarfile.open(fileobj=artifact, mode="w:gz") as tar:
         module_dir = workflow_config.module.replace(".", os.path.sep)
         for root, _, files in os.walk(module_dir):
-            if _is_match(root, _IGNORE_DIRECTORIES):
-                continue
-
             for filename in files:
-                if _is_match(filename, _IGNORE_FILES):
+                if not filename.endswith(".py"):
                     continue
 
                 file_path = os.path.join(root, filename)
@@ -133,12 +125,3 @@ Visit at: https://app.vellum.ai/workflow-sandboxes/{response.workflow_sandbox_id
     if requires_save:
         config.save()
         logger.info("Updated vellum.lock file.")
-
-
-def _is_match(path: str, patterns: list[str]) -> bool:
-    for regex in patterns:
-        matches = re.findall(regex, path)
-        if matches:
-            return True
-
-    return False

--- a/ee/vellum_cli/push.py
+++ b/ee/vellum_cli/push.py
@@ -20,13 +20,10 @@ from vellum_cli.logger import load_cli_logger
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
-_IGNORE_DIRECTORIES = [
-    r".*__pycache__"
-]
+_IGNORE_DIRECTORIES = [r".*__pycache__"]
 
-_IGNORE_FILES = [
-    r"\.DS_Store"
-]
+_IGNORE_FILES = [r"\.DS_Store"]
+
 
 def push_command(
     module: Optional[str] = None,


### PR DESCRIPTION
~~We can't really use the .pyc files since their compiled based on the python version and think the python versions hafta be compatible. Also they were causing the encoding error I ran into. Im going also patch this on django by checking the encoding of a file somehow or something but this raises a question in my head of what if they want to include some non utf-8 data? How would vembda even handle that should we just.~~

I think it might be safe here just to exclude all non .py files instead of excluding specific things but not 100% sure?

Also why arn't we just serializing and running this through the codegen service for consistency?