### PR TITLE
Consolidate Adornable class logic into new BaseAdornableNode

### DIFF
--- a/src/vellum/workflows/nodes/bases/base_adornable_node.py
+++ b/src/vellum/workflows/nodes/bases/base_adornable_node.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from vellum.workflows import BaseWorkflow
 
 
-class BaseAdornableNodeMeta(BaseNodeMeta):
+class _BaseAdornmentNodeMeta(BaseNodeMeta):
     def __new__(cls, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
         node_class = super().__new__(cls, name, bases, dct)
 
@@ -17,7 +17,7 @@ class BaseAdornableNodeMeta(BaseNodeMeta):
         if not subworkflow_attribute:
             return node_class
 
-        if not issubclass(node_class, BaseAdornableNode):
+        if not issubclass(node_class, BaseAdornmentNode):
             raise ValueError("BaseAdornableNodeMeta can only be used on subclasses of BaseAdornableNode")
 
         subworkflow_outputs = getattr(subworkflow_attribute, "Outputs")
@@ -40,7 +40,7 @@ class BaseAdornableNodeMeta(BaseNodeMeta):
         try:
             return super().__getattribute__(name)
         except AttributeError:
-            if name != "__wrapped_node__" and issubclass(cls, BaseAdornableNode):
+            if name != "__wrapped_node__" and issubclass(cls, BaseAdornmentNode):
                 return getattr(cls.__wrapped_node__, name)
             raise
 
@@ -55,15 +55,14 @@ class BaseAdornableNodeMeta(BaseNodeMeta):
         }
 
 
