### PR TITLE
Use addError for entity 404 errors in create node context

### DIFF
--- a/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
+++ b/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
@@ -7,6 +7,7 @@ export function workflowContextFactory(
     workflowClassName,
     workflowRawEdges,
     codeExecutionNodeCodeRepresentationOverride,
+    strict = true,
   }: Partial<WorkflowContext.Args> = {
     codeExecutionNodeCodeRepresentationOverride: "STANDALONE",
   }
@@ -18,7 +19,7 @@ export function workflowContextFactory(
     workflowClassName: workflowClassName || "Workflow",
     vellumApiKey: "<TEST_API_KEY>",
     workflowRawEdges: workflowRawEdges || [],
-    strict: true,
+    strict,
     codeExecutionNodeCodeRepresentationOverride,
   });
 }

--- a/ee/codegen/src/context/node-context/guardrail-node.ts
+++ b/ee/codegen/src/context/node-context/guardrail-node.ts
@@ -7,7 +7,7 @@ import { GuardrailNode as GuardrailNodeType } from "src/types/vellum";
 
 export declare namespace GuardrailNodeContext {
   interface Args extends BaseNodeContext.Args<GuardrailNodeType> {
-    metricDefinitionsHistoryItem: MetricDefinitionHistoryItem;
+    metricDefinitionsHistoryItem: MetricDefinitionHistoryItem | undefined;
   }
 }
 
@@ -15,7 +15,9 @@ export class GuardrailNodeContext extends BaseNodeContext<GuardrailNodeType> {
   baseNodeClassName = "GuardrailNode";
   baseNodeDisplayClassName = "BaseGuardrailNodeDisplay";
 
-  public readonly metricDefinitionsHistoryItem: MetricDefinitionHistoryItem;
+  public readonly metricDefinitionsHistoryItem:
+    | MetricDefinitionHistoryItem
+    | undefined;
 
   constructor(args: GuardrailNodeContext.Args) {
     super(args);
@@ -24,6 +26,10 @@ export class GuardrailNodeContext extends BaseNodeContext<GuardrailNodeType> {
   }
 
   getNodeOutputNamesById(): Record<string, string> {
+    if (!this.metricDefinitionsHistoryItem) {
+      return {};
+    }
+
     return this.metricDefinitionsHistoryItem.outputVariables.reduce(
       (acc, variable) => {
         acc[variable.id] = variable.key;

--- a/ee/codegen/src/generators/errors.ts
+++ b/ee/codegen/src/generators/errors.ts
@@ -3,7 +3,8 @@ export type CodegenErrorCode =
   | "NODE_ATTRIBUTE_GENERATION_ERROR"
   | "NODE_PORT_GENERATION_ERROR"
   | "NODE_NOT_FOUND_ERROR"
-  | "UNSUPPORTED_SANDBOX_INPUT_ERROR";
+  | "UNSUPPORTED_SANDBOX_INPUT_ERROR"
+  | "ENTITY_NOT_FOUND_ERROR";
 
 export abstract class BaseCodegenError extends Error {
   abstract code: CodegenErrorCode;
@@ -36,6 +37,13 @@ export class NodePortGenerationError extends BaseCodegenError {
  */
 export class NodeNotFoundError extends BaseCodegenError {
   code = "NODE_NOT_FOUND_ERROR" as const;
+}
+
+/**
+ * An error that raises when a vellum entity is not found.
+ */
+export class EntityNotFoundError extends BaseCodegenError {
+  code = "ENTITY_NOT_FOUND_ERROR" as const;
 }
 
 /**

--- a/ee/codegen/src/generators/nodes/guardrail-node.ts
+++ b/ee/codegen/src/generators/nodes/guardrail-node.ts
@@ -102,37 +102,37 @@ export class GuardrailNode extends BaseSingleFileNode<
     return python.field({
       name: "output_display",
       initializer: python.TypeInstantiation.dict(
-        this.nodeContext.metricDefinitionsHistoryItem.outputVariables.map(
-          (output) => {
-            const name = this.nodeContext.getNodeOutputNameById(output.id);
+        (
+          this.nodeContext.metricDefinitionsHistoryItem?.outputVariables ?? []
+        ).map((output) => {
+          const name = this.nodeContext.getNodeOutputNameById(output.id);
 
-            return {
-              key: python.reference({
-                name: this.nodeContext.nodeClassName,
-                modulePath: this.nodeContext.nodeModulePath,
-                attribute: [OUTPUTS_CLASS_NAME, name],
+          return {
+            key: python.reference({
+              name: this.nodeContext.nodeClassName,
+              modulePath: this.nodeContext.nodeModulePath,
+              attribute: [OUTPUTS_CLASS_NAME, name],
+            }),
+            value: python.instantiateClass({
+              classReference: python.reference({
+                name: "NodeOutputDisplay",
+                modulePath:
+                  this.workflowContext.sdkModulePathNames
+                    .NODE_DISPLAY_TYPES_MODULE_PATH,
               }),
-              value: python.instantiateClass({
-                classReference: python.reference({
-                  name: "NodeOutputDisplay",
-                  modulePath:
-                    this.workflowContext.sdkModulePathNames
-                      .NODE_DISPLAY_TYPES_MODULE_PATH,
+              arguments_: [
+                python.methodArgument({
+                  name: "id",
+                  value: python.TypeInstantiation.uuid(output.id),
                 }),
-                arguments_: [
-                  python.methodArgument({
-                    name: "id",
-                    value: python.TypeInstantiation.uuid(output.id),
-                  }),
-                  python.methodArgument({
-                    name: "name",
-                    value: python.TypeInstantiation.str(output.key),
-                  }),
-                ],
-              }),
-            };
-          }
-        )
+                python.methodArgument({
+                  name: "name",
+                  value: python.TypeInstantiation.str(output.key),
+                }),
+              ],
+            }),
+          };
+        })
       ),
     });
   }


### PR DESCRIPTION
So based off what was said about the addError in my last codegen PR, it seems like catching the 404 and adding an error would be advantageous and just move onto the other nodes so we can get all of the errors for every node with the workflow and they don't get hidden as internal server errors? Will add test if my understanding of our error handling is correct here