### PR TITLE
Graph Gen: Setup test and implementation for Single Port pointing to a set

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -141,6 +141,18 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
+exports[`Workflow > write > graph > should be correct for a single port pointing to a set 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.conditional_node import ConditionalNode
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_2 import TemplatingNode2
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = ConditionalNode.Ports.branch_1 >> {TemplatingNode, TemplatingNode2}
+"
+`;
+
 exports[`Workflow > write > graph > should be correct for set of a branch and a node 1`] = `
 "from vellum.workflows import BaseWorkflow
 from .nodes.templating_node import TemplatingNode

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -1409,6 +1409,85 @@ describe("Workflow", () => {
         workflow.getWorkflowFile().write(writer);
         expect(await writer.toStringFormatted()).toMatchSnapshot();
       });
+
+      it("should be correct for a single port pointing to a set", async () => {
+        const inputs = codegen.inputs({ workflowContext });
+
+        const templatingNodeData1 = templatingNodeFactory();
+        const templatingNodeContext1 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData1,
+        });
+        workflowContext.addNodeContext(templatingNodeContext1);
+
+        const templatingNodeData2 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+          label: "Templating Node 2",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+        });
+        const templatingNodeContext2 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData2,
+        });
+        workflowContext.addNodeContext(templatingNodeContext2);
+
+        const conditionalNodeData = conditionalNodeFactory();
+        const conditionalNodeContext = await createNodeContext({
+          workflowContext,
+          nodeData: conditionalNodeData,
+        });
+        workflowContext.addNodeContext(conditionalNodeContext);
+        const conditionalIfSourceHandleId =
+          conditionalNodeData.data.conditions[0]?.sourceHandleId;
+        const conditionalElseSourceHandleId =
+          conditionalNodeData.data.conditions[1]?.sourceHandleId;
+        if (!conditionalIfSourceHandleId || !conditionalElseSourceHandleId) {
+          throw new Error("Handle IDs are required");
+        }
+
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: conditionalNodeData.id,
+            targetHandleId: conditionalNodeData.data.targetHandleId,
+          },
+          {
+            id: "edge-2",
+            type: "DEFAULT",
+            sourceNodeId: conditionalNodeData.id,
+            sourceHandleId: conditionalIfSourceHandleId,
+            targetNodeId: templatingNodeData1.id,
+            targetHandleId: templatingNodeData1.data.targetHandleId,
+          },
+          {
+            id: "edge-3",
+            type: "DEFAULT",
+            sourceNodeId: conditionalNodeData.id,
+            sourceHandleId: conditionalIfSourceHandleId,
+            targetNodeId: templatingNodeData2.id,
+            targetHandleId: templatingNodeData2.data.targetHandleId,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
+
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [
+            conditionalNodeData,
+            templatingNodeData1,
+            templatingNodeData2,
+          ],
+        });
+
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
     });
   });
 });

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -214,6 +214,27 @@ export class GraphAttribute extends AstNode {
               ],
             };
           }
+        } else if (mutableAst.type === "port_reference") {
+          if (sourceNode) {
+            const sourceNodePortContext = sourceNode.portContextsById.get(
+              edge.sourceHandleId
+            );
+            if (sourceNodePortContext === mutableAst.reference) {
+              return {
+                type: "right_shift",
+                lhs: mutableAst,
+                rhs: { type: "node_reference", reference: targetNode },
+              };
+            }
+          } else if (sourceNode == graphSourceNode) {
+            return {
+              type: "set",
+              values: [
+                mutableAst,
+                { type: "node_reference", reference: targetNode },
+              ],
+            };
+          }
         } else if (mutableAst.type === "set") {
           const newSet = mutableAst.values.map((subAst) => {
             const canBeAdded = this.isNodeInBranch(sourceNode, subAst);


### PR DESCRIPTION
`graph = A.Ports.a >> {B, C}`

Eventually building up to: https://github.com/vellum-ai/vellum-python-sdks/pull/409/files