### PR TITLE
Introduce a constant value reference

### DIFF
--- a/src/vellum/workflows/descriptors/tests/test_utils.py
+++ b/src/vellum/workflows/descriptors/tests/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 
 from vellum.workflows.descriptors.utils import resolve_value
 from vellum.workflows.nodes.bases.base import BaseNode
-from vellum.workflows.references.constant import ConstantReference
+from vellum.workflows.references.constant import ConstantValueReference
 from vellum.workflows.state.base import BaseState
 
 
@@ -74,7 +74,7 @@ class DummyNode(BaseNode[FixtureState]):
             True,
         ),
         (FixtureState.zeta["foo"], "bar"),
-        (ConstantReference(1), 1),
+        (ConstantValueReference(1), 1),
     ],
     ids=[
         "or",
@@ -118,7 +118,7 @@ class DummyNode(BaseNode[FixtureState]):
         "is_not_blank",
         "or_and",
         "accessor",
-        "constant_reference",
+        "constants",
     ],
 )
 def test_resolve_value__happy_path(descriptor, expected_value):

--- a/src/vellum/workflows/descriptors/tests/test_utils.py
+++ b/src/vellum/workflows/descriptors/tests/test_utils.py
@@ -2,6 +2,7 @@ import pytest
 
 from vellum.workflows.descriptors.utils import resolve_value
 from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.references.constant import ConstantReference
 from vellum.workflows.state.base import BaseState
 
 
@@ -73,6 +74,7 @@ class DummyNode(BaseNode[FixtureState]):
             True,
         ),
         (FixtureState.zeta["foo"], "bar"),
+        (ConstantReference(1), 1),
     ],
     ids=[
         "or",
@@ -116,6 +118,7 @@ class DummyNode(BaseNode[FixtureState]):
         "is_not_blank",
         "or_and",
         "accessor",
+        "constant_reference",
     ],
 )
 def test_resolve_value__happy_path(descriptor, expected_value):

--- a/src/vellum/workflows/references/constant.py
+++ b/src/vellum/workflows/references/constant.py
@@ -1,0 +1,21 @@
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from vellum.workflows.descriptors.base import BaseDescriptor
+
+if TYPE_CHECKING:
+    from vellum.workflows.state.base import BaseState
+
+_T = TypeVar("_T")
+
+
+class ConstantReference(BaseDescriptor[_T], Generic[_T]):
+    def __init__(
+        self,
+        value: _T,
+    ) -> None:
+        self._value = value
+        types = (type(self._value),)
+        super().__init__(name=str(self._value), types=types)
+
+    def resolve(self, state: "BaseState") -> _T:
+        return self._value

--- a/src/vellum/workflows/references/constant.py
+++ b/src/vellum/workflows/references/constant.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 _T = TypeVar("_T")
 
 
-class ConstantReference(BaseDescriptor[_T], Generic[_T]):
+class ConstantValueReference(BaseDescriptor[_T], Generic[_T]):
     def __init__(
         self,
         value: _T,


### PR DESCRIPTION
We've talked a bit about the need of a constant reference. This is a wrapper of constants, compatible with our descriptor language and could serialize/codegen from existing `CONSTANT_VALUE` pointers to and from Vellum.

Looking to use it in some of the mocks work