-class BaseAdornableNode(
+class BaseAdornmentNode(
     BaseNode[StateType],
     Generic[StateType],
-    metaclass=BaseAdornableNodeMeta,
+    metaclass=_BaseAdornmentNodeMeta,
 ):
     """
-    A base node that makes the node "Adornable" - meaning it can wrap another node. The
-    wrapped node is stored in the `__wrapped_node__` attribute and is redefined as a single
-    node subworkflow.
+    A base node that enables the node to be used as an adornment - meaning it can wrap another node. The
+    wrapped node is stored in the `__wrapped_node__` attribute and is redefined as a single-node subworkflow.
     """
 
     __wrapped_node__: Optional[Type["BaseNode"]] = None

--- a/src/vellum/workflows/nodes/bases/base_adornable_node.py
+++ b/src/vellum/workflows/nodes/bases/base_adornable_node.py
@@ -1,0 +1,78 @@
+from typing import TYPE_CHECKING, Any, Dict, Generic, Optional, Tuple, Type
+
+from vellum.workflows.nodes.bases.base import BaseNode, BaseNodeMeta
+from vellum.workflows.outputs.base import BaseOutputs
+from vellum.workflows.references.output import OutputReference
+from vellum.workflows.types.generics import StateType
+
+if TYPE_CHECKING:
+    from vellum.workflows import BaseWorkflow
+
+
+class BaseAdornableNodeMeta(BaseNodeMeta):
+    def __new__(cls, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
+        node_class = super().__new__(cls, name, bases, dct)
+
+        subworkflow_attribute = dct.get("subworkflow")
+        if not subworkflow_attribute:
+            return node_class
+
+        if not issubclass(node_class, BaseAdornableNode):
+            raise ValueError("BaseAdornableNodeMeta can only be used on subclasses of BaseAdornableNode")
+
+        subworkflow_outputs = getattr(subworkflow_attribute, "Outputs")
+        if not issubclass(subworkflow_outputs, BaseOutputs):
+            raise ValueError("subworkflow.Outputs must be a subclass of BaseOutputs")
+
+        outputs_class = dct.get("Outputs")
+        if not outputs_class:
+            raise ValueError("Outputs class not found in base classes")
+
+        if not issubclass(outputs_class, BaseNode.Outputs):
+            raise ValueError("Outputs class must be a subclass of BaseNode.Outputs")
+
+        for descriptor in subworkflow_outputs:
+            node_class.__annotate_outputs_class__(outputs_class, descriptor)
+
+        return node_class
+
+    def __getattribute__(cls, name: str) -> Any:
+        try:
+            return super().__getattribute__(name)
+        except AttributeError:
+            if name != "__wrapped_node__" and issubclass(cls, BaseAdornableNode):
+                return getattr(cls.__wrapped_node__, name)
+            raise
+
+    @property
+    def _localns(cls) -> Dict[str, Any]:
+        if not hasattr(cls, "SubworkflowInputs"):
+            return super()._localns
+
+        return {
+            **super()._localns,
+            "SubworkflowInputs": getattr(cls, "SubworkflowInputs"),
+        }
+
+
+class BaseAdornableNode(
+    BaseNode[StateType],
+    Generic[StateType],
+    metaclass=BaseAdornableNodeMeta,
+):
+    """
+    A base node that makes the node "Adornable" - meaning it can wrap another node. The
+    wrapped node is stored in the `__wrapped_node__` attribute and is redefined as a single
+    node subworkflow.
+    """
+
+    __wrapped_node__: Optional[Type["BaseNode"]] = None
+    subworkflow: Type["BaseWorkflow"]
+
+    @classmethod
+    def __annotate_outputs_class__(
+        cls, subworkflow_outputs_class: Type[BaseOutputs], reference: OutputReference
+    ) -> None:
+        # Subclasses of BaseAdornableNode can override this method to provider their own
+        # approach to annotating the outputs class based on the `subworkflow.Outputs`
+        setattr(subworkflow_outputs_class, reference.name, reference)

--- a/src/vellum/workflows/nodes/core/retry_node/node.py
+++ b/src/vellum/workflows/nodes/core/retry_node/node.py
@@ -4,12 +4,12 @@ from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases import BaseNode
-from vellum.workflows.nodes.bases.base_adornable_node import BaseAdornableNode
+from vellum.workflows.nodes.bases.base_adornable_node import BaseAdornmentNode
 from vellum.workflows.nodes.utils import create_adornment
 from vellum.workflows.types.generics import StateType
 
 
-class RetryNode(BaseAdornableNode[StateType], Generic[StateType]):
+class RetryNode(BaseAdornmentNode[StateType], Generic[StateType]):
     """
     Used to retry a Subworkflow a specified number of times.
 

--- a/src/vellum/workflows/nodes/core/retry_node/node.py
+++ b/src/vellum/workflows/nodes/core/retry_node/node.py
@@ -1,60 +1,15 @@
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Optional, Tuple, Type
+from typing import Callable, Generic, Optional, Type
 
 from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases import BaseNode
-from vellum.workflows.nodes.bases.base import BaseNodeMeta
+from vellum.workflows.nodes.bases.base_adornable_node import BaseAdornableNode
 from vellum.workflows.nodes.utils import create_adornment
-from vellum.workflows.outputs.base import BaseOutputs
-from vellum.workflows.state.base import BaseState
 from vellum.workflows.types.generics import StateType
 
-if TYPE_CHECKING:
-    from vellum.workflows import BaseWorkflow
 
-
-class _RetryNodeMeta(BaseNodeMeta):
-    def __new__(cls, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
-        node_class = super().__new__(cls, name, bases, dct)
-
-        subworkflow_attribute = dct.get("subworkflow")
-        if not subworkflow_attribute:
-            return node_class
-
-        subworkflow_outputs = getattr(subworkflow_attribute, "Outputs")
-        if not issubclass(subworkflow_outputs, BaseOutputs):
-            raise ValueError("subworkflow.Outputs must be a subclass of BaseOutputs")
-
-        outputs_class = dct.get("Outputs")
-        if not outputs_class:
-            raise ValueError("Outputs class not found in base classes")
-
-        if not issubclass(outputs_class, BaseNode.Outputs):
-            raise ValueError("Outputs class must be a subclass of BaseNode.Outputs")
-
-        for descriptor in subworkflow_outputs:
-            setattr(outputs_class, descriptor.name, descriptor)
-
-        return node_class
-
-    def __getattribute__(cls, name: str) -> Any:
-        try:
-            return super().__getattribute__(name)
-        except AttributeError:
-            if name != "__wrapped_node__" and issubclass(cls, RetryNode):
-                return getattr(cls.__wrapped_node__, name)
-            raise
-
-    @property
-    def _localns(cls) -> Dict[str, Any]:
-        return {
-            **super()._localns,
-            "SubworkflowInputs": getattr(cls, "SubworkflowInputs"),
-        }
-
-
-class RetryNode(BaseNode[StateType], Generic[StateType], metaclass=_RetryNodeMeta):
+class RetryNode(BaseAdornableNode[StateType], Generic[StateType]):
     """
     Used to retry a Subworkflow a specified number of times.
 
@@ -63,10 +18,8 @@ class RetryNode(BaseNode[StateType], Generic[StateType], metaclass=_RetryNodeMet
     subworkflow: Type["BaseWorkflow[SubworkflowInputs, BaseState]"] - The Subworkflow to execute
     """
 
-    __wrapped_node__: Optional[Type["BaseNode"]] = None
     max_attempts: int
     retry_on_error_code: Optional[WorkflowErrorCode] = None
-    subworkflow: Type["BaseWorkflow[SubworkflowInputs, BaseState]"]
 
     class SubworkflowInputs(BaseInputs):
         attempt_number: int

--- a/src/vellum/workflows/nodes/core/try_node/node.py
+++ b/src/vellum/workflows/nodes/core/try_node/node.py
@@ -3,7 +3,7 @@ from typing import Callable, Generic, Iterator, Optional, Set, Type
 from vellum.workflows.errors.types import WorkflowError, WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.bases import BaseNode
-from vellum.workflows.nodes.bases.base_adornable_node import BaseAdornableNode
+from vellum.workflows.nodes.bases.base_adornable_node import BaseAdornmentNode
 from vellum.workflows.nodes.utils import create_adornment
 from vellum.workflows.outputs.base import BaseOutput, BaseOutputs
 from vellum.workflows.references.output import OutputReference
@@ -12,7 +12,7 @@ from vellum.workflows.types.generics import StateType
 from vellum.workflows.workflows.event_filters import all_workflow_event_filter
 
 
-class TryNode(BaseAdornableNode[StateType], Generic[StateType]):
+class TryNode(BaseAdornmentNode[StateType], Generic[StateType]):
     """
     Used to execute a Subworkflow and handle errors.
 

--- a/src/vellum/workflows/nodes/core/try_node/node.py
+++ b/src/vellum/workflows/nodes/core/try_node/node.py
@@ -1,58 +1,18 @@
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Iterator, Optional, Set, Tuple, Type
+from typing import Callable, Generic, Iterator, Optional, Set, Type
 
 from vellum.workflows.errors.types import WorkflowError, WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.bases import BaseNode
-from vellum.workflows.nodes.bases.base import BaseNodeMeta
+from vellum.workflows.nodes.bases.base_adornable_node import BaseAdornableNode
 from vellum.workflows.nodes.utils import create_adornment
 from vellum.workflows.outputs.base import BaseOutput, BaseOutputs
+from vellum.workflows.references.output import OutputReference
 from vellum.workflows.state.context import WorkflowContext
 from vellum.workflows.types.generics import StateType
 from vellum.workflows.workflows.event_filters import all_workflow_event_filter
 
-if TYPE_CHECKING:
-    from vellum.workflows import BaseWorkflow
 
-Subworkflow = Type["BaseWorkflow"]
-
-
-class _TryNodeMeta(BaseNodeMeta):
-    def __new__(cls, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
-        node_class = super().__new__(cls, name, bases, dct)
-
-        subworkflow_attribute = dct.get("subworkflow")
-        if not subworkflow_attribute:
-            return node_class
-
-        subworkflow_outputs = getattr(subworkflow_attribute, "Outputs")
-        if not issubclass(subworkflow_outputs, BaseOutputs):
-            raise ValueError("subworkflow.Outputs must be a subclass of BaseOutputs")
-
-        outputs_class = dct.get("Outputs")
-        if not outputs_class:
-            raise ValueError("Outputs class not found in base classes")
-
-        if not issubclass(outputs_class, BaseNode.Outputs):
-            raise ValueError("Outputs class must be a subclass of BaseNode.Outputs")
-
-        for descriptor in subworkflow_outputs:
-            if descriptor.name == "error":
-                raise ValueError("`error` is a reserved name for TryNode.Outputs")
-
-            setattr(outputs_class, descriptor.name, descriptor)
-
-        return node_class
-
-    def __getattribute__(cls, name: str) -> Any:
-        try:
-            return super().__getattribute__(name)
-        except AttributeError:
-            if name != "__wrapped_node__" and issubclass(cls, TryNode):
-                return getattr(cls.__wrapped_node__, name)
-            raise
-
-
-class TryNode(BaseNode[StateType], Generic[StateType], metaclass=_TryNodeMeta):
+class TryNode(BaseAdornableNode[StateType], Generic[StateType]):
     """
     Used to execute a Subworkflow and handle errors.
 
@@ -60,9 +20,7 @@ class TryNode(BaseNode[StateType], Generic[StateType], metaclass=_TryNodeMeta):
     subworkflow: Type["BaseWorkflow"] - The Subworkflow to execute
     """
 
-    __wrapped_node__: Optional[Type["BaseNode"]] = None
     on_error_code: Optional[WorkflowErrorCode] = None
-    subworkflow: Type["BaseWorkflow"]
 
     class Outputs(BaseNode.Outputs):
         error: Optional[WorkflowError] = None
@@ -127,3 +85,12 @@ Message: {event.error.message}""",
     @classmethod
     def wrap(cls, on_error_code: Optional[WorkflowErrorCode] = None) -> Callable[..., Type["TryNode"]]:
         return create_adornment(cls, attributes={"on_error_code": on_error_code})
+
+    @classmethod
+    def __annotate_outputs_class__(
+        cls, subworkflow_outputs_class: Type[BaseOutputs], reference: OutputReference
+    ) -> None:
+        if reference.name == "error":
+            raise ValueError("`error` is a reserved name for TryNode.Outputs")
+
+        setattr(subworkflow_outputs_class, reference.name, reference)


### PR DESCRIPTION
Quick detour referenced here: https://github.com/vellum-ai/vellum-python-sdks/pull/551#discussion_r1902219687

With this PR, users in the future will be able to define _their own_ adornable nodes. There should be no logic changes in this PR - simply a consolidation of common logic.

Will await this PR on naming feedback before merging