### PR TITLE
is_nil code generation for node outputs referenced in conditional node ports

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -20,6 +20,7 @@ import {
   PromptTemplateBlock,
   VellumLogicalConditionGroup,
   ConditionalNodeConditionData,
+  NodeOutputData,
 } from "src/types/vellum";
 
 export function entrypointNodeDataFactory(): EntrypointNode {
@@ -698,9 +699,11 @@ export function subworkflowDeploymentNodeDataFactory(): SubworkflowNode {
 
 export function conditionalNodeWithNullOperatorFactory({
   id,
+  nodeOutputReference,
 }: {
+  nodeOutputReference: NodeOutputData;
   id?: string;
-} = {}): ConditionalNode {
+}): ConditionalNode {
   const nodeData: ConditionalNode = {
     id: id ?? "b81a4453-7b80-41ea-bd55-c62df8878fd3",
     type: WorkflowNodeType.CONDITIONAL,
@@ -721,6 +724,12 @@ export function conditionalNodeWithNullOperatorFactory({
                 fieldNodeInputId: "2cb6582e-c329-4952-8598-097830b766c7",
                 operator: "null",
               },
+              {
+                id: "ad6bcb67-f21b-4af9-8d4b-ac8d3ba297cd",
+                rules: [],
+                fieldNodeInputId: "2cb6582e-c329-4952-8598-097830b766c8",
+                operator: "null",
+              },
             ],
             combinator: "AND",
           },
@@ -739,6 +748,19 @@ export function conditionalNodeWithNullOperatorFactory({
               data: {
                 inputVariableId: "d2287fee-98fb-421c-9464-e54d8f70f046",
               },
+            },
+          ],
+          combinator: "OR",
+        },
+      },
+      {
+        id: "2cb6582e-c329-4952-8598-097830b766c8",
+        key: "ad6bcb67-f21b-4af9-8d4b-ac8d3ba297cd.field",
+        value: {
+          rules: [
+            {
+              type: "NODE_OUTPUT",
+              data: nodeOutputReference,
             },
           ],
           combinator: "OR",

--- a/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
@@ -162,7 +162,13 @@ class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
                 field_node_input_id=None,
                 value_node_input_id=None,
             ),
-            rhs=None,
+            rhs=RuleIdMap(
+                id=UUID("ad6bcb67-f21b-4af9-8d4b-ac8d3ba297cd"),
+                lhs=None,
+                rhs=None,
+                field_node_input_id=None,
+                value_node_input_id=None,
+            ),
             field_node_input_id=None,
             value_node_input_id=None,
         )
