### PR TITLE
Support various other json inputs in our prompt nodes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
       - id: trailing-whitespace
         # Exclude python files, which might have a valid use for trailing whitespaces (e.g. in triple-quoted strings)
-        exclude: '(\.py$)|(.*\.ts\.snap$)'
+        exclude: '(\.py$)|(.*\.ts\.snap$)|.mock'
       - id: end-of-file-fixer
 
   - repo: https://github.com/adrienverge/yamllint.git
@@ -14,6 +14,7 @@ repos:
     hooks:
       - id: yamllint
         args: [-d=relaxed]
+        exclude: .mock
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.16.0
@@ -45,6 +46,7 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
+        exclude: src/vellum/client
 
   - repo: local
     hooks:

--- a/ee/vellum_ee/workflows/display/utils/vellum.py
+++ b/ee/vellum_ee/workflows/display/utils/vellum.py
@@ -9,7 +9,6 @@ from vellum.workflows.references import OutputReference, WorkflowInputReference
 from vellum.workflows.references.execution_count import ExecutionCountReference
 from vellum.workflows.references.node import NodeReference
 from vellum.workflows.references.vellum_secret import VellumSecretReference
-from vellum.workflows.types.core import VellumValuePrimitive
 from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
 from vellum.workflows.vellum_client import create_vellum_client
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
@@ -93,7 +92,7 @@ def create_node_input_value_pointer_rule(
     raise ValueError(f"Unsupported descriptor type: {value.__class__.__name__}")
 
 
-def primitive_to_vellum_value(value: VellumValuePrimitive) -> VellumValue:
+def primitive_to_vellum_value(value: Any) -> VellumValue:
     """Converts a python primitive to a VellumVariableValue"""
 
     if isinstance(value, str):

--- a/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
@@ -26,9 +26,9 @@ def test_inline_prompt_node__json_inputs(vellum_adhoc_prompt_client):
         blocks = []
         prompt_inputs = {
             "a_dict": {"foo": "bar"},
-            # "a_list": [1, 2, 3],
-            "a_dataclass": MyDataClass(hello="world"),  # type: ignore[dict-item]
-            "a_pydantic": MyPydantic(example="example"),  # type: ignore[dict-item]
+            "a_list": [1, 2, 3],
+            "a_dataclass": MyDataClass(hello="world"),
+            "a_pydantic": MyPydantic(example="example"),
         }
 
     # AND a known response from invoking an inline prompt
@@ -57,8 +57,8 @@ def test_inline_prompt_node__json_inputs(vellum_adhoc_prompt_client):
     assert mock_api.call_count == 1
     assert mock_api.call_args.kwargs["input_values"] == [
         PromptRequestJsonInput(key="a_dict", type="JSON", value={"foo": "bar"}),
-        # PromptRequestJsonInput(key="a_list", type="JSON", value=[1, 2, 3]),
+        PromptRequestJsonInput(key="a_list", type="JSON", value=[1, 2, 3]),
         PromptRequestJsonInput(key="a_dataclass", type="JSON", value={"hello": "world"}),
         PromptRequestJsonInput(key="a_pydantic", type="JSON", value={"example": "example"}),
     ]
-    assert len(mock_api.call_args.kwargs["input_variables"]) == 3  # 4
+    assert len(mock_api.call_args.kwargs["input_variables"]) == 4

--- a/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+
+from vellum.client.core.pydantic_utilities import UniversalBaseModel
+from vellum.workflows.nodes.displayable.inline_prompt_node.node import InlinePromptNode
+
+
+def test_inline_prompt_node__json_inputs(vellum_adhoc_prompt_client):
+    # GIVEN a prompt node with various inputs
+    @dataclass
+    class MyDataClass:
+        hello: str
+
+    class MyPydantic(UniversalBaseModel):
+        example: str
+
+    class MyNode(InlinePromptNode):
+        prompt_inputs = {
+            "a_dict": {"foo": "bar"},
+            "a_list": [1, 2, 3],
+            "a_dataclass": MyDataClass(hello="world"),
+            "a_pydantic": MyPydantic(example="example"),
+        }
+
+    # WHEN the node is run
+    list(MyNode().run())
+
+    # THEN the prompt is executed with the correct inputs
+    mock_api = vellum_adhoc_prompt_client.adhoc_execute_prompt_stream
+    assert mock_api.call_count == 1
+    assert mock_api.call_args[0]["input_values"] == {
+        "a_dict": {"type": "JSON", "value": {"foo": "bar"}},
+        "a_list": {"type": "JSON", "value": [1, 2, 3]},
+        "a_dataclass": {"type": "JSON", "value": {"hello": "world"}},
+        "a_pydantic": {"type": "JSON", "value": {"example": "example"}},
+    }
+    assert len(mock_api.call_args[0]["input_variables"]) == 4

--- a/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
@@ -1,6 +1,14 @@
 from dataclasses import dataclass
+from uuid import uuid4
+from typing import Any, Iterator, List
 
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
+from vellum.client.types.execute_prompt_event import ExecutePromptEvent
+from vellum.client.types.fulfilled_execute_prompt_event import FulfilledExecutePromptEvent
+from vellum.client.types.initiated_execute_prompt_event import InitiatedExecutePromptEvent
+from vellum.client.types.prompt_output import PromptOutput
+from vellum.client.types.prompt_request_json_input import PromptRequestJsonInput
+from vellum.client.types.string_vellum_value import StringVellumValue
 from vellum.workflows.nodes.displayable.inline_prompt_node.node import InlinePromptNode
 
 
@@ -14,12 +22,32 @@ def test_inline_prompt_node__json_inputs(vellum_adhoc_prompt_client):
         example: str
 
     class MyNode(InlinePromptNode):
+        ml_model = "gpt-4o"
+        blocks = []
         prompt_inputs = {
             "a_dict": {"foo": "bar"},
-            "a_list": [1, 2, 3],
-            "a_dataclass": MyDataClass(hello="world"),
-            "a_pydantic": MyPydantic(example="example"),
+            # "a_list": [1, 2, 3],
+            "a_dataclass": MyDataClass(hello="world"),  # type: ignore[dict-item]
+            "a_pydantic": MyPydantic(example="example"),  # type: ignore[dict-item]
         }
+
+    # AND a known response from invoking an inline prompt
+    expected_outputs: List[PromptOutput] = [
+        StringVellumValue(value="Test"),
+    ]
+
+    def generate_prompt_events(*args: Any, **kwargs: Any) -> Iterator[ExecutePromptEvent]:
+        execution_id = str(uuid4())
+        events: List[ExecutePromptEvent] = [
+            InitiatedExecutePromptEvent(execution_id=execution_id),
+            FulfilledExecutePromptEvent(
+                execution_id=execution_id,
+                outputs=expected_outputs,
+            ),
+        ]
+        yield from events
+
+    vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_prompt_events
 
     # WHEN the node is run
     list(MyNode().run())
@@ -27,10 +55,10 @@ def test_inline_prompt_node__json_inputs(vellum_adhoc_prompt_client):
     # THEN the prompt is executed with the correct inputs
     mock_api = vellum_adhoc_prompt_client.adhoc_execute_prompt_stream
     assert mock_api.call_count == 1
-    assert mock_api.call_args[0]["input_values"] == {
-        "a_dict": {"type": "JSON", "value": {"foo": "bar"}},
-        "a_list": {"type": "JSON", "value": [1, 2, 3]},
-        "a_dataclass": {"type": "JSON", "value": {"hello": "world"}},
-        "a_pydantic": {"type": "JSON", "value": {"example": "example"}},
-    }
-    assert len(mock_api.call_args[0]["input_variables"]) == 4
+    assert mock_api.call_args.kwargs["input_values"] == [
+        PromptRequestJsonInput(key="a_dict", type="JSON", value={"foo": "bar"}),
+        # PromptRequestJsonInput(key="a_list", type="JSON", value=[1, 2, 3]),
+        PromptRequestJsonInput(key="a_dataclass", type="JSON", value={"hello": "world"}),
+        PromptRequestJsonInput(key="a_pydantic", type="JSON", value={"example": "example"}),
+    ]
+    assert len(mock_api.call_args.kwargs["input_variables"]) == 3  # 4

--- a/src/vellum/workflows/types/core.py
+++ b/src/vellum/workflows/types/core.py
@@ -27,10 +27,7 @@ class VellumSecret:
         self.name = name
 
 
-EntityInputsInterface = Dict[
-    str,
-    Any,
-]
+EntityInputsInterface = Dict[str, Any]
 
 
 class MergeBehavior(Enum):

--- a/src/vellum/workflows/types/core.py
+++ b/src/vellum/workflows/types/core.py
@@ -1,27 +1,12 @@
 from enum import Enum
 from typing import (  # type: ignore[attr-defined]
+    Any,
     Dict,
     List,
     Union,
     _GenericAlias,
     _SpecialGenericAlias,
     _UnionGenericAlias,
-)
-
-from vellum import (
-    ChatMessage,
-    FunctionCall,
-    FunctionCallRequest,
-    SearchResult,
-    SearchResultRequest,
-    VellumAudio,
-    VellumAudioRequest,
-    VellumError,
-    VellumErrorRequest,
-    VellumImage,
-    VellumImageRequest,
-    VellumValue,
-    VellumValueRequest,
 )
 
 JsonArray = List["Json"]
@@ -42,41 +27,9 @@ class VellumSecret:
         self.name = name
 
 
-VellumValuePrimitive = Union[
-    # String inputs
-    str,
-    # Chat history inputs
-    List[ChatMessage],
-    List[ChatMessage],
-    # Search results inputs
-    List[SearchResultRequest],
-    List[SearchResult],
-    # JSON inputs
-    Json,
-    # Number inputs
-    float,
-    # Function Call Inputs
-    FunctionCall,
-    FunctionCallRequest,
-    # Error Inputs
-    VellumError,
-    VellumErrorRequest,
-    # Array Inputs
-    List[VellumValueRequest],
-    List[VellumValue],
-    # Image Inputs
-    VellumImage,
-    VellumImageRequest,
-    # Audio Inputs
-    VellumAudio,
-    VellumAudioRequest,
-    # Vellum Secrets
-    VellumSecret,
-]
-
 EntityInputsInterface = Dict[
     str,
-    VellumValuePrimitive,
+    Any,
 ]
 
 


### PR DESCRIPTION
This was a poor devx issue that @awlevin ran into while spinning up extending base node docs. We can now accept any json serializable as a JSON input for a prompt by default.

PR is blocked on a vellum schema change we need to make, and a mypy issue