### PR TITLE
Improve Interfaces for `SandboxRunner` and `WorkflowContext`

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`WorkflowProjectGenerator > inlude sandbox > should include a sandbox.py file when passed sandboxInputs 1`] = `
 "from vellum import ArrayChatMessageContent, ChatMessage, StringChatMessageContent
-from vellum.workflows.sandbox import SandboxRunner
+from vellum.workflows.sandbox import WorkflowSandboxRunner
 
 from .inputs import Inputs
 from .workflow import Workflow
@@ -11,8 +11,8 @@ if __name__ != "__main__":
     raise Exception("This file is not meant to be imported")
 
 
-runner = SandboxRunner(
-    workflow=Workflow,
+runner = WorkflowSandboxRunner(
+    workflow=Workflow(),
     inputs=[
         Inputs(
             input="foo",

--- a/ee/codegen/src/generators/workflow-sandbox-file.ts
+++ b/ee/codegen/src/generators/workflow-sandbox-file.ts
@@ -32,16 +32,19 @@ export class WorkflowSandboxFile extends BasePersistedFile {
       name: "runner",
       initializer: python.instantiateClass({
         classReference: python.reference({
-          name: "SandboxRunner",
+          name: "WorkflowSandboxRunner",
           modulePath:
             this.workflowContext.sdkModulePathNames.SANDBOX_RUNNER_MODULE_PATH,
         }),
         arguments_: [
           python.methodArgument({
             name: "workflow",
-            value: python.reference({
-              name: this.workflowContext.workflowClassName,
-              modulePath: this.workflowContext.modulePath,
+            value: python.instantiateClass({
+              classReference: python.reference({
+                name: this.workflowContext.workflowClassName,
+                modulePath: this.workflowContext.modulePath,
+              }),
+              arguments_: [],
             }),
           }),
           python.methodArgument({

--- a/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
+++ b/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
@@ -29,9 +29,7 @@ class InlineSubworkflowNode(BaseSubworkflowNode[StateType], Generic[StateType, W
         with execution_context(parent_context=get_parent_context() or self._context.parent_context):
             subworkflow = self.subworkflow(
                 parent_state=self.state,
-                context=WorkflowContext(
-                    _vellum_client=self._context._vellum_client,
-                ),
+                context=WorkflowContext(vellum_client=self._context.vellum_client),
             )
             subworkflow_stream = subworkflow.stream(
                 inputs=self._compile_subworkflow_inputs(),

--- a/src/vellum/workflows/nodes/core/map_node/node.py
+++ b/src/vellum/workflows/nodes/core/map_node/node.py
@@ -108,7 +108,7 @@ class MapNode(BaseNode, Generic[StateType, MapNodeItemType]):
             self._run_subworkflow(item=item, index=index)
 
     def _run_subworkflow(self, *, item: MapNodeItemType, index: int) -> None:
-        context = WorkflowContext(_vellum_client=self._context._vellum_client)
+        context = WorkflowContext(vellum_client=self._context.vellum_client)
         subworkflow = self.subworkflow(parent_state=self.state, context=context)
         events = subworkflow.stream(
             inputs=self.SubworkflowInputs(index=index, item=item, all_items=self.items),

--- a/src/vellum/workflows/nodes/core/try_node/node.py
+++ b/src/vellum/workflows/nodes/core/try_node/node.py
@@ -73,9 +73,7 @@ class TryNode(BaseNode[StateType], Generic[StateType], metaclass=_TryNodeMeta):
     def run(self) -> Iterator[BaseOutput]:
         subworkflow = self.subworkflow(
             parent_state=self.state,
-            context=WorkflowContext(
-                _vellum_client=self._context._vellum_client,
-            ),
+            context=WorkflowContext(vellum_client=self._context.vellum_client),
         )
         subworkflow_stream = subworkflow.stream(
             event_filter=all_workflow_event_filter,

--- a/src/vellum/workflows/nodes/core/try_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/core/try_node/tests/test_node.py
@@ -103,7 +103,7 @@ def test_try_node__use_parent_execution_context():
     # WHEN the node is run with a custom vellum client
     node = TestNode(
         context=WorkflowContext(
-            _vellum_client=Vellum(api_key="test-key"),
+            vellum_client=Vellum(api_key="test-key"),
         )
     )
     outputs = list(node.run())

--- a/src/vellum/workflows/sandbox.py
+++ b/src/vellum/workflows/sandbox.py
@@ -1,4 +1,4 @@
-from typing import Generic, Sequence, Type
+from typing import Generic, Sequence
 
 import dotenv
 
@@ -10,7 +10,7 @@ from vellum.workflows.workflows.event_filters import root_workflow_event_filter
 
 
 class SandboxRunner(Generic[WorkflowType]):
-    def __init__(self, workflow: Type[WorkflowType], inputs: Sequence[BaseInputs]):
+    def __init__(self, workflow: WorkflowType, inputs: Sequence[BaseInputs]):
         if not inputs:
             raise ValueError("Inputs are required to have at least one defined inputs")
 
@@ -30,8 +30,7 @@ class SandboxRunner(Generic[WorkflowType]):
 
         selected_inputs = self._inputs[index]
 
-        workflow = self._workflow()
-        events = workflow.stream(
+        events = self._workflow.stream(
             inputs=selected_inputs,
             event_filter=root_workflow_event_filter,
         )

--- a/src/vellum/workflows/sandbox.py
+++ b/src/vellum/workflows/sandbox.py
@@ -9,7 +9,7 @@ from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.workflows.event_filters import root_workflow_event_filter
 
 
-class SandboxRunner(Generic[WorkflowType]):
+class WorkflowSandboxRunner(Generic[WorkflowType]):
     def __init__(self, workflow: WorkflowType, inputs: Sequence[BaseInputs]):
         if not inputs:
             raise ValueError("Inputs are required to have at least one defined inputs")

--- a/src/vellum/workflows/state/context.py
+++ b/src/vellum/workflows/state/context.py
@@ -13,11 +13,12 @@ if TYPE_CHECKING:
 class WorkflowContext:
     def __init__(
         self,
-        _vellum_client: Optional[Vellum] = None,
-        _parent_context: Optional[ParentContext] = None,
+        *,
+        vellum_client: Optional[Vellum] = None,
+        parent_context: Optional[ParentContext] = None,
     ):
-        self._vellum_client = _vellum_client
-        self._parent_context = _parent_context
+        self._vellum_client = vellum_client
+        self._parent_context = parent_context
         self._event_queue: Optional[Queue["WorkflowEvent"]] = None
 
     @cached_property

--- a/src/vellum/workflows/tests/test_sandbox.py
+++ b/src/vellum/workflows/tests/test_sandbox.py
@@ -3,7 +3,7 @@ from typing import List
 
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode
-from vellum.workflows.sandbox import SandboxRunner
+from vellum.workflows.sandbox import WorkflowSandboxRunner
 from vellum.workflows.state.base import BaseState
 from vellum.workflows.workflows.base import BaseWorkflow
 
@@ -49,7 +49,7 @@ def test_sandbox_runner__happy_path(mock_logger, run_kwargs, expected_last_log):
     ]
 
     # WHEN we run the sandbox
-    runner = SandboxRunner(workflow=Workflow(), inputs=inputs)
+    runner = WorkflowSandboxRunner(workflow=Workflow(), inputs=inputs)
     runner.run(**run_kwargs)
 
     # THEN we see the logs

--- a/src/vellum/workflows/tests/test_sandbox.py
+++ b/src/vellum/workflows/tests/test_sandbox.py
@@ -49,7 +49,7 @@ def test_sandbox_runner__happy_path(mock_logger, run_kwargs, expected_last_log):
     ]
 
     # WHEN we run the sandbox
-    runner = SandboxRunner(workflow=Workflow, inputs=inputs)
+    runner = SandboxRunner(workflow=Workflow(), inputs=inputs)
     runner.run(**run_kwargs)
 
     # THEN we see the logs

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -121,10 +121,11 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
 
     def __init__(
         self,
+        *,
+        context: Optional[WorkflowContext] = None,
         parent_state: Optional[BaseState] = None,
         emitters: Optional[List[BaseWorkflowEmitter]] = None,
         resolvers: Optional[List[BaseWorkflowResolver]] = None,
-        context: Optional[WorkflowContext] = None,
     ):
         self._parent_state = parent_state
         self.emitters = emitters or (self.emitters if hasattr(self, "emitters") else [])

--- a/tests/workflows/basic_parent_context/tests/test_basic_parent_context_workflow_runner.py
+++ b/tests/workflows/basic_parent_context/tests/test_basic_parent_context_workflow_runner.py
@@ -61,7 +61,7 @@ def test_stream_workflow__happy_path_inital_context():
     assert initial_parent_context.parent is not None
     assert type(initial_parent_context.node_definition) is CodeResourceDefinition
 
-    workflow = TrivialWorkflow(context=WorkflowContext(_parent_context=initial_parent_context))
+    workflow = TrivialWorkflow(context=WorkflowContext(parent_context=initial_parent_context))
 
     events = list(workflow.stream(event_filter=root_workflow_event_filter))
 


### PR DESCRIPTION
# Rationale

When trying to run and debug Workflows locally, @NgoHarrison and I found ourselves wanting to have more control over the `WorkflowContext` that was being used in a `SandboxRunner`. Our goal was to drive the urls of the Vellum CLI, which I later discovered was possible via env vars and handled as part of `create_vellum_client`. Despite this, I think it's very reasonable to give users greater control by passing instances of things they care about, rather than forcing them to use env vars and know about them.

# Changes
1. Improve names of kwargs in `WorkflowContext.__init__`
2. Pass Workflow instances instead of their class when instantiating `SandboxRunner`
3. Rename from `SandboxRunner` to `WorkflowSandboxRunner`
4. Update codegen to generate the newly expected code.