### PR TITLE
Remove `getNodeDefinition`

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ApiNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "api_node",
-  ],
-  "name": "APINode",
-}
-`;
-
 exports[`ApiNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseAPINodeDisplay
 from ...nodes.api_node import APINode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CodeExecutionNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "code_execution_node",
-  ],
-  "name": "CodeExecutionNode",
-}
-`;
-
 exports[`CodeExecutionNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
 from ...nodes.code_execution_node import CodeExecutionNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ConditionalNode > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "conditional_node",
-  ],
-  "name": "ConditionalNode",
-}
-`;
-
 exports[`ConditionalNode > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from ...nodes.conditional_node import ConditionalNode
@@ -101,17 +90,6 @@ class ConditionalNode(BaseConditionalNode):
 "
 `;
 
-exports[`ConditionalNode with invalid uuid for field and value node input ids > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "conditional_node",
-  ],
-  "name": "ConditionalNode",
-}
-`;
-
 exports[`ConditionalNode with invalid uuid for field and value node input ids > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from ...nodes.conditional_node import ConditionalNode
@@ -177,17 +155,6 @@ class ConditionalNode(BaseConditionalNode):
         branch_1 = Port.on_if(Inputs.field.equals(Inputs.field))
         branch_2 = Port.on_else()
 "
-`;
-
-exports[`ConditionalNode with null operator > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "conditional_node",
-  ],
-  "name": "ConditionalNode",
-}
 `;
 
 exports[`ConditionalNode with null operator > getNodeDisplayFile 1`] = `

--- a/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ErrorNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "error_node",
-  ],
-  "name": "ErrorNode",
-}
-`;
-
 exports[`ErrorNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
 from ...nodes.error_node import ErrorNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`FinalOutputNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "final_output_node",
-  ],
-  "name": "FinalOutputNode",
-}
-`;
-
 exports[`FinalOutputNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from ...nodes.final_output_node import FinalOutputNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/generic-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`GenericNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "my_custom_node",
-  ],
-  "name": "MyCustomNode",
-}
-`;
-
 exports[`GenericNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseNodeDisplay
 from ...nodes.my_custom_node import MyCustomNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`GuardrailNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "guardrail_node",
-  ],
-  "name": "GuardrailNode",
-}
-`;
-
 exports[`GuardrailNode > basic > getNodeDisplayFile - multiple output variables 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseGuardrailNodeDisplay
 from ...nodes.guardrail_node import GuardrailNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`InlinePromptNode > CHAT_MESSAGE block type > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "prompt_node",
-  ],
-  "name": "PromptNode",
-}
-`;
-
 exports[`InlinePromptNode > CHAT_MESSAGE block type > basic > getNodeDisplayFile for CHAT_MESSAGE block type 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from ...nodes.prompt_node import PromptNode
@@ -287,17 +276,6 @@ Summarize the following text:
 "
 `;
 
-exports[`InlinePromptNode > FUNCTION_DEFINITION block type > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "prompt_node",
-  ],
-  "name": "PromptNode",
-}
-`;
-
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > basic > getNodeDisplayFile for FUNCTION_DEFINITION block type 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from ...nodes.prompt_node import PromptNode
@@ -505,17 +483,6 @@ class PromptNode(InlinePromptNode):
 "
 `;
 
