### PR TITLE
Setup test case for strict param during codegen

### DIFF
--- a/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
+++ b/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
@@ -13,5 +13,6 @@ export function workflowContextFactory({
     workflowClassName: workflowClassName || "Workflow",
     vellumApiKey: "<TEST_API_KEY>",
     workflowRawEdges: workflowRawEdges || [],
+    strict: true,
   });
 }

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -13,6 +13,7 @@ import { makeTempDir } from "./helpers/temp-dir";
 
 import { SpyMocks } from "src/__test__/utils/SpyMocks";
 import { WorkflowProjectGenerator } from "src/project";
+import { NodeAttributeGenerationError } from "src/generators/errors";
 
 describe("WorkflowProjectGenerator", () => {
   let tempDir: string;
@@ -112,5 +113,53 @@ describe("WorkflowProjectGenerator", () => {
         }
       }
     );
+
+    it("should generate code even if a node fails to generate", async () => {
+      const displayData = {};
+      const project = new WorkflowProjectGenerator({
+        absolutePathToOutputDirectory: tempDir,
+        workflowVersionExecConfigData: displayData,
+        moduleName: "code",
+        vellumApiKey: "<TEST_API_KEY>",
+      });
+
+      await project.generateCode();
+
+      expect(
+        fs.existsSync(join(tempDir, project.getModuleName(), "workflow.py"))
+      ).toBe(true);
+      expect(
+        fs.existsSync(join(tempDir, project.getModuleName(), "nodes"))
+      ).toBe(true);
+      expect(
+        fs.existsSync(
+          join(tempDir, project.getModuleName(), "nodes", "bad_node.py")
+        )
+      ).toBe(false);
+
+      const errorLogPath = join(tempDir, project.getModuleName(), "error.log");
+      expect(fs.existsSync(errorLogPath)).toBe(true);
+      expect(fs.readFileSync(errorLogPath, "utf-8")).toBe(`\
+Encountered 1 error(s) while generating code:
+
+Failed to generate node "BadNode": Failed to find output "foo" in node "Bar"
+`);
+    });
+    });
+
+    it("should fail to generate code if a node fails in strict mode", async () => {
+      const displayData = {};
+      const project = new WorkflowProjectGenerator({
+        absolutePathToOutputDirectory: tempDir,
+        workflowVersionExecConfigData: displayData,
+        moduleName: "code",
+        vellumApiKey: "<TEST_API_KEY>",
+        strict: true,
+      });
+
+      expect(project.generateCode()).rejects.toThrow(
+        new NodeAttributeGenerationError("test")
+      );
+    });
   });
 });

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -21,6 +21,7 @@ describe("WorkflowProjectGenerator", () => {
   beforeEach(async () => {
     tempDir = makeTempDir("project-test");
     await mkdir(tempDir, { recursive: true });
+    console.log("tempDir", tempDir);
   });
 
   afterEach(async () => {
@@ -113,9 +114,84 @@ describe("WorkflowProjectGenerator", () => {
         }
       }
     );
+  });
+  describe("failure cases", () => {
+    const displayData = {
+      workflow_raw_data: {
+        nodes: [
+          {
+            id: "entry",
+            type: "ENTRYPOINT",
+            data: {
+              label: "Entrypoint",
+              source_handle_id: "entry_source",
+              target_handle_id: "entry_target",
+            },
+            inputs: [],
+          },
+          {
+            id: "bad_node",
+            type: "TEMPLATING",
+            data: {
+              label: "Bad Node",
+              template_node_input_id: "template",
+              output_id: "output",
+              output_type: "STRING",
+              source_handle_id: "template_source",
+              target_handle_id: "template_target",
+            },
+            inputs: [
+              {
+                id: "template",
+                key: "template",
+                value: {
+                  combinator: "OR",
+                  rules: [
+                    {
+                      type: "CONSTANT_VALUE",
+                      data: {
+                        type: "STRING",
+                        value: "foo",
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                id: "input",
+                key: "other",
+                value: {
+                  combinator: "OR",
+                  rules: [
+                    {
+                      type: "NODE_OUTPUT",
+                      data: {
+                        node_id: "node_that_doesnt_exist",
+                        output_id: "output",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+        edges: [
+          {
+            source_node_id: "entry",
+            source_handle_id: "entry_source",
+            target_node_id: "bad_node",
+            target_handle_id: "template_target",
+            type: "DEFAULT",
+            id: "edge_1",
+          },
+        ],
+      },
+      input_variables: [],
+      output_variables: [],
+    };
 
     it("should generate code even if a node fails to generate", async () => {
-      const displayData = {};
       const project = new WorkflowProjectGenerator({
         absolutePathToOutputDirectory: tempDir,
         workflowVersionExecConfigData: displayData,
@@ -131,24 +207,34 @@ describe("WorkflowProjectGenerator", () => {
       expect(
         fs.existsSync(join(tempDir, project.getModuleName(), "nodes"))
       ).toBe(true);
-      expect(
-        fs.existsSync(
-          join(tempDir, project.getModuleName(), "nodes", "bad_node.py")
-        )
-      ).toBe(false);
+
+      const badNodePath = join(
+        tempDir,
+        project.getModuleName(),
+        "nodes",
+        "bad_node.py"
+      );
+      expect(fs.existsSync(badNodePath)).toBe(true);
+      expect(fs.readFileSync(badNodePath, "utf-8")).toBe(`\
+from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+
+
+class BadNode(TemplatingNode[BaseState, str]):
+    template = "foo"
+    inputs = {}
+`);
 
       const errorLogPath = join(tempDir, project.getModuleName(), "error.log");
       expect(fs.existsSync(errorLogPath)).toBe(true);
       expect(fs.readFileSync(errorLogPath, "utf-8")).toBe(`\
 Encountered 1 error(s) while generating code:
 
-Failed to generate node "BadNode": Failed to find output "foo" in node "Bar"
+- Failed to generate attribute 'BadNode.inputs.other': Failed to find node with id 'node_that_doesnt_exist'
 `);
-    });
     });
 
     it("should fail to generate code if a node fails in strict mode", async () => {
-      const displayData = {};
       const project = new WorkflowProjectGenerator({
         absolutePathToOutputDirectory: tempDir,
         workflowVersionExecConfigData: displayData,
@@ -158,7 +244,9 @@ Failed to generate node "BadNode": Failed to find output "foo" in node "Bar"
       });
 
       expect(project.generateCode()).rejects.toThrow(
-        new NodeAttributeGenerationError("test")
+        new NodeAttributeGenerationError(
+          "Failed to generate attribute 'BadNode.inputs.other': Failed to find node with id 'node_that_doesnt_exist'"
+        )
       );
     });
   });

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -12,8 +12,8 @@ import {
 import { makeTempDir } from "./helpers/temp-dir";
 
 import { SpyMocks } from "src/__test__/utils/SpyMocks";
-import { WorkflowProjectGenerator } from "src/project";
 import { NodeAttributeGenerationError } from "src/generators/errors";
+import { WorkflowProjectGenerator } from "src/project";
 
 describe("WorkflowProjectGenerator", () => {
   let tempDir: string;
@@ -21,7 +21,6 @@ describe("WorkflowProjectGenerator", () => {
   beforeEach(async () => {
     tempDir = makeTempDir("project-test");
     await mkdir(tempDir, { recursive: true });
-    console.log("tempDir", tempDir);
   });
 
   afterEach(async () => {

--- a/ee/codegen/src/codegen.ts
+++ b/ee/codegen/src/codegen.ts
@@ -7,6 +7,7 @@ import {
   VellumVariable,
   Workflow,
 } from "./generators";
+import { BasePersistedFile } from "./generators/base-persisted-file";
 
 export function vellumVariable(args: VellumVariable.Args): VellumVariable {
   return new VellumVariable(args);
@@ -32,6 +33,6 @@ export function initFile(args: InitFile.Args): InitFile {
   return new InitFile(args);
 }
 
-export function errorLogFile(args: ErrorLogFile.Args): ErrorLogFile {
+export function errorLogFile(args: BasePersistedFile.Args): ErrorLogFile {
   return new ErrorLogFile(args);
 }

--- a/ee/codegen/src/codegen.ts
+++ b/ee/codegen/src/codegen.ts
@@ -1,4 +1,5 @@
 import {
+  ErrorLogFile,
   InitFile,
   Inputs,
   NodeInput,
@@ -29,4 +30,8 @@ export function workflow(args: Workflow.Args): Workflow {
 
 export function initFile(args: InitFile.Args): InitFile {
   return new InitFile(args);
+}
+
+export function errorLogFile(args: ErrorLogFile.Args): ErrorLogFile {
+  return new ErrorLogFile(args);
 }

--- a/ee/codegen/src/generators/error-log-file.ts
+++ b/ee/codegen/src/generators/error-log-file.ts
@@ -1,12 +1,9 @@
-import { AstNode } from "@fern-api/python-ast/core/AstNode";
-
-import { BasePersistedFile } from "./base-persisted-file";
 import { writeFile } from "fs/promises";
 import { join } from "path";
 
-export declare namespace ErrorLogFile {
-  interface Args extends BasePersistedFile.Args {}
-}
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+
+import { BasePersistedFile } from "./base-persisted-file";
 
 export class ErrorLogFile extends BasePersistedFile {
   protected getFileStatements(): AstNode[] {

--- a/ee/codegen/src/generators/error-log-file.ts
+++ b/ee/codegen/src/generators/error-log-file.ts
@@ -1,0 +1,42 @@
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+
+import { BasePersistedFile } from "./base-persisted-file";
+import { writeFile } from "fs/promises";
+import { join } from "path";
+
+export declare namespace ErrorLogFile {
+  interface Args extends BasePersistedFile.Args {}
+}
+
+export class ErrorLogFile extends BasePersistedFile {
+  protected getFileStatements(): AstNode[] {
+    return [];
+  }
+
+  protected getModulePath(): string[] {
+    return [];
+  }
+
+  public async persist(): Promise<void> {
+    const errors = this.workflowContext.getErrors();
+    if (errors.length === 0) {
+      return;
+    }
+
+    const filePath = join(
+      this.workflowContext.absolutePathToOutputDirectory,
+      this.workflowContext.moduleName,
+      "error.log"
+    );
+    const content = errors.map((error) => `- ${error.message}`).join("\n");
+
+    await writeFile(
+      filePath,
+      `\
+Encountered ${errors.length} error(s) while generating code:
+
+${content}
+`
+    );
+  }
+}

--- a/ee/codegen/src/generators/index.ts
+++ b/ee/codegen/src/generators/index.ts
@@ -1,3 +1,4 @@
+export { ErrorLogFile } from "./error-log-file";
 export { InitFile } from "./init-file";
 export { Inputs } from "./inputs";
 export { NodeInput } from "./node-inputs";

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -150,11 +150,13 @@ export abstract class BaseNode<
         generatedNodeInputs.set(nodeInputData.key, nodeInput);
       } catch (error) {
         if (error instanceof BaseCodegenError) {
-          throw new NodeAttributeGenerationError(
+          const nodeAttributeGenerationError = new NodeAttributeGenerationError(
             `Failed to generate attribute '${this.nodeContext.nodeClassName}.inputs.${nodeInputData.key}': ${error.message}`
           );
+          this.workflowContext.addError(nodeAttributeGenerationError);
+        } else {
+          throw error;
         }
-        throw error;
       }
     });
 

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -16,8 +16,11 @@ import {
 } from "./constants";
 import { createNodeContext, WorkflowContext } from "./context";
 import { InputVariableContext } from "./context/input-variable-context";
-import { InitFile, Inputs, Workflow } from "./generators";
-import { ProjectSerializationError } from "./generators/errors";
+import { ErrorLogFile, InitFile, Inputs, Workflow } from "./generators";
+import {
+  NodeAttributeGenerationError,
+  ProjectSerializationError,
+} from "./generators/errors";
 import { BaseNode } from "./generators/nodes/bases";
 import { GuardrailNode } from "./generators/nodes/guardrail-node";
 import { InlineSubworkflowNode } from "./generators/nodes/inline-subworkflow-node";
@@ -69,6 +72,7 @@ import { assertUnreachable } from "src/utils/typing";
 export declare namespace WorkflowProjectGenerator {
   interface BaseArgs {
     moduleName: string;
+    strict?: boolean;
   }
 
   interface BaseProject extends BaseArgs {
@@ -142,6 +146,7 @@ ${errors.slice(0, 3).map((err) => {
         workflowClassName,
         vellumApiKey,
         workflowRawEdges: rawEdges,
+        strict: rest.strict,
       });
     }
   }
@@ -176,6 +181,9 @@ ${errors.slice(0, 3).map((err) => {
       // nodes/*
       ...this.generateNodeFiles(nodes),
     ]);
+
+    // error.log
+    await this.generateErrorLogFile().persist();
 
     const setupCfgPath = this.resolvePythonConfigFilePath();
     const isortCmd = process.env.ISORT_CMD ?? "isort";
@@ -336,7 +344,7 @@ ${errors.slice(0, 3).map((err) => {
     });
 
     const nodeIds = nodesToGenerate.map((nodeData) => getNodeId(nodeData));
-    const nodes = this.generateNodes(nodeIds);
+    const nodes = await this.generateNodes(nodeIds);
 
     const workflow = codegen.workflow({
       moduleName,
@@ -349,168 +357,170 @@ ${errors.slice(0, 3).map((err) => {
     return { inputs, workflow, nodes };
   }
 
-  private generateNodes(
+  private async generateNodes(
     nodeIds: string[]
-  ): BaseNode<WorkflowDataNode, BaseNodeContext<WorkflowDataNode>>[] {
+  ): Promise<BaseNode<WorkflowDataNode, BaseNodeContext<WorkflowDataNode>>[]> {
     const nodes: BaseNode<
       WorkflowDataNode,
       BaseNodeContext<WorkflowDataNode>
     >[] = [];
 
-    nodeIds.forEach(async (nodeId) => {
-      let node: BaseNode<WorkflowDataNode, BaseNodeContext<WorkflowDataNode>>;
+    await Promise.all(
+      nodeIds.map(async (nodeId) => {
+        let node: BaseNode<WorkflowDataNode, BaseNodeContext<WorkflowDataNode>>;
 
-      const nodeContext = this.workflowContext.getNodeContext(nodeId);
-      const nodeData = nodeContext.nodeData;
+        const nodeContext = this.workflowContext.getNodeContext(nodeId);
+        const nodeData = nodeContext.nodeData;
 
-      const nodeType = nodeData.type;
-      switch (nodeType) {
-        case WorkflowNodeTypeEnum.SEARCH: {
-          node = new SearchNode({
-            workflowContext: this.workflowContext,
-            nodeContext: nodeContext as TextSearchNodeContext,
-          });
-          break;
-        }
-        case WorkflowNodeTypeEnum.SUBWORKFLOW: {
-          const variant = nodeData.data.variant;
-          switch (variant) {
-            case "INLINE":
-              node = new InlineSubworkflowNode({
-                workflowContext: this.workflowContext,
-                nodeContext: nodeContext as InlineSubworkflowNodeContext,
-              });
-              break;
-            case "DEPLOYMENT":
-              node = new SubworkflowDeploymentNode({
-                workflowContext: this.workflowContext,
-                nodeContext: nodeContext as SubworkflowDeploymentNodeContext,
-              });
-              break;
-            default: {
-              assertUnreachable(variant);
-            }
+        const nodeType = nodeData.type;
+        switch (nodeType) {
+          case WorkflowNodeTypeEnum.SEARCH: {
+            node = new SearchNode({
+              workflowContext: this.workflowContext,
+              nodeContext: nodeContext as TextSearchNodeContext,
+            });
+            break;
           }
-          break;
-        }
-        case WorkflowNodeTypeEnum.MAP: {
-          const mapNodeVariant = nodeData.data.variant;
-          switch (mapNodeVariant) {
-            case "INLINE":
-              node = new MapNode({
-                workflowContext: this.workflowContext,
-                nodeContext: nodeContext as MapNodeContext,
-              });
-              break;
-            case "DEPLOYMENT":
-              throw new Error(`DEPLOYMENT variant not yet supported`);
-            default: {
-              assertUnreachable(mapNodeVariant);
+          case WorkflowNodeTypeEnum.SUBWORKFLOW: {
+            const variant = nodeData.data.variant;
+            switch (variant) {
+              case "INLINE":
+                node = new InlineSubworkflowNode({
+                  workflowContext: this.workflowContext,
+                  nodeContext: nodeContext as InlineSubworkflowNodeContext,
+                });
+                break;
+              case "DEPLOYMENT":
+                node = new SubworkflowDeploymentNode({
+                  workflowContext: this.workflowContext,
+                  nodeContext: nodeContext as SubworkflowDeploymentNodeContext,
+                });
+                break;
+              default: {
+                assertUnreachable(variant);
+              }
             }
+            break;
           }
-          break;
-        }
-        case WorkflowNodeTypeEnum.METRIC: {
-          node = new GuardrailNode({
-            workflowContext: this.workflowContext,
-            nodeContext: nodeContext as GuardrailNodeContext,
-          });
-          break;
-        }
-        case WorkflowNodeTypeEnum.CODE_EXECUTION: {
-          node = new CodeExecutionNode({
-            workflowContext: this.workflowContext,
-            nodeContext: nodeContext as CodeExecutionContext,
-          });
-          break;
-        }
-        case WorkflowNodeTypeEnum.PROMPT: {
-          const promptNodeVariant = nodeData.data.variant;
-
-          switch (promptNodeVariant) {
-            case "INLINE":
-              node = new InlinePromptNode({
-                workflowContext: this.workflowContext,
-                nodeContext: nodeContext as InlinePromptNodeContext,
-              });
-              break;
-            case "DEPLOYMENT":
-              node = new PromptDeploymentNode({
-                workflowContext: this.workflowContext,
-                nodeContext: nodeContext as PromptDeploymentNodeContext,
-              });
-              break;
-            case "LEGACY":
-              throw new Error(
-                `LEGACY variant should have been converted to INLINE variant by this point.`
-              );
-            default: {
-              assertUnreachable(promptNodeVariant);
+          case WorkflowNodeTypeEnum.MAP: {
+            const mapNodeVariant = nodeData.data.variant;
+            switch (mapNodeVariant) {
+              case "INLINE":
+                node = new MapNode({
+                  workflowContext: this.workflowContext,
+                  nodeContext: nodeContext as MapNodeContext,
+                });
+                break;
+              case "DEPLOYMENT":
+                throw new Error(`DEPLOYMENT variant not yet supported`);
+              default: {
+                assertUnreachable(mapNodeVariant);
+              }
             }
+            break;
           }
-          break;
-        }
-        case WorkflowNodeTypeEnum.TEMPLATING: {
-          node = new TemplatingNode({
-            workflowContext: this.workflowContext,
-            nodeContext: nodeContext as TemplatingNodeContext,
-          });
-          break;
-        }
-        case WorkflowNodeTypeEnum.CONDITIONAL: {
-          node = new ConditionalNode({
-            workflowContext: this.workflowContext,
-            nodeContext: nodeContext as ConditionalNodeContext,
-          });
-          break;
-        }
-        case WorkflowNodeTypeEnum.TERMINAL: {
-          node = new FinalOutputNode({
-            workflowContext: this.workflowContext,
-            nodeContext: nodeContext as FinalOutputNodeContext,
-          });
-          break;
-        }
-        case WorkflowNodeTypeEnum.MERGE: {
-          node = new MergeNode({
-            workflowContext: this.workflowContext,
-            nodeContext: nodeContext as MergeNodeContext,
-          });
-          break;
-        }
-        case WorkflowNodeTypeEnum.ERROR: {
-          node = new ErrorNode({
-            workflowContext: this.workflowContext,
-            nodeContext: nodeContext as ErrorNodeContext,
-          });
-          break;
-        }
-        case WorkflowNodeTypeEnum.NOTE: {
-          node = new NoteNode({
-            workflowContext: this.workflowContext,
-            nodeContext: nodeContext as NoteNodeContext,
-          });
-          break;
-        }
-        case WorkflowNodeTypeEnum.API:
-          node = new ApiNode({
-            workflowContext: this.workflowContext,
-            nodeContext: nodeContext as ApiNodeContext,
-          });
-          break;
-        case WorkflowNodeTypeEnum.GENERIC:
-          node = new GenericNode({
-            workflowContext: this.workflowContext,
-            nodeContext: nodeContext as GenericNodeContext,
-          });
-          break;
-        default: {
-          throw new Error(`Unsupported node type: ${nodeType}`);
-        }
-      }
+          case WorkflowNodeTypeEnum.METRIC: {
+            node = new GuardrailNode({
+              workflowContext: this.workflowContext,
+              nodeContext: nodeContext as GuardrailNodeContext,
+            });
+            break;
+          }
+          case WorkflowNodeTypeEnum.CODE_EXECUTION: {
+            node = new CodeExecutionNode({
+              workflowContext: this.workflowContext,
+              nodeContext: nodeContext as CodeExecutionContext,
+            });
+            break;
+          }
+          case WorkflowNodeTypeEnum.PROMPT: {
+            const promptNodeVariant = nodeData.data.variant;
 
-      nodes.push(node);
-    });
+            switch (promptNodeVariant) {
+              case "INLINE":
+                node = new InlinePromptNode({
+                  workflowContext: this.workflowContext,
+                  nodeContext: nodeContext as InlinePromptNodeContext,
+                });
+                break;
+              case "DEPLOYMENT":
+                node = new PromptDeploymentNode({
+                  workflowContext: this.workflowContext,
+                  nodeContext: nodeContext as PromptDeploymentNodeContext,
+                });
+                break;
+              case "LEGACY":
+                throw new Error(
+                  `LEGACY variant should have been converted to INLINE variant by this point.`
+                );
+              default: {
+                assertUnreachable(promptNodeVariant);
+              }
+            }
+            break;
+          }
+          case WorkflowNodeTypeEnum.TEMPLATING: {
+            node = new TemplatingNode({
+              workflowContext: this.workflowContext,
+              nodeContext: nodeContext as TemplatingNodeContext,
+            });
+            break;
+          }
+          case WorkflowNodeTypeEnum.CONDITIONAL: {
+            node = new ConditionalNode({
+              workflowContext: this.workflowContext,
+              nodeContext: nodeContext as ConditionalNodeContext,
+            });
+            break;
+          }
+          case WorkflowNodeTypeEnum.TERMINAL: {
+            node = new FinalOutputNode({
+              workflowContext: this.workflowContext,
+              nodeContext: nodeContext as FinalOutputNodeContext,
+            });
+            break;
+          }
+          case WorkflowNodeTypeEnum.MERGE: {
+            node = new MergeNode({
+              workflowContext: this.workflowContext,
+              nodeContext: nodeContext as MergeNodeContext,
+            });
+            break;
+          }
+          case WorkflowNodeTypeEnum.ERROR: {
+            node = new ErrorNode({
+              workflowContext: this.workflowContext,
+              nodeContext: nodeContext as ErrorNodeContext,
+            });
+            break;
+          }
+          case WorkflowNodeTypeEnum.NOTE: {
+            node = new NoteNode({
+              workflowContext: this.workflowContext,
+              nodeContext: nodeContext as NoteNodeContext,
+            });
+            break;
+          }
+          case WorkflowNodeTypeEnum.API:
+            node = new ApiNode({
+              workflowContext: this.workflowContext,
+              nodeContext: nodeContext as ApiNodeContext,
+            });
+            break;
+          case WorkflowNodeTypeEnum.GENERIC:
+            node = new GenericNode({
+              workflowContext: this.workflowContext,
+              nodeContext: nodeContext as GenericNodeContext,
+            });
+            break;
+          default: {
+            throw new Error(`Unsupported node type: ${nodeType}`);
+          }
+        }
+
+        nodes.push(node);
+      })
+    );
 
     return nodes;
   }
@@ -595,6 +605,12 @@ ${errors.slice(0, 3).map((err) => {
       // nodes/* and display/nodes/*
       ...nodePromises,
     ];
+  }
+
+  private generateErrorLogFile(): ErrorLogFile {
+    return codegen.errorLogFile({
+      workflowContext: this.workflowContext,
+    });
   }
 
   private resolvePythonConfigFilePath(): string {

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -17,10 +17,7 @@ import {
 import { createNodeContext, WorkflowContext } from "./context";
 import { InputVariableContext } from "./context/input-variable-context";
 import { ErrorLogFile, InitFile, Inputs, Workflow } from "./generators";
-import {
-  NodeAttributeGenerationError,
-  ProjectSerializationError,
-} from "./generators/errors";
+import { ProjectSerializationError } from "./generators/errors";
 import { BaseNode } from "./generators/nodes/bases";
 import { GuardrailNode } from "./generators/nodes/guardrail-node";
 import { InlineSubworkflowNode } from "./generators/nodes/inline-subworkflow-node";


### PR DESCRIPTION
The plan is to solve this ticket in two stages:
- Stage 1 - pull `--strict`
    - Codegen will now pull as much as possible. Any errors it encounters will be emitted to the console.
    - users could run `vellum workflows pull --strict` to instead fail codegen upon seeing errors immediately instead of trying to complete.
- Stage 2 - push `--check`
    - Serialization by default will fail early if it sees any errors.
    - users could run `vellum workflows push --check` to instead run the full serialization and print any issues to the console
        - We likely should report back any _diffs_ as well, but this will be ticketed separately.

This PR is only the first part of Stage 1. Looking to use this for feedback on the api and overall approach first before continuing