### PR TITLE
Support multiple mocks for the same node

### DIFF
--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -49,6 +49,7 @@ from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.ports.port import Port
 from vellum.workflows.references import ExternalInputReference, OutputReference
 from vellum.workflows.state.base import BaseState
+from vellum.workflows.types.cycle_map import CycleMap
 from vellum.workflows.types.generics import OutputsType, StateType, WorkflowInputsType
 
 if TYPE_CHECKING:
@@ -124,9 +125,7 @@ class WorkflowRunner(Generic[StateType]):
 
         self._dependencies: Dict[Type[BaseNode], Set[Type[BaseNode]]] = defaultdict(set)
         self._state_forks: Set[StateType] = {self._initial_state}
-        self._mocks_by_node_outputs_class = (
-            {mock.__class__: mock for mock in node_output_mocks} if node_output_mocks else {}
-        )
+        self._mocks_by_node_outputs_class = CycleMap(items=node_output_mocks or [], key_by=lambda mock: mock.__class__)
 
         self._active_nodes_by_execution_id: Dict[UUID, BaseNode[StateType]] = {}
         self._cancel_signal = cancel_signal

--- a/src/vellum/workflows/types/cycle_map.py
+++ b/src/vellum/workflows/types/cycle_map.py
@@ -1,0 +1,34 @@
+from typing import Callable, Dict, Generic, List, TypeVar
+
+_K = TypeVar("_K")
+_T = TypeVar("_T")
+
+
+class CycleMap(Generic[_K, _T]):
+    """
+    A map that cycles through a list of items for each key.
+    """
+
+    def __init__(self, items: List[_T], key_by: Callable[[_T], _K]):
+        self._items: Dict[_K, List[_T]] = {}
+        for item in items:
+            self._add_item(key_by(item), item)
+
+    def _add_item(self, key: _K, item: _T):
+        if key not in self._items:
+            self._items[key] = []
+        self._items[key].append(item)
+
+    def _get_item(self, key: _K) -> _T:
+        item = self._items[key].pop(0)
+        self._items[key].append(item)
+        return item
+
+    def __getitem__(self, key: _K) -> _T:
+        return self._get_item(key)
+
+    def __setitem__(self, key: _K, value: _T):
+        self._add_item(key, value)
+
+    def __contains__(self, key: _K) -> bool:
+        return key in self._items

--- a/tests/workflows/basic_looping/tests/test_workflow.py
+++ b/tests/workflows/basic_looping/tests/test_workflow.py
@@ -1,4 +1,4 @@
-from tests.workflows.basic_looping.workflow import BasicLoopingWorkflow
+from tests.workflows.basic_looping.workflow import BasicLoopingWorkflow, StartNode
 
 
 def test_workflow__happy_path():
@@ -12,3 +12,21 @@ def test_workflow__happy_path():
     assert terminal_event.name == "workflow.execution.fulfilled"
     assert terminal_event.outputs.final_value == 13
     assert terminal_event.outputs.node_execution_count == 5
+
+
+def test_workflow__happy_path_with_mocks():
+    # GIVEN a workflow that defines a loop
+    workflow = BasicLoopingWorkflow()
+
+    # WHEN we run the workflow
+    terminal_event = workflow.run(
+        node_output_mocks=[
+            StartNode.Outputs(final_value=5),
+            StartNode.Outputs(final_value=15),
+        ]
+    )
+
+    # THEN we should get the expected output
+    assert terminal_event.name == "workflow.execution.fulfilled"
+    assert terminal_event.outputs.final_value == 15
+    assert terminal_event.outputs.node_execution_count == 2


### PR DESCRIPTION
In trying to cutover the prototype repo to using mocks, I noticed that some of the workflows would require mocking the same node multiple times in the context of a loop. This PR introduces a `CycleMap` that enables this functionality by cycling through the mocks defined for a particular node.