-exports[`InlinePromptNode > JINJA block type > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "prompt_node",
-  ],
-  "name": "PromptNode",
-}
-`;
-
 exports[`InlinePromptNode > JINJA block type > basic > getNodeDisplayFile for JINJA block type 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from ...nodes.prompt_node import PromptNode
@@ -718,17 +685,6 @@ class PromptNode(InlinePromptNode):
         custom_parameters={},
     )
 "
-`;
-
-exports[`InlinePromptNode > RICH_TEXT block type > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "prompt_node",
-  ],
-  "name": "PromptNode",
-}
 `;
 
 exports[`InlinePromptNode > RICH_TEXT block type > basic > getNodeDisplayFile for RICH_TEXT block type 1`] = `
@@ -951,17 +907,6 @@ class PromptNode(InlinePromptNode):
         custom_parameters={},
     )
 "
-`;
-
-exports[`InlinePromptNode > VARIABLE block type > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "prompt_node",
-  ],
-  "name": "PromptNode",
-}
 `;
 
 exports[`InlinePromptNode > VARIABLE block type > basic > getNodeDisplayFile for VARIABLE block type 1`] = `

--- a/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`MergeNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "merge_node",
-  ],
-  "name": "MergeNode",
-}
-`;
-
 exports[`MergeNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseMergeNodeDisplay
 from ...nodes.merge_node import MergeNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`InlinePromptNode referenced by Conditional Node > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "conditional_node",
-  ],
-  "name": "ConditionalNode",
-}
-`;
-
 exports[`InlinePromptNode referenced by Conditional Node > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from ...nodes.conditional_node import ConditionalNode
@@ -82,17 +71,6 @@ class ConditionalNode(BaseConditionalNode):
 "
 `;
 
-exports[`InlinePromptNode referenced by Templating Node > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "templating_node",
-  ],
-  "name": "TemplatingNode",
-}
-`;
-
 exports[`InlinePromptNode referenced by Templating Node > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from ...nodes.templating_node import TemplatingNode
@@ -141,39 +119,6 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
         "text": PromptNode.Outputs.results,
     }
 "
-`;
-
-exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDefinition with 'takes array output id' 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "conditional_node",
-  ],
-  "name": "ConditionalNode",
-}
-`;
-
-exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDefinition with 'takes error output id' 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "conditional_node",
-  ],
-  "name": "ConditionalNode",
-}
-`;
-
-exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDefinition with 'takes output id' 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "conditional_node",
-  ],
-  "name": "ConditionalNode",
-}
 `;
 
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDisplayFile with 'takes array output id' 1`] = `

--- a/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`NoteNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "note_node",
-  ],
-  "name": "NoteNode",
-}
-`;
-
 exports[`NoteNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseNoteNodeDisplay
 from ...nodes.note_node import NoteNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`PromptDeploymentNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "prompt_deployment_node",
-  ],
-  "name": "PromptDeploymentNode",
-}
-`;
-
 exports[`PromptDeploymentNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BasePromptDeploymentNodeDisplay
 from ...nodes.prompt_deployment_node import PromptDeploymentNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`TextSearchNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "search_node",
-  ],
-  "name": "SearchNode",
-}
-`;
-
 exports[`TextSearchNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from ...nodes.search_node import SearchNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`SubworkflowDeploymentNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "subworkflow_node",
-  ],
-  "name": "SubworkflowNode",
-}
-`;
-
 exports[`SubworkflowDeploymentNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
 from ...nodes.subworkflow_node import SubworkflowNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -1,16 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`TemplatingNode > basic > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "templating_node",
-  ],
-  "name": "TemplatingNode",
-}
-`;
-
 exports[`TemplatingNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from ...nodes.templating_node import TemplatingNode
@@ -58,17 +47,6 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
         "text": "Hello, world!",
     }
 "
