### PR TITLE
Display Node Imports on Load from Module

### DIFF
--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -435,37 +435,38 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
         elif len(workflows) > 1:
             raise ValueError(f"Multiple workflows found in {module_path}")
         try:
-            # Import the nodes package
-            nodes_package = importlib.import_module(f"{module_path}.display.nodes")
-
-            # Use the loader to get the code
-            if hasattr(nodes_package, "__spec__") and nodes_package.__spec__ and nodes_package.__spec__.loader:
-                loader = nodes_package.__spec__.loader
-
-                # Check if the loader has a code attribute
-                if hasattr(loader, "code"):
-                    code = loader.code
-
-                    # Parse the code to find import statements
-                    import_lines = [line.strip() for line in code.splitlines() if line.startswith("from ")]
-
-                    # Import each module specified in the code
-                    for line in import_lines:
-                        try:
-                            # Extract module name from the import line
-                            module_name = line.split(" ")[1]
-                            full_module_path = f"{module_path}.display.nodes{module_name}"
-                            importlib.import_module(full_module_path)
-                        except Exception:
-                            continue
-
-            # Also import from workflow.py
-            importlib.import_module(f"{module_path}.display.workflow")
-
+            BaseWorkflow.import_node_display(module_path)
         except ModuleNotFoundError:
             pass
 
         return workflows[0]
+
+    @staticmethod
+    def import_node_display(module_path):
+        # Import the nodes package
+        nodes_package = importlib.import_module(f"{module_path}.display.nodes")
+        # Use the loader to get the code
+        if hasattr(nodes_package, "__spec__") and nodes_package.__spec__ and nodes_package.__spec__.loader:
+            loader = nodes_package.__spec__.loader
+
+            # Check if the loader has a code attribute
+            if hasattr(loader, "code"):
+                code = loader.code
+
+                # Parse the code to find import statements
+                import_lines = [line.strip() for line in code.splitlines() if line.startswith("from ")]
+
+                # Import each module specified in the code
+                for line in import_lines:
+                    try:
+                        # Extract module name from the import line
+                        module_name = line.split(" ")[1]
+                        full_module_path = f"{module_path}.display.nodes{module_name}"
+                        importlib.import_module(full_module_path)
+                    except Exception:
+                        continue
+        # Also import from workflow.py
+        importlib.import_module(f"{module_path}.display.workflow")
 
 
 WorkflowExecutionInitiatedBody.model_rebuild()

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -2,15 +2,10 @@
 
 import importlib
 import inspect
-import os
-import re
-import sys
 
 from vellum.plugins.utils import load_runtime_plugins
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum.workflows.workflows.event_filters import workflow_event_filter
-from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
-from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 load_runtime_plugins()
 

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -418,7 +418,7 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
         return most_recent_state_snapshot
 
     @staticmethod
-    def load_from_module(module_path: str) -> Tuple[Type["BaseWorkflow"], Dict[str, Any]]:
+    def load_from_module(module_path: str) -> Type["BaseWorkflow"]:
         workflow_path = f"{module_path}.workflow"
         module = importlib.import_module(workflow_path)
         workflows: List[Type[BaseWorkflow]] = []

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -461,16 +461,16 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
                             module_name = line.split(" ")[1]
                             full_module_path = f"{module_path}.display.nodes{module_name}"
                             importlib.import_module(full_module_path)
-                        except Exception as e:
+                        except Exception:
                             continue
 
             # Also import from workflow.py
             importlib.import_module(f"{module_path}.display.workflow")
 
-            return workflows[0]
+        except ModuleNotFoundError:
+            pass
 
-        except Exception as e:
-            raise ImportError(f"Unable to import from '{module_path}.display' error: {e}")
+            return workflows[0]
 
 
 WorkflowExecutionInitiatedBody.model_rebuild()

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -470,7 +470,7 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
         except ModuleNotFoundError:
             pass
 
-            return workflows[0]
+        return workflows[0]
 
 
 WorkflowExecutionInitiatedBody.model_rebuild()

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -444,7 +444,7 @@ class BaseWorkflow(Generic[WorkflowInputsType, StateType], metaclass=_BaseWorkfl
             nodes_package = importlib.import_module(f"{module_path}.display.nodes")
 
             # Use the loader to get the code
-            if hasattr(nodes_package, "__spec__") and nodes_package.__spec__.loader:
+            if hasattr(nodes_package, "__spec__") and nodes_package.__spec__ and nodes_package.__spec__.loader:
                 loader = nodes_package.__spec__.loader
 
                 # Check if the loader has a code attribute


### PR DESCRIPTION
aight SECOND go

stuff is complicated due to the virtual file loading -- there's no real directory and we can't really exec the import by itself (we need to load up the modules in order to run the import)

anway loom: https://www.loom.com/share/81739a276f4647b09ebdd539f3279317?sid=ac41ebbb-4b6c-4f2d-8517-0f51ada4ac9c

im up for cleaning some of this up as well -- or if there's better suggestions