### PR TITLE
Remove redundant type arg during LogicalCondition codegen

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
@@ -105,17 +105,14 @@ class SearchNode(BaseSearchNode):
         filters=SearchFiltersRequest(
             external_ids=None,
             metadata=VellumValueLogicalConditionGroupRequest(
-                type="LOGICAL_CONDITION_GROUP",
                 combinator="AND",
                 negated=False,
                 conditions=[
                     VellumValueLogicalConditionGroupRequest(
-                        type="LOGICAL_CONDITION_GROUP",
                         combinator="AND",
                         negated=False,
                         conditions=[
                             VellumValueLogicalConditionRequest(
-                                type="LOGICAL_CONDITION",
                                 lhs_variable=Inputs.var1,
                                 operator="=",
                                 rhs_variable=Inputs.var1,
@@ -228,27 +225,17 @@ class SearchNode(BaseSearchNode):
         filters=SearchFiltersRequest(
             external_ids=None,
             metadata=VellumValueLogicalConditionGroupRequest(
-                type="LOGICAL_CONDITION_GROUP",
                 combinator="AND",
                 negated=False,
                 conditions=[
                     VellumValueLogicalConditionRequest(
-                        type="LOGICAL_CONDITION",
-                        lhs_variable="TYPE",
-                        operator="=",
-                        rhs_variable="VENDOR",
+                        lhs_variable="TYPE", operator="=", rhs_variable="VENDOR"
                     ),
                     VellumValueLogicalConditionRequest(
-                        type="LOGICAL_CONDITION",
-                        lhs_variable="STATUS",
-                        operator="=",
-                        rhs_variable="1",
+                        lhs_variable="STATUS", operator="=", rhs_variable="1"
                     ),
                     VellumValueLogicalConditionRequest(
-                        type="LOGICAL_CONDITION",
-                        lhs_variable="DELETED_AT",
-                        operator="null",
-                        rhs_variable="true",
+                        lhs_variable="DELETED_AT", operator="null", rhs_variable="true"
                     ),
                 ],
             ),
@@ -344,17 +331,14 @@ class SearchNode(BaseSearchNode):
         filters=SearchFiltersRequest(
             external_ids=None,
             metadata=VellumValueLogicalConditionGroupRequest(
-                type="LOGICAL_CONDITION_GROUP",
                 combinator="AND",
                 negated=False,
                 conditions=[
                     VellumValueLogicalConditionGroupRequest(
-                        type="LOGICAL_CONDITION_GROUP",
                         combinator="AND",
                         negated=False,
                         conditions=[
                             VellumValueLogicalConditionRequest(
-                                type="LOGICAL_CONDITION",
                                 lhs_variable=Inputs.var1,
                                 operator="=",
                                 rhs_variable=Inputs.var1,

--- a/ee/codegen/src/generators/nodes/search-node.ts
+++ b/ee/codegen/src/generators/nodes/search-node.ts
@@ -435,10 +435,6 @@ export class SearchNodeMetadataFilters extends AstNode {
       }),
       arguments_: [
         python.methodArgument({
-          name: "type",
-          value: python.TypeInstantiation.str("LOGICAL_CONDITION_GROUP"),
-        }),
-        python.methodArgument({
           name: "combinator",
           value: python.TypeInstantiation.str(data.combinator),
         }),
@@ -475,10 +471,6 @@ export class SearchNodeMetadataFilters extends AstNode {
         modulePath: [...VELLUM_CLIENT_MODULE_PATH, "types"],
       }),
       arguments_: [
-        python.methodArgument({
-          name: "type",
-          value: python.TypeInstantiation.str("LOGICAL_CONDITION"),
-        }),
         python.methodArgument({
           name: "lhs_variable",
           value: lhs,

--- a/ee/codegen_integration/fixtures/simple_search_node/code/nodes/search_node.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/nodes/search_node.py
@@ -15,15 +15,14 @@ class SearchNode(BaseSearchNode):
         filters=SearchFiltersRequest(
             external_ids=None,
             metadata=VellumValueLogicalConditionGroupRequest(
-                type="LOGICAL_CONDITION_GROUP",
                 combinator="AND",
                 negated=False,
                 conditions=[
                     VellumValueLogicalConditionRequest(
-                        type="LOGICAL_CONDITION", lhs_variable=Inputs.var1, operator="=", rhs_variable=Inputs.var1
+                        lhs_variable=Inputs.var1, operator="=", rhs_variable=Inputs.var1
                     ),
                     VellumValueLogicalConditionRequest(
-                        type="LOGICAL_CONDITION", lhs_variable=Inputs.var1, operator="=", rhs_variable=Inputs.var1
+                        lhs_variable=Inputs.var1, operator="=", rhs_variable=Inputs.var1
                     ),
                 ],
             ),


### PR DESCRIPTION
We don't need to specify `type` arguments where it's already defaulted. Quick cleanup I noticed while poking around search metadata filter stuff