### PR TITLE
Always infer NodeDisplay._node from generic parameter

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -142,12 +142,4 @@ class BaseNodeDisplay(Generic[NodeType]):
         super().__init_subclass__(**kwargs)
 
         node_class = cls.infer_node_class()
-        # if "SimpleCode" in node_class.__module__:
-        #     breakpoint()
-        # if has_wrapped_node(node_class):
-        #     wrapped_node = get_wrapped_node(node_class)
-        #     if wrapped_node._is_wrapped_node:
-        #         cls._node_display_registry[wrapped_node] = cls
-        #         return
-
         cls._node_display_registry[node_class] = cls

--- a/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
+++ b/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
@@ -1,3 +1,4 @@
+import types
 from typing import Optional, Type
 
 from vellum.workflows.types.generics import NodeType
@@ -11,9 +12,17 @@ def get_node_display_class(
         node_display_class = base_class.get_from_node_display_registry(node_class)
     except KeyError:
         try:
-            return get_node_display_class(
+            base_node_display_class = get_node_display_class(
                 base_class, node_class.__bases__[0], node_class if root_node_class is None else root_node_class
             )
+
+            # `base_node_display_class` is always a Generic class, so it's safe to index into it
+            NodeDisplayBaseClass = base_node_display_class[node_class]  # type: ignore[index]
+            NodeDisplayClass = types.new_class(
+                f"{node_class.__name__}Display",
+                bases=(NodeDisplayBaseClass,),
+            )
+            return NodeDisplayClass
         except IndexError:
             return base_class
 

--- a/ee/vellum_ee/workflows/display/nodes/tests/test_base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/tests/test_base_node_display.py
@@ -15,7 +15,7 @@ def node_with_implicit_properties():
 
     expected_id = UUID("ace7f746-4fe6-45c7-8207-fc8a4d0c7f6f")
 
-    return MyNode, MyNodeDisplay, expected_id
+    return MyNodeDisplay, expected_id
 
 
 @pytest.fixture
@@ -28,7 +28,7 @@ def node_with_explicit_properties():
     class MyNodeDisplay(BaseNodeDisplay[MyNode]):
         node_id = explicit_id
 
-    return MyNode, MyNodeDisplay, explicit_id
+    return MyNodeDisplay, explicit_id
 
 
 @pytest.fixture(
@@ -42,6 +42,6 @@ def node_info(request):
 
 
 def test_get_id(node_info):
-    node, node_display, expected_id = node_info
+    node_display, expected_id = node_info
 
-    assert node_display(node).node_id == expected_id
+    assert node_display().node_id == expected_id

--- a/ee/vellum_ee/workflows/display/nodes/vellum/merge_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/merge_node.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from typing import Any, ClassVar, Generic, List, Optional, Type, TypeVar
+from typing import Any, ClassVar, Generic, List, Optional, TypeVar
 
 from vellum.workflows.nodes.displayable import MergeNode
 from vellum.workflows.types.core import JsonObject
@@ -14,8 +14,8 @@ _MergeNodeType = TypeVar("_MergeNodeType", bound=MergeNode)
 class BaseMergeNodeDisplay(BaseNodeVellumDisplay[_MergeNodeType], Generic[_MergeNodeType]):
     target_handle_ids: ClassVar[List[UUID]]
 
-    def __init__(self, node: Type[_MergeNodeType]):
-        super().__init__(node)
+    def __init__(self):
+        super().__init__()
         self._target_handle_iterator = 0
 
     def serialize(self, display_context: WorkflowDisplayContext, **kwargs: Any) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_utils.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_utils.py
@@ -37,6 +37,10 @@ class MyNodeA(BaseNode):
         output: str
 
 
+class MyNodeADisplay(BaseNodeVellumDisplay[MyNodeA]):
+    pass
+
+
 class MyNodeB(BaseNode):
     example = MyNodeA.Outputs.output
     fallback_example = MyNodeA.Outputs.output.coalesce(Inputs.example_workflow_input).coalesce("fallback")
@@ -99,7 +103,7 @@ def test_create_node_input_value_pointer_rules(
                 ),
             },
             node_displays={
-                MyNodeA: BaseNodeVellumDisplay(MyNodeA),
+                MyNodeA: MyNodeADisplay(),
             },
         ),
     )

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -154,7 +154,7 @@ class BaseWorkflowDisplay(
 
     def _get_node_display(self, node: Type[BaseNode]) -> NodeDisplayType:
         node_display_class = get_node_display_class(self.node_display_base_class, node)
-        node_display = node_display_class(node)
+        node_display = node_display_class()
 
         if not isinstance(node_display, self.node_display_base_class):
             raise ValueError(f"{node.__name__} must be a subclass of {self.node_display_base_class.__name__}")

--- a/src/vellum/workflows/nodes/utils.py
+++ b/src/vellum/workflows/nodes/utils.py
@@ -7,13 +7,6 @@ from vellum.workflows.types.generics import NodeType
 ADORNMENT_MODULE_NAME = "<adornment>"
 
 
-def get_unadorned_node(node: Type[NodeType]) -> Type[BaseNode]:
-    if has_wrapped_node(node):
-        return get_unadorned_node(get_wrapped_node(node))
-
-    return node
-
-
 @cache
 def get_wrapped_node(node: Type[NodeType]) -> Type[BaseNode]:
     wrapped_node = getattr(node, "__wrapped_node__", None)

--- a/src/vellum/workflows/nodes/utils.py
+++ b/src/vellum/workflows/nodes/utils.py
@@ -2,28 +2,31 @@ from functools import cache
 from typing import Type
 
 from vellum.workflows.nodes import BaseNode
-from vellum.workflows.references import NodeReference
 from vellum.workflows.types.generics import NodeType
 
 ADORNMENT_MODULE_NAME = "<adornment>"
 
 
+def get_unadorned_node(node: Type[NodeType]) -> Type[BaseNode]:
+    if has_wrapped_node(node):
+        return get_unadorned_node(get_wrapped_node(node))
+
+    return node
+
+
 @cache
 def get_wrapped_node(node: Type[NodeType]) -> Type[BaseNode]:
-    if hasattr(node, "subworkflow"):
-        subworkflow = node.subworkflow
-        if isinstance(subworkflow, NodeReference) and subworkflow.instance:
-            graph = subworkflow.instance.graph
-            if issubclass(graph, BaseNode):
-                return graph
+    wrapped_node = getattr(node, "__wrapped_node__", None)
+    if wrapped_node is None:
+        raise AttributeError("Wrapped node not found")
 
-    raise TypeError("Wrapped subworkflow contains more than one node")
+    return wrapped_node
 
 
 def has_wrapped_node(node: Type[NodeType]) -> bool:
     try:
         get_wrapped_node(node)
-    except TypeError:
+    except AttributeError:
         return False
 
     return True


### PR DESCRIPTION
Node display classes were previously always accepting a node arg in the __init__ method. This is strictly speaking not necessary - the generic class is sufficient to drive this behavior. 

This PR removes the init arg and infers the underlying `_node` attribute using the generic. This will set us up to have a future PR where display classes will be able to annotate the id directly onto the node class, so that we don't need to import logic from `ee` into our sdk