### PR TITLE
[Codegen] Integrate Improvements from `python-ast=0.0.20`

### DIFF
--- a/ee/codegen/package-lock.json
+++ b/ee/codegen/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@vellum-ai/vellum-codegen",
       "version": "0.12.6",
       "dependencies": {
-        "@fern-api/python-ast": "^0.0.19",
+        "@fern-api/python-ast": "^0.0.20",
         "@fern-fern/generator-cli-sdk": "file:./stubs/generator-cli-sdk",
         "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
         "lodash": "^4.17.21",
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@fern-api/python-ast": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.19.tgz",
-      "integrity": "sha512-4s+KZGaYow4FXKEUfGfK6HU1oXtSDefPW4qI4Z2vdq2JrHzmOZj19myXjtnPVCSe9/sMfJWwQ6qx+FZ8TmYZOA==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.20.tgz",
+      "integrity": "sha512-tV/S0v4z9HVs6QKFdibItE1N2GYIJvFKDRWXrEpyhPnike3xqr/+1zdXGJ6NlwhbL39jKKyrBH5kLNQSr2isQw==",
       "dependencies": {
         "@fern-api/base-generator": "0.0.6",
         "@fern-api/core-utils": "^0.15.0-rc63",
@@ -6720,9 +6720,9 @@
       }
     },
     "@fern-api/python-ast": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.19.tgz",