-`;
-
-exports[`TemplatingNode > basic with json output type > getNodeDefinition 1`] = `
-{
-  "module": [
-    "code",
-    "nodes",
-    "templating_node",
-  ],
-  "name": "TemplatingNode",
-}
 `;
 
 exports[`TemplatingNode > basic with json output type > getNodeDisplayFile 1`] = `

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -64,10 +64,6 @@ describe("ApiNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 
   describe("reject on error enabled", () => {

--- a/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
@@ -43,10 +43,6 @@ describe("CodeExecutionNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 
   describe("code representation override", () => {

--- a/ee/codegen/src/__test__/nodes/conditional-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/conditional-node.test.ts
@@ -60,10 +60,6 @@ describe("ConditionalNode", () => {
     node.getNodeDisplayFile().write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
   });
-
-  it("getNodeDefinition", () => {
-    expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-  });
 });
 
 describe("ConditionalNode with invalid uuid for field and value node input ids", () => {
@@ -108,10 +104,6 @@ describe("ConditionalNode with invalid uuid for field and value node input ids",
   it("getNodeDisplayFile", async () => {
     node.getNodeDisplayFile().write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
-  });
-
-  it("getNodeDefinition", () => {
-    expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
   });
 
   function constructConditionalNodeWithInvalidUUID(): ConditionalNodeType {
@@ -248,10 +240,6 @@ describe("ConditionalNode with null operator", () => {
   it("getNodeDisplayFile", async () => {
     node.getNodeDisplayFile().write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
-  });
-
-  it("getNodeDefinition", () => {
-    expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
   });
 });
 

--- a/ee/codegen/src/__test__/nodes/error-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/error-node.test.ts
@@ -42,9 +42,5 @@ describe("ErrorNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/final-output-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/final-output-node.test.ts
@@ -42,9 +42,5 @@ describe("FinalOutputNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/generic-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-node.test.ts
@@ -42,9 +42,5 @@ describe("GenericNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
@@ -129,12 +129,6 @@ describe("GuardrailNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", async () => {
-      const node = await createNode({ outputVariables: [] });
-
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 
   describe("reject on error enabled", () => {

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -69,10 +69,6 @@ describe("InlinePromptNode", () => {
         node.getNodeDisplayFile().write(writer);
         expect(await writer.toStringFormatted()).toMatchSnapshot();
       });
-
-      it("getNodeDefinition", () => {
-        expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-      });
     });
 
     describe("reject on error enabled", () => {

--- a/ee/codegen/src/__test__/nodes/merge-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/merge-node.test.ts
@@ -42,9 +42,5 @@ describe("MergeNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -75,10 +75,6 @@ describe("InlinePromptNode referenced by Conditional Node", () => {
     node.getNodeDisplayFile().write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
   });
-
-  it("getNodeDefinition", () => {
-    expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-  });
 });
 
 describe("Prompt Deployment Node referenced by Conditional Node", () => {
@@ -127,11 +123,6 @@ describe("Prompt Deployment Node referenced by Conditional Node", () => {
     await setupNode(id);
     node.getNodeDisplayFile().write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
-  });
-
-  it.each(testCases)("getNodeDefinition with $name", async ({ id }) => {
-    await setupNode(id);
-    expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
   });
 
   async function setupNode(outputId: string) {
@@ -216,9 +207,5 @@ describe("InlinePromptNode referenced by Templating Node", () => {
   it("getNodeDisplayFile", async () => {
     node.getNodeDisplayFile().write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
-  });
-
-  it("getNodeDefinition", () => {
-    expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
   });
 });

--- a/ee/codegen/src/__test__/nodes/note-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/note-node.test.ts
@@ -42,9 +42,5 @@ describe("NoteNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
@@ -42,9 +42,5 @@ describe("PromptDeploymentNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -75,10 +75,6 @@ describe("TextSearchNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 
   describe("reject on error enabled", () => {

--- a/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
@@ -55,9 +55,5 @@ describe("SubworkflowDeploymentNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 });

--- a/ee/codegen/src/__test__/nodes/templating-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/templating-node.test.ts
@@ -55,10 +55,6 @@ describe("TemplatingNode", () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
-    });
   });
 
   describe("basic with json output type", () => {
@@ -87,10 +83,6 @@ describe("TemplatingNode", () => {
     it("getNodeDisplayFile", async () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
-    });
-
-    it("getNodeDefinition", () => {
-      expect(node.nodeContext.getNodeDefinition()).toMatchSnapshot();
     });
   });
 

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -1,7 +1,7 @@
 import { WorkflowContext } from "src/context";
 import { PortContext } from "src/context/port-context";
 import { NodeOutputNotFoundError } from "src/generators/errors";
-import { CodeResourceDefinition, WorkflowDataNode } from "src/types/vellum";
+import { WorkflowDataNode } from "src/types/vellum";
 import { toPythonSafeSnakeCase } from "src/utils/casing";
 import { getNodeId, getNodeLabel } from "src/utils/nodes";
 import {
@@ -90,13 +90,6 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
 
   public getNodeLabel(): string {
     return getNodeLabel(this.nodeData);
-  }
-
-  public getNodeDefinition(): CodeResourceDefinition {
-    return {
-      name: this.nodeClassName,
-      module: this.nodeModulePath,
-    };
   }
 
   public getNodeOutputNameById(outputId: string): string {


### PR DESCRIPTION
We no longer have any need for codegen to retrieve node definitions and this logic can be safely removed.