### PR TITLE
[Codegen] Generate Standalone Script Files by Default

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -120,7 +120,7 @@ from vellum.workflows.state import BaseState
 
 
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
-    code = """print('Hello, World!')"""
+    filepath = "./script.py"
     code_inputs = {}
     output_type = "STRING"
     runtime = "PYTHON_3_11"

--- a/ee/codegen/src/generators/nodes/code-execution-node.ts
+++ b/ee/codegen/src/generators/nodes/code-execution-node.ts
@@ -329,6 +329,8 @@ export class CodeExecutionNode extends BaseSingleFileNode<
       return false;
     }
 
-    return !!this.nodeData.data.filepath;
+    // By default, we generate standalone code files unless there's an override saying otherwise.
+    // If no filepath is specified, we'll create a `script.py` file in the node directory.
+    return true;
   }
 }


### PR DESCRIPTION
We were erroneously using the presence of a `filepath` to determine whether we should generate the code that backs a Code Execution Node as a standalone file or inlined attribute. Instead, we should default to standalone unless there's an override saying otherwise.