### PR TITLE
Improved Jinja Template Serialization of pydantic objects

### DIFF
--- a/src/vellum/utils/templating/render.py
+++ b/src/vellum/utils/templating/render.py
@@ -28,6 +28,9 @@ def render_sandboxed_jinja_template(
             keep_trailing_newline=True,
             finalize=finalize,
         )
+        environment.policies["json.dumps_kwargs"] = {
+            "cls": DefaultStateEncoder,
+        }
 
         if jinja_custom_filters:
             environment.filters.update(jinja_custom_filters)

--- a/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
@@ -1,5 +1,6 @@
 import json
 
+from vellum.client.types.function_call import FunctionCall
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.templating_node.node import TemplatingNode
 from vellum.workflows.state import BaseState
@@ -106,3 +107,19 @@ def test_templating_node__execution_count_reference():
 
     # THEN the output is just the total
     assert outputs.result == "0"
+
+
+def test_templating_node__pydantic_to_json():
+    # GIVEN a templating node that uses tojson on a pydantic model
+    class JSONTemplateNode(TemplatingNode[BaseState, Json]):
+        template = "{{ function_call | tojson }}"
+        inputs = {
+            "function_call": FunctionCall(name="test", arguments={"key": "value"}),
+        }
+
+    # WHEN the node is run
+    node = JSONTemplateNode()
+    outputs = node.run()
+
+    # THEN the output is the expected JSON
+    assert outputs.result == {"name": "test", "arguments": {"key": "value"}}

--- a/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
@@ -122,4 +122,4 @@ def test_templating_node__pydantic_to_json():
     outputs = node.run()
 
     # THEN the output is the expected JSON
-    assert outputs.result == {"name": "test", "arguments": {"key": "value"}}
+    assert outputs.result == {"name": "test", "arguments": {"key": "value"}, "id": None}

--- a/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
@@ -22,7 +22,9 @@ def test_templating_node__dict_output():
     outputs = node.run()
 
     # THEN the output is json serializable
-    assert json.loads(outputs.result) == {"key": "value"}
+    # https://app.shortcut.com/vellum/story/6132
+    dump: str = outputs.result  # type: ignore[assignment]
+    assert json.loads(dump) == {"key": "value"}
 
 
 def test_templating_node__int_output():


### PR DESCRIPTION
@awlevin ran into a bug yesterday building a workflow that will also affect our SDK. The first two commits are the test and implementations respectively to solve that bug, which I also plan to apply to Vellum.

The third commit was a mypy issue that I also investigated yesterday, that came up bc of the new test, but ended up working around it in the prototype repo. Basically Templating Node Outputs are not being inferred with the correct Outputs class (since it's auto amended in the metaclass).

I made good headway in making the Outputs class correct, but attributes are still typed incorrectly, so am deferring further investigation.