@@ -176,7 +182,10 @@ class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
     node_input_ids_by_name = {
         "ad6bcb67-f21b-4af9-8d4b-ac8d3ba297cc.field": UUID(
             "2cb6582e-c329-4952-8598-097830b766c7"
-        )
+        ),
+        "ad6bcb67-f21b-4af9-8d4b-ac8d3ba297cd.field": UUID(
+            "2cb6582e-c329-4952-8598-097830b766c8"
+        ),
     }
     port_displays = {}
     display_data = NodeDisplayData(
@@ -191,10 +200,13 @@ exports[`ConditionalNode with null operator > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port
 from ..inputs import Inputs
+from .templating_node import TemplatingNode
 
 
 class ConditionalNode(BaseConditionalNode):
     class Ports(BaseConditionalNode.Ports):
-        branch_1 = Port.on_if(Inputs.field.is_null())
+        branch_1 = Port.on_if(
+            Inputs.field.is_null() and TemplatingNode.Outputs.result.is_nil()
+        )
 "
 `;

--- a/ee/codegen/src/__test__/nodes/conditional-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/conditional-node.test.ts
@@ -6,9 +6,11 @@ import { inputVariableContextFactory } from "src/__test__/helpers/input-variable
 import {
   conditionalNodeFactory,
   conditionalNodeWithNullOperatorFactory,
+  templatingNodeFactory,
 } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { ConditionalNodeContext } from "src/context/node-context/conditional-node";
+import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import { ConditionalNode } from "src/generators/nodes/conditional-node";
 import {
   ConditionalNode as ConditionalNodeType,
@@ -73,7 +75,13 @@ describe("ConditionalNode with null operator", () => {
     workflowContext = workflowContextFactory();
     writer = new Writer();
 
-    const nodeData = conditionalNodeWithNullOperatorFactory();
+    const templatingNode = templatingNodeFactory();
+    const nodeData = conditionalNodeWithNullOperatorFactory({
+      nodeOutputReference: {
+        nodeId: templatingNode.id,
+        outputId: templatingNode.data.outputId,
+      },
+    });
 
     workflowContext.addInputVariableContext(
       inputVariableContextFactory({
@@ -85,6 +93,12 @@ describe("ConditionalNode with null operator", () => {
         workflowContext,
       })
     );
+
+    const upstreamNodeContext = (await createNodeContext({
+      workflowContext,
+      nodeData: templatingNode,
+    })) as TemplatingNodeContext;
+    workflowContext.addNodeContext(upstreamNodeContext);
 
     const nodeContext = (await createNodeContext({
       workflowContext,

--- a/ee/codegen/src/generators/conditional-node-port.ts
+++ b/ee/codegen/src/generators/conditional-node-port.ts
@@ -5,6 +5,8 @@ import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
 import { isNil } from "lodash";
 
+import { NodePortGenerationError } from "./errors";
+
 import { PortContext } from "src/context/port-context";
 import { Expression } from "src/generators/expression";
 import { NodeInput } from "src/generators/node-inputs";
@@ -145,8 +147,13 @@ export class ConditionalNodePort extends AstNode {
     }
     const lhs = this.nodeInputsByKey.get(lhsKey);
     const rhs = !isNil(rhsKey) ? this.nodeInputsByKey.get(rhsKey) : undefined;
+    if (isNil(lhs)) {
+      throw new NodePortGenerationError(
+        `Node ${this.nodeLabel} is missing required left-hand side input field with key: ${lhsKey}`
+      );
+    }
     const expression = conditionData.operator
-      ? this.convertOperatorToMethod(conditionData.operator)
+      ? this.convertOperatorToMethod(conditionData.operator, lhs)
       : undefined;
     if (isNil(lhs) || isNil(expression)) {
       throw new Error("Port conditions require a lhs and an expression");
@@ -158,7 +165,11 @@ export class ConditionalNodePort extends AstNode {
     });
   }
 
-  private convertOperatorToMethod(operator: string): string {
+  private convertOperatorToMethod(operator: string, lhs: NodeInput): string {
+    // Legacy conditional nodes in legacy workflows assumed `is_nil` functionality
+    // for the `null` operator. This workaround is to support that cutover.
+    const isNodeOutput =
+      lhs.nodeInputData.value.rules[0]?.type === "NODE_OUTPUT";
     const operatorMappings: { [key: string]: string } = {
       "=": "equals",
       "!=": "does_not_equal",
@@ -172,8 +183,8 @@ export class ConditionalNodePort extends AstNode {
       doesNotContain: "does_not_contain",
       doesNotBeginWith: "does_not_begin_with",
       doesNotEndWith: "does_not_end_with",
-      null: "is_null()",
-      notNull: "is_not_null()",
+      null: isNodeOutput ? "is_nil()" : "is_null()",
+      notNull: isNodeOutput ? "is_not_nil()" : "is_not_null()",
       in: "in",
       notIn: "not_in",
       between: "between",

--- a/ee/codegen/src/generators/conditional-node-port.ts
+++ b/ee/codegen/src/generators/conditional-node-port.ts
@@ -149,14 +149,16 @@ export class ConditionalNodePort extends AstNode {
     const rhs = !isNil(rhsKey) ? this.nodeInputsByKey.get(rhsKey) : undefined;
     if (isNil(lhs)) {
       throw new NodePortGenerationError(
-        `Node ${this.nodeLabel} is missing required left-hand side input field with key: ${lhsKey}`
+        `Node ${this.nodeLabel} is missing required left-hand side input field with key: ${lhsKey} for rule: ${ruleIdx} in condition: ${this.conditionalNodeDataIndex}`
       );
     }
     const expression = conditionData.operator
       ? this.convertOperatorToMethod(conditionData.operator, lhs)
       : undefined;
-    if (isNil(lhs) || isNil(expression)) {
-      throw new Error("Port conditions require a lhs and an expression");
+    if (isNil(expression)) {
+      throw new NodePortGenerationError(
+        `Node ${this.nodeLabel} is missing required operator for rule: ${ruleIdx} in condition: ${this.conditionalNodeDataIndex}`
+      );
     }
     return new Expression({
       lhs: lhs,
@@ -192,7 +194,9 @@ export class ConditionalNodePort extends AstNode {
     };
     const value = operatorMappings[operator];
     if (!value) {
-      throw new Error(`This operator: ${operator} is not supported`);
+      throw new NodePortGenerationError(
+        `This operator: ${operator} is not supported`
+      );
     }
     return value;
   }

--- a/ee/codegen/src/generators/errors.ts
+++ b/ee/codegen/src/generators/errors.ts
@@ -1,6 +1,7 @@
 export type CodegenErrorCode =
   | "PROJECT_SERIALIZATION_ERROR"
   | "NODE_ATTRIBUTE_GENERATION_ERROR"
+  | "NODE_PORT_GENERATION_ERROR"
   | "NODE_NOT_FOUND_ERROR";
 
 export abstract class BaseCodegenError extends Error {
@@ -20,6 +21,13 @@ export class ProjectSerializationError extends BaseCodegenError {
  */
 export class NodeAttributeGenerationError extends BaseCodegenError {
   code = "NODE_ATTRIBUTE_GENERATION_ERROR" as const;
+}
+
+/**
+ * An error that raises when generating a node port fails.
+ */
+export class NodePortGenerationError extends BaseCodegenError {
+  code = "NODE_PORT_GENERATION_ERROR" as const;
 }
 
 /**

--- a/ee/vellum_ee/workflows/display/nodes/vellum/conditional_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/conditional_node.py
@@ -16,8 +16,12 @@ from vellum.workflows.expressions.equals import EqualsExpression
 from vellum.workflows.expressions.greater_than import GreaterThanExpression
 from vellum.workflows.expressions.greater_than_or_equal_to import GreaterThanOrEqualToExpression
 from vellum.workflows.expressions.in_ import InExpression
+from vellum.workflows.expressions.is_nil import IsNilExpression
+from vellum.workflows.expressions.is_not_nil import IsNotNilExpression
 from vellum.workflows.expressions.is_not_null import IsNotNullExpression
+from vellum.workflows.expressions.is_not_undefined import IsNotUndefinedExpression
 from vellum.workflows.expressions.is_null import IsNullExpression
+from vellum.workflows.expressions.is_undefined import IsUndefinedExpression
 from vellum.workflows.expressions.less_than import LessThanExpression
 from vellum.workflows.expressions.less_than_or_equal_to import LessThanOrEqualToExpression
 from vellum.workflows.expressions.not_between import NotBetweenExpression
@@ -242,9 +246,9 @@ but the defined conditions have length {len(condition_ids)}"""
             return "doesNotBeginWith"
         elif isinstance(descriptor, DoesNotEndWithExpression):
             return "doesNotEndWith"
-        elif isinstance(descriptor, IsNullExpression):
+        elif isinstance(descriptor, (IsNullExpression, IsNilExpression, IsUndefinedExpression)):
             return "null"
-        elif isinstance(descriptor, IsNotNullExpression):
+        elif isinstance(descriptor, (IsNotNullExpression, IsNotNilExpression, IsNotUndefinedExpression)):
             return "notNull"
         elif isinstance(descriptor, InExpression):
             return "in"


### PR DESCRIPTION
This PR conditionally codegen's is_nil depending on whether it's referencing a node output within legacy conditional nodes.