### PR TITLE
Update sandbox codegen to use sanitized names for input args

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
@@ -41,24 +41,3 @@ runner = WorkflowSandboxRunner(
 runner.run()
 "
 `;
-
-exports[`Workflow Sandbox > write > should generate the same snapshot for snake and camel casing with unique contexts 1`] = `
-"from vellum.workflows.sandbox import WorkflowSandboxRunner
-from .workflow import Workflow
-from .inputs import Inputs
-
-if __name__ != "__main__":
-    raise Exception("This file is not meant to be imported")
-
-
-runner = WorkflowSandboxRunner(
-    workflow=Workflow(),
-    inputs=[
-        Inputs(some_foo="some-value"),
-        Inputs(some_bar="some-value"),
-    ],
-)
-
-runner.run()
-"
-`;

--- a/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
@@ -1,0 +1,64 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Workflow Sandbox > write > should generate correct and same code for snake and camel casing of input names 1`] = `
+"from vellum.workflows.sandbox import WorkflowSandboxRunner
+from .workflow import Workflow
+from .inputs import Inputs
+
+if __name__ != "__main__":
+    raise Exception("This file is not meant to be imported")
+
+
+runner = WorkflowSandboxRunner(
+    workflow=Workflow(),
+    inputs=[
+        Inputs(some_foo="some-value"),
+        Inputs(some_bar="some-value"),
+    ],
+)
+
+runner.run()
+"
+`;
+
+exports[`Workflow Sandbox > write > should generate correct code given inputs 1`] = `
+"from vellum.workflows.sandbox import WorkflowSandboxRunner
+from .workflow import Workflow
+from .inputs import Inputs
+
+if __name__ != "__main__":
+    raise Exception("This file is not meant to be imported")
+
+
+runner = WorkflowSandboxRunner(
+    workflow=Workflow(),
+    inputs=[
+        Inputs(some_foo="some-value"),
+        Inputs(some_bar="some-value"),
+    ],
+)
+
+runner.run()
+"
+`;
+
+exports[`Workflow Sandbox > write > should generate the same snapshot for snake and camel casing with unique contexts 1`] = `
+"from vellum.workflows.sandbox import WorkflowSandboxRunner
+from .workflow import Workflow
+from .inputs import Inputs
+
+if __name__ != "__main__":
+    raise Exception("This file is not meant to be imported")
+
+
+runner = WorkflowSandboxRunner(
+    workflow=Workflow(),
+    inputs=[
+        Inputs(some_foo="some-value"),
+        Inputs(some_bar="some-value"),
+    ],
+)
+
+runner.run()
+"
+`;

--- a/ee/codegen/src/__test__/workflow-sandbox.test.ts
+++ b/ee/codegen/src/__test__/workflow-sandbox.test.ts
@@ -1,0 +1,78 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { VellumVariable } from "vellum-ai/api";
+import { StringInput } from "vellum-ai/api/types";
+
+import { workflowContextFactory } from "./helpers";
+import { inputVariableContextFactory } from "./helpers/input-variable-context-factory";
+
+import * as codegen from "src/codegen";
+import { WorkflowSandboxInputs } from "src/types/vellum";
+
+describe("Workflow Sandbox", () => {
+  const generateSandboxFile = async (
+    inputVariables: VellumVariable[]
+  ): Promise<string> => {
+    const writer = new Writer();
+    const uniqueWorkflowContext = workflowContextFactory();
+
+    inputVariables.forEach((inputVariableData) => {
+      uniqueWorkflowContext.addInputVariableContext(
+        inputVariableContextFactory({
+          inputVariableData: inputVariableData,
+          workflowContext: uniqueWorkflowContext,
+        })
+      );
+    });
+
+    const sandboxInputs: WorkflowSandboxInputs[] = inputVariables.map(
+      (inputVariableData) => {
+        return [
+          {
+            name: inputVariableData.key,
+            type: "STRING",
+            value: "some-value",
+          },
+        ] as StringInput[];
+      }
+    );
+
+    const sandbox = codegen.workflowSandboxFile({
+      workflowContext: uniqueWorkflowContext,
+      sandboxInputs,
+    });
+
+    sandbox.write(writer);
+    return await writer.toStringFormatted();
+  };
+
+  describe("write", () => {
+    it("should generate correct code given inputs", async () => {
+      const inputVariables: VellumVariable[] = [
+        { id: "1", key: "some_foo", type: "STRING" },
+        { id: "2", key: "some_bar", type: "STRING" },
+      ];
+
+      const sandboxFile = await generateSandboxFile(inputVariables);
+      expect(sandboxFile).toMatchSnapshot();
+    });
+
+    it("should generate correct and same code for snake and camel casing of input names", async () => {
+      const snakeCasedVariables: VellumVariable[] = [
+        { id: "1", key: "some_foo", type: "STRING" },
+        { id: "2", key: "some_bar", type: "STRING" },
+      ];
+
+      const camelCasedVariables: VellumVariable[] = [
+        { id: "1", key: "someFoo", type: "STRING" },
+        { id: "2", key: "someBar", type: "STRING" },
+      ];
+
+      const snakeCasedResult = await generateSandboxFile(snakeCasedVariables);
+      const camelCasedResult = await generateSandboxFile(camelCasedVariables);
+
+      // Assert that both results match the same snapshot
+      expect(snakeCasedResult).toEqual(camelCasedResult);
+      expect(snakeCasedResult).toMatchSnapshot();
+    });
+  });
+});

--- a/ee/codegen/src/context/input-variable-context.ts
+++ b/ee/codegen/src/context/input-variable-context.ts
@@ -38,6 +38,10 @@ export class InputVariableContext {
     return this.inputVariableData;
   }
 
