### PR TITLE
[Codegen] Handle Missing Input Variables

### DIFF
--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/__snapshots__/input-variable-pointer.test.ts.snap
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/__snapshots__/input-variable-pointer.test.ts.snap
@@ -4,3 +4,8 @@ exports[`InputVariablePointer > should generate correct Python code 1`] = `
 "Inputs.test_variable
 "
 `;
+
+exports[`InputVariablePointer > should handle when it's referencing an input variable that no longer exists 1`] = `
+"None
+"
+`;

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/input-variable-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/input-variable-pointer.test.ts
@@ -42,4 +42,22 @@ describe("InputVariablePointer", () => {
 
     expect(await writer.toStringFormatted()).toMatchSnapshot();
   });
+
+  it("should handle when it's referencing an input variable that no longer exists", async () => {
+    const workflowContext = workflowContextFactory();
+
+    const inputVariablePointer = new InputVariablePointerRule({
+      workflowContext: workflowContext,
+      nodeInputValuePointerRule: {
+        type: "INPUT_VARIABLE",
+        data: {
+          inputVariableId: "missing-input-id",
+        },
+      },
+    });
+
+    inputVariablePointer.write(writer);
+
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
 });

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -211,11 +211,17 @@ export class WorkflowContext {
     this.addUsedInputVariableName(inputVariableContext.name);
   }
 
+  public findInputVariableContextById(
+    inputVariableId: string
+  ): InputVariableContext | undefined {
+    return this.globalInputVariableContextsById.get(inputVariableId);
+  }
+
   public getInputVariableContextById(
     inputVariableId: string
   ): InputVariableContext {
     const inputVariableContext =
-      this.globalInputVariableContextsById.get(inputVariableId);
+      this.findInputVariableContextById(inputVariableId);
 
     if (!inputVariableContext) {
       throw new Error(

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/input-variable-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/input-variable-pointer.ts
@@ -5,13 +5,20 @@ import { BaseNodeInputValuePointerRule } from "./base";
 import { InputVariablePointer } from "src/types/vellum";
 
 export class InputVariablePointerRule extends BaseNodeInputValuePointerRule<InputVariablePointer> {
-  getAstNode(): python.Reference {
+  getAstNode(): python.AstNode {
     const inputVariablePointerRuleData = this.nodeInputValuePointerRule.data;
 
     const inputVariableContext =
-      this.workflowContext.getInputVariableContextById(
+      this.workflowContext.findInputVariableContextById(
         inputVariablePointerRuleData.inputVariableId
       );
+
+    if (!inputVariableContext) {
+      console.warn(
+        `Could not find input variable context with id ${inputVariablePointerRuleData.inputVariableId}`
+      );
+      return python.TypeInstantiation.none();
+    }
 
     return python.reference({
       name: "Inputs",


### PR DESCRIPTION
It's possible for users to delete an Input Variable in the UI and not update Node Inputs afterwards. It doesn't appear that we go through and clean up these references and so instead, codegen must handle this edge case.