### PR TITLE
Use new function definition compilation in base inline prompt node

### DIFF
--- a/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
@@ -1,6 +1,6 @@
 import json
 from uuid import uuid4
-from typing import ClassVar, Generic, Iterator, List, Optional, Tuple, cast
+from typing import Callable, ClassVar, Generic, Iterator, List, Optional, Tuple, Union, cast
 
 from vellum import (
     AdHocExecutePromptEvent,
@@ -24,6 +24,7 @@ from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.displayable.bases.base_prompt_node import BasePromptNode
 from vellum.workflows.nodes.displayable.bases.inline_prompt_node.constants import DEFAULT_PROMPT_PARAMETERS
 from vellum.workflows.types.generics import StateType
+from vellum.workflows.utils.functions import compile_function_definition
 
 
 class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
@@ -45,7 +46,7 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
     blocks: ClassVar[List[PromptBlock]]
 
     # The functions/tools that a Prompt has access to
-    functions: Optional[List[FunctionDefinition]] = OMIT
+    functions: Optional[List[Union[FunctionDefinition, Callable]]] = None
 
     parameters: PromptParameters = DEFAULT_PROMPT_PARAMETERS
     expand_meta: Optional[AdHocExpandMeta] = OMIT
@@ -59,6 +60,14 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
             "execution_context": {"parent_context": parent_context},
             **request_options.get("additional_body_parameters", {}),
         }
+        normalized_functions = (
+            [
+                function if isinstance(function, FunctionDefinition) else compile_function_definition(function)
+                for function in self.functions
+            ]
+            if self.functions
+            else None
+        )
 
         return self._context.vellum_client.ad_hoc.adhoc_execute_prompt_stream(
             ml_model=self.ml_model,
@@ -66,7 +75,7 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
             input_variables=input_variables,
             parameters=self.parameters,
             blocks=self.blocks,
-            functions=self.functions,
+            functions=normalized_functions,
             expand_meta=self.expand_meta,
             request_options=self.request_options,
         )

--- a/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
@@ -26,7 +26,7 @@ from vellum.workflows.nodes.displayable.bases.inline_prompt_node.constants impor
 from vellum.workflows.types.generics import StateType
 
 
-class BaseInlinePromptNode(BasePromptNode, Generic[StateType]):
+class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
     """
     Used to execute a Prompt defined inline.
 

--- a/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
@@ -5,10 +5,14 @@ from typing import Any, Iterator, List
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
 from vellum.client.types.execute_prompt_event import ExecutePromptEvent
 from vellum.client.types.fulfilled_execute_prompt_event import FulfilledExecutePromptEvent
+from vellum.client.types.function_call import FunctionCall
+from vellum.client.types.function_call_vellum_value import FunctionCallVellumValue
+from vellum.client.types.function_definition import FunctionDefinition
 from vellum.client.types.initiated_execute_prompt_event import InitiatedExecutePromptEvent
 from vellum.client.types.prompt_output import PromptOutput
 from vellum.client.types.prompt_request_json_input import PromptRequestJsonInput
 from vellum.client.types.string_vellum_value import StringVellumValue
+from vellum.workflows.nodes.displayable.bases.inline_prompt_node.node import BaseInlinePromptNode
 from vellum.workflows.nodes.displayable.inline_prompt_node.node import InlinePromptNode
 
 
@@ -62,3 +66,54 @@ def test_inline_prompt_node__json_inputs(vellum_adhoc_prompt_client):
         PromptRequestJsonInput(key="a_pydantic", type="JSON", value={"example": "example"}),
     ]
     assert len(mock_api.call_args.kwargs["input_variables"]) == 4
+
+
+def test_inline_prompt_node__function_definitions(vellum_adhoc_prompt_client):
+    # GIVEN a function definition
+    def my_function(foo: str, bar: int) -> None:
+        pass
+
+    # AND a prompt node with a accepting that function definition
+    class MyNode(BaseInlinePromptNode):
+        ml_model = "gpt-4o"
+        functions = [my_function]
+        prompt_inputs = {}
+        blocks = []
+
+    # AND a known response from invoking an inline prompt
+    expected_outputs: List[PromptOutput] = [
+        FunctionCallVellumValue(value=FunctionCall(name="my_function", arguments={"foo": "hello", "bar": 1})),
+    ]
+
+    def generate_prompt_events(*args: Any, **kwargs: Any) -> Iterator[ExecutePromptEvent]:
+        execution_id = str(uuid4())
+        events: List[ExecutePromptEvent] = [
+            InitiatedExecutePromptEvent(execution_id=execution_id),
+            FulfilledExecutePromptEvent(
+                execution_id=execution_id,
+                outputs=expected_outputs,
+            ),
+        ]
+        yield from events
+
+    vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_prompt_events
+
+    # WHEN the node is run
+    list(MyNode().run())
+
+    # THEN the prompt is executed with the correct inputs
+    mock_api = vellum_adhoc_prompt_client.adhoc_execute_prompt_stream
+    assert mock_api.call_count == 1
+    assert mock_api.call_args.kwargs["functions"] == [
+        FunctionDefinition(
+            name="my_function",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "foo": {"type": "string"},
+                    "bar": {"type": "integer"},
+                },
+                "required": ["foo", "bar"],
+            },
+        ),
+    ]

--- a/src/vellum/workflows/nodes/displayable/tests/test_inline_text_prompt_node.py
+++ b/src/vellum/workflows/nodes/displayable/tests/test_inline_text_prompt_node.py
@@ -75,7 +75,7 @@ def test_inline_text_prompt_node__basic(vellum_adhoc_prompt_client):
     vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.assert_called_once_with(
         blocks=[],
         expand_meta=Ellipsis,
-        functions=Ellipsis,
+        functions=None,
         input_values=[],
         input_variables=[],
         ml_model="gpt-4o",

--- a/tests/workflows/basic_inline_prompt_node/tests/test_workflow.py
+++ b/tests/workflows/basic_inline_prompt_node/tests/test_workflow.py
@@ -87,7 +87,7 @@ def test_run_workflow__happy_path(vellum_adhoc_prompt_client, mock_uuid4_generat
             ),
         ],
         expand_meta=OMIT,
-        functions=OMIT,
+        functions=None,
         request_options=None,
     )
 


### PR DESCRIPTION
All of the new function compilation logic comes to a head as we incorporate it into base prompt node.

In the next PR we will use a new node that will spin off these function definitions into new nodes, resolve the values, and feed back into the model