### PR TITLE
use node 18 in codegen publish script

### DIFF
--- a/.github/workflows/ci-codegen.yaml
+++ b/.github/workflows/ci-codegen.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '18.17.0'
       - name: Install dependencies
         run: npm install
         working-directory: ee/codegen


### PR DESCRIPTION
Looking to resolve this error: https://github.com/vellum-ai/vellum-python-sdks/actions/runs/12400376060/job/34617451862