### PR TITLE
Setup tests and implementation for pydantic models as default values

### DIFF
--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -72,6 +72,12 @@ def _compile_default_value(default: Any) -> Any:
             field.name: _compile_default_value(getattr(default, field.name)) for field in dataclasses.fields(default)
         }
 
+    if isinstance(default, BaseModel):
+        return {
+            field_name: _compile_default_value(getattr(default, field_name))
+            for field_name in default.model_fields.keys()
+        }
+
     return default
 
 

--- a/src/vellum/workflows/utils/tests/test_functions.py
+++ b/src/vellum/workflows/utils/tests/test_functions.py
@@ -232,3 +232,33 @@ def test_compile_function_definition__default_dataclass():
             },
         },
     )
+
+
+def test_compile_function_definition__default_pydantic():
+    # GIVEN a function with a pydantic model as the default value
+    class MyPydanticModel(BaseModel):
+        a: int
+        b: str
+
+    def my_function(c: MyPydanticModel = MyPydanticModel(a=1, b="hello")):
+        pass
+
+    # WHEN compiling the function
+    compiled_function = compile_function_definition(my_function)
+
+    # THEN it should return the compiled function definition
+    assert compiled_function == FunctionDefinition(
+        name="my_function",
+        parameters={
+            "type": "object",
+            "properties": {"c": {"$ref": "#/$defs/MyPydanticModel", "default": {"a": 1, "b": "hello"}}},
+            "required": [],
+            "$defs": {
+                "MyPydanticModel": {
+                    "type": "object",
+                    "properties": {"a": {"type": "integer"}, "b": {"type": "string"}},
+                    "required": ["a", "b"],
+                }
+            },
+        },
+    )


### PR DESCRIPTION
Repeating what we did for dataclasses for pydantic. With this, we could now start integrating function compilation with prompt nodes.