### PR TITLE
Fix hash of search node query inputs

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
@@ -154,12 +154,12 @@ class BaseSearchNodeDisplay(BaseNodeVellumDisplay[_SearchNodeType], Generic[_Sea
             lhs_query_input_id = (
                 self.input_variable_ids_by_logical_id[lhs_variable_id]
                 if self.input_variable_ids_by_logical_id
-                else uuid4_from_hash(f"{self.node_id}|{hash(path)}")
+                else uuid4_from_hash(f"{self.node_id}|{hash(tuple(path))}")
             )
             rhs_query_input_id = (
                 self.input_variable_ids_by_logical_id[rhs_variable_id]
                 if self.input_variable_ids_by_logical_id
-                else uuid4_from_hash(f"{self.node_id}|{hash(path)}")
+                else uuid4_from_hash(f"{self.node_id}|{hash(tuple(path))}")
             )
 
             return (


### PR DESCRIPTION
The path variable is a list so it isn't hashable