### PR TITLE
Abstract TryNode's decorator logic to a separate utility

### DIFF
--- a/src/vellum/workflows/nodes/utils.py
+++ b/src/vellum/workflows/nodes/utils.py
@@ -1,5 +1,7 @@
 from functools import cache
-from typing import Type
+import sys
+from types import ModuleType
+from typing import Any, Callable, Optional, Type, TypeVar
 
 from vellum.workflows.nodes import BaseNode
 from vellum.workflows.ports.port import Port
@@ -42,3 +44,44 @@ def has_wrapped_node(node: Type[NodeType]) -> bool:
         return False
 
     return True
+
+
+AdornableNode = TypeVar("AdornableNode", bound=BaseNode)
+
+
+def create_adornment(
+    adornable_cls: Type[AdornableNode], attributes: Optional[dict[str, Any]] = None
+) -> Callable[..., Type["AdornableNode"]]:
+    def decorator(inner_cls: Type[BaseNode]) -> Type["AdornableNode"]:
+        # Investigate how to use dependency injection to avoid circular imports
+        # https://app.shortcut.com/vellum/story/4116
+        from vellum.workflows import BaseWorkflow
+
+        inner_cls._is_wrapped_node = True
+
+        class Subworkflow(BaseWorkflow):
+            graph = inner_cls
+
+            # mypy is wrong here, this works and is defined
+            class Outputs(inner_cls.Outputs):  # type: ignore[name-defined]
+                pass
+
+        dynamic_module = f"{inner_cls.__module__}.{inner_cls.__name__}.{ADORNMENT_MODULE_NAME}"
+        # This dynamic module allows calls to `type_hints` to work
+        sys.modules[dynamic_module] = ModuleType(dynamic_module)
+
+        # We use a dynamic wrapped node class to be uniquely tied to this `inner_cls` node during serialization
+        WrappedNode = type(
+            adornable_cls.__name__,
+            (adornable_cls,),
+            {
+                "__wrapped_node__": inner_cls,
+                "__module__": dynamic_module,
+                "subworkflow": Subworkflow,
+                "Ports": type("Ports", (adornable_cls.Ports,), {port.name: port.copy() for port in inner_cls.Ports}),
+                **(attributes or {}),
+            },
+        )
+        return WrappedNode
+
+    return decorator


### PR DESCRIPTION
There are nodes in the prototype repo that use retry node, which currently fail node output mocking because retry node and map node's adornment logic is lagging behind Try Node. This PR starts down the path of consolidating the three:
- This PR: Separate out into its own utility method
- Next PR: Cutover RetryNode
- Last PR: Cutover MapNode

There should be little to no logic changes in this PR. Simply moving TryNode's `wrap` logic to its own utility