### PR TITLE
Add support for casting to json types for templating nodes

### DIFF
--- a/src/vellum/workflows/nodes/core/templating_node/node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/node.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Callable, ClassVar, Dict, Generic, Mapping, Tuple, Type, TypeVar, Union, get_args
 
 from vellum.utils.templating.constants import DEFAULT_JINJA_CUSTOM_FILTERS, DEFAULT_JINJA_GLOBALS
@@ -86,6 +87,12 @@ class TemplatingNode(BaseNode[StateType], Generic[StateType, _OutputType], metac
 
         if output_type is bool:
             return bool(rendered_template)
+
+        if output_type is Any:
+            try:
+                return json.loads(rendered_template)
+            except json.JSONDecodeError:
+                raise ValueError("Invalid JSON format for rendered_template")
 
         raise ValueError(f"Unsupported output type: {output_type}")
 

--- a/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
@@ -1,7 +1,9 @@
 import json
+from typing import Any
 
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.templating_node.node import TemplatingNode
+from vellum.workflows.state import BaseState
 
 
 def test_templating_node__dict_output():
@@ -20,6 +22,70 @@ def test_templating_node__dict_output():
 
     # THEN the output is json serializable
     assert json.loads(outputs.result) == {"key": "value"}
+
+
+def test_templating_node__int_output():
+    # GIVEN a templating node that outputs an integer
+    class IntTemplateNode(TemplatingNode[BaseState, int]):
+        template = "{{ data }}"
+        inputs = {
+            "data": 42,
+        }
+
+    # WHEN the node is run
+    node = IntTemplateNode()
+    outputs = node.run()
+
+    # THEN the output is the expected integer
+    assert outputs.result == 42
+
+
+def test_templating_node__float_output():
+    # GIVEN a templating node that outputs a float
+    class FloatTemplateNode(TemplatingNode[BaseState, float]):
+        template = "{{ data }}"
+        inputs = {
+            "data": 42.5,
+        }
+
+    # WHEN the node is run
+    node = FloatTemplateNode()
+    outputs = node.run()
+
+    # THEN the output is the expected float
+    assert outputs.result == 42.5
+
+
+def test_templating_node__bool_output():
+    # GIVEN a templating node that outputs a bool
+    class BoolTemplateNode(TemplatingNode[BaseState, bool]):
+        template = "{{ data }}"
+        inputs = {
+            "data": True,
+        }
+
+    # WHEN the node is run
+    node = BoolTemplateNode()
+    outputs = node.run()
+
+    # THEN the output is the expected bool
+    assert outputs.result is True
+
+
+def test_templating_node__json_output():
+    # GIVEN a templating node that outputs JSON
+    class JSONTemplateNode(TemplatingNode[BaseState, Any]):
+        template = "{{ data }}"
+        inputs = {
+            "data": {"key": "value"},
+        }
+
+    # WHEN the node is run
+    node = JSONTemplateNode()
+    outputs = node.run()
+
+    # THEN the output is the expected JSON
+    assert outputs.result == {"key": "value"}
 
 
 def test_templating_node__execution_count_reference():


### PR DESCRIPTION
This came up from a customer workflow with this class:
`class CastToJSON(TemplatingNode[BaseState, Any]):`

We don't currently support Any casting. This PR tries to cast to json if it is Any since codegen is generating `Any` if we have output type of `Json`