-      "integrity": "sha512-4s+KZGaYow4FXKEUfGfK6HU1oXtSDefPW4qI4Z2vdq2JrHzmOZj19myXjtnPVCSe9/sMfJWwQ6qx+FZ8TmYZOA==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.20.tgz",
+      "integrity": "sha512-tV/S0v4z9HVs6QKFdibItE1N2GYIJvFKDRWXrEpyhPnike3xqr/+1zdXGJ6NlwhbL39jKKyrBH5kLNQSr2isQw==",
       "requires": {
         "@fern-api/base-generator": "0.0.6",
         "@fern-api/core-utils": "^0.15.0-rc63",

--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -31,7 +31,7 @@
     "upgrade-codegen-service": "ts-node-esm --project tsconfig.json scripts/upgrade-codegen-service.mts"
   },
   "dependencies": {
-    "@fern-api/python-ast": "^0.0.19",
+    "@fern-api/python-ast": "^0.0.20",
     "@fern-fern/generator-cli-sdk": "file:./stubs/generator-cli-sdk",
     "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
     "lodash": "^4.17.21",

--- a/ee/codegen/src/__test__/__snapshots__/chat-message-content.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/chat-message-content.test.ts.snap
@@ -5,7 +5,10 @@ exports[`ChatMessageContent > ARRAY > should write an array of content correctly
     StringChatMessageContentRequest(value="First message"),
     FunctionCallChatMessageContentRequest(
         value=FunctionCallChatMessageContentValueRequest(
-            name="get_weather", arguments={"location": "Seattle"}
+            name="get_weather",
+            arguments={
+                "location": "Seattle",
+            },
         )
     ),
 ]
@@ -14,7 +17,10 @@ exports[`ChatMessageContent > ARRAY > should write an array of content correctly
 
 exports[`ChatMessageContent > AUDIO > should write an audio content correctly 1`] = `
 "AudioChatMessageContentRequest(
-    src="https://example.com/audio.mp3", metadata={"key": "value"}
+    src="https://example.com/audio.mp3",
+    metadata={
+        "key": "value",
+    },
 )
 "
 `;
@@ -24,7 +30,10 @@ exports[`ChatMessageContent > FUNCTION_CALL > should write a function call conte
     value=FunctionCallChatMessageContentValueRequest(
         id="123",
         name="get_weather",
-        arguments={"location": "New York", "unit": "celsius"},
+        arguments={
+            "location": "New York",
+            "unit": "celsius",
+        },
     )
 )
 "
@@ -33,7 +42,11 @@ exports[`ChatMessageContent > FUNCTION_CALL > should write a function call conte
 exports[`ChatMessageContent > FUNCTION_CALL > should write a function call content without id correctly 1`] = `
 "FunctionCallChatMessageContentRequest(
     value=FunctionCallChatMessageContentValueRequest(
-        name="get_weather", arguments={"location": "New York", "unit": "celsius"}
+        name="get_weather",
+        arguments={
+            "location": "New York",
+            "unit": "celsius",
+        },
     )
 )
 "
@@ -41,7 +54,10 @@ exports[`ChatMessageContent > FUNCTION_CALL > should write a function call conte
 
 exports[`ChatMessageContent > IMAGE > should write an image content correctly 1`] = `
 "ImageChatMessageContentRequest(
-    src="https://example.com/image.png", metadata={"key": "value"}
+    src="https://example.com/image.png",
+    metadata={
+        "key": "value",
+    },
 )
 "
 `;

--- a/ee/codegen/src/__test__/__snapshots__/inputs.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/inputs.test.ts.snap
@@ -118,7 +118,10 @@ from vellum import FunctionCall
 
 class Inputs(BaseInputs):
     function_call_input: FunctionCall = FunctionCall(
-        arguments={"arg1": "Hello World"}, name="function_call"
+        arguments={
+            "arg1": "Hello World",
+        },
+        name="function_call",
     )
 "
 `;
@@ -139,7 +142,9 @@ from typing import Any
 
 
 class Inputs(BaseInputs):
-    json_input: Any = {"key": "value"}
+    json_input: Any = {
+        "key": "value",
+    }
 "
 `;
 

--- a/ee/codegen/src/__test__/__snapshots__/json.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/json.test.ts.snap
@@ -1,7 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Json > write > should handle arrays 1`] = `
-"[1, "test", True]
+"[
+    1,
+    "test",
+    True,
+]
 "
 `;
 
@@ -21,7 +25,11 @@ exports[`Json > write > should handle complex nested structures 1`] = `
     "metadata": {
         "created": "2024-01-01",
         "modified": "2024-01-02",
-        "tags": ["important", "test", "complex"],
+        "tags": [
+            "important",
+            "test",
+            "complex",
+        ],
     },
     "data": {
         "users": [
@@ -29,19 +37,38 @@ exports[`Json > write > should handle complex nested structures 1`] = `
                 "id": 1,
                 "name": "John Doe",
                 "settings": {
-                    "preferences": {"theme": "dark", "notifications": True},
-                    "permissions": ["read", "write"],
+                    "preferences": {
+                        "theme": "dark",
+                        "notifications": True,
+                    },
+                    "permissions": [
+                        "read",
+                        "write",
+                    ],
                 },
-                "scores": [98.5, 87.2, 92],
+                "scores": [
+                    98.5,
+                    87.2,
+                    92,
+                ],
             },
             {
                 "id": 2,
                 "name": "Jane Smith",
                 "settings": {
-                    "preferences": {"theme": "light", "notifications": False},
-                    "permissions": ["read"],
+                    "preferences": {
+                        "theme": "light",
+                        "notifications": False,
+                    },
+                    "permissions": [
+                        "read",
+                    ],
                 },
-                "scores": [95, 88.5, 91.2],
+                "scores": [
+                    95,
+                    88.5,
+                    91.2,
+                ],
             },
         ],
         "statistics": {
@@ -51,7 +78,11 @@ exports[`Json > write > should handle complex nested structures 1`] = `
             "metadata": {
                 "lastUpdated": "2024-01-02",
                 "source": "system",
-                "flags": [None, True, False],
+                "flags": [
+                    None,
+                    True,
+                    False,
+                ],
             },
         },
     },
@@ -70,7 +101,18 @@ exports[`Json > write > should handle integers 1`] = `
 `;
 
 exports[`Json > write > should handle nested structures 1`] = `
-"{"array": [1, 2, 3], "nested": {"a": 1, "b": "test"}, "null": None}
+"{
+    "array": [
+        1,
+        2,
+        3,
+    ],
+    "nested": {
+        "a": 1,
+        "b": "test",
+    },
+    "null": None,
+}
 "
 `;
 
@@ -80,7 +122,10 @@ exports[`Json > write > should handle null values 1`] = `
 `;
 
 exports[`Json > write > should handle objects 1`] = `
-"{"key": "value", "num": 123}
+"{
+    "key": "value",
+    "num": 123,
+}
 "
 `;
 

--- a/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
@@ -20,7 +20,13 @@ exports[`VellumValue > ERROR > should write a ERROR value correctly 1`] = `
 `;
 
 exports[`VellumValue > FUNCTION_CALL > should write a FUNCTION_CALL value correctly 1`] = `
-"FunctionCall(arguments={"key": "value"}, name="test", id="123")
+"FunctionCall(
+    arguments={
+        "key": "value",
+    },
+    name="test",
+    id="123",
+)
 "
 `;
 
@@ -30,7 +36,16 @@ exports[`VellumValue > IMAGE > should write a IMAGE value correctly 1`] = `
 `;
 
 exports[`VellumValue > JSON > should write a JSON value correctly 1`] = `
-"{"key": "value", "nested": {"array": [1, 2, 3]}}
+"{
+    "key": "value",
+    "nested": {
+        "array": [
+            1,
+            2,
+            3,
+        ],
+    },
+}
 "
 `;
 

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -24,7 +24,10 @@ from .nodes.merge_node import MergeNode
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = {TemplatingNode >> TemplatingNode3, TemplatingNode2} >> MergeNode
+    graph = {
+        TemplatingNode >> TemplatingNode3,
+        TemplatingNode2,
+    } >> MergeNode
 "
 `;
 
@@ -37,7 +40,14 @@ from .nodes.templating_node_3 import TemplatingNode3
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = {TemplatingNode, TemplatingNode2} >> MergeNode >> TemplatingNode3
+    graph = (
+        {
+            TemplatingNode,
+            TemplatingNode2,
+        }
+        >> MergeNode
+        >> TemplatingNode3
+    )
 "
 `;
 
@@ -49,7 +59,10 @@ from .nodes.merge_node import MergeNode
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = {TemplatingNode, TemplatingNode2} >> MergeNode
+    graph = {
+        TemplatingNode,
+        TemplatingNode2,
+    } >> MergeNode
 "
 `;
 
@@ -62,7 +75,11 @@ from .nodes.merge_node import MergeNode
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = {TemplatingNode, TemplatingNode2, TemplatingNode3} >> MergeNode
+    graph = {
+        TemplatingNode,
+        TemplatingNode2,
+        TemplatingNode3,
+    } >> MergeNode
 "
 `;
 
@@ -73,7 +90,10 @@ from .nodes.templating_node_2 import TemplatingNode2
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = {TemplatingNode, TemplatingNode2}
+    graph = {
+        TemplatingNode,
+        TemplatingNode2,
+    }
 "
 `;
 
@@ -131,7 +151,11 @@ class TestWorkflow(BaseWorkflow):
         ConditionalNode.Ports.branch_1 >> TemplatingNode,
         ConditionalNode.Ports.branch_2
         >> {
-            ConditionalNode2.Ports.branch_2 >> {TemplatingNode3, TemplatingNode4},
+            ConditionalNode2.Ports.branch_2
+            >> {
+                TemplatingNode3,
+                TemplatingNode4,
+            },
             TemplatingNode2,
         },
     }
@@ -146,7 +170,10 @@ from .nodes.templating_node_3 import TemplatingNode3
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = TemplatingNode >> {TemplatingNode2, TemplatingNode3}
+    graph = TemplatingNode >> {
+        TemplatingNode2,
+        TemplatingNode3,
+    }
 "
 `;
 
@@ -159,7 +186,14 @@ from .nodes.templating_node_4 import TemplatingNode4
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = TemplatingNode >> {TemplatingNode2, TemplatingNode3} >> TemplatingNode4
+    graph = (
+        TemplatingNode
+        >> {
+            TemplatingNode2,
+            TemplatingNode3,
+        }
+        >> TemplatingNode4
+    )
 "
 `;
 
@@ -171,7 +205,10 @@ from .nodes.templating_node_2 import TemplatingNode2
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = ConditionalNode.Ports.branch_1 >> {TemplatingNode, TemplatingNode2}
+    graph = ConditionalNode.Ports.branch_1 >> {
+        TemplatingNode,
+        TemplatingNode2,
+    }
 "
 `;
 
@@ -186,7 +223,11 @@ from .nodes.templating_node_3 import TemplatingNode3
 class TestWorkflow(BaseWorkflow):
     graph = {
         ConditionalNode.Ports.branch_1 >> TemplatingNode,
-        ConditionalNode.Ports.branch_2 >> {TemplatingNode2, TemplatingNode3},
+        ConditionalNode.Ports.branch_2
+        >> {
+            TemplatingNode2,
+            TemplatingNode3,
+        },
     }
 "
 `;
@@ -199,7 +240,10 @@ from .nodes.templating_node_3 import TemplatingNode3
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = {TemplatingNode >> TemplatingNode2, TemplatingNode3}
+    graph = {
+        TemplatingNode >> TemplatingNode2,
+        TemplatingNode3,
+    }
 "
 `;
 
@@ -215,7 +259,10 @@ from .nodes.templating_node_5 import TemplatingNode5
 
 class TestWorkflow(BaseWorkflow):
     graph = (
-        {TemplatingNode >> TemplatingNode3 >> TemplatingNode4, TemplatingNode2}
+        {
+            TemplatingNode >> TemplatingNode3 >> TemplatingNode4,
+            TemplatingNode2,
+        }
         >> MergeNode
         >> TemplatingNode5
     )
@@ -230,7 +277,11 @@ from .nodes.templating_node_3 import TemplatingNode3
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = {TemplatingNode, TemplatingNode2, TemplatingNode3}
+    graph = {
+        TemplatingNode,
+        TemplatingNode2,
+        TemplatingNode3,
+    }
 "
 `;
 
@@ -248,7 +299,10 @@ class TestWorkflow(BaseWorkflow):
     graph = {
         ConditionalNode.Ports.branch_1
         >> TemplatingNode
-        >> {TemplatingNode3 >> TemplatingNode4, TemplatingNode5},
+        >> {
+            TemplatingNode3 >> TemplatingNode4,
+            TemplatingNode5,
+        },
         ConditionalNode.Ports.branch_2 >> TemplatingNode2 >> TemplatingNode3,
     }
 "

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -88,7 +88,7 @@ from vellum.workflows.state import BaseState
 
 
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
-    code = """print('Hello, World!')"""
+    code = """print(\\'Hello, World!\\')"""
     code_inputs = {}
     output_type = "STRING"
     runtime = "PYTHON_3_11"

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -74,7 +74,6 @@ from vellum.workflows.state import BaseState
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
     filepath = "./script.py"
     code_inputs = {}
-    output_type = "STRING"
     runtime = "PYTHON_3_11"
     packages = None
 "
@@ -90,7 +89,6 @@ from vellum.workflows.state import BaseState
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
     code = """print(\\'Hello, World!\\')"""
     code_inputs = {}
-    output_type = "STRING"
     runtime = "PYTHON_3_11"
     packages = None
 "
@@ -106,7 +104,6 @@ from vellum.workflows.state import BaseState
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
     filepath = "./script.py"
     code_inputs = {}
-    output_type = "STRING"
     runtime = "PYTHON_3_11"
     packages = None
 "
@@ -122,7 +119,6 @@ from vellum.workflows.state import BaseState
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
     filepath = "./script.py"
     code_inputs = {}
-    output_type = "STRING"
     runtime = "PYTHON_3_11"
     packages = None
 "

--- a/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
@@ -110,7 +110,10 @@ from ..inputs import Inputs
 
 class GuardrailNode(BaseGuardrailNode):
     metric_definition = "589df5bd-8c0d-4797-9a84-9598ecd043de"
-    metric_inputs = {"expected": Inputs.expected, "actual": Inputs.output}
+    metric_inputs = {
+        "expected": Inputs.expected,
+        "actual": Inputs.output,
+    }
     release_tag = "LATEST"
 "
 `;
@@ -122,7 +125,10 @@ from ..inputs import Inputs
 
 class GuardrailNode(BaseGuardrailNode):
     metric_definition = "589df5bd-8c0d-4797-9a84-9598ecd043de"
-    metric_inputs = {"expected": Inputs.expected, "actual": Inputs.output}
+    metric_inputs = {
+        "expected": Inputs.expected,
+        "actual": Inputs.output,
+    }
     release_tag = "LATEST"
 "
 `;
@@ -182,7 +188,10 @@ from ..inputs import Inputs
 @TryNode.wrap()
 class GuardrailNode(BaseGuardrailNode):
     metric_definition = "589df5bd-8c0d-4797-9a84-9598ecd043de"
-    metric_inputs = {"expected": Inputs.expected, "actual": Inputs.output}
+    metric_inputs = {
+        "expected": Inputs.expected,
+        "actual": Inputs.output,
+    }
     release_tag = "LATEST"
 "
 `;

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -77,8 +77,6 @@ class PromptNode(InlinePromptNode):
     blocks = [
         ChatMessagePromptBlock(
             chat_role="SYSTEM",
-            chat_source=None,
-            chat_message_unterminated=False,
             blocks=[
                 RichTextPromptBlock(
                     blocks=[
@@ -169,8 +167,6 @@ class PromptNode(InlinePromptNode):
     blocks = [
         ChatMessagePromptBlock(
             chat_role="SYSTEM",
-            chat_source=None,
-            chat_message_unterminated=False,
             blocks=[
                 RichTextPromptBlock(
                     blocks=[
@@ -267,8 +263,6 @@ class PromptNode(InlinePromptNode):
     blocks = [
         ChatMessagePromptBlock(
             chat_role="SYSTEM",
-            chat_source=None,
-            chat_message_unterminated=False,
             blocks=[
                 RichTextPromptBlock(
                     blocks=[

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -95,8 +95,11 @@ Summarize the following text:
                     ]
                 )
             ],
-        )
+        ),
     ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -108,7 +111,6 @@ Summarize the following text:
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;
 
@@ -185,8 +187,11 @@ Summarize the following text:
                     ]
                 )
             ],
-        )
+        ),
     ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -198,7 +203,6 @@ Summarize the following text:
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;
 
@@ -281,8 +285,11 @@ Summarize the following text:
                     ]
                 )
             ],
-        )
+        ),
     ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -294,7 +301,6 @@ Summarize the following text:
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;
 
@@ -360,13 +366,19 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > basic > getNodeFile for FUNCTION_DEFINITION block type 1`] = `
 "from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import PromptParameters, FunctionDefinition
 from ..inputs import Inputs
+from vellum import FunctionDefinition, PromptParameters
 
 
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = []
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
+    functions = [
+        FunctionDefinition(name="functionTest", description="This is a test function"),
+    ]
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -378,10 +390,6 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
-    functions = [
-        FunctionDefinition(name="functionTest", description="This is a test function")
-    ]
 "
 `;
 
@@ -425,13 +433,19 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > legacy prompt variant > getNodeFile for FUNCTION_DEFINITION block type 1`] = `
 "from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import PromptParameters, FunctionDefinition
 from ..inputs import Inputs
+from vellum import FunctionDefinition, PromptParameters
 
 
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = []
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
+    functions = [
+        FunctionDefinition(name="functionTest", description="This is a test function"),
+    ]
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -443,10 +457,6 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
-    functions = [
-        FunctionDefinition(name="functionTest", description="This is a test function")
-    ]
 "
 `;
 
@@ -495,14 +505,20 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > reject on error enabled > getNodeFile for FUNCTION_DEFINITION block type 1`] = `
 "from vellum.workflows.nodes.displayable import InlinePromptNode
 from vellum.workflows.nodes.core import TryNode
-from vellum import PromptParameters, FunctionDefinition
 from ..inputs import Inputs
+from vellum import FunctionDefinition, PromptParameters
 
 
 @TryNode.wrap()
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = []
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
+    functions = [
+        FunctionDefinition(name="functionTest", description="This is a test function"),
+    ]
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -514,10 +530,6 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
-    functions = [
-        FunctionDefinition(name="functionTest", description="This is a test function")
-    ]
 "
 `;
 
@@ -590,8 +602,11 @@ from ..inputs import Inputs
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = [
-        JinjaPromptBlock(template="""Summarize what this means {{ INPUT_VARIABLE }}""")
+        JinjaPromptBlock(template="""Summarize what this means {{ INPUT_VARIABLE }}"""),
     ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -603,7 +618,6 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;
 
@@ -654,8 +668,11 @@ from ..inputs import Inputs
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = [
-        JinjaPromptBlock(template="""Summarize what this means {{ INPUT_VARIABLE }}""")
+        JinjaPromptBlock(template="""Summarize what this means {{ INPUT_VARIABLE }}"""),
     ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -667,7 +684,6 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;
 
@@ -724,8 +740,11 @@ from ..inputs import Inputs
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = [
-        JinjaPromptBlock(template="""Summarize what this means {{ INPUT_VARIABLE }}""")
+        JinjaPromptBlock(template="""Summarize what this means {{ INPUT_VARIABLE }}"""),
     ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -737,7 +756,6 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;
 
@@ -816,8 +834,11 @@ class PromptNode(InlinePromptNode):
                     state="ENABLED", cache_config=None, text="""Hello World!"""
                 )
             ]
-        )
+        ),
     ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -829,7 +850,6 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;
 
@@ -886,8 +906,11 @@ class PromptNode(InlinePromptNode):
                     state="ENABLED", cache_config=None, text="""Hello World!"""
                 )
             ]
-        )
+        ),
     ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -899,7 +922,6 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;
 
@@ -962,8 +984,11 @@ class PromptNode(InlinePromptNode):
                     state="ENABLED", cache_config=None, text="""Hello World!"""
                 )
             ]
-        )
+        ),
     ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -975,7 +1000,6 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;
 
@@ -1047,7 +1071,12 @@ from ..inputs import Inputs
 
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
-    blocks = [VariablePromptBlock(input_variable="text")]
+    blocks = [
+        VariablePromptBlock(input_variable="text"),
+    ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -1059,7 +1088,6 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;
 
@@ -1109,7 +1137,12 @@ from ..inputs import Inputs
 
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
-    blocks = [VariablePromptBlock(input_variable="text")]
+    blocks = [
+        VariablePromptBlock(input_variable="text"),
+    ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -1121,7 +1154,6 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;
 
@@ -1177,7 +1209,12 @@ from ..inputs import Inputs
 @TryNode.wrap()
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
-    blocks = [VariablePromptBlock(input_variable="text")]
+    blocks = [
+        VariablePromptBlock(input_variable="text"),
+    ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -1189,6 +1226,5 @@ class PromptNode(InlinePromptNode):
         logit_bias={},
         custom_parameters={},
     )
-    prompt_inputs = {"text": Inputs.text}
 "
 `;

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -99,7 +99,7 @@ Summarize the following text:
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -189,7 +189,7 @@ Summarize the following text:
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -285,7 +285,7 @@ Summarize the following text:
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -374,7 +374,7 @@ class PromptNode(InlinePromptNode):
         FunctionDefinition(name="functionTest", description="This is a test function"),
     ]
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -441,7 +441,7 @@ class PromptNode(InlinePromptNode):
         FunctionDefinition(name="functionTest", description="This is a test function"),
     ]
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -514,7 +514,7 @@ class PromptNode(InlinePromptNode):
         FunctionDefinition(name="functionTest", description="This is a test function"),
     ]
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -602,7 +602,7 @@ class PromptNode(InlinePromptNode):
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -668,7 +668,7 @@ class PromptNode(InlinePromptNode):
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -740,7 +740,7 @@ class PromptNode(InlinePromptNode):
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -834,7 +834,7 @@ class PromptNode(InlinePromptNode):
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -906,7 +906,7 @@ class PromptNode(InlinePromptNode):
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -984,7 +984,7 @@ class PromptNode(InlinePromptNode):
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -1072,7 +1072,7 @@ class PromptNode(InlinePromptNode):
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -1138,7 +1138,7 @@ class PromptNode(InlinePromptNode):
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,
@@ -1210,7 +1210,7 @@ class PromptNode(InlinePromptNode):
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,

