### PR TITLE
Improve node output not found error handling

### DIFF
--- a/ee/codegen/src/__test__/nodes/base-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/base-node.test.ts
@@ -38,5 +38,48 @@ describe("BaseNode", () => {
         )
       );
     });
+
+    it("should throw the expected error when a input references an invalid output", async () => {
+      const workflowContext = workflowContextFactory();
+
+      const templatingNodeData = templatingNodeFactory();
+      const templatingNodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData: templatingNodeData,
+      })) as TemplatingNodeContext;
+      workflowContext.addNodeContext(templatingNodeContext);
+
+      const templatingNode2Data = templatingNodeFactory({
+        label: "TemplatingNode2",
+        id: "12345678-1234-5678-1234-567812345678",
+        sourceHandleId: "12345678-1234-5678-1234-567812345679",
+        targetHandleId: "12345678-1234-5678-1234-56781234567a",
+        inputRules: [
+          {
+            type: "NODE_OUTPUT",
+            data: {
+              nodeId: templatingNodeData.id,
+              outputId: "90abcdef-90ab-cdef-90ab-cdef90abcdef",
+            },
+          },
+        ],
+      });
+      const templatingNode2Context = (await createNodeContext({
+        workflowContext,
+        nodeData: templatingNode2Data,
+      })) as TemplatingNodeContext;
+      workflowContext.addNodeContext(templatingNode2Context);
+
+      expect(() => {
+        new TemplatingNode({
+          workflowContext,
+          nodeContext: templatingNode2Context,
+        });
+      }).toThrow(
+        new NodeAttributeGenerationError(
+          "Failed to generate attribute 'TemplatingNode2.inputs.text': Failed to find output with id '90abcdef-90ab-cdef-90ab-cdef90abcdef'"
+        )
+      );
+    });
   });
 });

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -1,5 +1,6 @@
 import { WorkflowContext } from "src/context";
 import { PortContext } from "src/context/port-context";
+import { NodeOutputNotFoundError } from "src/generators/errors";
 import { WorkflowDataNode, WorkflowNodeDefinition } from "src/types/vellum";
 import { toPythonSafeSnakeCase } from "src/utils/casing";
 import { getNodeId, getNodeLabel } from "src/utils/nodes";
@@ -118,7 +119,9 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
     const nodeOutputName = this.nodeOutputNamesById[outputId];
 
     if (!nodeOutputName) {
-      throw new Error(`Node output name not found for output ID: ${outputId}`);
+      throw new NodeOutputNotFoundError(
+        `Failed to find output with id '${outputId}'`
+      );
     }
 
     return toPythonSafeSnakeCase(nodeOutputName, "output");

--- a/ee/codegen/src/generators/errors.ts
+++ b/ee/codegen/src/generators/errors.ts
@@ -3,6 +3,7 @@ export type CodegenErrorCode =
   | "NODE_ATTRIBUTE_GENERATION_ERROR"
   | "NODE_PORT_GENERATION_ERROR"
   | "NODE_NOT_FOUND_ERROR"
+  | "NODE_OUTPUT_NOT_FOUND_ERROR"
   | "UNSUPPORTED_SANDBOX_INPUT_ERROR"
   | "ENTITY_NOT_FOUND_ERROR";
 
@@ -51,4 +52,11 @@ export class EntityNotFoundError extends BaseCodegenError {
  */
 export class UnsupportedSandboxInputError extends BaseCodegenError {
   code = "UNSUPPORTED_SANDBOX_INPUT_ERROR" as const;
+}
+
+/**
+ * An error that raises when a node output is not found.
+ */
+export class NodeOutputNotFoundError extends BaseCodegenError {
+  code = "NODE_OUTPUT_NOT_FOUND_ERROR" as const;
 }

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
@@ -17,12 +17,6 @@ export class NodeOutputPointerRule extends BaseNodeInputValuePointerRule<NodeOut
       nodeOutputPointerRuleData.outputId
     );
 
-    if (!nodeOutputName) {
-      throw new Error(
-        `Node output name not found for node ID: ${nodeOutputPointerRuleData.nodeId} and output ID: ${nodeOutputPointerRuleData.outputId}`
-      );
-    }
-
     return python.reference({
       name: nodeContext.nodeClassName,
       modulePath: nodeContext.nodeModulePath,


### PR DESCRIPTION
Adds node output not found failures to go through our error handling framework, spurred from woflow's workflow: https://vellum-ai.slack.com/archives/C06P13ABK0W/p1735918466793119