### PR TITLE
revert node version bump for ci

### DIFF
--- a/.github/workflows/ci-codegen.yaml
+++ b/.github/workflows/ci-codegen.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.18.0'
+          node-version: '18.17.0'
       - name: Install dependencies
         run: npm install
         working-directory: ee/codegen


### PR DESCRIPTION
We want to keep 18.17 everywhere