### PR TITLE
[Codegen] Fix Reference Tracking for Chat Messages

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/chat-message-content.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/chat-message-content.test.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ChatMessageContent > ARRAY > should write an array of content correctly 1`] = `
-"ArrayChatMessageContentRequest(
+"ArrayChatMessageContent(
     value=[
-        StringChatMessageContentRequest(value="First message"),
-        FunctionCallChatMessageContentRequest(
-            value=FunctionCallChatMessageContentValueRequest(
+        StringChatMessageContent(value="First message"),
+        FunctionCallChatMessageContent(
+            value=FunctionCallChatMessageContentValue(
                 name="get_weather",
                 arguments={
                     "location": "Seattle",
@@ -18,7 +18,7 @@ exports[`ChatMessageContent > ARRAY > should write an array of content correctly
 `;
 
 exports[`ChatMessageContent > AUDIO > should write an audio content correctly 1`] = `
-"AudioChatMessageContentRequest(
+"AudioChatMessageContent(
     src="https://example.com/audio.mp3",
     metadata={
         "key": "value",
@@ -28,8 +28,8 @@ exports[`ChatMessageContent > AUDIO > should write an audio content correctly 1`
 `;
 
 exports[`ChatMessageContent > FUNCTION_CALL > should write a function call content with id correctly 1`] = `
-"FunctionCallChatMessageContentRequest(
-    value=FunctionCallChatMessageContentValueRequest(
+"FunctionCallChatMessageContent(
+    value=FunctionCallChatMessageContentValue(
         id="123",
         name="get_weather",
         arguments={
@@ -42,8 +42,8 @@ exports[`ChatMessageContent > FUNCTION_CALL > should write a function call conte
 `;
 
 exports[`ChatMessageContent > FUNCTION_CALL > should write a function call content without id correctly 1`] = `
-"FunctionCallChatMessageContentRequest(
-    value=FunctionCallChatMessageContentValueRequest(
+"FunctionCallChatMessageContent(
+    value=FunctionCallChatMessageContentValue(
         name="get_weather",
         arguments={
             "location": "New York",
@@ -55,7 +55,7 @@ exports[`ChatMessageContent > FUNCTION_CALL > should write a function call conte
 `;
 
 exports[`ChatMessageContent > IMAGE > should write an image content correctly 1`] = `
-"ImageChatMessageContentRequest(
+"ImageChatMessageContent(
     src="https://example.com/image.png",
     metadata={
         "key": "value",
@@ -64,4 +64,4 @@ exports[`ChatMessageContent > IMAGE > should write an image content correctly 1`
 "
 `;
 
-exports[`ChatMessageContent > STRING > should write a string content correctly 1`] = `"StringChatMessageContentRequest(value="Hello, AI!")"`;
+exports[`ChatMessageContent > STRING > should write a string content correctly 1`] = `"StringChatMessageContent(value="Hello, AI!")"`;

--- a/ee/codegen/src/__test__/__snapshots__/inputs.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/inputs.test.ts.snap
@@ -97,7 +97,7 @@ from vellum import ChatMessage
 
 class Inputs(BaseInputs):
     chat_history_input: List[ChatMessage] = [
-        ChatMessageRequest(role="USER", text="foo bar"),
+        ChatMessage(role="USER", text="foo bar"),
     ]
 "
 `;

--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`WorkflowProjectGenerator > inlude sandbox > should include a sandbox.py file when passed sandboxInputs 1`] = `
-"from vellum import ArrayChatMessageContentRequest, StringChatMessageContentRequest
+"from vellum import ArrayChatMessageContent, ChatMessage, StringChatMessageContent
 from vellum.workflows.sandbox import SandboxRunner
 
 from .inputs import Inputs
@@ -17,23 +17,23 @@ runner = SandboxRunner(
         Inputs(
             input="foo",
             chat=[
-                ChatMessageRequest(role="USER", text="foo"),
+                ChatMessage(role="USER", text="foo"),
             ],
         ),
         Inputs(
             input="bar",
             chat=[
-                ChatMessageRequest(role="USER", content=StringChatMessageContentRequest(value="bar")),
+                ChatMessage(role="USER", content=StringChatMessageContent(value="bar")),
             ],
         ),
         Inputs(
             input="hello",
             chat=[
-                ChatMessageRequest(
+                ChatMessage(
                     role="USER",
-                    content=ArrayChatMessageContentRequest(
+                    content=ArrayChatMessageContent(
                         value=[
-                            StringChatMessageContentRequest(value="hello"),
+                            StringChatMessageContent(value="hello"),
                         ]
                     ),
                 ),

--- a/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
@@ -14,9 +14,9 @@ exports[`VellumValue > AUDIO > should write a AUDIO value correctly 1`] = `
 "
 `;
 
-exports[`VellumValue > CHAT_HISTORY > should write a CHAT_HISTORY value with a string content 1`] = `"[ChatMessageRequest(role="USER", content=StringChatMessageContentRequest(value="Hello, AI!")),]"`;
+exports[`VellumValue > CHAT_HISTORY > should write a CHAT_HISTORY value with a string content 1`] = `"[ChatMessage(role="USER", content=StringChatMessageContent(value="Hello, AI!")),]"`;
 
-exports[`VellumValue > CHAT_HISTORY > should write a CHAT_HISTORY value with just text 1`] = `"[ChatMessageRequest(role="USER", text="Hello, AI!"),]"`;
+exports[`VellumValue > CHAT_HISTORY > should write a CHAT_HISTORY value with just text 1`] = `"[ChatMessage(role="USER", text="Hello, AI!"),]"`;
 
 exports[`VellumValue > ERROR > should write a ERROR value correctly 1`] = `
 "VellumError(message="This is an error!", code="INTERNAL_SERVER_ERROR")

--- a/ee/codegen/src/__test__/chat-message-content.test.ts
+++ b/ee/codegen/src/__test__/chat-message-content.test.ts
@@ -16,6 +16,7 @@ describe("ChatMessageContent", () => {
       });
       chatMessageContent.write(writer);
       expect(await writer.toString()).toMatchSnapshot();
+      expect(chatMessageContent.getReferences()).toHaveLength(1);
     });
   });
 
@@ -36,6 +37,7 @@ describe("ChatMessageContent", () => {
       });
       chatMessageContent.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(chatMessageContent.getReferences()).toHaveLength(2);
     });
 
     it("should write a function call content without id correctly", async () => {
@@ -53,6 +55,7 @@ describe("ChatMessageContent", () => {
       });
       chatMessageContent.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(chatMessageContent.getReferences()).toHaveLength(2);
     });
   });
   describe("ARRAY", () => {
@@ -79,7 +82,7 @@ describe("ChatMessageContent", () => {
       });
       chatMessageContent.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
-      expect(chatMessageContent.getReferences()).toHaveLength(5);
+      expect(chatMessageContent.getReferences()).toHaveLength(4);
     });
   });
 
@@ -96,7 +99,7 @@ describe("ChatMessageContent", () => {
       });
       chatMessageContent.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
-      expect(chatMessageContent.getReferences()).toHaveLength(2);
+      expect(chatMessageContent.getReferences()).toHaveLength(1);
     });
   });
 
@@ -113,7 +116,7 @@ describe("ChatMessageContent", () => {
       });
       chatMessageContent.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
-      expect(chatMessageContent.getReferences()).toHaveLength(2);
+      expect(chatMessageContent.getReferences()).toHaveLength(1);
     });
   });
 });

--- a/ee/codegen/src/__test__/vellum-variable-value.test.ts
+++ b/ee/codegen/src/__test__/vellum-variable-value.test.ts
@@ -19,6 +19,7 @@ describe("VellumValue", () => {
       });
       stringValue.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(stringValue.getReferences()).toHaveLength(0);
     });
   });
 
@@ -32,6 +33,7 @@ describe("VellumValue", () => {
       });
       numberValue.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(numberValue.getReferences()).toHaveLength(0);
     });
   });
 
@@ -50,6 +52,7 @@ describe("VellumValue", () => {
       });
       chatHistoryValue.write(writer);
       expect(await writer.toString()).toMatchSnapshot();
+      expect(chatHistoryValue.getReferences()).toHaveLength(1);
     });
 
     it("should write a CHAT_HISTORY value with a string content", async () => {
@@ -66,6 +69,7 @@ describe("VellumValue", () => {
       });
       chatHistoryValue.write(writer);
       expect(await writer.toString()).toMatchSnapshot();
+      expect(chatHistoryValue.getReferences()).toHaveLength(2);
     });
   });
 
@@ -82,6 +86,7 @@ describe("VellumValue", () => {
       });
       jsonValue.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(jsonValue.getReferences()).toHaveLength(0);
     });
   });
 
@@ -98,6 +103,7 @@ describe("VellumValue", () => {
       });
       errorValue.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(errorValue.getReferences()).toHaveLength(1);
     });
   });
 
@@ -113,6 +119,7 @@ describe("VellumValue", () => {
       });
       imageValue.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(imageValue.getReferences()).toHaveLength(1);
     });
   });
 
@@ -132,6 +139,7 @@ describe("VellumValue", () => {
       });
       functionCallValue.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(functionCallValue.getReferences()).toHaveLength(1);
     });
   });
 
@@ -160,6 +168,7 @@ describe("VellumValue", () => {
       });
       arrayValue.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(arrayValue.getReferences()).toHaveLength(1);
     });
   });
 
@@ -175,6 +184,7 @@ describe("VellumValue", () => {
       });
       audioValue.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(audioValue.getReferences()).toHaveLength(1);
     });
   });
 

--- a/ee/codegen/src/generators/chat-message-content.ts
+++ b/ee/codegen/src/generators/chat-message-content.ts
@@ -6,11 +6,279 @@ import { isNil } from "lodash";
 import {
   ChatMessageContentRequest as ChatMessageContentRequestType,
   ChatMessageContent as ChatMessageContentType,
+  FunctionCallChatMessageContentValueRequest as FunctionCallChatMessageContentValueRequestType,
+  FunctionCallChatMessageContentValue as FunctionCallChatMessageContentValueType,
+  ArrayChatMessageContentItemRequest as ArrayChatMessageContentItemRequestType,
+  ArrayChatMessageContentItem as ArrayChatMessageContentItemType,
+  VellumImage as VellumImageType,
+  VellumImageRequest as VellumImageRequestType,
+  VellumAudio as VellumAudioType,
+  VellumAudioRequest as VellumAudioRequestType,
 } from "vellum-ai/api";
 
 import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
 import { Json } from "src/generators/json";
 import { assertUnreachable } from "src/utils/typing";
+
+class StringChatMessageContent extends AstNode {
+  private astNode: AstNode;
+
+  public constructor(value: string, isRequestType: boolean) {
+    super();
+    this.astNode = this.generateAstNode(value, isRequestType);
+  }
+
+  private generateAstNode(value: string, isRequestType: boolean): AstNode {
+    const astNode = python.instantiateClass({
+      classReference: python.reference({
+        name: "StringChatMessageContent" + (isRequestType ? "Request" : ""),
+        modulePath: VELLUM_CLIENT_MODULE_PATH,
+      }),
+      arguments_: [
+        python.methodArgument({
+          name: "value",
+          value: python.TypeInstantiation.str(value),
+        }),
+      ],
+    });
+    this.inheritReferences(astNode);
+    return astNode;
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
+  }
+}
+
+class FunctionCallChatMessageContentValue extends AstNode {
+  private astNode: AstNode;
+
+  public constructor(
+    value:
+      | FunctionCallChatMessageContentValueRequestType
+      | FunctionCallChatMessageContentValueType,
+    isRequestType: boolean
+  ) {
+    super();
+    this.astNode = this.generateAstNode(value, isRequestType);
+  }
+
+  private generateAstNode(
+    value:
+      | FunctionCallChatMessageContentValueRequestType
+      | FunctionCallChatMessageContentValueType,
+    isRequestType: boolean
+  ): AstNode {
+    const functionCallChatMessageContentValueArgs: MethodArgument[] = [];
+
+    if (value.id !== undefined) {
+      functionCallChatMessageContentValueArgs.push(
+        new MethodArgument({
+          name: "id",
+          value: python.TypeInstantiation.str(value.id),
+        })
+      );
+    }
+
+    functionCallChatMessageContentValueArgs.push(
+      new MethodArgument({
+        name: "name",
+        value: python.TypeInstantiation.str(value.name),
+      })
+    );
+
+    if (value.arguments !== undefined) {
+      functionCallChatMessageContentValueArgs.push(
+        new MethodArgument({
+          name: "arguments",
+          value: new Json(value.arguments),
+        })
+      );
+    }
+
+    const functionCallChatMessageContentValueRequestRef = python.reference({
+      name:
+        "FunctionCallChatMessageContentValue" +
+        (isRequestType ? "Request" : ""),
+      modulePath: VELLUM_CLIENT_MODULE_PATH,
+    });
+
+    const functionCallChatMessageContentValueInstance = python.instantiateClass(
+      {
+        classReference: functionCallChatMessageContentValueRequestRef,
+        arguments_: functionCallChatMessageContentValueArgs,
+      }
+    );
+
+    const astNode = python.instantiateClass({
+      classReference: python.reference({
+        name:
+          "FunctionCallChatMessageContent" + (isRequestType ? "Request" : ""),
+        modulePath: VELLUM_CLIENT_MODULE_PATH,
+      }),
+      arguments_: [
+        new MethodArgument({
+          name: "value",
+          value: functionCallChatMessageContentValueInstance,
+        }),
+      ],
+    });
+    this.inheritReferences(astNode);
+    return astNode;
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
+  }
+}
+
+class ArrayChatMessageContent extends AstNode {
+  private astNode: AstNode;
+
+  public constructor(
+    value:
+      | ArrayChatMessageContentItemRequestType[]
+      | ArrayChatMessageContentItemType[],
+    isRequestType: boolean
+  ) {
+    super();
+    this.astNode = this.generateAstNode(value, isRequestType);
+  }
+
+  private generateAstNode(
+    value:
+      | ArrayChatMessageContentItemRequestType[]
+      | ArrayChatMessageContentItemType[],
+    isRequestType: boolean
+  ): AstNode {
+    const arrayElements = value.map(
+      (element) =>
+        new ChatMessageContent({
+          chatMessageContent: element as ChatMessageContentRequestType,
+        })
+    );
+    const astNode = python.instantiateClass({
+      classReference: python.reference({
+        name: "ArrayChatMessageContent" + (isRequestType ? "Request" : ""),
+        modulePath: VELLUM_CLIENT_MODULE_PATH,
+      }),
+      arguments_: [
+        python.methodArgument({
+          name: "value",
+          value: python.TypeInstantiation.list(arrayElements, {
+            endWithComma: true,
+          }),
+        }),
+      ],
+    });
+    this.inheritReferences(astNode);
+    return astNode;
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
+  }
+}
+
+class ImageChatMessageContent extends AstNode {
+  private astNode: AstNode;
+
+  public constructor(
+    value: VellumImageType | VellumImageRequestType,
+    isRequestType: boolean
+  ) {
+    super();
+    this.astNode = this.generateAstNode(value, isRequestType);
+  }
+
+  private generateAstNode(
+    value: VellumImageType | VellumImageRequestType,
+    isRequestType: boolean
+  ): AstNode {
+    const imageChatMessageContentRequestRef = python.reference({
+      name: "ImageChatMessageContent" + (isRequestType ? "Request" : ""),
+      modulePath: VELLUM_CLIENT_MODULE_PATH,
+    });
+
+    const arguments_ = [
+      python.methodArgument({
+        name: "src",
+        value: python.TypeInstantiation.str(value.src),
+      }),
+    ];
+
+    if (!isNil(value.metadata)) {
+      const metadataJson = new Json(value.metadata);
+      arguments_.push(
+        python.methodArgument({
+          name: "metadata",
+          value: metadataJson,
+        })
+      );
+    }
+
+    const astNode = python.instantiateClass({
+      classReference: imageChatMessageContentRequestRef,
+      arguments_: arguments_,
+    });
+    this.inheritReferences(astNode);
+    return astNode;
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
+  }
+}
+
+class AudioChatMessageContent extends AstNode {
+  private astNode: AstNode;
+
+  public constructor(
+    value: VellumAudioType | VellumAudioRequestType,
+    isRequestType: boolean
+  ) {
+    super();
+    this.astNode = this.generateAstNode(value, isRequestType);
+  }
+
+  private generateAstNode(
+    value: VellumAudioType | VellumAudioRequestType,
+    isRequestType: boolean
+  ): AstNode {
+    const audioChatMessageContentRequestRef = python.reference({
+      name: "AudioChatMessageContent" + (isRequestType ? "Request" : ""),
+      modulePath: VELLUM_CLIENT_MODULE_PATH,
+    });
+
+    const arguments_ = [
+      python.methodArgument({
+        name: "src",
+        value: python.TypeInstantiation.str(value.src),
+      }),
+    ];
+
+    if (!isNil(value.metadata)) {
+      const metadataJson = new Json(value.metadata);
+      arguments_.push(
+        python.methodArgument({
+          name: "metadata",
+          value: metadataJson,
+        })
+      );
+    }
+
+    const astNode = python.instantiateClass({
+      classReference: audioChatMessageContentRequestRef,
+      arguments_: arguments_,
+    });
+    this.inheritReferences(astNode);
+    return astNode;
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
+  }
+}
 
 export namespace ChatMessageContent {
   export interface Args {
@@ -34,171 +302,51 @@ export class ChatMessageContent extends AstNode {
     chatMessageContent: ChatMessageContentRequestType | ChatMessageContentType,
     isRequestType: boolean
   ): AstNode {
-    const contentType = chatMessageContent.type;
-
     let astNode: AstNode;
 
-    if (contentType === "STRING") {
-      const stringContentValue = chatMessageContent.value;
-
-      astNode = python.instantiateClass({
-        classReference: python.reference({
-          name: "StringChatMessageContent" + (isRequestType ? "Request" : ""),
-          modulePath: VELLUM_CLIENT_MODULE_PATH,
-        }),
-        arguments_: [
-          python.methodArgument({
-            name: "value",
-            value: python.TypeInstantiation.str(stringContentValue),
-          }),
-        ],
-      });
-    } else if (contentType === "FUNCTION_CALL") {
-      const functionCallChatMessageContentValue = chatMessageContent.value;
-
-      const functionCallChatMessageContentValueArgs: MethodArgument[] = [];
-
-      if (functionCallChatMessageContentValue.id !== undefined) {
-        functionCallChatMessageContentValueArgs.push(
-          new MethodArgument({
-            name: "id",
-            value: python.TypeInstantiation.str(
-              functionCallChatMessageContentValue.id
-            ),
-          })
+    const contentType = chatMessageContent.type;
+    switch (contentType) {
+      case "STRING": {
+        astNode = new StringChatMessageContent(
+          chatMessageContent.value,
+          isRequestType
         );
+        break;
       }
-
-      functionCallChatMessageContentValueArgs.push(
-        new MethodArgument({
-          name: "name",
-          value: python.TypeInstantiation.str(
-            functionCallChatMessageContentValue.name
-          ),
-        })
-      );
-
-      if (functionCallChatMessageContentValue.arguments !== undefined) {
-        functionCallChatMessageContentValueArgs.push(
-          new MethodArgument({
-            name: "arguments",
-            value: new Json(functionCallChatMessageContentValue.arguments),
-          })
+      case "FUNCTION_CALL": {
+        astNode = new FunctionCallChatMessageContentValue(
+          chatMessageContent.value,
+          isRequestType
         );
+        break;
       }
-
-      const functionCallChatMessageContentValueRequestRef = python.reference({
-        name:
-          "FunctionCallChatMessageContentValue" +
-          (isRequestType ? "Request" : ""),
-        modulePath: VELLUM_CLIENT_MODULE_PATH,
-      });
-
-      const functionCallChatMessageContentValueInstance =
-        python.instantiateClass({
-          classReference: functionCallChatMessageContentValueRequestRef,
-          arguments_: functionCallChatMessageContentValueArgs,
-        });
-
-      astNode = python.instantiateClass({
-        classReference: python.reference({
-          name:
-            "FunctionCallChatMessageContent" + (isRequestType ? "Request" : ""),
-          modulePath: VELLUM_CLIENT_MODULE_PATH,
-        }),
-        arguments_: [
-          new MethodArgument({
-            name: "value",
-            value: functionCallChatMessageContentValueInstance,
-          }),
-        ],
-      });
-    } else if (contentType === "ARRAY") {
-      const arrayValue = chatMessageContent.value;
-      const arrayElements = arrayValue.map(
-        (element) =>
-          new ChatMessageContent({
-            chatMessageContent: element as ChatMessageContentRequestType,
-          })
-      );
-      astNode = python.instantiateClass({
-        classReference: python.reference({
-          name: "ArrayChatMessageContent" + (isRequestType ? "Request" : ""),
-          modulePath: VELLUM_CLIENT_MODULE_PATH,
-        }),
-        arguments_: [
-          python.methodArgument({
-            name: "value",
-            value: python.TypeInstantiation.list(arrayElements, {
-              endWithComma: true,
-            }),
-          }),
-        ],
-      });
-    } else if (contentType === "IMAGE") {
-      const imageContentValue = chatMessageContent.value;
-
-      const imageChatMessageContentRequestRef = python.reference({
-        name: "ImageChatMessageContent" + (isRequestType ? "Request" : ""),
-        modulePath: VELLUM_CLIENT_MODULE_PATH,
-      });
-
-      const arguments_ = [
-        python.methodArgument({
-          name: "src",
-          value: python.TypeInstantiation.str(imageContentValue.src),
-        }),
-      ];
-
-      if (!isNil(imageContentValue.metadata)) {
-        const metadataJson = new Json(imageContentValue.metadata);
-        arguments_.push(
-          python.methodArgument({
-            name: "metadata",
-            value: metadataJson,
-          })
+      case "ARRAY": {
+        astNode = new ArrayChatMessageContent(
+          chatMessageContent.value,
+          isRequestType
         );
+        break;
       }
-
-      astNode = python.instantiateClass({
-        classReference: imageChatMessageContentRequestRef,
-        arguments_: arguments_,
-      });
-    } else if (contentType === "AUDIO") {
-      const audioContentValue = chatMessageContent.value;
-
-      const audioChatMessageContentRequestRef = python.reference({
-        name: "AudioChatMessageContent" + (isRequestType ? "Request" : ""),
-        modulePath: VELLUM_CLIENT_MODULE_PATH,
-      });
-
-      const arguments_ = [
-        python.methodArgument({
-          name: "src",
-          value: python.TypeInstantiation.str(audioContentValue.src),
-        }),
-      ];
-
-      if (!isNil(audioContentValue.metadata)) {
-        const metadataJson = new Json(audioContentValue.metadata);
-        arguments_.push(
-          python.methodArgument({
-            name: "metadata",
-            value: metadataJson,
-          })
+      case "IMAGE": {
+        astNode = new ImageChatMessageContent(
+          chatMessageContent.value,
+          isRequestType
         );
+        break;
       }
-
-      astNode = python.instantiateClass({
-        classReference: audioChatMessageContentRequestRef,
-        arguments_: arguments_,
-      });
-    } else {
-      assertUnreachable(contentType);
+      case "AUDIO": {
+        astNode = new AudioChatMessageContent(
+          chatMessageContent.value,
+          isRequestType
+        );
+        break;
+      }
+      default: {
+        assertUnreachable(contentType);
+      }
     }
 
     this.inheritReferences(astNode);
-
     return astNode;
   }
 

--- a/ee/codegen/src/generators/chat-message-content.ts
+++ b/ee/codegen/src/generators/chat-message-content.ts
@@ -292,7 +292,7 @@ export class ChatMessageContent extends AstNode {
 
   public constructor({
     chatMessageContent,
-    isRequestType = true,
+    isRequestType = false,
   }: ChatMessageContent.Args) {
     super();
     this.astNode = this.generateAstNode(chatMessageContent, isRequestType);

--- a/ee/codegen/src/generators/vellum-variable-value.ts
+++ b/ee/codegen/src/generators/vellum-variable-value.ts
@@ -76,7 +76,7 @@ class ChatHistoryVellumValue extends AstNode {
 
   public constructor({
     value,
-    isRequestType = true,
+    isRequestType = false,
   }: {
     value: ChatMessageRequest[];
     isRequestType?: boolean;

--- a/ee/codegen/src/generators/vellum-variable-value.ts
+++ b/ee/codegen/src/generators/vellum-variable-value.ts
@@ -19,38 +19,51 @@ import { Json } from "src/generators/json";
 import { assertUnreachable } from "src/utils/typing";
 
 class StringVellumValue extends AstNode {
-  private value: string;
+  private astNode: AstNode;
 
   public constructor(value: string) {
     super();
-    this.value = value;
+    this.astNode = this.generateAstNode(value);
+  }
+
+  private generateAstNode(value: string): AstNode {
+    return python.TypeInstantiation.str(value);
   }
 
   public write(writer: Writer): void {
-    python.TypeInstantiation.str(this.value).write(writer);
+    this.astNode.write(writer);
   }
 }
 
 class NumberVellumValue extends AstNode {
-  private value: number;
+  private astNode: AstNode;
 
   public constructor(value: number) {
     super();
-    this.value = value;
+    this.astNode = this.generateAstNode(value);
+  }
+
+  private generateAstNode(value: number): AstNode {
+    return python.TypeInstantiation.float(value);
   }
 
   public write(writer: Writer): void {
-    python.TypeInstantiation.float(this.value).write(writer);
+    this.astNode.write(writer);
   }
 }
 
 class JsonVellumValue extends AstNode {
-  private astNode: Json;
+  private astNode: AstNode;
 
   public constructor(value: unknown) {
     super();
-    this.astNode = new Json(value);
-    this.inheritReferences(this.astNode);
+    this.astNode = this.generateAstNode(value);
+  }
+
+  private generateAstNode(value: unknown): AstNode {
+    const astNode = new Json(value);
+    this.inheritReferences(astNode);
+    return astNode;
   }
 
   public write(writer: Writer): void {
@@ -59,9 +72,7 @@ class JsonVellumValue extends AstNode {
 }
 
 class ChatHistoryVellumValue extends AstNode {
-  private value: ChatMessageRequest[];
-  private isRequestType: boolean;
-  private contentsByIndex: Map<number, ChatMessageContent>;
+  private astNode: AstNode;
 
   public constructor({
     value,
@@ -71,32 +82,14 @@ class ChatHistoryVellumValue extends AstNode {
     isRequestType?: boolean;
   }) {
     super();
-    this.value = value;
-    this.isRequestType = isRequestType;
-    this.contentsByIndex = new Map();
-
-    this.setContentsByIndex();
+    this.astNode = this.generateAstNode(value, isRequestType);
   }
 
-  private setContentsByIndex(): void {
-    this.value.forEach((chatMessage, index) => {
-      if (chatMessage.content !== undefined) {
-        const content = new ChatMessageContent({
-          chatMessageContent: chatMessage.content,
-          isRequestType: this.isRequestType,
-        });
-
-        this.inheritReferences(content);
-
-        this.contentsByIndex.set(index, content);
-      }
-    });
-  }
-
-  public write(writer: Writer): void {
-    const chatHistoryValue = this.value;
-
-    const chatMessages = chatHistoryValue.map((chatMessage, index) => {
+  private generateAstNode(
+    value: ChatMessageRequest[],
+    isRequestType: boolean
+  ): AstNode {
+    const chatMessages = value.map((chatMessage) => {
       const arguments_ = [
         python.methodArgument({
           name: "role",
@@ -123,10 +116,10 @@ class ChatHistoryVellumValue extends AstNode {
       }
 
       if (chatMessage.content !== undefined) {
-        const content = this.contentsByIndex.get(index);
-        if (content === undefined) {
-          throw new Error("Content not found");
-        }
+        const content = new ChatMessageContent({
+          chatMessageContent: chatMessage.content,
+          isRequestType,
+        });
 
         arguments_.push(
           python.methodArgument({
@@ -138,16 +131,22 @@ class ChatHistoryVellumValue extends AstNode {
 
       return python.instantiateClass({
         classReference: python.reference({
-          name: "ChatMessage" + (this.isRequestType ? "Request" : ""),
+          name: "ChatMessage" + (isRequestType ? "Request" : ""),
           modulePath: VELLUM_CLIENT_MODULE_PATH,
         }),
         arguments_: arguments_,
       });
     });
 
-    python.TypeInstantiation.list(chatMessages, { endWithComma: true }).write(
-      writer
-    );
+    const astNode = python.TypeInstantiation.list(chatMessages, {
+      endWithComma: true,
+    });
+    this.inheritReferences(astNode);
+    return astNode;
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
   }
 }
 
@@ -156,11 +155,11 @@ class ErrorVellumValue extends AstNode {
 
   public constructor(value: VellumError) {
     super();
-    this.astNode = this.generateVellumError(value);
+    this.astNode = this.generateAstNode(value);
   }
 
-  private generateVellumError({ message, code }: VellumError) {
-    const vellumErrorClass = python.instantiateClass({
+  private generateAstNode({ message, code }: VellumError) {
+    const astNode = python.instantiateClass({
       classReference: python.reference({
         name: "VellumError",
         modulePath: VELLUM_CLIENT_MODULE_PATH,
@@ -176,8 +175,8 @@ class ErrorVellumValue extends AstNode {
         }),
       ],
     });
-    this.inheritReferences(vellumErrorClass);
-    return vellumErrorClass;
+    this.inheritReferences(astNode);
+    return astNode;
   }
 
   public write(writer: Writer): void {
@@ -186,39 +185,45 @@ class ErrorVellumValue extends AstNode {
 }
 
 class ImageVellumValue extends AstNode {
-  private value: VellumImage;
+  private astNode: AstNode;
 
   public constructor(value: VellumImage) {
     super();
-    this.value = value;
+    this.astNode = this.generateAstNode(value);
   }
 
-  public write(writer: Writer): void {
+  private generateAstNode(value: VellumImage): AstNode {
     const arguments_ = [
       python.methodArgument({
         name: "src",
-        value: python.TypeInstantiation.str(this.value.src),
+        value: python.TypeInstantiation.str(value.src),
       }),
     ];
 
-    if (!isNil(this.value.metadata)) {
+    if (!isNil(value.metadata)) {
       arguments_.push(
         python.methodArgument({
           name: "metadata",
-          value: new Json(this.value.metadata),
+          value: new Json(value.metadata),
         })
       );
     }
 
-    python
-      .instantiateClass({
-        classReference: python.reference({
-          name: "VellumImage",
-          modulePath: VELLUM_CLIENT_MODULE_PATH,
-        }),
-        arguments_: arguments_,
-      })
-      .write(writer);
+    const astNode = python.instantiateClass({
+      classReference: python.reference({
+        name: "VellumImage",
+        modulePath: VELLUM_CLIENT_MODULE_PATH,
+      }),
+      arguments_: arguments_,
+    });
+
+    this.inheritReferences(astNode);
+
+    return astNode;
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
   }
 }
 
@@ -227,14 +232,21 @@ class ArrayVellumValue extends AstNode {
 
   public constructor(value: unknown) {
     super();
+    this.astNode = this.generateAstNode(value);
+  }
+
+  private generateAstNode(value: unknown): AstNode {
     if (!Array.isArray(value)) {
       throw new Error("Expected array value for ArrayVellumValue");
     }
-    this.astNode = python.TypeInstantiation.list(
+
+    const astNode = python.TypeInstantiation.list(
       value.map((item) => new VellumValue({ vellumValue: item })),
       { endWithComma: true }
     );
-    this.inheritReferences(this.astNode);
+
+    this.inheritReferences(astNode);
+    return astNode;
   }
 
   public write(writer: Writer): void {
@@ -243,81 +255,90 @@ class ArrayVellumValue extends AstNode {
 }
 
 class AudioVellumValue extends AstNode {
-  private value: VellumAudio;
+  private astNode: python.AstNode;
 
   public constructor(value: VellumAudio) {
     super();
-    this.value = value;
+    this.astNode = this.generateAstNode(value);
   }
 
-  public write(writer: Writer): void {
+  private generateAstNode(value: VellumAudio): AstNode {
     const arguments_ = [
       python.methodArgument({
         name: "src",
-        value: python.TypeInstantiation.str(this.value.src),
+        value: python.TypeInstantiation.str(value.src),
       }),
     ];
 
-    if (!isNil(this.value.metadata)) {
+    if (!isNil(value.metadata)) {
       arguments_.push(
         python.methodArgument({
           name: "metadata",
-          value: new Json(this.value.metadata),
+          value: new Json(value.metadata),
         })
       );
     }
 
-    python
-      .instantiateClass({
-        classReference: python.reference({
-          name: "VellumAudio",
-          modulePath: VELLUM_CLIENT_MODULE_PATH,
-        }),
-        arguments_: arguments_,
-      })
-      .write(writer);
+    const astNode = python.instantiateClass({
+      classReference: python.reference({
+        name: "VellumAudio",
+        modulePath: VELLUM_CLIENT_MODULE_PATH,
+      }),
+      arguments_: arguments_,
+    });
+
+    this.inheritReferences(astNode);
+    return astNode;
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
   }
 }
 
 class FunctionCallVellumValue extends AstNode {
-  private value: FunctionCall;
+  private astNode: python.AstNode;
 
   public constructor(value: FunctionCall) {
     super();
-    this.value = value;
-    this.inheritReferences(new Json(this.value.arguments));
+    this.astNode = this.generateAstNode(value);
   }
 
-  public write(writer: Writer): void {
+  private generateAstNode(value: FunctionCall): AstNode {
     const arguments_ = [
       python.methodArgument({
         name: "arguments",
-        value: new Json(this.value.arguments),
+        value: new Json(value.arguments),
       }),
       python.methodArgument({
         name: "name",
-        value: python.TypeInstantiation.str(this.value.name),
+        value: python.TypeInstantiation.str(value.name),
       }),
     ];
 
-    if (!isNil(this.value.id)) {
+    if (!isNil(value.id)) {
       arguments_.push(
         python.methodArgument({
           name: "id",
-          value: python.TypeInstantiation.str(this.value.id),
+          value: python.TypeInstantiation.str(value.id),
         })
       );
     }
 
-    python
-      .instantiateClass({
-        classReference: python.reference({
-          name: "FunctionCall",
-          modulePath: VELLUM_CLIENT_MODULE_PATH,
-        }),
-        arguments_: arguments_,
-      })
-      .write(writer);
+    const astNode = python.instantiateClass({
+      classReference: python.reference({
+        name: "FunctionCall",
+        modulePath: VELLUM_CLIENT_MODULE_PATH,
+      }),
+      arguments_: arguments_,
+    });
+
+    this.inheritReferences(astNode);
+    return astNode;
+  }
+
+  public write(writer: Writer): void {
+    this.astNode.write(writer);
   }
 }
 
@@ -465,7 +486,7 @@ export class VellumValue extends AstNode {
 
   public write(writer: Writer): void {
     if (this.astNode === null) {
-      writer.write("None");
+      python.TypeInstantiation.none().write(writer);
       return;
     }
 


### PR DESCRIPTION
While pulling down the `sandbox.py` file for our Basic RAG Workflow, I noticed that some imports were missing.

The root cause of this is that we were creating AST Nodes in various `write` methods instead of in our constructors. This PR performs some refactoring to make sure that all reference tracking works as expected and also modualrizes the code a bit further.