### PR TITLE
Fix circular import issue breaking workflows with merge node

### DIFF
--- a/ee/codegen_integration/test_fixtures.py
+++ b/ee/codegen_integration/test_fixtures.py
@@ -1,0 +1,13 @@
+import importlib
+
+
+def test_fixtures__ensure_all_fixtures_are_importable(code_to_display_fixture_paths):
+    """Confirms that all of our fixtures can be importable."""
+
+    _, code_dir = code_to_display_fixture_paths
+    base_module_path = __name__.split(".")[:-1]
+    code_sub_path = code_dir.split("/".join(base_module_path))[1].split("/")[1:]
+    module_path = ".".join(base_module_path + code_sub_path + ["workflow"])
+
+    workflow = importlib.import_module(module_path)
+    assert hasattr(workflow, "Workflow")

--- a/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
@@ -30,6 +30,9 @@ class BaseNodeVellumDisplay(BaseNodeDisplay[NodeType]):
     def get_target_handle_id(self) -> UUID:
         return self._get_node_display_uuid("target_handle_id")
 
+    def get_target_handle_id_by_source_node_id(self, source_node_id: UUID) -> UUID:
+        return self.get_target_handle_id()
+
     def get_source_handle_id(self, port_displays: Dict[Port, PortDisplay]) -> UUID:
         default_port = self._node.Ports.default
         default_port_display = port_displays[default_port]

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -12,7 +12,6 @@ from vellum.workflows.references import WorkflowInputReference
 from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
-from vellum_ee.workflows.display.nodes import BaseMergeNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
@@ -369,10 +368,7 @@ class VellumWorkflowDisplay(
         target_node_id = target_node_display.node_id
 
         target_handle_id: UUID
-        if isinstance(target_node_display, BaseMergeNodeDisplay):
-            target_handle_id = target_node_display.get_target_handle_id_by_source_node_id(source_node_id)
-        else:
-            target_handle_id = target_node_display.get_target_handle_id()
+        target_handle_id = target_node_display.get_target_handle_id_by_source_node_id(source_node_id)
 
         return self._generate_edge_display_from_source(
             source_node_id, source_handle_id, target_node_id, target_handle_id, overrides


### PR DESCRIPTION
Importing a workflows with merge node display was crashing - this should resolve and introduces a test to protect against any fast follows