### PR TITLE
Support Subworkflow Nodes with inputs as Attributes

### DIFF
--- a/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
+++ b/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, ClassVar, Generic, Iterator, Optional, Set, Type, TypeVar, Union
 
+from vellum.workflows.constants import UNDEF
 from vellum.workflows.context import execution_context, get_parent_context
 from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
@@ -27,7 +28,7 @@ class InlineSubworkflowNode(BaseNode[StateType], Generic[StateType, WorkflowInpu
     """
 
     subworkflow: Type["BaseWorkflow[WorkflowInputsType, InnerStateType]"]
-    subworkflow_inputs: ClassVar[Union[EntityInputsInterface, BaseInputs]] = {}
+    subworkflow_inputs: ClassVar[Union[EntityInputsInterface, BaseInputs, UNDEF]] = UNDEF
 
     def run(self) -> Iterator[BaseOutput]:
         with execution_context(parent_context=get_parent_context() or self._context.parent_context):
@@ -71,7 +72,14 @@ class InlineSubworkflowNode(BaseNode[StateType], Generic[StateType, WorkflowInpu
 
     def _compile_subworkflow_inputs(self) -> WorkflowInputsType:
         inputs_class = self.subworkflow.get_inputs_class()
-        if isinstance(self.subworkflow_inputs, dict):
+        if self.subworkflow_inputs is UNDEF:
+            inputs_dict = {}
+            for descriptor in inputs_class:
+                if hasattr(self, descriptor.name):
+                    inputs_dict[descriptor.name] = getattr(self, descriptor.name)
+
+            return inputs_class(**inputs_dict)
+        elif isinstance(self.subworkflow_inputs, dict):
             return inputs_class(**self.subworkflow_inputs)
         elif isinstance(self.subworkflow_inputs, inputs_class):
             return self.subworkflow_inputs

--- a/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
+++ b/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
@@ -28,7 +28,7 @@ class InlineSubworkflowNode(BaseNode[StateType], Generic[StateType, WorkflowInpu
     """
 
     subworkflow: Type["BaseWorkflow[WorkflowInputsType, InnerStateType]"]
-    subworkflow_inputs: ClassVar[Union[EntityInputsInterface, BaseInputs, UNDEF]] = UNDEF
+    subworkflow_inputs: ClassVar[Union[EntityInputsInterface, BaseInputs, Type[UNDEF]]] = UNDEF
 
     def run(self) -> Iterator[BaseOutput]:
         with execution_context(parent_context=get_parent_context() or self._context.parent_context):

--- a/src/vellum/workflows/nodes/core/inline_subworkflow_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/core/inline_subworkflow_node/tests/test_node.py
@@ -39,3 +39,19 @@ def test_inline_subworkflow_node__inputs(inputs):
     assert events == [
         BaseOutput(name="out", value="bar"),
     ]
+
+
+def test_inline_subworkflow_node__support_inputs_as_attributes():
+    # GIVEN a node setup with subworkflow inputs
+    class MyNode(InlineSubworkflowNode):
+        subworkflow = MySubworkflow
+        foo = "bar"
+
+    # WHEN the node is run
+    node = MyNode()
+    events = list(node.run())
+
+    # THEN the output is as expected
+    assert events == [
+        BaseOutput(name="out", value="bar"),
+    ]


### PR DESCRIPTION
This PR implements support for the ideal case as specified here: https://vellum-ai.slack.com/archives/C06P13ABK0W/p1735310036893499?thread_ts=1735309195.646639&cid=C06P13ABK0W

Left OOS from this PR is type hint support for these attributes. While this is something worth interrogating and supporting, the full solution would require pyright/mypy-as-ide-plugin support, both of which we are deferring to post marketing release.