### PR TITLE
[SC-5606] Generate array output id for inline prompt node context

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -642,6 +642,8 @@ export function templatingNodeFactory({
   errorOutputId,
   inputRules,
   outputType = VellumVariableType.String,
+  inputReferenceId,
+  inputReferenceNodeId,
 }: {
   id?: string;
   label?: string;
@@ -650,30 +652,59 @@ export function templatingNodeFactory({
   errorOutputId?: string;
   inputRules?: NodeInputValuePointerRule[];
   outputType?: VellumVariableType;
+  inputReferenceId?: string;
+  inputReferenceNodeId?: string;
 } = {}): TemplatingNode {
   const nodeData: TemplatingNode = {
-    id: id ?? "7e09927b-6d6f-4829-92c9-54e66bdcaf80",
+    id: id ?? "46e221ab-a749-41a2-9242-b1f5bf31f3a5",
     type: WorkflowNodeType.TEMPLATING,
     data: {
       label: label ?? "Templating Node",
       outputId: "2d4f1826-de75-499a-8f84-0a690c8136ad",
       errorOutputId,
-      sourceHandleId: sourceHandleId ?? "dd8397b1-5a41-4fa0-8c24-e5dffee4fb98",
-      targetHandleId: targetHandleId ?? "3feb7e71-ec63-4d58-82ba-c3df829a2948",
+      sourceHandleId: sourceHandleId ?? "6ee2c814-d0a5-4ec9-83b6-45156e2f22c4",
+      targetHandleId: targetHandleId ?? "3960c8e1-9baa-4b9c-991d-e399d16a45aa",
       templateNodeInputId: "7b8af68b-cf60-4fca-9c57-868042b5b616",
       outputType: outputType,
     },
     inputs: [
       {
-        id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
+        id: "9feb7b5e-5947-496d-b56f-1e2627730796",
         key: "text",
         value: {
-          rules: inputRules ?? [
+          rules:
+            inputReferenceId && inputReferenceNodeId
+              ? [
+                  {
+                    type: "NODE_OUTPUT",
+                    data: {
+                      nodeId: inputReferenceNodeId,
+                      outputId: inputReferenceId,
+                    },
+                  },
+                ]
+              : inputRules ?? [
+                  {
+                    type: "CONSTANT_VALUE",
+                    data: {
+                      type: "STRING",
+                      value: "Hello, world!",
+                    },
+                  },
+                ],
+          combinator: "OR",
+        },
+      },
+      {
+        id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
+        key: "template",
+        value: {
+          rules: [
             {
               type: "CONSTANT_VALUE",
               data: {
                 type: "STRING",
-                value: "Hello, world!",
+                value: "{{ output[0].type }}",
               },
             },
           ],

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -644,6 +644,7 @@ export function templatingNodeFactory({
   outputType = VellumVariableType.String,
   inputReferenceId,
   inputReferenceNodeId,
+  template,
 }: {
   id?: string;
   label?: string;
@@ -654,7 +655,16 @@ export function templatingNodeFactory({
   outputType?: VellumVariableType;
   inputReferenceId?: string;
   inputReferenceNodeId?: string;
+  template?: NodeInputValuePointerRule;
 } = {}): TemplatingNode {
+  const defaultTemplate: NodeInputValuePointerRule = {
+    type: "CONSTANT_VALUE",
+    data: {
+      type: "STRING",
+      value: "Hello, World!",
+    },
+  };
+
   const nodeData: TemplatingNode = {
     id: id ?? "46e221ab-a749-41a2-9242-b1f5bf31f3a5",
     type: WorkflowNodeType.TEMPLATING,
@@ -699,15 +709,7 @@ export function templatingNodeFactory({
         id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
         key: "template",
         value: {
-          rules: [
-            {
-              type: "CONSTANT_VALUE",
-              data: {
-                type: "STRING",
-                value: "{{ output[0].type }}",
-              },
-            },
-          ],
+          rules: [template ?? defaultTemplate],
           combinator: "OR",
         },
       },

--- a/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
@@ -93,6 +93,78 @@ class ConditionalNode(BaseConditionalNode):
 "
 `;
 
+exports[`InlinePromptNode referenced by Templating Node > getNodeDefinition 1`] = `
+{
+  "bases": [
+    {
+      "module": [
+        "vellum",
+        "workflows",
+        "nodes",
+        "core",
+      ],
+      "name": "TemplatingNode",
+    },
+  ],
+  "module": [
+    "code",
+    "nodes",
+    "templating_node",
+  ],
+  "name": "TemplatingNode",
+}
+`;
+
+exports[`InlinePromptNode referenced by Templating Node > getNodeDisplayFile 1`] = `
+"from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from ...nodes.templating_node import TemplatingNode
+from uuid import UUID
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
+    label = "Templating Node"
+    node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
+    target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
+    template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
+    node_input_ids_by_name = {
+        "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
+        "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),
+    }
+    output_display = {
+        TemplatingNode.Outputs.result: NodeOutputDisplay(
+            id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="result"
+        )
+    }
+    port_displays = {
+        TemplatingNode.Ports.default: PortDisplayOverrides(
+            id=UUID("6ee2c814-d0a5-4ec9-83b6-45156e2f22c4")
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=0, y=0), width=None, height=None
+    )
+"
+`;
+
+exports[`InlinePromptNode referenced by Templating Node > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
+from vellum.workflows.state import BaseState
+from .prompt_node import PromptNode
+
+
+class TemplatingNode(BaseTemplatingNode[BaseState, str]):
+    template = """{{ output[0].type }}"""
+    inputs = {
+        "text": PromptNode.Outputs.results,
+    }
+"
+`;
+
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDefinition with 'takes array output id' 1`] = `
 {
   "bases": [

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -35,10 +35,13 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 
 class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
-    node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
-    target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
+    node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
+    target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
     template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
-    node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
+    node_input_ids_by_name = {
+        "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
+        "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),
+    }
     output_display = {
         TemplatingNode.Outputs.result: NodeOutputDisplay(
             id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="result"
@@ -46,7 +49,7 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     }
     port_displays = {
         TemplatingNode.Ports.default: PortDisplayOverrides(
-            id=UUID("dd8397b1-5a41-4fa0-8c24-e5dffee4fb98")
+            id=UUID("6ee2c814-d0a5-4ec9-83b6-45156e2f22c4")
         )
     }
     display_data = NodeDisplayData(
@@ -61,8 +64,10 @@ from vellum.workflows.state import BaseState
 
 
 class TemplatingNode(BaseTemplatingNode[BaseState, str]):
-    template = """Hello, world!"""
-    inputs = {}
+    template = """{{ output[0].type }}"""
+    inputs = {
+        "text": "Hello, world!",
+    }
 "
 `;
 
@@ -101,10 +106,13 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 
 class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
-    node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
-    target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
+    node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
+    target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
     template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
-    node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
+    node_input_ids_by_name = {
+        "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
+        "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),
+    }
     output_display = {
         TemplatingNode.Outputs.result: NodeOutputDisplay(
             id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="result"
@@ -112,7 +120,7 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     }
     port_displays = {
         TemplatingNode.Ports.default: PortDisplayOverrides(
-            id=UUID("dd8397b1-5a41-4fa0-8c24-e5dffee4fb98")
+            id=UUID("6ee2c814-d0a5-4ec9-83b6-45156e2f22c4")
         )
     }
     display_data = NodeDisplayData(
@@ -128,8 +136,10 @@ from vellum.workflows.types.core import Json
 
 
 class TemplatingNode(BaseTemplatingNode[BaseState, Json]):
-    template = """Hello, world!"""
-    inputs = {}
+    template = """{{ output[0].type }}"""
+    inputs = {
+        "text": "Hello, world!",
+    }
 "
 `;
 
@@ -150,10 +160,13 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 @BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
 class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
-    node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
-    target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
+    node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
+    target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
     template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
-    node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
+    node_input_ids_by_name = {
+        "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
+        "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),
+    }
     output_display = {
         TemplatingNode.Outputs.result: NodeOutputDisplay(
             id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="result"
@@ -161,7 +174,7 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     }
     port_displays = {
         TemplatingNode.Ports.default: PortDisplayOverrides(
-            id=UUID("dd8397b1-5a41-4fa0-8c24-e5dffee4fb98")
+            id=UUID("6ee2c814-d0a5-4ec9-83b6-45156e2f22c4")
         )
     }
     display_data = NodeDisplayData(
@@ -178,7 +191,9 @@ from vellum.workflows.nodes.core import TryNode
 
 @TryNode.wrap()
 class TemplatingNode(BaseTemplatingNode[BaseState, str]):
-    template = """Hello, world!"""
-    inputs = {}
+    template = """{{ output[0].type }}"""
+    inputs = {
+        "text": "Hello, world!",
+    }
 "
 `;

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -64,7 +64,7 @@ from vellum.workflows.state import BaseState
 
 
 class TemplatingNode(BaseTemplatingNode[BaseState, str]):
-    template = """{{ output[0].type }}"""
+    template = """Hello, World!"""
     inputs = {
         "text": "Hello, world!",
     }
@@ -136,7 +136,7 @@ from vellum.workflows.types.core import Json
 
 
 class TemplatingNode(BaseTemplatingNode[BaseState, Json]):
-    template = """{{ output[0].type }}"""
+    template = """Hello, World!"""
     inputs = {
         "text": "Hello, world!",
     }
@@ -191,7 +191,7 @@ from vellum.workflows.nodes.core import TryNode
 
 @TryNode.wrap()
 class TemplatingNode(BaseTemplatingNode[BaseState, str]):
-    template = """{{ output[0].type }}"""
+    template = """Hello, World!"""
     inputs = {
         "text": "Hello, world!",
     }

--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -16,7 +16,7 @@ import { PromptDeploymentNodeContext } from "src/context/node-context/prompt-dep
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import { ConditionalNode } from "src/generators/nodes/conditional-node";
 import { TemplatingNode } from "src/generators/nodes/templating-node";
-import {ConstantValuePointer} from "src/types/vellum";
+import { ConstantValuePointer } from "src/types/vellum";
 
 describe("InlinePromptNode referenced by Conditional Node", () => {
   let workflowContext: WorkflowContext;

--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -7,12 +7,15 @@ import {
   conditionalNodeFactory,
   inlinePromptNodeDataInlineVariantFactory,
   promptDeploymentNodeDataFactory,
+  templatingNodeFactory,
 } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { ConditionalNodeContext } from "src/context/node-context/conditional-node";
 import { InlinePromptNodeContext } from "src/context/node-context/inline-prompt-node";
 import { PromptDeploymentNodeContext } from "src/context/node-context/prompt-deployment-node";
+import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import { ConditionalNode } from "src/generators/nodes/conditional-node";
+import { TemplatingNode } from "src/generators/nodes/templating-node";
 
 describe("InlinePromptNode referenced by Conditional Node", () => {
   let workflowContext: WorkflowContext;
@@ -158,4 +161,54 @@ describe("Prompt Deployment Node referenced by Conditional Node", () => {
       nodeContext: conditionalNodeContext,
     });
   }
+});
+
+describe("InlinePromptNode referenced by Templating Node", () => {
+  let workflowContext: WorkflowContext;
+  let writer: Writer;
+  let node: TemplatingNode;
+  beforeEach(async () => {
+    workflowContext = workflowContextFactory();
+    writer = new Writer();
+
+    const promptNode = inlinePromptNodeDataInlineVariantFactory({
+      blockType: "JINJA",
+    });
+
+    const promptNodeContext = (await createNodeContext({
+      workflowContext,
+      nodeData: promptNode,
+    })) as InlinePromptNodeContext;
+    workflowContext.addNodeContext(promptNodeContext);
+
+    const templatingNode = templatingNodeFactory({
+      inputReferenceId: promptNode.data.arrayOutputId,
+      inputReferenceNodeId: promptNode.id,
+    });
+
+    const templatingNodeContext = (await createNodeContext({
+      workflowContext,
+      nodeData: templatingNode,
+    })) as TemplatingNodeContext;
+    workflowContext.addNodeContext(templatingNodeContext);
+
+    node = new TemplatingNode({
+      workflowContext,
+      nodeContext: templatingNodeContext,
+    });
+  });
+
+  it("getNodeFile", async () => {
+    node.getNodeFile().write(writer);
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
+
+  it("getNodeDisplayFile", async () => {
+    node.getNodeDisplayFile().write(writer);
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
+
+  it("getNodeDefinition", () => {
+    expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
+  });
 });

--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -16,6 +16,7 @@ import { PromptDeploymentNodeContext } from "src/context/node-context/prompt-dep
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import { ConditionalNode } from "src/generators/nodes/conditional-node";
 import { TemplatingNode } from "src/generators/nodes/templating-node";
+import {ConstantValuePointer} from "src/types/vellum";
 
 describe("InlinePromptNode referenced by Conditional Node", () => {
   let workflowContext: WorkflowContext;
@@ -181,9 +182,18 @@ describe("InlinePromptNode referenced by Templating Node", () => {
     })) as InlinePromptNodeContext;
     workflowContext.addNodeContext(promptNodeContext);
 
+    const template: ConstantValuePointer = {
+      type: "CONSTANT_VALUE",
+      data: {
+        type: "STRING",
+        value: "{{ output[0].type }}",
+      },
+    };
+
     const templatingNode = templatingNodeFactory({
       inputReferenceId: promptNode.data.arrayOutputId,
       inputReferenceNodeId: promptNode.id,
+      template: template,
     });
 
     const templatingNodeContext = (await createNodeContext({

--- a/ee/codegen/src/context/node-context/inline-prompt-node.ts
+++ b/ee/codegen/src/context/node-context/inline-prompt-node.ts
@@ -12,6 +12,7 @@ export class InlinePromptNodeContext extends BaseNodeContext<InlinePromptNodeTyp
       ...(this.nodeData.data.errorOutputId
         ? { [this.nodeData.data.errorOutputId]: "error" }
         : {}),
+      [this.nodeData.data.arrayOutputId]: "results",
     };
   }
 


### PR DESCRIPTION
This issue came from the pdf to image workflow: https://app.vellum.ai/workflow-sandboxes/8dd47593-ce0d-4ddc-a131-005096d18414

The templating node in this workflow was referencing the array output id of the prompt node. However, we currently do not expose that array output id in the prompt node context. This PR adds it to the context so that it can be referenced