### PR TITLE
Prevent Displayable Prompt Nodes from failing on just function call responses

### DIFF
--- a/src/vellum/workflows/nodes/displayable/inline_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/inline_prompt_node/node.py
@@ -39,11 +39,8 @@ class InlinePromptNode(BaseInlinePromptNode[StateType]):
 
         string_output = next((output for output in outputs if output.type == "STRING"), None)
         if not string_output or string_output.value is None:
-            output_types = {output.type for output in outputs}
-            is_plural = len(output_types) > 1
-            raise NodeException(
-                message=f"Expected to receive a non-null string output from Prompt. Only found outputs of type{'s' if is_plural else ''}: {', '.join(output_types)}",  # noqa: E501
-                code=WorkflowErrorCode.INTERNAL_ERROR,
-            )
+            value = ""
+        else:
+            value = string_output.value
 
-        yield BaseOutput(name="text", value=string_output.value)
+        yield BaseOutput(name="text", value=value)

--- a/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
@@ -12,7 +12,6 @@ from vellum.client.types.initiated_execute_prompt_event import InitiatedExecuteP
 from vellum.client.types.prompt_output import PromptOutput
 from vellum.client.types.prompt_request_json_input import PromptRequestJsonInput
 from vellum.client.types.string_vellum_value import StringVellumValue
-from vellum.workflows.nodes.displayable.bases.inline_prompt_node.node import BaseInlinePromptNode
 from vellum.workflows.nodes.displayable.inline_prompt_node.node import InlinePromptNode
 
 
@@ -74,7 +73,7 @@ def test_inline_prompt_node__function_definitions(vellum_adhoc_prompt_client):
         pass
 
     # AND a prompt node with a accepting that function definition
-    class MyNode(BaseInlinePromptNode):
+    class MyNode(InlinePromptNode):
         ml_model = "gpt-4o"
         functions = [my_function]
         prompt_inputs = {}

--- a/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
@@ -98,7 +98,7 @@ def test_inline_prompt_node__function_definitions(vellum_adhoc_prompt_client):
     vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_prompt_events
 
     # WHEN the node is run
-    list(MyNode().run())
+    outputs = list(MyNode().run())
 
     # THEN the prompt is executed with the correct inputs
     mock_api = vellum_adhoc_prompt_client.adhoc_execute_prompt_stream
@@ -116,3 +116,15 @@ def test_inline_prompt_node__function_definitions(vellum_adhoc_prompt_client):
             },
         ),
     ]
+    assert (
+        outputs[-1].value
+        == """{
+    "arguments": {
+        "foo": "hello",
+        "bar": 1
+    },
+    "id": null,
+    "name": "my_function",
+    "state": null
+}"""
+    )


### PR DESCRIPTION
Prompt Nodes that will be used in the UI currently fail if the prompt returns _just_ a function call. Our behavior here should model what we do with legacy runner as much as possible, which is to always return a text output using [this helper](https://github.com/vellum-ai/vellum/blob/main/django/app/predict/utils.py#L68-L82).

This PR updates the run method of our `InlinePromptNode` to use an updated/adapted version of the above logic. 