### PR TITLE
Setup test and implement solution for port within a set pointing to a set

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -196,6 +196,22 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
+exports[`Workflow > write > should be correct for port within set to a set 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.conditional_node import ConditionalNode
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_2 import TemplatingNode2
+from .nodes.templating_node_3 import TemplatingNode3
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = {
+        ConditionalNode.Ports.branch_1 >> TemplatingNode,
+        ConditionalNode.Ports.branch_2 >> {TemplatingNode2, TemplatingNode3},
+    }
+"
+`;
+
 exports[`Workflow > write > should generate correct code when there are input variables 1`] = `
 "from vellum.workflows import BaseWorkflow
 

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -1489,5 +1489,117 @@ describe("Workflow", () => {
         expect(await writer.toStringFormatted()).toMatchSnapshot();
       });
     });
+
+    it("should be correct for port within set to a set", async () => {
+      const inputs = codegen.inputs({ workflowContext });
+
+      const templatingNodeData1 = templatingNodeFactory();
+      const templatingNodeContext1 = await createNodeContext({
+        workflowContext,
+        nodeData: templatingNodeData1,
+      });
+      workflowContext.addNodeContext(templatingNodeContext1);
+
+      const templatingNodeData2 = templatingNodeFactory({
+        id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+        label: "Templating Node 2",
+        sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+        targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+      });
+      const templatingNodeContext2 = await createNodeContext({
+        workflowContext,
+        nodeData: templatingNodeData2,
+      });
+      workflowContext.addNodeContext(templatingNodeContext2);
+
+      const templatingNodeData3 = templatingNodeFactory({
+        id: "7e09927b-6d6f-4829-92c9-54e66bdcaf83",
+        label: "Templating Node 3",
+        sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9b",
+        targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294b",
+      });
+      const templatingNodeContext3 = await createNodeContext({
+        workflowContext,
+        nodeData: templatingNodeData3,
+      });
+      workflowContext.addNodeContext(templatingNodeContext3);
+
+      const templatingNodeData4 = templatingNodeFactory({
+        id: "7e09927b-6d6f-4829-92c9-54e66bdcaf84",
+        label: "Templating Node 4",
+        sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9c",
+        targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294c",
+      });
+      const templatingNodeContext4 = await createNodeContext({
+        workflowContext,
+        nodeData: templatingNodeData4,
+      });
+      workflowContext.addNodeContext(templatingNodeContext4);
+
+      const conditionalNodeData = conditionalNodeFactory();
+      const conditionalNodeContext = await createNodeContext({
+        workflowContext,
+        nodeData: conditionalNodeData,
+      });
+      workflowContext.addNodeContext(conditionalNodeContext);
+      const conditionalIfSourceHandleId =
+        conditionalNodeData.data.conditions[0]?.sourceHandleId;
+      const conditionalElseSourceHandleId =
+        conditionalNodeData.data.conditions[1]?.sourceHandleId;
+      if (!conditionalIfSourceHandleId || !conditionalElseSourceHandleId) {
+        throw new Error("Handle IDs are required");
+      }
+
+      const edges: WorkflowEdge[] = [
+        {
+          id: "edge-1",
+          type: "DEFAULT",
+          sourceNodeId: entrypointNode.id,
+          sourceHandleId: entrypointNode.data.sourceHandleId,
+          targetNodeId: conditionalNodeData.id,
+          targetHandleId: conditionalNodeData.data.targetHandleId,
+        },
+        {
+          id: "edge-2",
+          type: "DEFAULT",
+          sourceNodeId: conditionalNodeData.id,
+          sourceHandleId: conditionalIfSourceHandleId,
+          targetNodeId: templatingNodeData1.id,
+          targetHandleId: templatingNodeData1.data.targetHandleId,
+        },
+        {
+          id: "edge-3",
+          type: "DEFAULT",
+          sourceNodeId: conditionalNodeData.id,
+          sourceHandleId: conditionalElseSourceHandleId,
+          targetNodeId: templatingNodeData2.id,
+          targetHandleId: templatingNodeData2.data.targetHandleId,
+        },
+        {
+          id: "edge-4",
+          type: "DEFAULT",
+          sourceNodeId: conditionalNodeData.id,
+          sourceHandleId: conditionalElseSourceHandleId,
+          targetNodeId: templatingNodeData3.id,
+          targetHandleId: templatingNodeData3.data.targetHandleId,
+        },
+      ];
+      workflowContext.addWorkflowEdges(edges);
+
+      const workflow = codegen.workflow({
+        moduleName,
+        workflowContext,
+        inputs,
+        nodes: [
+          conditionalNodeData,
+          templatingNodeData1,
+          templatingNodeData2,
+          templatingNodeData3,
+        ],
+      });
+
+      workflow.getWorkflowFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
```python
graph = {
    A.ports.if >> B,
    A.ports.else >> {C, D}
}
```

What made this case tricky is that when adding an edge to a set (eg `A.ports.else >> D`), our algorithm iterates over all members of the set to see which one to add it to. In this case, both members shared the node `A` so both were valid. We want our algorithm to only add it to one, so we implement a max priority score on which one to choose.

Eventually building up to: https://github.com/vellum-ai/vellum-python-sdks/pull/409/files