--- a/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
@@ -30,7 +30,11 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 
 class NoteNodeDisplay(BaseNoteNodeDisplay[NoteNode]):
     text = "This is a note"
-    style = {"color": "red", "fontSize": 12, "fontWeight": "bold"}
+    style = {
+        "color": "red",
+        "fontSize": 12,
+        "fontWeight": "bold",
+    }
     node_input_ids_by_name = {}
     display_data = NodeDisplayData(
         position=NodeDisplayPosition(x=0, y=0), width=None, height=None

--- a/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
@@ -75,6 +75,8 @@ exports[`PromptDeploymentNode > basic > getNodeFile 1`] = `
 class PromptDeploymentNode(BasePromptDeploymentNode):
     deployment = "afd05488-7a25-4ff2-b87b-878e9552474e"
     release_tag = "LATEST"
-    prompt_inputs = {"my_var_1": None}
+    prompt_inputs = {
+        "my_var_1": None,
+    }
 "
 `;

--- a/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
@@ -66,7 +66,9 @@ exports[`SubworkflowDeploymentNode > basic > getNodeFile 1`] = `
 class SubworkflowNode(SubworkflowDeploymentNode):
     deployment = "test-deployment"
     release_tag = "LATEST"
-    subworkflow_inputs = {"input": None}
+    subworkflow_inputs = {
+        "input": None,
+    }
 
     class Outputs(SubworkflowDeploymentNode.Outputs):
         output_1: str

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -696,7 +696,10 @@ export class GraphAttribute extends AstNode {
 
     if (mutableAst.type === "set") {
       return python.TypeInstantiation.set(
-        mutableAst.values.map((ast) => this.getGraphAttributeAstNode(ast))
+        mutableAst.values.map((ast) => this.getGraphAttributeAstNode(ast)),
+        {
+          endWithComma: true,
+        }
       );
     }
 

--- a/ee/codegen/src/generators/json.ts
+++ b/ee/codegen/src/generators/json.ts
@@ -45,7 +45,10 @@ export class Json extends AstNode {
           const jsonValue = new Json(item);
           this.inheritReferences(jsonValue);
           return jsonValue;
-        })
+        }),
+        {
+          endWithComma: true,
+        }
       );
     }
 
@@ -59,7 +62,9 @@ export class Json extends AstNode {
           value: jsonValue,
         };
       });
-      return python.TypeInstantiation.dict(entries);
+      return python.TypeInstantiation.dict(entries, {
+        endWithComma: true,
+      });
     }
 
     throw new Error(`Unsupported JSON value type: ${typeof value}`);

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -73,7 +73,10 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
                 key,
                 value,
               };
-            })
+            }),
+            {
+              endWithComma: true,
+            }
           ),
         })
       );

--- a/ee/codegen/src/generators/nodes/code-execution-node.ts
+++ b/ee/codegen/src/generators/nodes/code-execution-node.ts
@@ -102,15 +102,11 @@ export class CodeExecutionNode extends BaseSingleFileNode<
           codeInputs.map((codeInput) => ({
             key: python.TypeInstantiation.str(codeInput.nodeInputData.key),
             value: codeInput,
-          }))
+          })),
+          {
+            endWithComma: true,
+          }
         ),
-      })
-    );
-
-    statements.push(
-      python.field({
-        name: "output_type",
-        initializer: python.TypeInstantiation.str(nodeData.outputType),
       })
     );
 

--- a/ee/codegen/src/generators/nodes/code-execution-node.ts
+++ b/ee/codegen/src/generators/nodes/code-execution-node.ts
@@ -139,7 +139,10 @@ export class CodeExecutionNode extends BaseSingleFileNode<
                     }),
                   ],
                 })
-              )
+              ),
+              {
+                endWithComma: true,
+              }
             )
           : python.TypeInstantiation.none(),
       })

--- a/ee/codegen/src/generators/nodes/guardrail-node.ts
+++ b/ee/codegen/src/generators/nodes/guardrail-node.ts
@@ -33,7 +33,10 @@ export class GuardrailNode extends BaseSingleFileNode<
           Array.from(this.nodeInputsByKey.entries()).map(([key, value]) => ({
             key: python.TypeInstantiation.str(key),
             value: value,
-          }))
+          })),
+          {
+            endWithComma: true,
+          }
         ),
       })
     );

--- a/ee/codegen/src/generators/nodes/inline-prompt-node.ts
+++ b/ee/codegen/src/generators/nodes/inline-prompt-node.ts
@@ -60,17 +60,11 @@ export class InlinePromptNode extends BaseSingleFileNode<
                 )
               ),
             });
-          })
+          }),
+          {
+            endWithComma: true,
+          }
         ),
-      })
-    );
-
-    statements.push(
-      python.field({
-        name: "parameters",
-        initializer: new PromptParameters({
-          promptParametersRequest: this.nodeData.data.execConfig.parameters,
-        }),
       })
     );
 
@@ -81,7 +75,10 @@ export class InlinePromptNode extends BaseSingleFileNode<
           Array.from(this.nodeInputsByKey.entries()).map(([key, value]) => ({
             key: python.TypeInstantiation.str(key),
             value: value,
-          }))
+          })),
+          {
+            endWithComma: true,
+          }
         ),
       })
     );
@@ -94,11 +91,23 @@ export class InlinePromptNode extends BaseSingleFileNode<
             functionDefinitions.map(
               (functionDefinition) =>
                 new FunctionDefinition({ functionDefinition })
-            )
+            ),
+            {
+              endWithComma: true,
+            }
           ),
         })
       );
     }
+
+    statements.push(
+      python.field({
+        name: "parameters",
+        initializer: new PromptParameters({
+          promptParametersRequest: this.nodeData.data.execConfig.parameters,
+        }),
+      })
+    );
 
     return statements;
   }

--- a/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
@@ -42,7 +42,10 @@ export class PromptDeploymentNode extends BaseSingleFileNode<
           Array.from(this.nodeInputsByKey.entries()).map(([key, value]) => ({
             key: python.TypeInstantiation.str(key),
             value: value,
-          }))
+          })),
+          {
+            endWithComma: true,
+          }
         ),
       })
     );

--- a/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
@@ -45,7 +45,10 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
           Array.from(this.nodeInputsByKey.entries()).map(([key, value]) => ({
             key: python.TypeInstantiation.str(key),
             value: value,
-          }))
+          })),
+          {
+            endWithComma: true,
+          }
         ),
       })
     );

--- a/ee/codegen/src/generators/nodes/templating-node.ts
+++ b/ee/codegen/src/generators/nodes/templating-node.ts
@@ -46,7 +46,10 @@ export class TemplatingNode extends BaseSingleFileNode<
           otherInputs.map((codeInput) => ({
             key: python.TypeInstantiation.str(codeInput.nodeInputData.key),
             value: codeInput,
-          }))
+          })),
+          {
+            endWithComma: true,
+          }
         ),
       })
     );

--- a/ee/codegen/src/generators/prompt-block.ts
+++ b/ee/codegen/src/generators/prompt-block.ts
@@ -1,6 +1,7 @@
 import { python } from "@fern-api/python-ast";
 import { ClassInstantiation } from "@fern-api/python-ast/ClassInstantiation";
 import { MethodArgument } from "@fern-api/python-ast/MethodArgument";
+import { isNil } from "lodash";
 import { PlainTextPromptBlock as PlainTextPromptBlockType } from "vellum-ai/api";
 
 import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
@@ -102,28 +103,27 @@ export class PromptBlock extends BasePromptBlock<PromptTemplateBlockExcludingFun
       );
     }
 
-    classArgs.push(
-      new MethodArgument({
-        name: "chat_source",
-        value: promptBlock.properties.chatSource
-          ? python.TypeInstantiation.str(promptBlock.properties.chatSource)
-          : python.TypeInstantiation.none(),
-      })
-    );
+    if (!isNil(promptBlock.properties.chatSource)) {
+      classArgs.push(
+        new MethodArgument({
+          name: "chat_source",
+          value: python.TypeInstantiation.str(
+            promptBlock.properties.chatSource
+          ),
+        })
+      );
+    }
 
-    const chatMessageUnterminatedValue =
-      promptBlock.properties.chatMessageUnterminated !== undefined &&
-      promptBlock.properties.chatMessageUnterminated !== null
-        ? python.TypeInstantiation.bool(
+    if (promptBlock.properties.chatMessageUnterminated) {
+      classArgs.push(
+        new MethodArgument({
+          name: "chat_message_unterminated",
+          value: python.TypeInstantiation.bool(
             promptBlock.properties.chatMessageUnterminated
-          )
-        : python.TypeInstantiation.none();
-    classArgs.push(
-      new MethodArgument({
-        name: "chat_message_unterminated",
-        value: chatMessageUnterminatedValue,
-      })
-    );
+          ),
+        })
+      );
+    }
 
     const childBlocks = promptBlock.properties.blocks.filter(
       (block): block is PromptTemplateBlockExcludingFunctionDefinition =>

--- a/ee/codegen/src/generators/prompt-parameters-request.ts
+++ b/ee/codegen/src/generators/prompt-parameters-request.ts
@@ -35,13 +35,11 @@ export class PromptParameters extends AstNode {
   private generatePromptParameters(): python.ClassInstantiation {
     const classArgs: MethodArgument[] = [];
 
-    const stopValue = isNil(this.promptParametersRequest.stop)
-      ? python.TypeInstantiation.none()
-      : python.TypeInstantiation.list(
-          this.promptParametersRequest.stop.map((str) =>
-            python.TypeInstantiation.str(str)
-          )
-        );
+    const stopValue = python.TypeInstantiation.list(
+      (this.promptParametersRequest.stop ?? []).map((str) =>
+        python.TypeInstantiation.str(str)
+      )
+    );
     classArgs.push(
       new MethodArgument({
         name: "stop",

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/nodes/code_execution_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/nodes/code_execution_node/__init__.py
@@ -7,7 +7,10 @@ from ...inputs import Inputs
 
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
     filepath = "./script.py"
-    code_inputs = {"arg": Inputs.input}
-    output_type = "STRING"
+    code_inputs = {
+        "arg": Inputs.input,
+    }
     runtime = "PYTHON_3_11_6"
-    packages = [CodeExecutionPackage(name="requests", version="2.26.0")]
+    packages = [
+        CodeExecutionPackage(name="requests", version="2.26.0"),
+    ]

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/nodes/guardrail_node.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/nodes/guardrail_node.py
@@ -5,5 +5,8 @@ from ..inputs import Inputs
 
 class GuardrailNode(BaseGuardrailNode):
     metric_definition = "589df5bd-8c0d-4797-9a84-9598ecd043de"
-    metric_inputs = {"expected": Inputs.expected, "actual": Inputs.actual}
+    metric_inputs = {
+        "expected": Inputs.expected,
+        "actual": Inputs.actual,
+    }
     release_tag = "LATEST"

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/templating_node_3.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/nodes/templating_node_3.py
@@ -10,4 +10,7 @@ class TemplatingNode3(TemplatingNode[BaseState, str]):
 {{ input_a }}
 {{ input_b }}\
 """
-    inputs = {"input_a": TemplatingNode1.Outputs.result, "input_b": TemplatingNode2.Outputs.result}
+    inputs = {
+        "input_a": TemplatingNode1.Outputs.result,
+        "input_b": TemplatingNode2.Outputs.result,
+    }

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/workflow.py
@@ -8,7 +8,15 @@ from .nodes.templating_node_3 import TemplatingNode3
 
 
 class Workflow(BaseWorkflow):
-    graph = {TemplatingNode2, TemplatingNode1} >> MergeNode >> TemplatingNode3 >> FinalOutput
+    graph = (
+        {
+            TemplatingNode2,
+            TemplatingNode1,
+        }
+        >> MergeNode
+        >> TemplatingNode3
+        >> FinalOutput
+    )
 
     class Outputs(BaseWorkflow.Outputs):
         final_output = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/nodes/prompt_node.py
@@ -15,8 +15,6 @@ class PromptNode(InlinePromptNode):
     blocks = [
         ChatMessagePromptBlock(
             chat_role="SYSTEM",
-            chat_source=None,
-            chat_message_unterminated=False,
             blocks=[
                 RichTextPromptBlock(
                     blocks=[

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/nodes/prompt_node.py
@@ -33,8 +33,11 @@ What is the origin of the following phrase
                     ]
                 )
             ],
-        )
+        ),
     ]
+    prompt_inputs = {
+        "text": "Hello, World!",
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -46,4 +49,3 @@ What is the origin of the following phrase
         logit_bias={},
         custom_parameters=None,
     )
-    prompt_inputs = {"text": "Hello, World!"}

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/nodes/prompt_node.py
@@ -37,7 +37,7 @@ What is the origin of the following phrase
         "text": "Hello, World!",
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
@@ -36,7 +36,7 @@
           "target_handle_id": "e31c38be-ef5a-4c20-ab8b-9315f3e75ff8",
           "exec_config": {
             "parameters": {
-              "stop": null,
+              "stop": [],
               "temperature": 0.0,
               "max_tokens": 1000,
               "top_p": 1.0,

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/nodes/prompt_node.py
@@ -15,8 +15,6 @@ class PromptNode(InlinePromptNode):
     blocks = [
         ChatMessagePromptBlock(
             chat_role="SYSTEM",
-            chat_source=None,
-            chat_message_unterminated=False,
             blocks=[
                 RichTextPromptBlock(
                     blocks=[

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/nodes/prompt_node.py
@@ -37,7 +37,7 @@ Summarize the following text:
         "text": Inputs.text,
     }
     parameters = PromptParameters(
-        stop=None,
+        stop=[],
         temperature=0,
         max_tokens=1000,
         top_p=1,

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/nodes/prompt_node.py
@@ -33,8 +33,11 @@ Summarize the following text:
                     ]
                 )
             ],
-        )
+        ),
     ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
     parameters = PromptParameters(
         stop=None,
         temperature=0,
@@ -46,4 +49,3 @@ Summarize the following text:
         logit_bias={},
         custom_parameters=None,
     )
-    prompt_inputs = {"text": Inputs.text}

--- a/ee/codegen_integration/fixtures/simple_prompt_node/display_data/simple_prompt_node.json
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/display_data/simple_prompt_node.json
@@ -36,7 +36,7 @@
           "target_handle_id": "3feb7e71-ec63-4d58-82ba-c3df829a2948",
           "exec_config": {
             "parameters": {
-              "stop": null,
+              "stop": [],
               "temperature": 0.0,
               "max_tokens": 1000,
               "top_p": 1.0,

--- a/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
@@ -27,8 +27,8 @@ class BaseCodeExecutionNodeDisplay(BaseNodeVellumDisplay[_CodeExecutionNodeType]
         node = self._node
         node_id = self.node_id
         raw_code = raise_if_descriptor(node.code)
-        code_value = None
 
+        code_value: Optional[str]
         if raw_code:
             code_value = raw_code
         else:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
@@ -104,13 +104,12 @@ class BaseInlinePromptNodeDisplay(BaseNodeVellumDisplay[_InlinePromptNodeType], 
             chat_properties: JsonObject = {
                 "chat_role": prompt_block.chat_role,
                 "chat_source": prompt_block.chat_source,
+                "chat_message_unterminated": bool(prompt_block.chat_message_unterminated),
                 "blocks": [
                     self._generate_prompt_block(block, input_variable_id_by_name, path + [i])
                     for i, block in enumerate(prompt_block.blocks)
                 ],
             }
-            if prompt_block.chat_message_unterminated is not None:
-                chat_properties["chat_message_unterminated"] = prompt_block.chat_message_unterminated
 
             block = {
                 "block_type": "CHAT_MESSAGE",


### PR DESCRIPTION
Makes a few improvements to codegen, namely:
1. Adds trailing commas to the end of most iterables.
2. No longer codegens the unnecessary `output_type` attribute for Code Execution Nodes