### PR TITLE
Add code execution tests and throw node attribute generation error

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -2,6 +2,7 @@ import { VellumVariableType } from "vellum-ai/api";
 
 import {
   EntrypointNode,
+  CodeExecutionNode,
   GuardrailNode,
   SearchNode,
   FinalOutputNode,
@@ -1028,6 +1029,71 @@ export function apiNodeFactory({
             },
           ],
           combinator: "OR",
+        },
+      },
+    ],
+    displayData: {
+      width: 462,
+      height: 288,
+      position: {
+        x: 2075.7067885117494,
+        y: 234.65663468515768,
+      },
+    },
+  };
+  return nodeData;
+}
+
+export function codeExecutionNodeFactory({
+  codeInputValueRule,
+}: {
+  codeInputValueRule?: NodeInputValuePointerRule;
+} = {}): CodeExecutionNode {
+  const nodeData: CodeExecutionNode = {
+    id: "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
+    type: "CODE_EXECUTION",
+    data: {
+      label: "Code Execution Node",
+      codeInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+      outputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
+      outputType: "STRING",
+      runtimeInputId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
+      targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
+      sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
+    },
+    inputs: [
+      {
+        id: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+        key: "code",
+        value: {
+          combinator: "OR",
+          rules: codeInputValueRule
+            ? [codeInputValueRule]
+            : [
+                {
+                  type: "CONSTANT_VALUE",
+                  data: {
+                    type: "STRING",
+                    value: "print('Hello, World!')",
+                  },
+                },
+              ],
+        },
+      },
+      {
+        id: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
+        key: "runtime",
+        value: {
+          combinator: "OR",
+          rules: [
+            {
+              type: "CONSTANT_VALUE",
+              data: {
+                type: "STRING",
+                value: "PYTHON_3_11",
+              },
+            },
+          ],
         },
       },
     ],

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -1,0 +1,81 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CodeExecutionNode > basic > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "displayable",
+      ],
+      "name": "CodeExecutionNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "code_execution_node",
+  ],
+  "name": "CodeExecutionNode",
+}
+`;
+
+exports[`CodeExecutionNode > basic > getNodeDisplayFile 1`] = `
+"from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
+from ...nodes.code_execution_node import CodeExecutionNode
+from uuid import UUID
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class CodeExecutionNodeDisplay(BaseCodeExecutionNodeDisplay[CodeExecutionNode]):
+    label = "Code Execution Node"
+    node_id = UUID("2cd960a3-cb8a-43ed-9e3f-f003fc480951")
+    target_handle_id = UUID("06573a05-e6f0-48b9-bc6e-07e06d0bc1b1")
+    code_input_id = UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
+    runtime_input_id = UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e")
+    output_id = UUID("81b270c0-4deb-4db3-aae5-138f79531b2b")
+    log_output_id = None
+    node_input_ids_by_name = {
+        "code": UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc"),
+        "runtime": UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e"),
+    }
+    output_display = {
+        CodeExecutionNode.Outputs.result: NodeOutputDisplay(
+            id=UUID("81b270c0-4deb-4db3-aae5-138f79531b2b"), name="result"
+        ),
+        CodeExecutionNode.Outputs.log: NodeOutputDisplay(id=None, name="log"),
+    }
+    port_displays = {
+        CodeExecutionNode.Ports.default: PortDisplayOverrides(
+            id=UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e")
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=2075.7067885117494, y=234.65663468515768),
+        width=462,
+        height=288,
+    )
+"
+`;
+
+exports[`CodeExecutionNode > basic > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import (
+    CodeExecutionNode as BaseCodeExecutionNode,
+)
+from vellum.workflows.state import BaseState
+
+
+class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
+    filepath = "./script.py"
+    code_inputs = {}
+    output_type = "STRING"
+    runtime = "PYTHON_3_11"
+    packages = None
+"
+`;

--- a/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
@@ -1,0 +1,81 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { beforeEach } from "vitest";
+
+import { workflowContextFactory } from "src/__test__/helpers";
+import { codeExecutionNodeFactory } from "src/__test__/helpers/node-data-factories";
+import { createNodeContext, WorkflowContext } from "src/context";
+import { CodeExecutionContext } from "src/context/node-context/code-execution-node";
+import { NodeAttributeGenerationError } from "src/generators/errors";
+import { CodeExecutionNode } from "src/generators/nodes/code-execution-node";
+
+describe("CodeExecutionNode", () => {
+  let workflowContext: WorkflowContext;
+  let writer: Writer;
+  let node: CodeExecutionNode;
+
+  beforeEach(() => {
+    workflowContext = workflowContextFactory();
+    writer = new Writer();
+  });
+
+  describe("basic", () => {
+    beforeEach(async () => {
+      const nodeData = codeExecutionNodeFactory();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as CodeExecutionContext;
+      workflowContext.addNodeContext(nodeContext);
+
+      node = new CodeExecutionNode({
+        workflowContext: workflowContext,
+        nodeContext,
+      });
+    });
+
+    it("getNodeFile", async () => {
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("getNodeDisplayFile", async () => {
+      node.getNodeDisplayFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("getNodeDefinition", () => {
+      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+    });
+  });
+
+  describe("failure cases", () => {
+    it("rejects if code input is not a constant string", async () => {
+      const nodeData = codeExecutionNodeFactory({
+        codeInputValueRule: {
+          type: "CONSTANT_VALUE",
+          data: {
+            type: "JSON",
+            value: null,
+          },
+        },
+      });
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as CodeExecutionContext;
+      workflowContext.addNodeContext(nodeContext);
+
+      expect(() => {
+        new CodeExecutionNode({
+          workflowContext: workflowContext,
+          nodeContext,
+        });
+      }).toThrow(
+        new NodeAttributeGenerationError(
+          "Expected to find code input with constant string value"
+        )
+      );
+    });
+  });
+});


### PR DESCRIPTION
Adds our new error for the following [sentry error](https://vellum.sentry.io/issues/6155986060/?referrer=slack&notification_uuid=c2030f02-2c7e-454e-9738-8f3f28076f18&alert_rule_id=15639644&alert_type=issue)

<img width="964" alt="Screenshot 2024-12-18 at 8 30 06 AM" src="https://github.com/user-attachments/assets/885febf5-495d-462e-a9e3-6438dc984826" />

In a future PR, we will be catching NodeAttributeGenerationError's and raising 4xx instead (from codegen).

Also used this as an opportunity to start the code execution node generation test in general