### PR TITLE
Cutover Map node to new BaseAdornmentNode

### DIFF
--- a/src/vellum/workflows/nodes/bases/base_adornment_node.py
+++ b/src/vellum/workflows/nodes/bases/base_adornment_node.py
@@ -69,9 +69,7 @@ class BaseAdornmentNode(
     subworkflow: Type["BaseWorkflow"]
 
     @classmethod
-    def __annotate_outputs_class__(
-        cls, subworkflow_outputs_class: Type[BaseOutputs], reference: OutputReference
-    ) -> None:
+    def __annotate_outputs_class__(cls, outputs_class: Type[BaseOutputs], reference: OutputReference) -> None:
         # Subclasses of BaseAdornableNode can override this method to provider their own
         # approach to annotating the outputs class based on the `subworkflow.Outputs`
-        setattr(subworkflow_outputs_class, reference.name, reference)
+        setattr(outputs_class, reference.name, reference)

--- a/src/vellum/workflows/nodes/core/retry_node/node.py
+++ b/src/vellum/workflows/nodes/core/retry_node/node.py
@@ -4,7 +4,7 @@ from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases import BaseNode
-from vellum.workflows.nodes.bases.base_adornable_node import BaseAdornmentNode
+from vellum.workflows.nodes.bases.base_adornment_node import BaseAdornmentNode
 from vellum.workflows.nodes.utils import create_adornment
 from vellum.workflows.types.generics import StateType
 

--- a/src/vellum/workflows/nodes/core/try_node/node.py
+++ b/src/vellum/workflows/nodes/core/try_node/node.py
@@ -3,7 +3,7 @@ from typing import Callable, Generic, Iterator, Optional, Set, Type
 from vellum.workflows.errors.types import WorkflowError, WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.bases import BaseNode
-from vellum.workflows.nodes.bases.base_adornable_node import BaseAdornmentNode
+from vellum.workflows.nodes.bases.base_adornment_node import BaseAdornmentNode
 from vellum.workflows.nodes.utils import create_adornment
 from vellum.workflows.outputs.base import BaseOutput, BaseOutputs
 from vellum.workflows.references.output import OutputReference
@@ -87,10 +87,8 @@ Message: {event.error.message}""",
         return create_adornment(cls, attributes={"on_error_code": on_error_code})
 
     @classmethod
-    def __annotate_outputs_class__(
-        cls, subworkflow_outputs_class: Type[BaseOutputs], reference: OutputReference
-    ) -> None:
+    def __annotate_outputs_class__(cls, outputs_class: Type[BaseOutputs], reference: OutputReference) -> None:
         if reference.name == "error":
             raise ValueError("`error` is a reserved name for TryNode.Outputs")
 
-        setattr(subworkflow_outputs_class, reference.name, reference)
+        setattr(outputs_class, reference.name, reference)

--- a/tests/workflows/basic_map_node/workflow.py
+++ b/tests/workflows/basic_map_node/workflow.py
@@ -34,9 +34,6 @@ class MapFruitsNode(MapNode):
     items = Inputs.fruits
     subworkflow = IterationSubworkflow
 
-    class Outputs(BaseOutputs):
-        count: List[int]
-
 
 class SimpleMapExample(BaseWorkflow[Inputs, BaseState]):
     graph = MapFruitsNode


### PR DESCRIPTION
This PR completes our adornment consolidation series. All feature work that we did for Try Nodes should now apply for map and retry node adornments once we start working on them, and in the future, users will be able to create their own adornment nodes