### PR TITLE
Support Templating node outputs for pydantic models

### DIFF
--- a/src/vellum/workflows/nodes/core/templating_node/node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/node.py
@@ -73,6 +73,7 @@ class TemplatingNode(BaseNode[StateType], Generic[StateType, _OutputType], metac
         original_base = get_original_base(self.__class__)
         all_args = get_args(original_base)
 
+        output_type: Any
         if len(all_args) < 2 or isinstance(all_args[1], TypeVar):
             output_type = str
         else:
@@ -110,6 +111,14 @@ class TemplatingNode(BaseNode[StateType], Generic[StateType, _OutputType], metac
                 return json.loads(rendered_template)
             except json.JSONDecodeError:
                 raise ValueError("Invalid JSON format for rendered_template")
+
+        if issubclass(output_type, BaseModel):
+            try:
+                data = json.loads(rendered_template)
+            except json.JSONDecodeError:
+                raise ValueError("Invalid JSON format for rendered_template")
+
+            return output_type.model_validate(data)
 
         raise ValueError(f"Unsupported output type: {output_type}")
 

--- a/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
@@ -141,3 +141,17 @@ def test_templating_node__chat_history_output():
 
     # THEN the output is the expected chat history
     assert outputs.result == [ChatMessage(role="USER", text="Hello")]
+
+
+def test_templating_node__function_call_output():
+    # GIVEN a templating node that outputs a function call
+    class FunctionCallTemplateNode(TemplatingNode[BaseState, FunctionCall]):
+        template = '{"name": "test", "arguments": {"key": "value"}}'
+        inputs = {}
+
+    # WHEN the node is run
+    node = FunctionCallTemplateNode()
+    outputs = node.run()
+
+    # THEN the output is the expected function call
+    assert outputs.result == FunctionCall(name="test", arguments={"key": "value"})


### PR DESCRIPTION
Follows up on https://github.com/vellum-ai/vellum-python-sdks/pull/634 with a similar fix for FunctionCall's