### PR TITLE
[Codegen][Part 4] Add codegen support of workflow value descriptors

### DIFF
--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/workflow-value-descriptor.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/workflow-value-descriptor.test.ts.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`WorkflowValueDescriptor > expressions > generates binary expression with nested workflow value descriptors 1`] = `
+"TestNode.Outputs.my_output.equals("expected-value").equals("another-expected-value")
+"
+`;
+
+exports[`WorkflowValueDescriptor > expressions > generates binary expression with node output and constant 1`] = `
+"TestNode.Outputs.my_output.equals("expected-value")
+"
+`;
+
+exports[`WorkflowValueDescriptor > expressions > generates ternary expression with input variables 1`] = `
+"Inputs.count.between(1, 10)
+"
+`;
+
+exports[`WorkflowValueDescriptor > expressions > generates unary expression with input variable 1`] = `
+"Inputs.count.is_null()
+"
+`;

--- a/ee/codegen/src/__test__/nodes/generic-nodes/workflow-value-descriptor.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/workflow-value-descriptor.test.ts
@@ -1,0 +1,166 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { workflowContextFactory } from "src/__test__/helpers";
+import { inputVariableContextFactory } from "src/__test__/helpers/input-variable-context-factory";
+import { WorkflowContext } from "src/context";
+import { BaseNodeContext } from "src/context/node-context/base";
+import { WorkflowValueDescriptor } from "src/generators/workflow-value-descriptor";
+import {
+  WorkflowDataNode,
+  WorkflowValueDescriptor as WorkflowValueDescriptorType,
+} from "src/types/vellum";
+
+describe("WorkflowValueDescriptor", () => {
+  let workflowContext: WorkflowContext;
+  let writer: Writer;
+
+  beforeEach(() => {
+    workflowContext = workflowContextFactory();
+    writer = new Writer();
+
+    workflowContext.addInputVariableContext(
+      inputVariableContextFactory({
+        inputVariableData: {
+          id: "input-1",
+          key: "count",
+          type: "NUMBER",
+        },
+        workflowContext,
+      })
+    );
+
+    vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
+      nodeClassName: "TestNode",
+      path: ["nodes", "test-node-path"],
+      getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),
+    } as unknown as BaseNodeContext<WorkflowDataNode>);
+  });
+
+  describe("expressions", () => {
+    it("generates unary expression with input variable", async () => {
+      const descriptor: WorkflowValueDescriptorType = {
+        type: "UNARY_EXPRESSION",
+        operator: "null",
+        lhs: {
+          type: "INPUT_VARIABLE",
+          data: {
+            inputVariableId: "input-1",
+          },
+        },
+      };
+
+      const valueDescriptor = new WorkflowValueDescriptor({
+        workflowValueDescriptor: descriptor,
+        workflowContext,
+      });
+
+      valueDescriptor.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("generates binary expression with node output and constant", async () => {
+      const descriptor: WorkflowValueDescriptorType = {
+        type: "BINARY_EXPRESSION",
+        operator: "=",
+        lhs: {
+          type: "NODE_OUTPUT",
+          data: {
+            nodeId: "node-1",
+            outputId: "output-1",
+          },
+        },
+        rhs: {
+          type: "CONSTANT_VALUE",
+          data: {
+            type: "STRING",
+            value: "expected-value",
+          },
+        },
+      };
+
+      const valueDescriptor = new WorkflowValueDescriptor({
+        workflowValueDescriptor: descriptor,
+        workflowContext,
+      });
+
+      valueDescriptor.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("generates binary expression with nested workflow value descriptors", async () => {
+      const descriptor: WorkflowValueDescriptorType = {
+        type: "BINARY_EXPRESSION",
+        operator: "=",
+        lhs: {
+          type: "BINARY_EXPRESSION",
+          operator: "=",
+          lhs: {
+            type: "NODE_OUTPUT",
+            data: {
+              nodeId: "node-1",
+              outputId: "output-1",
+            },
+          },
+          rhs: {
+            type: "CONSTANT_VALUE",
+            data: {
+              type: "STRING",
+              value: "expected-value",
+            },
+          },
+        },
+        rhs: {
+          type: "CONSTANT_VALUE",
+          data: {
+            type: "STRING",
+            value: "another-expected-value",
+          },
+        },
+      };
+
+      const valueDescriptor = new WorkflowValueDescriptor({
+        workflowValueDescriptor: descriptor,
+        workflowContext,
+      });
+
+      valueDescriptor.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("generates ternary expression with input variables", async () => {
+      const descriptor: WorkflowValueDescriptorType = {
+        type: "TERNARY_EXPRESSION",
+        operator: "between",
+        base: {
+          type: "INPUT_VARIABLE",
+          data: {
+            inputVariableId: "input-1",
+          },
+        },
+        lhs: {
+          type: "CONSTANT_VALUE",
+          data: {
+            type: "NUMBER",
+            value: 1,
+          },
+        },
+        rhs: {
+          type: "CONSTANT_VALUE",
+          data: {
+            type: "NUMBER",
+            value: 10,
+          },
+        },
+      };
+
+      const valueDescriptor = new WorkflowValueDescriptor({
+        workflowValueDescriptor: descriptor,
+        workflowContext,
+      });
+
+      valueDescriptor.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+});

--- a/ee/codegen/src/generators/expression.ts
+++ b/ee/codegen/src/generators/expression.ts
@@ -2,24 +2,31 @@ import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
+import { NodeAttributeGenerationError } from "src/generators/errors";
+
 export declare namespace Expression {
   interface Args {
     lhs: AstNode;
     expression: string;
     rhs?: AstNode | undefined;
+    base?: AstNode | undefined;
   }
 }
 
 export class Expression extends AstNode {
   private readonly astNode: AstNode;
 
-  constructor({ lhs, expression, rhs }: Expression.Args) {
+  constructor({ lhs, expression, rhs, base }: Expression.Args) {
     super();
-
-    this.astNode = this.generateAstNode({ lhs, expression, rhs });
+    this.astNode = this.generateAstNode({ lhs, expression, rhs, base });
   }
 
-  private generateAstNode({ lhs, expression, rhs }: Expression.Args): AstNode {
+  private generateAstNode({
+    lhs,
+    expression,
+    rhs,
+    base,
+  }: Expression.Args): AstNode {
     this.inheritReferences(lhs);
     if (rhs) {
       this.inheritReferences(rhs);
@@ -28,10 +35,36 @@ export class Expression extends AstNode {
     // TODO: We should ideally perform this using native fern functionality, but it requires being able to create
     //  a Reference object from an existing AstNode, which in turn requires all AstNode's to internally track their
     //  name and modulePath.
-    const rhsExpression = rhs ? `(${rhs.toString()})` : "()";
-    const rawExpression = `${lhs.toString()}.${expression}${rhsExpression}`;
+
+    const rawExpression = base
+      ? this.generateExpressionWithBase(base, expression, lhs, rhs)
+      : this.generateStandardExpression(lhs, expression, rhs);
 
     return python.codeBlock(rawExpression);
+  }
+
+  private generateExpressionWithBase(
+    base: AstNode,
+    expression: string,
+    lhs: AstNode,
+    rhs: AstNode | undefined
+  ): string {
+    if (!rhs) {
+      throw new NodeAttributeGenerationError(
+        "rhs must be defined if base is defined"
+      );
+    }
+    this.inheritReferences(base);
+    return `${base.toString()}.${expression}(${lhs.toString()}, ${rhs.toString()})`;
+  }
+
+  private generateStandardExpression(
+    lhs: AstNode,
+    expression: string,
+    rhs: AstNode | undefined
+  ): string {
+    const rhsExpression = rhs ? `(${rhs.toString()})` : "()";
+    return `${lhs.toString()}.${expression}${rhsExpression}`;
   }
 
   public write(writer: Writer) {

--- a/ee/codegen/src/generators/workflow-value-descriptor.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor.ts
@@ -10,7 +10,10 @@ import {
 } from "src/generators/errors";
 import { Expression } from "src/generators/expression";
 import { NodeInputValuePointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule";
-import { WorkflowValueDescriptor as WorkflowValueDescriptorType } from "src/types/vellum";
+import {
+  OperatorMapping,
+  WorkflowValueDescriptor as WorkflowValueDescriptorType,
+} from "src/types/vellum";
 import { assertUnreachable } from "src/utils/typing";
 
 export namespace WorkflowValueDescriptor {
@@ -47,7 +50,7 @@ export class WorkflowValueDescriptor extends AstNode {
     workflowValueDescriptor: WorkflowValueDescriptorType
   ): AstNode {
     // Base case
-    if (this.isPointer(workflowValueDescriptor)) {
+    if (this.isReference(workflowValueDescriptor)) {
       return new NodeInputValuePointerRule({
         workflowContext: this.workflowContext,
         nodeInputValuePointerRuleData: workflowValueDescriptor,
@@ -92,12 +95,10 @@ export class WorkflowValueDescriptor extends AstNode {
 
   private convertOperatorType(
     workflowValueDescriptor: WorkflowValueDescriptorType
-  ): string {
+  ): OperatorMapping {
     if (this.isExpression(workflowValueDescriptor)) {
       const operator = workflowValueDescriptor.operator;
-
-      const isNodeOutput = workflowValueDescriptor.lhs.type === "NODE_OUTPUT";
-      const operatorMappings: { [key: string]: string } = {
+      const operatorMappings: Record<string, OperatorMapping> = {
         "=": "equals",
         "!=": "does_not_equal",
         "<": "less_than",
@@ -110,8 +111,8 @@ export class WorkflowValueDescriptor extends AstNode {
         doesNotContain: "does_not_contain",
         doesNotBeginWith: "does_not_begin_with",
         doesNotEndWith: "does_not_end_with",
-        null: isNodeOutput ? "is_nil" : "is_null",
-        notNull: isNodeOutput ? "is_not_nil" : "is_not_null",
+        null: "is_null",
+        notNull: "is_not_null",
         in: "in",
         notIn: "not_in",
         between: "between",
@@ -139,7 +140,7 @@ export class WorkflowValueDescriptor extends AstNode {
     );
   }
 
-  private isPointer(workflowValueDescriptor: WorkflowValueDescriptorType) {
+  private isReference(workflowValueDescriptor: WorkflowValueDescriptorType) {
     return (
       workflowValueDescriptor.type === "NODE_OUTPUT" ||
       workflowValueDescriptor.type === "INPUT_VARIABLE" ||

--- a/ee/codegen/src/generators/workflow-value-descriptor.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor.ts
@@ -1,0 +1,155 @@
+import { python } from "@fern-api/python-ast";
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { isNil } from "lodash";
+
+import { WorkflowContext } from "src/context";
+import {
+  NodeAttributeGenerationError,
+  NodePortGenerationError,
+} from "src/generators/errors";
+import { Expression } from "src/generators/expression";
+import { NodeInputValuePointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule";
+import { WorkflowValueDescriptor as WorkflowValueDescriptorType } from "src/types/vellum";
+import { assertUnreachable } from "src/utils/typing";
+
+export namespace WorkflowValueDescriptor {
+  export interface Args {
+    workflowValueDescriptor: WorkflowValueDescriptorType;
+    workflowContext: WorkflowContext;
+  }
+}
+
+export class WorkflowValueDescriptor extends AstNode {
+  private workflowContext: WorkflowContext;
+  private astNode: AstNode;
+
+  public constructor(args: WorkflowValueDescriptor.Args) {
+    super();
+
+    this.workflowContext = args.workflowContext;
+    this.astNode = this.generateWorkflowValueDescriptor(
+      args.workflowValueDescriptor
+    );
+    this.inheritReferences(this.astNode);
+  }
+
+  private generateWorkflowValueDescriptor(
+    workflowValueDescriptor: WorkflowValueDescriptorType
+  ): AstNode {
+    if (isNil(workflowValueDescriptor)) {
+      return python.TypeInstantiation.none();
+    }
+    return this.buildExpression(workflowValueDescriptor);
+  }
+
+  private buildExpression(
+    workflowValueDescriptor: WorkflowValueDescriptorType
+  ): AstNode {
+    // Base case
+    if (this.isPointer(workflowValueDescriptor)) {
+      return new NodeInputValuePointerRule({
+        workflowContext: this.workflowContext,
+        nodeInputValuePointerRuleData: workflowValueDescriptor,
+      });
+    }
+
+    switch (workflowValueDescriptor.type) {
+      case "UNARY_EXPRESSION": {
+        const lhs = this.buildExpression(workflowValueDescriptor.lhs);
+        const operator = this.convertOperatorType(workflowValueDescriptor);
+        return new Expression({
+          lhs,
+          expression: operator,
+        });
+      }
+      case "BINARY_EXPRESSION": {
+        const lhs = this.buildExpression(workflowValueDescriptor.lhs);
+        const rhs = this.buildExpression(workflowValueDescriptor.rhs);
+        const operator = this.convertOperatorType(workflowValueDescriptor);
+        return new Expression({
+          lhs,
+          expression: operator,
+          rhs,
+        });
+      }
+      case "TERNARY_EXPRESSION": {
+        const base = this.buildExpression(workflowValueDescriptor.base);
+        const lhs = this.buildExpression(workflowValueDescriptor.lhs);
+        const rhs = this.buildExpression(workflowValueDescriptor.rhs);
+        const operator = this.convertOperatorType(workflowValueDescriptor);
+        return new Expression({
+          lhs: lhs,
+          expression: operator,
+          rhs: rhs,
+          base: base,
+        });
+      }
+      default:
+        assertUnreachable(workflowValueDescriptor);
+    }
+  }
+
+  private convertOperatorType(
+    workflowValueDescriptor: WorkflowValueDescriptorType
+  ): string {
+    if (this.isExpression(workflowValueDescriptor)) {
+      const operator = workflowValueDescriptor.operator;
+
+      const isNodeOutput = workflowValueDescriptor.lhs.type === "NODE_OUTPUT";
+      const operatorMappings: { [key: string]: string } = {
+        "=": "equals",
+        "!=": "does_not_equal",
+        "<": "less_than",
+        ">": "greater_than",
+        "<=": "less_than_or_equal_to",
+        ">=": "greater_than_or_equal_to",
+        contains: "contains",
+        beginsWith: "begins_with",
+        endsWith: "ends_with",
+        doesNotContain: "does_not_contain",
+        doesNotBeginWith: "does_not_begin_with",
+        doesNotEndWith: "does_not_end_with",
+        null: isNodeOutput ? "is_nil" : "is_null",
+        notNull: isNodeOutput ? "is_not_nil" : "is_not_null",
+        in: "in",
+        notIn: "not_in",
+        between: "between",
+        notBetween: "not_between",
+      };
+      const value = operatorMappings[operator];
+      if (!value) {
+        throw new NodePortGenerationError(
+          `This operator: ${operator} is not supported`
+        );
+      }
+      return value;
+    } else {
+      throw new NodeAttributeGenerationError(
+        `Operators should exist on expression and not be null`
+      );
+    }
+  }
+
+  private isExpression(workflowValueDescriptor: WorkflowValueDescriptorType) {
+    return (
+      workflowValueDescriptor.type === "UNARY_EXPRESSION" ||
+      workflowValueDescriptor.type === "BINARY_EXPRESSION" ||
+      workflowValueDescriptor.type === "TERNARY_EXPRESSION"
+    );
+  }
+
+  private isPointer(workflowValueDescriptor: WorkflowValueDescriptorType) {
+    return (
+      workflowValueDescriptor.type === "NODE_OUTPUT" ||
+      workflowValueDescriptor.type === "INPUT_VARIABLE" ||
+      workflowValueDescriptor.type === "CONSTANT_VALUE" ||
+      workflowValueDescriptor.type === "WORKSPACE_SECRET" ||
+      workflowValueDescriptor.type === "EXECUTION_COUNTER"
+    );
+  }
+
+  write(writer: Writer): void {
+    this.astNode.write(writer);
+  }
+}

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -777,3 +777,23 @@ export interface AdornmentNode {
   base: CodeResourceDefinition;
   attributes: NodeAttribute[];
 }
+
+export type OperatorMapping =
+  | "equals"
+  | "does_not_equal"
+  | "less_than"
+  | "greater_than"
+  | "less_than_or_equal_to"
+  | "greater_than_or_equal_to"
+  | "contains"
+  | "begins_with"
+  | "ends_with"
+  | "does_not_contain"
+  | "does_not_begin_with"
+  | "does_not_end_with"
+  | "is_null"
+  | "is_not_null"
+  | "in"
+  | "not_in"
+  | "between"
+  | "not_between";


### PR DESCRIPTION
This PR introduces the base for codegen'ing workflow value descriptors. This can then be used later in node ports and node attributes which I will update in subsequent PRs