+  public getRawName(): string {
+    return this.inputVariableData.key;
+  }
+
   private generateSanitizedInputVariableName(): string {
     const defaultName = "input_";
     const rawInputVariableName = this.inputVariableData.key;

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -232,6 +232,31 @@ export class WorkflowContext {
     return inputVariableContext;
   }
 
+  public findInputVariableContextByRawName(
+    rawName: string
+  ): InputVariableContext | undefined {
+    const inputVariableContext = Array.from(
+      this.inputVariableContextsById.values()
+    ).find((inputContext) => inputContext.getRawName() === rawName);
+
+    return inputVariableContext;
+  }
+
+  public getInputVariableContextByRawName(
+    rawName: string
+  ): InputVariableContext {
+    const inputVariableContext =
+      this.findInputVariableContextByRawName(rawName);
+
+    if (!inputVariableContext) {
+      throw new Error(
+        `Input variable context not found for raw name: ${rawName}`
+      );
+    }
+
+    return inputVariableContext;
+  }
+
   public isOutputVariableNameUsed(outputVariableName: string): boolean {
     return this.outputVariableNames.has(outputVariableName);
   }

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -54,7 +54,7 @@ export class WorkflowContext {
 
   // Track what input variables names are used within this workflow so that we can ensure name uniqueness when adding
   // new input variables.
-  public readonly inputVariableNames: Set<string> = new Set();
+  private readonly inputVariableNames: Set<string> = new Set();
 
   // Maps node IDs to a mapping of output IDs to output names.
   // Tracks local and global contexts in the case of nested workflows.

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -54,7 +54,7 @@ export class WorkflowContext {
 
   // Track what input variables names are used within this workflow so that we can ensure name uniqueness when adding
   // new input variables.
-  private readonly inputVariableNames: Set<string> = new Set();
+  public readonly inputVariableNames: Set<string> = new Set();
 
   // Maps node IDs to a mapping of output IDs to output names.
   // Tracks local and global contexts in the case of nested workflows.

--- a/ee/codegen/src/generators/inputs.ts
+++ b/ee/codegen/src/generators/inputs.ts
@@ -77,7 +77,7 @@ export class Inputs extends BasePersistedFile {
         variable: {
           id: inputVariableData.id,
           // Use the sanitized name from the input variable context to ensure it's a valid
-          // attribute name (as opposed to the raw name from hte input variable data).
+          // attribute name (as opposed to the raw name from the input variable data).
           name: inputVariableName,
           type: inputVariableData.type,
           required: inputVariableData.required,

--- a/ee/codegen/src/generators/workflow-sandbox-file.ts
+++ b/ee/codegen/src/generators/workflow-sandbox-file.ts
@@ -1,6 +1,5 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { isNil } from "lodash";
 
 import { vellumValue } from "src/codegen";
 import { BasePersistedFile } from "src/generators/base-persisted-file";
@@ -80,30 +79,17 @@ if __name__ != "__main__":
         name: "Inputs",
         modulePath: getGeneratedInputsModulePath(this.workflowContext),
       }),
-      arguments_: inputs.map((input) =>
-        python.methodArgument({
-          name: this.getName(input.name),
+      arguments_: inputs.map((input) => {
+        const inputVariableContext =
+          this.workflowContext.getInputVariableContextByRawName(input.name);
+
+        return python.methodArgument({
+          name: inputVariableContext.name,
           value: vellumValue({
             vellumValue: input,
           }),
-        })
-      ),
+        });
+      }),
     });
-  }
-
-  private getName(name: string): string {
-    // Check if the sandbox input name exists in the input variable names used for this workflow
-    // All input variables have been sanitized already and are all in snake casing
-    const sanitizedName = Array.from(
-      this.workflowContext.inputVariableContextsById.values()
-    ).find(
-      (inputContext) => inputContext.getInputVariableData().key === name
-    )?.name;
-    if (isNil(sanitizedName)) {
-      throw new Error(
-        `Invalid sandbox input name: ${name}: This name was not used for input variable generation.`
-      );
-    }
-    return sanitizedName;
   }
 }

--- a/ee/codegen/src/generators/workflow-sandbox-file.ts
+++ b/ee/codegen/src/generators/workflow-sandbox-file.ts
@@ -1,10 +1,10 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
+import { isNil } from "lodash";
 
 import { vellumValue } from "src/codegen";
 import { BasePersistedFile } from "src/generators/base-persisted-file";
 import { WorkflowSandboxInputs } from "src/types/vellum";
-import { toPythonSafeSnakeCase } from "src/utils/casing";
 import { getGeneratedInputsModulePath } from "src/utils/paths";
 
 export declare namespace WorkflowSandboxFile {
@@ -94,12 +94,16 @@ if __name__ != "__main__":
   private getName(name: string): string {
     // Check if the sandbox input name exists in the input variable names used for this workflow
     // All input variables have been sanitized already and are all in snake casing
-    const snakeCaseName = toPythonSafeSnakeCase(name);
-    if (!this.workflowContext.inputVariableNames.has(snakeCaseName)) {
+    const sanitizedName = Array.from(
+      this.workflowContext.inputVariableContextsById.values()
+    ).find(
+      (inputContext) => inputContext.getInputVariableData().key === name
+    )?.name;
+    if (isNil(sanitizedName)) {
       throw new Error(
         `Invalid sandbox input name: ${name}: This name was not used for input variable generation.`
       );
     }
-    return snakeCaseName;
+    return sanitizedName;
   }
 }


### PR DESCRIPTION
This was coming up from a customer workflow. They had the input variable names for the workflow sandbox as camel case (i.e `someFoo`) This was causing a compile issue since the `Inputs.py` file is being codegen'd with the sanitized name (includes converting it to python snake case). This PR is to fix that