### PR TITLE
Exclude `prompts/` and `utils/` from Fern

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -7,6 +7,8 @@ examples
 Makefile
 src/vellum/evaluations
 src/vellum/plugins
+src/vellum/prompts
+src/vellum/utils
 src/vellum/workflows
 scripts
 tests/workflows


### PR DESCRIPTION
Updates fern ignore so that these new directories don't get wiped during codegen.