### PR TITLE
Fix mypy issues with code execution nodes not inferring outputs results type

### DIFF
--- a/tests/workflows/basic_code_execution_node/try_workflow.py
+++ b/tests/workflows/basic_code_execution_node/try_workflow.py
@@ -11,10 +11,6 @@ class SimpleCodeExecutionNode(CodeExecutionNode[BaseState, int]):
     filepath = "./tests/code.py"
     code_inputs = {}
 
-    class Outputs(CodeExecutionNode.Outputs):
-        result: int
-        log: str
-
 
 class TrySimpleCodeExecutionWorkflow(BaseWorkflow):
     graph = SimpleCodeExecutionNode


### PR DESCRIPTION
Mypy does not like assignments like these:
`code_inputs = {"text", SomeNodeThatExtendsCodeExecutionNode.Outputs.Result}`