### PR TITLE
Convert upgrade codegen service to typescript

### DIFF
--- a/ee/codegen/package-lock.json
+++ b/ee/codegen/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@octokit/auth-app": "^7.1.3",
         "@types/lodash": "^4.17.13",
-        "@types/node": "^22.7.5",
+        "@types/node": "^22.10.2",
         "@typescript-eslint/eslint-plugin": "^8.9.0",
         "@typescript-eslint/parser": "^8.9.0",
         "eslint": "^8.56.0",
@@ -1237,12 +1237,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.7.tgz",
-      "integrity": "sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==",
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -6004,9 +6004,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true
     },
     "node_modules/universal-github-app-jwt": {
@@ -7116,12 +7116,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.7.tgz",
-      "integrity": "sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==",
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
       "dev": true,
       "requires": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "@typescript-eslint/eslint-plugin": {
@@ -10390,9 +10390,9 @@
       }
     },
     "undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true
     },
     "universal-github-app-jwt": {

--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -28,7 +28,7 @@
     "types": "tsc --noEmit",
     "start": "node --loader ts-node/esm --experimental-specifier-resolution=node src/index.ts",
     "version:codegen": "node scripts/version.js",
-    "upgrade-codegen-service": "node scripts/upgrade-codegen-service.js"
+    "upgrade-codegen-service": "ts-node-esm --project tsconfig.json scripts/upgrade-codegen-service.mts"
   },
   "dependencies": {
     "@fern-api/python-ast": "^0.0.18",
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@octokit/auth-app": "^7.1.3",
     "@types/lodash": "^4.17.13",
-    "@types/node": "^22.7.5",
+    "@types/node": "^22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.9.0",
     "@typescript-eslint/parser": "^8.9.0",
     "eslint": "^8.56.0",

--- a/ee/codegen/scripts/upgrade-codegen-service.mts
+++ b/ee/codegen/scripts/upgrade-codegen-service.mts
@@ -1,10 +1,10 @@
-const packageJson = require("../package.json");
-const { createAppAuth } = require("@octokit/auth-app");
-const path = require("path");
-const os = require("os");
-const { execSync } = require("child_process");
+import { createAppAuth } from "@octokit/auth-app";
+import path from "path";
+import os from "os";
+import { execSync } from "child_process";
+import packageJson from "../package.json" assert { type: "json" };
 
-export const getGithubToken = async () => {
+const getGithubToken = async () => {
   const appId = process.env.VELLUM_AUTOMATION_APP_ID;
   const privateKey = process.env.VELLUM_AUTOMATION_PRIVATE_KEY;
   const installationId = process.env.VELLUM_AUTOMATION_INSTALLATION_ID;
@@ -30,7 +30,7 @@ const main = async () => {
   console.log("Upgrading codegen service to version", version);
 
   const githubToken = await getGithubToken();
-  const targetDir = path.join(os.tmpdir(), `codegen-service-${id}`);
+  const targetDir = path.join(os.tmpdir(), `codegen-service-${version}`);
 
   const repoUrl = `https://x-access-token:${githubToken}@github.com/vellum-ai/codegen-service.git`;
   execSync(`git clone ${repoUrl} ${targetDir}`, { stdio: "inherit" });
@@ -55,6 +55,7 @@ const main = async () => {
   });
   execSync(`git push origin ${branchName}`, { stdio: "inherit" });
   console.log("Successfully pushed branch", branchName);
+  process.exit(0);
 };
 
 main();

--- a/ee/codegen/tsconfig.json
+++ b/ee/codegen/tsconfig.json
@@ -24,7 +24,7 @@
     "declaration": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitReturns": true,
-    "types": ["node", "vitest/globals"],
+    "types": ["node", "vitest/globals"]
   },
   "include": ["./src/**/*"],
   "ts-node": {

--- a/ee/codegen/tsconfig.json
+++ b/ee/codegen/tsconfig.json
@@ -24,7 +24,11 @@
     "declaration": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitReturns": true,
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals"],
   },
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "ts-node": {
+    "esm": true,
+    "experimentalSpecifierResolution": "node"
+  }
 }


### PR DESCRIPTION
Generated this PR: https://github.com/vellum-ai/codegen-service/pull/35. Invoked script locally to test, will in the future be invoked after release cut

Do we feel comfortable pushing these commits straight to codegen-service's main?