### PR TITLE
WIP - Static Node IDs in new map.py file

### DIFF
--- a/ee/codegen/src/codegen.ts
+++ b/ee/codegen/src/codegen.ts
@@ -8,6 +8,7 @@ import {
   Workflow,
 } from "./generators";
 import { BasePersistedFile } from "./generators/base-persisted-file";
+import { IdentifierFile } from "./generators/identifier-file";
 import { WorkflowSandboxFile } from "./generators/workflow-sandbox-file";
 
 export function vellumVariable(args: VellumVariable.Args): VellumVariable {
@@ -42,4 +43,8 @@ export function workflowSandboxFile(
   args: WorkflowSandboxFile.Args
 ): WorkflowSandboxFile {
   return new WorkflowSandboxFile(args);
+}
+
+export function identifierFile(args: IdentifierFile.Args): IdentifierFile {
+  return new IdentifierFile(args);
 }

--- a/ee/codegen/src/generators/identifier-file.ts
+++ b/ee/codegen/src/generators/identifier-file.ts
@@ -1,0 +1,52 @@
+import { python } from "@fern-api/python-ast";
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+
+import { BaseNodeContext } from "src/context/node-context/base";
+import { BasePersistedFile } from "src/generators/base-persisted-file";
+import { BaseNode } from "src/generators/nodes/bases";
+import { WorkflowDataNode } from "src/types/vellum";
+
+export declare namespace IdentifierFile {
+  interface Args extends BasePersistedFile.Args {
+    nodes: BaseNode<WorkflowDataNode, BaseNodeContext<WorkflowDataNode>>[];
+  }
+}
+
+export class IdentifierFile extends BasePersistedFile {
+  private readonly nodes: BaseNode<
+    WorkflowDataNode,
+    BaseNodeContext<WorkflowDataNode>
+  >[];
+
+  public constructor({ workflowContext, nodes }: IdentifierFile.Args) {
+    super({ workflowContext });
+    this.nodes = nodes;
+  }
+
+  protected getModulePath(): string[] {
+    return [this.workflowContext.moduleName, "map"];
+  }
+
+  protected getFileStatements(): AstNode[] {
+    const identifierFileMapField = python.field({
+      name: "__identifiers__",
+      initializer: python.TypeInstantiation.dict([
+        ...this.nodes.map((node) => {
+          return {
+            // key: python.reference({
+            //   name: node.nodeContext.nodeClassName,
+            //   modulePath: node.nodeContext.nodeModulePath,
+            // }),
+            key: python.TypeInstantiation.str(
+              node.getNodeModulePath().join(".") + "." + node.getNodeClassName()
+            ),
+            value: python.TypeInstantiation.uuid(node.nodeContext.getNodeId()),
+          };
+        }),
+      ]),
+    });
+    this.inheritReferences(identifierFileMapField);
+
+    return [identifierFileMapField];
+  }
+}

--- a/ee/codegen/src/generators/identifier-file.ts
+++ b/ee/codegen/src/generators/identifier-file.ts
@@ -33,10 +33,6 @@ export class IdentifierFile extends BasePersistedFile {
       initializer: python.TypeInstantiation.dict([
         ...this.nodes.map((node) => {
           return {
-            // key: python.reference({
-            //   name: node.nodeContext.nodeClassName,
-            //   modulePath: node.nodeContext.nodeModulePath,
-            // }),
             key: python.TypeInstantiation.str(
               node.getNodeModulePath().join(".") + "." + node.getNodeClassName()
             ),

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -555,7 +555,26 @@ ${errors.slice(0, 3).map((err) => {
           }),
         ]),
       });
-      rootNodesInitFileStatements.push(nodeInitFileAllField);
+      const nodeInitFileMapField = python.field({
+        name: "__identifiers",
+        initializer: python.TypeInstantiation.dict([
+          ...nodes.map((node) => {
+            return {
+              key: python.reference({
+                name: node.nodeContext.nodeClassName,
+                modulePath: node.nodeContext.nodeModulePath,
+              }),
+              value: python.TypeInstantiation.uuid(
+                node.nodeContext.getNodeId()
+              ),
+            };
+          }),
+        ]),
+      });
+      rootNodesInitFileStatements.push(
+        nodeInitFileAllField,
+        nodeInitFileMapField
+      );
 
       const nodeDisplayInitFileAllField = python.field({
         name: "__all__",

--- a/poetry.lock
+++ b/poetry.lock
@@ -608,13 +608,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "identify"
-version = "2.6.3"
+version = "2.6.4"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "identify-2.6.3-py2.py3-none-any.whl", hash = "sha256:9edba65473324c2ea9684b1f944fe3191db3345e50b6d04571d10ed164f8d7bd"},
-    {file = "identify-2.6.3.tar.gz", hash = "sha256:62f5dae9b5fef52c84cc188514e9ea4f3f636b1d8799ab5ebc475471f9e47a02"},
+    {file = "identify-2.6.4-py2.py3-none-any.whl", hash = "sha256:993b0f01b97e0568c179bb9196391ff391bfb88a99099dbf5ce392b68f42d0af"},
+    {file = "identify-2.6.4.tar.gz", hash = "sha256:285a7d27e397652e8cafe537a6cc97dd470a970f48fb2e9d979aa38eae5513ac"},
 ]
 
 [package.extras]


### PR DESCRIPTION
quick loom over new file: https://www.loom.com/share/d8bcd0a884f54954bfef4860f5f2f85e

the gist is that the events are using hashes of the node/workflow modules instead of the node_ids that we pull from sandboxes

this is the first step to mapping ids -- we'll check this file for our path on init, and if we have a UUID, we'll use it

looking for quick thoughts, one other thought I had was to just save the __id__ on each file for us, but I can't imagine that would be a great experience for developers

cc: @dvargas92495 PR w/ Issue found: https://github.com/vellum-ai/vellum/pull/7056