### PR TITLE
Fix Graph Generation issue related to multiple branches from the same node

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -285,6 +285,21 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
+exports[`Workflow > write > graph > should be correct for two branches from the same node 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+from .nodes.merge_node import MergeNode
+from .nodes.templating_node_2 import TemplatingNode2
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = TemplatingNode >> {
+        MergeNode,
+        TemplatingNode2 >> MergeNode,
+    }
+"
+`;
+
 exports[`Workflow > write > graph > should be correct for two branches merging from sets 1`] = `
 "from vellum.workflows import BaseWorkflow
 from .nodes.conditional_node import ConditionalNode

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -1912,6 +1912,87 @@ describe("Workflow", () => {
         workflow.getWorkflowFile().write(writer);
         expect(await writer.toStringFormatted()).toMatchSnapshot();
       });
+
+      it("should be correct for two branches from the same node", async () => {
+        const inputs = codegen.inputs({ workflowContext });
+
+        const templatingNodeData1 = templatingNodeFactory();
+        const templatingNodeContext1 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData1,
+        });
+        workflowContext.addNodeContext(templatingNodeContext1);
+
+        const templatingNodeData2 = templatingNodeFactory({
+          id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+          label: "Templating Node 2",
+          sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+          targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+        });
+        const templatingNodeContext2 = await createNodeContext({
+          workflowContext,
+          nodeData: templatingNodeData2,
+        });
+        workflowContext.addNodeContext(templatingNodeContext2);
+
+        const mergeNodeData = mergeNodeDataFactory();
+        const mergeNodeContext = await createNodeContext({
+          workflowContext,
+          nodeData: mergeNodeData,
+        });
+        workflowContext.addNodeContext(mergeNodeContext);
+        const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
+        const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
+        if (!mergeTargetHandle1 || !mergeTargetHandle2) {
+          throw new Error("Handle IDs are required");
+        }
+
+        const edges: WorkflowEdge[] = [
+          {
+            id: "edge-1",
+            type: "DEFAULT",
+            sourceNodeId: entrypointNode.id,
+            sourceHandleId: entrypointNode.data.sourceHandleId,
+            targetNodeId: templatingNodeData1.id,
+            targetHandleId: templatingNodeData1.data.targetHandleId,
+          },
+          {
+            id: "edge-2",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData1.id,
+            sourceHandleId: templatingNodeData1.data.sourceHandleId,
+            targetNodeId: mergeNodeData.id,
+            targetHandleId: mergeTargetHandle1,
+          },
+          {
+            id: "edge-3",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData2.id,
+            sourceHandleId: templatingNodeData2.data.sourceHandleId,
+            targetNodeId: mergeNodeData.id,
+            targetHandleId: mergeTargetHandle2,
+          },
+          {
+            id: "edge-4",
+            type: "DEFAULT",
+            sourceNodeId: templatingNodeData1.id,
+            sourceHandleId: templatingNodeData1.data.sourceHandleId,
+            targetNodeId: templatingNodeData2.id,
+            targetHandleId: templatingNodeData2.data.targetHandleId,
+          },
+        ];
+        workflowContext.addWorkflowEdges(edges);
+
+        const workflow = codegen.workflow({
+          moduleName,
+          workflowContext,
+          inputs,
+          nodes: [templatingNodeData1, templatingNodeData2, mergeNodeData],
+        });
+
+        workflow.getWorkflowFile().write(writer);
+        expect(await writer.toStringFormatted()).toMatchSnapshot();
+      });
     });
   });
 });


### PR DESCRIPTION
```
graph = A >> { B >> C, C }
```

Normally we want to "optimize common targets" here but having each element in the set pop the last node. In this case, popping one of the branches produces a `None` 