### PR TITLE
Fix infer types in future versions of python

### DIFF
--- a/src/vellum/workflows/types/tests/test_utils.py
+++ b/src/vellum/workflows/types/tests/test_utils.py
@@ -21,6 +21,7 @@ class ExampleClass:
     zeta: ClassVar[str]
     eta: List[str]
     kappa: Any
+    mu: list[str]
 
 
 T = TypeVar("T")
@@ -56,6 +57,7 @@ class ExampleNode(BaseNode):
         (ExampleInheritedClass, "beta", (int,)),
         (ExampleNode.Outputs, "iota", (str,)),
         (ExampleClass, "kappa", (Any,)),
+        (ExampleClass, "mu", (list[str],)),
     ],
     ids=[
         "str",
@@ -71,6 +73,7 @@ class ExampleNode(BaseNode):
         "inherited_parent_class_var",
         "try_node_output",
         "any",
+        "list_str_generic",
     ],
 )
 def test_infer_types(cls, attr_name, expected_type):
@@ -80,9 +83,9 @@ def test_infer_types(cls, attr_name, expected_type):
 @pytest.mark.parametrize(
     "cls, expected_attr_names",
     [
-        (ExampleClass, {"alpha", "beta", "gamma", "epsilon", "zeta", "eta", "kappa"}),
+        (ExampleClass, {"alpha", "beta", "gamma", "epsilon", "zeta", "eta", "kappa", "mu"}),
         (ExampleGenericClass, {"delta"}),
-        (ExampleInheritedClass, {"alpha", "beta", "gamma", "epsilon", "zeta", "eta", "theta", "kappa"}),
+        (ExampleInheritedClass, {"alpha", "beta", "gamma", "epsilon", "zeta", "eta", "theta", "kappa", "mu"}),
     ],
 )
 def test_class_attr_names(cls, expected_attr_names):

--- a/src/vellum/workflows/types/utils.py
+++ b/src/vellum/workflows/types/utils.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from datetime import datetime
 import importlib
+from types import GenericAlias
 from typing import (
     Any,
     ClassVar,
@@ -77,6 +78,9 @@ def infer_types(object_: Type, attr_name: str, localns: Optional[Dict[str, Any]]
                 return (type_hint,)
             if isinstance(type_hint, SpecialGenericAlias):
                 return (type_hint,)
+            if isinstance(type_hint, GenericAlias):
+                # In future versions of python, list[str] will be a `GenericAlias`
+                return (cast(Type, type_hint),)
             if isinstance(type_hint, TypeVar):
                 if type_hint in type_var_mapping:
                     return (type_var_mapping[type_hint],)


### PR DESCRIPTION
I was using a `list[str]` output in a vargas jr workflow (which is on python 3.13) and was getting a failure to run bc of `infer_types()` method. This PR is the fix