### PR TITLE
Actual support for codegenning two nodes with the same label

### DIFF
--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.test.ts
@@ -29,9 +29,7 @@ describe("ExecutionCounterPointer", () => {
     const workflowContext = workflowContextFactory();
 
     const node = searchNodeDataFactory();
-    workflowContext.addNodeContext(
-      await nodeContextFactory({ workflowContext, nodeData: node })
-    );
+    await nodeContextFactory({ workflowContext, nodeData: node });
 
     const executionCounterPointer = new ExecutionCounterPointerRule({
       workflowContext: workflowContext,

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -47,7 +47,6 @@ describe("ApiNode", () => {
         workflowContext,
         nodeData,
       })) as ApiNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new ApiNode({
         workflowContext: workflowContext,
@@ -76,7 +75,6 @@ describe("ApiNode", () => {
         workflowContext,
         nodeData,
       })) as ApiNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new ApiNode({
         workflowContext: workflowContext,

--- a/ee/codegen/src/__test__/nodes/base-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/base-node.test.ts
@@ -25,7 +25,6 @@ describe("BaseNode", () => {
         workflowContext,
         nodeData: templatingNodeData,
       })) as TemplatingNodeContext;
-      workflowContext.addNodeContext(templatingNodeContext);
 
       expect(() => {
         new TemplatingNode({
@@ -43,11 +42,10 @@ describe("BaseNode", () => {
       const workflowContext = workflowContextFactory();
 
       const templatingNodeData = templatingNodeFactory();
-      const templatingNodeContext = (await createNodeContext({
+      await createNodeContext({
         workflowContext,
         nodeData: templatingNodeData,
-      })) as TemplatingNodeContext;
-      workflowContext.addNodeContext(templatingNodeContext);
+      });
 
       const templatingNode2Data = templatingNodeFactory({
         label: "TemplatingNode2",
@@ -68,7 +66,6 @@ describe("BaseNode", () => {
         workflowContext,
         nodeData: templatingNode2Data,
       })) as TemplatingNodeContext;
-      workflowContext.addNodeContext(templatingNode2Context);
 
       expect(() => {
         new TemplatingNode({

--- a/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
@@ -26,10 +26,9 @@ describe("CodeExecutionNode", () => {
         workflowContext,
         nodeData,
       })) as CodeExecutionContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new CodeExecutionNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });
@@ -63,7 +62,6 @@ describe("CodeExecutionNode", () => {
           workflowContext,
           nodeData,
         })) as CodeExecutionContext;
-        workflowContext.addNodeContext(nodeContext);
 
         node = new CodeExecutionNode({
           workflowContext: workflowContext,
@@ -91,7 +89,6 @@ describe("CodeExecutionNode", () => {
         workflowContext,
         nodeData,
       })) as CodeExecutionContext;
-      workflowContext.addNodeContext(nodeContext);
 
       expect(() => {
         new CodeExecutionNode({

--- a/ee/codegen/src/__test__/nodes/conditional-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/conditional-node.test.ts
@@ -43,7 +43,6 @@ describe("ConditionalNode", () => {
       workflowContext,
       nodeData,
     })) as ConditionalNodeContext;
-    workflowContext.addNodeContext(nodeContext);
 
     node = new ConditionalNode({
       workflowContext,
@@ -88,7 +87,6 @@ describe("ConditionalNode with invalid uuid for field and value node input ids",
       workflowContext,
       nodeData,
     })) as ConditionalNodeContext;
-    workflowContext.addNodeContext(nodeContext);
 
     node = new ConditionalNode({
       workflowContext,
@@ -214,17 +212,15 @@ describe("ConditionalNode with null operator", () => {
       })
     );
 
-    const upstreamNodeContext = (await createNodeContext({
+    (await createNodeContext({
       workflowContext,
       nodeData: templatingNode,
     })) as TemplatingNodeContext;
-    workflowContext.addNodeContext(upstreamNodeContext);
 
     const nodeContext = (await createNodeContext({
       workflowContext,
       nodeData,
     })) as ConditionalNodeContext;
-    workflowContext.addNodeContext(nodeContext);
 
     node = new ConditionalNode({
       workflowContext,
@@ -269,7 +265,6 @@ describe("ConditionalNode with incorrect rule id references", () => {
       workflowContext,
       nodeData: invalidNodeData,
     })) as ConditionalNodeContext;
-    workflowContext.addNodeContext(nodeContext);
 
     node = new ConditionalNode({
       workflowContext,

--- a/ee/codegen/src/__test__/nodes/error-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/error-node.test.ts
@@ -25,7 +25,6 @@ describe("ErrorNode", () => {
         workflowContext,
         nodeData,
       })) as ErrorNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new ErrorNode({
         workflowContext,

--- a/ee/codegen/src/__test__/nodes/final-output-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/final-output-node.test.ts
@@ -25,10 +25,9 @@ describe("FinalOutputNode", () => {
         workflowContext,
         nodeData,
       })) as FinalOutputNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new FinalOutputNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });

--- a/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
@@ -9,7 +9,6 @@ import {
 } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { GenericNodeContext } from "src/context/node-context/generic-node";
-import { InlinePromptNodeContext } from "src/context/node-context/inline-prompt-node";
 import { GenericNode } from "src/generators/nodes/generic-node";
 import { NodeAttribute } from "src/types/vellum";
 
@@ -42,10 +41,9 @@ describe("GenericNode", () => {
         workflowContext,
         nodeData,
       })) as GenericNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new GenericNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });
@@ -67,11 +65,10 @@ describe("GenericNode", () => {
         blockType: "JINJA",
       });
 
-      const referencedNodeContext = (await createNodeContext({
+      await createNodeContext({
         workflowContext,
         nodeData: referencedNode,
-      })) as InlinePromptNodeContext;
-      workflowContext.addNodeContext(referencedNodeContext);
+      });
 
       const nodeAttributes: NodeAttribute[] = [
         {
@@ -96,10 +93,9 @@ describe("GenericNode", () => {
         workflowContext,
         nodeData,
       })) as GenericNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new GenericNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });

--- a/ee/codegen/src/__test__/nodes/generic-nodes/node-output.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/node-output.test.ts
@@ -41,7 +41,6 @@ describe("NodeOutput", () => {
         workflowContext,
         nodeData,
       })) as GenericNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       nodeOutput = new NodeOutputs({
         nodeOutputs: nodeOutputData,
@@ -91,7 +90,6 @@ describe("NodeOutput", () => {
         workflowContext,
         nodeData,
       })) as GenericNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       nodeOutput = new NodeOutputs({
         nodeOutputs: nodeOutputData,
@@ -137,7 +135,6 @@ describe("NodeOutput", () => {
         workflowContext,
         nodeData,
       })) as GenericNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       nodeOutput = new NodeOutputs({
         nodeOutputs: nodeOutputData,

--- a/ee/codegen/src/__test__/nodes/generic-nodes/node-ports.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/node-ports.test.ts
@@ -71,7 +71,6 @@ describe("NodePorts", () => {
         workflowContext,
         nodeData,
       })) as GenericNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       nodePorts = new NodePorts({
         nodePorts: nodePortsData,
@@ -154,7 +153,6 @@ describe("NodePorts", () => {
         workflowContext,
         nodeData,
       })) as GenericNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       nodePorts = new NodePorts({
         nodePorts: nodePortsData,

--- a/ee/codegen/src/__test__/nodes/generic-nodes/node-trigger.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/node-trigger.test.ts
@@ -33,7 +33,6 @@ describe("NodeTrigger", () => {
         workflowContext,
         nodeData,
       })) as GenericNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       nodeTrigger = new NodeTrigger({
         nodeTrigger: nodeTriggerData,

--- a/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
@@ -79,11 +79,12 @@ describe("GuardrailNode", () => {
     );
     const nodeData = guardrailNodeDataFactory({ errorOutputId });
 
-    const nodeContext = (await createNodeContext({
+    const nodeContext = createNodeContext({
       workflowContext,
       nodeData,
-    })) as GuardrailNodeContext;
+    }) as GuardrailNodeContext;
     workflowContext.addNodeContext(nodeContext);
+    await nodeContext.buildProperties();
 
     return new GuardrailNode({
       workflowContext: workflowContext,

--- a/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
@@ -79,15 +79,13 @@ describe("GuardrailNode", () => {
     );
     const nodeData = guardrailNodeDataFactory({ errorOutputId });
 
-    const nodeContext = createNodeContext({
+    const nodeContext = (await createNodeContext({
       workflowContext,
       nodeData,
-    }) as GuardrailNodeContext;
-    workflowContext.addNodeContext(nodeContext);
-    await nodeContext.buildProperties();
+    })) as GuardrailNodeContext;
 
     return new GuardrailNode({
-      workflowContext: workflowContext,
+      workflowContext,
       nodeContext,
     });
   };

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -48,11 +48,12 @@ describe("InlinePromptNode", () => {
           blockType,
         });
 
-        const nodeContext = (await createNodeContext({
+        const nodeContext = createNodeContext({
           workflowContext,
           nodeData,
-        })) as InlinePromptNodeContext;
+        }) as InlinePromptNodeContext;
         workflowContext.addNodeContext(nodeContext);
+        await nodeContext.buildProperties();
 
         node = new InlinePromptNode({
           workflowContext,
@@ -78,11 +79,12 @@ describe("InlinePromptNode", () => {
           errorOutputId: "e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f",
         });
 
-        const nodeContext = (await createNodeContext({
+        const nodeContext = createNodeContext({
           workflowContext,
           nodeData,
-        })) as InlinePromptNodeContext;
+        }) as InlinePromptNodeContext;
         workflowContext.addNodeContext(nodeContext);
+        await nodeContext.buildProperties();
 
         node = new InlinePromptNode({
           workflowContext,
@@ -111,11 +113,12 @@ describe("InlinePromptNode", () => {
           "gpt-4o-mini"
         );
 
-        const nodeContext = (await createNodeContext({
+        const nodeContext = createNodeContext({
           workflowContext,
           nodeData,
-        })) as InlinePromptNodeContext;
+        }) as InlinePromptNodeContext;
         workflowContext.addNodeContext(nodeContext);
+        await nodeContext.buildProperties();
 
         node = new InlinePromptNode({
           workflowContext,

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -48,12 +48,10 @@ describe("InlinePromptNode", () => {
           blockType,
         });
 
-        const nodeContext = createNodeContext({
+        const nodeContext = (await createNodeContext({
           workflowContext,
           nodeData,
-        }) as InlinePromptNodeContext;
-        workflowContext.addNodeContext(nodeContext);
-        await nodeContext.buildProperties();
+        })) as InlinePromptNodeContext;
 
         node = new InlinePromptNode({
           workflowContext,
@@ -79,12 +77,10 @@ describe("InlinePromptNode", () => {
           errorOutputId: "e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f",
         });
 
-        const nodeContext = createNodeContext({
+        const nodeContext = (await createNodeContext({
           workflowContext,
           nodeData,
-        }) as InlinePromptNodeContext;
-        workflowContext.addNodeContext(nodeContext);
-        await nodeContext.buildProperties();
+        })) as InlinePromptNodeContext;
 
         node = new InlinePromptNode({
           workflowContext,
@@ -113,12 +109,10 @@ describe("InlinePromptNode", () => {
           "gpt-4o-mini"
         );
 
-        const nodeContext = createNodeContext({
+        const nodeContext = (await createNodeContext({
           workflowContext,
           nodeData,
-        }) as InlinePromptNodeContext;
-        workflowContext.addNodeContext(nodeContext);
-        await nodeContext.buildProperties();
+        })) as InlinePromptNodeContext;
 
         node = new InlinePromptNode({
           workflowContext,

--- a/ee/codegen/src/__test__/nodes/merge-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/merge-node.test.ts
@@ -25,10 +25,9 @@ describe("MergeNode", () => {
         workflowContext,
         nodeData,
       })) as MergeNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new MergeNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });

--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -12,7 +12,6 @@ import {
 import { createNodeContext, WorkflowContext } from "src/context";
 import { ConditionalNodeContext } from "src/context/node-context/conditional-node";
 import { InlinePromptNodeContext } from "src/context/node-context/inline-prompt-node";
-import { PromptDeploymentNodeContext } from "src/context/node-context/prompt-deployment-node";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import { ConditionalNode } from "src/generators/nodes/conditional-node";
 import { TemplatingNode } from "src/generators/nodes/templating-node";
@@ -43,11 +42,10 @@ describe("InlinePromptNode referenced by Conditional Node", () => {
       errorOutputId: errorOutputId,
     });
 
-    const promptNodeContext = (await createNodeContext({
+    await createNodeContext({
       workflowContext,
       nodeData: promptNode,
-    })) as InlinePromptNodeContext;
-    workflowContext.addNodeContext(promptNodeContext);
+    });
 
     const conditionalNode = conditionalNodeFactory({
       inputReferenceId: errorOutputId,
@@ -58,7 +56,6 @@ describe("InlinePromptNode referenced by Conditional Node", () => {
       workflowContext,
       nodeData: conditionalNode,
     })) as ConditionalNodeContext;
-    workflowContext.addNodeContext(conditionalNodeContext);
 
     node = new ConditionalNode({
       workflowContext,
@@ -131,11 +128,10 @@ describe("Prompt Deployment Node referenced by Conditional Node", () => {
       errorOutputId: isErrorOutput ? outputId : undefined,
     });
 
-    const promptDeploymentNodeContext = (await createNodeContext({
+    await createNodeContext({
       workflowContext,
       nodeData: promptDeploymentNode,
-    })) as PromptDeploymentNodeContext;
-    workflowContext.addNodeContext(promptDeploymentNodeContext);
+    });
 
     const conditionalNode = conditionalNodeFactory({
       inputReferenceId: outputId,
@@ -146,7 +142,6 @@ describe("Prompt Deployment Node referenced by Conditional Node", () => {
       workflowContext,
       nodeData: conditionalNode,
     })) as ConditionalNodeContext;
-    workflowContext.addNodeContext(conditionalNodeContext);
 
     node = new ConditionalNode({
       workflowContext,
@@ -167,11 +162,10 @@ describe("InlinePromptNode referenced by Templating Node", () => {
       blockType: "JINJA",
     });
 
-    const promptNodeContext = (await createNodeContext({
+    (await createNodeContext({
       workflowContext,
       nodeData: promptNode,
     })) as InlinePromptNodeContext;
-    workflowContext.addNodeContext(promptNodeContext);
 
     const template: ConstantValuePointer = {
       type: "CONSTANT_VALUE",
@@ -191,7 +185,6 @@ describe("InlinePromptNode referenced by Templating Node", () => {
       workflowContext,
       nodeData: templatingNode,
     })) as TemplatingNodeContext;
-    workflowContext.addNodeContext(templatingNodeContext);
 
     node = new TemplatingNode({
       workflowContext,

--- a/ee/codegen/src/__test__/nodes/note-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/note-node.test.ts
@@ -25,10 +25,9 @@ describe("NoteNode", () => {
         workflowContext,
         nodeData,
       })) as NoteNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new NoteNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });

--- a/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
@@ -25,7 +25,6 @@ describe("PromptDeploymentNode", () => {
         workflowContext,
         nodeData,
       })) as PromptDeploymentNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new PromptDeploymentNode({
         workflowContext,

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -54,11 +54,12 @@ describe("TextSearchNode", () => {
     beforeEach(async () => {
       const nodeData = searchNodeDataFactory();
 
-      const nodeContext = (await createNodeContext({
+      const nodeContext = createNodeContext({
         workflowContext,
         nodeData,
-      })) as TextSearchNodeContext;
+      }) as TextSearchNodeContext;
       workflowContext.addNodeContext(nodeContext);
+      await nodeContext.buildProperties();
 
       node = new SearchNode({
         workflowContext: workflowContext,
@@ -83,11 +84,12 @@ describe("TextSearchNode", () => {
         errorOutputId: "af589f73-effe-4a80-b48f-fb912ac6ce67",
       });
 
-      const nodeContext = (await createNodeContext({
+      const nodeContext = createNodeContext({
         workflowContext,
         nodeData,
-      })) as TextSearchNodeContext;
+      }) as TextSearchNodeContext;
       workflowContext.addNodeContext(nodeContext);
+      await nodeContext.buildProperties();
 
       node = new SearchNode({
         workflowContext: workflowContext,
@@ -219,11 +221,12 @@ describe("TextSearchNode", () => {
         },
       });
 
-      const nodeContext = (await createNodeContext({
+      const nodeContext = createNodeContext({
         workflowContext,
         nodeData,
-      })) as TextSearchNodeContext;
+      }) as TextSearchNodeContext;
       workflowContext.addNodeContext(nodeContext);
+      await nodeContext.buildProperties();
 
       node = new SearchNode({
         workflowContext: workflowContext,
@@ -254,11 +257,12 @@ describe("TextSearchNode", () => {
 
       const nodeData = searchNodeDataFactory();
 
-      const nodeContext = (await createNodeContext({
+      const nodeContext = createNodeContext({
         workflowContext,
         nodeData,
-      })) as TextSearchNodeContext;
+      }) as TextSearchNodeContext;
       workflowContext.addNodeContext(nodeContext);
+      await nodeContext.buildProperties();
 
       node = new SearchNode({
         workflowContext: workflowContext,

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -54,15 +54,13 @@ describe("TextSearchNode", () => {
     beforeEach(async () => {
       const nodeData = searchNodeDataFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as TextSearchNodeContext;
-      workflowContext.addNodeContext(nodeContext);
-      await nodeContext.buildProperties();
+      })) as TextSearchNodeContext;
 
       node = new SearchNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });
@@ -84,15 +82,13 @@ describe("TextSearchNode", () => {
         errorOutputId: "af589f73-effe-4a80-b48f-fb912ac6ce67",
       });
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as TextSearchNodeContext;
-      workflowContext.addNodeContext(nodeContext);
-      await nodeContext.buildProperties();
+      })) as TextSearchNodeContext;
 
       node = new SearchNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });
@@ -221,15 +217,13 @@ describe("TextSearchNode", () => {
         },
       });
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as TextSearchNodeContext;
-      workflowContext.addNodeContext(nodeContext);
-      await nodeContext.buildProperties();
+      })) as TextSearchNodeContext;
 
       node = new SearchNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });
@@ -257,15 +251,13 @@ describe("TextSearchNode", () => {
 
       const nodeData = searchNodeDataFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as TextSearchNodeContext;
-      workflowContext.addNodeContext(nodeContext);
-      await nodeContext.buildProperties();
+      })) as TextSearchNodeContext;
 
       node = new SearchNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });

--- a/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
@@ -34,12 +34,10 @@ describe("SubworkflowDeploymentNode", () => {
 
       const nodeData = subworkflowDeploymentNodeDataFactory();
 
-      const nodeContext = createNodeContext({
+      const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,
-      }) as SubworkflowDeploymentNodeContext;
-      workflowContext.addNodeContext(nodeContext);
-      await nodeContext.buildProperties();
+      })) as SubworkflowDeploymentNodeContext;
 
       node = new SubworkflowDeploymentNode({
         workflowContext,

--- a/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
@@ -34,11 +34,12 @@ describe("SubworkflowDeploymentNode", () => {
 
       const nodeData = subworkflowDeploymentNodeDataFactory();
 
-      const nodeContext = (await createNodeContext({
+      const nodeContext = createNodeContext({
         workflowContext,
         nodeData,
-      })) as SubworkflowDeploymentNodeContext;
+      }) as SubworkflowDeploymentNodeContext;
       workflowContext.addNodeContext(nodeContext);
+      await nodeContext.buildProperties();
 
       node = new SubworkflowDeploymentNode({
         workflowContext,

--- a/ee/codegen/src/__test__/nodes/templating-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/templating-node.test.ts
@@ -38,10 +38,9 @@ describe("TemplatingNode", () => {
         workflowContext,
         nodeData,
       })) as TemplatingNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new TemplatingNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });
@@ -67,10 +66,9 @@ describe("TemplatingNode", () => {
         workflowContext,
         nodeData,
       })) as TemplatingNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new TemplatingNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });
@@ -96,10 +94,9 @@ describe("TemplatingNode", () => {
         workflowContext,
         nodeData,
       })) as TemplatingNodeContext;
-      workflowContext.addNodeContext(nodeContext);
 
       node = new TemplatingNode({
-        workflowContext: workflowContext,
+        workflowContext,
         nodeContext,
       });
     });

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -503,4 +503,119 @@ Encountered 1 error(s) while generating code:
       expect(fs.existsSync(workflowPath)).toBe(true);
     });
   });
+
+  describe("multiple nodes with the same label", () => {
+    const displayData = {
+      workflow_raw_data: {
+        nodes: [
+          {
+            id: "entry",
+            type: "ENTRYPOINT",
+            data: {
+              label: "Entrypoint",
+              source_handle_id: "entry_source",
+              target_handle_id: "entry_target",
+            },
+            inputs: [],
+          },
+          {
+            id: "templating-node",
+            type: "TEMPLATING",
+            data: {
+              label: "Templating Node",
+              template_node_input_id: "template",
+              output_id: "output",
+              output_type: "STRING",
+              source_handle_id: "template_source",
+              target_handle_id: "template_target",
+            },
+            inputs: [
+              {
+                id: "template",
+                key: "template",
+                value: {
+                  combinator: "OR",
+                  rules: [
+                    {
+                      type: "CONSTANT_VALUE",
+                      data: {
+                        type: "STRING",
+                        value: "hello",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            id: "templating-node-1",
+            type: "TEMPLATING",
+            data: {
+              label: "Templating Node",
+              template_node_input_id: "template",
+              output_id: "output",
+              output_type: "STRING",
+              source_handle_id: "template_source_1",
+              target_handle_id: "template_target_1",
+            },
+            inputs: [
+              {
+                id: "template",
+                key: "template",
+                value: {
+                  combinator: "OR",
+                  rules: [
+                    {
+                      type: "CONSTANT_VALUE",
+                      data: {
+                        type: "STRING",
+                        value: "world",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+        edges: [
+          {
+            source_node_id: "entry",
+            source_handle_id: "entry_source",
+            target_node_id: "templating-node",
+            target_handle_id: "template_target",
+            type: "DEFAULT",
+            id: "edge_1",
+          },
+          {
+            source_node_id: "templating-node",
+            source_handle_id: "template_source",
+            target_node_id: "templating-node-1",
+            target_handle_id: "template_target_1",
+            type: "DEFAULT",
+            id: "edge_2",
+          },
+        ],
+      },
+      input_variables: [],
+      output_variables: [],
+      runner_config: {},
+    };
+    it("should handle the case of multiple nodes with the same label", async () => {
+      const project = new WorkflowProjectGenerator({
+        absolutePathToOutputDirectory: tempDir,
+        workflowVersionExecConfigData: displayData,
+        moduleName: "code",
+        vellumApiKey: "<TEST_API_KEY>",
+      });
+
+      await project.generateCode();
+
+      const nodesPath = join(tempDir, project.getModuleName(), "nodes");
+      const nodeFiles = fs.readdirSync(nodesPath);
+      expect(nodeFiles).toContain("templating_node.py");
+      expect(nodeFiles).toContain("templating_node_1.py");
+    });
+  });
 });

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -37,12 +37,10 @@ describe("Workflow", () => {
     workflowContext.addEntrypointNode(entrypointNode);
 
     const nodeData = terminalNodeDataFactory();
-    workflowContext.addNodeContext(
-      await createNodeContext({
-        workflowContext: workflowContext,
-        nodeData,
-      })
-    );
+    await createNodeContext({
+      workflowContext: workflowContext,
+      nodeData,
+    });
 
     writer = new Writer();
   });
@@ -122,11 +120,10 @@ describe("Workflow", () => {
       const inputs = codegen.inputs({ workflowContext });
 
       const searchNodeData = searchNodeDataFactory();
-      const searchNodeContext = await createNodeContext({
+      await createNodeContext({
         workflowContext: workflowContext,
         nodeData: searchNodeData,
       });
-      workflowContext.addNodeContext(searchNodeContext);
 
       const edges: WorkflowEdge[] = [
         {
@@ -167,12 +164,10 @@ describe("Workflow", () => {
         sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb98",
         targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2948",
       });
-      workflowContext.addNodeContext(
-        await createNodeContext({
-          workflowContext: workflowContext,
-          nodeData: templatingNodeData1,
-        })
-      );
+      await createNodeContext({
+        workflowContext: workflowContext,
+        nodeData: templatingNodeData1,
+      });
 
       const templatingNodeData2 = templatingNodeFactory({
         id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -180,12 +175,10 @@ describe("Workflow", () => {
         sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
         targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
       });
-      workflowContext.addNodeContext(
-        await createNodeContext({
-          workflowContext: workflowContext,
-          nodeData: templatingNodeData2,
-        })
-      );
+      await createNodeContext({
+        workflowContext: workflowContext,
+        nodeData: templatingNodeData2,
+      });
 
       const edges: WorkflowEdge[] = [
         {
@@ -239,11 +232,10 @@ describe("Workflow", () => {
         );
 
         const searchNodeData = searchNodeDataFactory();
-        const searchNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext: workflowContext,
           nodeData: searchNodeData,
         });
-        workflowContext.addNodeContext(searchNodeContext);
 
         const edges: WorkflowEdge[] = [
           {
@@ -272,11 +264,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -284,11 +275,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const edges: WorkflowEdge[] = [
           {
@@ -325,11 +315,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -337,11 +326,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
@@ -349,11 +337,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const edges: WorkflowEdge[] = [
           {
@@ -402,11 +389,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -414,11 +400,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const edges: WorkflowEdge[] = [
           {
@@ -455,11 +440,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -467,18 +451,16 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const mergeNodeData = mergeNodeDataFactory();
-        const mergeNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: mergeNodeData,
         });
-        workflowContext.addNodeContext(mergeNodeContext);
         const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
         const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
         if (!mergeTargetHandle1 || !mergeTargetHandle2) {
@@ -536,11 +518,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -548,11 +529,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
@@ -560,18 +540,16 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const mergeNodeData = mergeNodeDataFactory();
-        const mergeNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: mergeNodeData,
         });
-        workflowContext.addNodeContext(mergeNodeContext);
         const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
         const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
         if (!mergeTargetHandle1 || !mergeTargetHandle2) {
@@ -650,11 +628,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -662,11 +639,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
@@ -674,18 +650,16 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const mergeNodeData = mergeNodeDataFactory();
-        const mergeNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: mergeNodeData,
         });
-        workflowContext.addNodeContext(mergeNodeContext);
         const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
         const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
         if (!mergeTargetHandle1 || !mergeTargetHandle2) {
@@ -756,11 +730,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -768,11 +741,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
@@ -780,18 +752,16 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const mergeNodeData = mergeNodeDataFactory();
-        const mergeNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: mergeNodeData,
         });
-        workflowContext.addNodeContext(mergeNodeContext);
         const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
         const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
         if (!mergeTargetHandle1 || !mergeTargetHandle2) {
@@ -862,11 +832,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -874,18 +843,16 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const conditionalNodeData = conditionalNodeFactory();
-        const conditionalNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: conditionalNodeData,
         });
-        workflowContext.addNodeContext(conditionalNodeContext);
         const conditionalIfSourceHandleId =
           conditionalNodeData.data.conditions[0]?.sourceHandleId;
         const conditionalElseSourceHandleId =
@@ -941,11 +908,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -953,11 +919,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
@@ -965,11 +930,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const edges: WorkflowEdge[] = [
           {
@@ -1018,11 +982,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -1030,11 +993,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
@@ -1042,11 +1004,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const edges: WorkflowEdge[] = [
           {
@@ -1095,11 +1056,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -1107,11 +1067,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
@@ -1119,11 +1078,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const edges: WorkflowEdge[] = [
           {
@@ -1172,11 +1130,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -1184,11 +1141,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
@@ -1196,11 +1152,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const templatingNodeData4 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf83",
@@ -1208,11 +1163,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9b",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294b",
         });
-        const templatingNodeContext4 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData4,
         });
-        workflowContext.addNodeContext(templatingNodeContext4);
 
         const edges: WorkflowEdge[] = [
           {
@@ -1278,11 +1232,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -1290,11 +1243,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf82",
@@ -1302,11 +1254,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9a",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294a",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const templatingNodeData4 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf83",
@@ -1314,11 +1265,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9b",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294b",
         });
-        const templatingNodeContext4 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData4,
         });
-        workflowContext.addNodeContext(templatingNodeContext4);
 
         const templatingNodeData5 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf84",
@@ -1326,18 +1276,16 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9c",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294c",
         });
-        const templatingNodeContext5 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData5,
         });
-        workflowContext.addNodeContext(templatingNodeContext5);
 
         const mergeNodeData = mergeNodeDataFactory();
-        const mergeNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: mergeNodeData,
         });
-        workflowContext.addNodeContext(mergeNodeContext);
         const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
         const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
         if (!mergeTargetHandle1 || !mergeTargetHandle2) {
@@ -1426,11 +1374,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -1438,18 +1385,16 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const conditionalNodeData = conditionalNodeFactory();
-        const conditionalNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: conditionalNodeData,
         });
-        workflowContext.addNodeContext(conditionalNodeContext);
         const conditionalIfSourceHandleId =
           conditionalNodeData.data.conditions[0]?.sourceHandleId;
         const conditionalElseSourceHandleId =
@@ -1505,11 +1450,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -1517,11 +1461,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf83",
@@ -1529,11 +1472,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9b",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294b",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const templatingNodeData4 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf84",
@@ -1541,18 +1483,16 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9c",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294c",
         });
-        const templatingNodeContext4 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData4,
         });
-        workflowContext.addNodeContext(templatingNodeContext4);
 
         const conditionalNodeData = conditionalNodeFactory();
-        const conditionalNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: conditionalNodeData,
         });
-        workflowContext.addNodeContext(conditionalNodeContext);
         const conditionalIfSourceHandleId =
           conditionalNodeData.data.conditions[0]?.sourceHandleId;
         const conditionalElseSourceHandleId =
@@ -1617,11 +1557,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -1629,11 +1568,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf83",
@@ -1641,11 +1579,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9b",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294b",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const templatingNodeData4 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf84",
@@ -1653,18 +1590,16 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9c",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294c",
         });
-        const templatingNodeContext4 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData4,
         });
-        workflowContext.addNodeContext(templatingNodeContext4);
 
         const conditionalNodeData = conditionalNodeFactory();
-        const conditionalNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: conditionalNodeData,
         });
-        workflowContext.addNodeContext(conditionalNodeContext);
         const conditionalIfSourceHandleId =
           conditionalNodeData.data.conditions[0]?.sourceHandleId;
         const conditionalElseSourceHandleId =
@@ -1680,11 +1615,10 @@ describe("Workflow", () => {
           ifSourceHandleId: "63345ab5-1a4d-48a1-ad33-91bec41f92a6",
           elseSourceHandleId: "14a8b603-6039-4491-92d4-868a4dae4c16",
         });
-        const conditionalNode2Context = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: conditionalNode2Data,
         });
-        workflowContext.addNodeContext(conditionalNode2Context);
         const conditional2IfSourceHandleId =
           conditionalNode2Data.data.conditions[0]?.sourceHandleId;
         const conditional2ElseSourceHandleId =
@@ -1767,11 +1701,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -1779,11 +1712,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const templatingNodeData3 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf83",
@@ -1791,11 +1723,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9b",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294b",
         });
-        const templatingNodeContext3 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData3,
         });
-        workflowContext.addNodeContext(templatingNodeContext3);
 
         const templatingNodeData4 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf84",
@@ -1803,11 +1734,10 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9c",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294c",
         });
-        const templatingNodeContext4 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData4,
         });
-        workflowContext.addNodeContext(templatingNodeContext4);
 
         const templatingNodeData5 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf85",
@@ -1815,18 +1745,16 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb9d",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294d",
         });
-        const templatingNodeContext5 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData5,
         });
-        workflowContext.addNodeContext(templatingNodeContext5);
 
         const conditionalNodeData = conditionalNodeFactory();
-        const conditionalNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: conditionalNodeData,
         });
-        workflowContext.addNodeContext(conditionalNodeContext);
         const conditionalIfSourceHandleId =
           conditionalNodeData.data.conditions[0]?.sourceHandleId;
         const conditionalElseSourceHandleId =
@@ -1917,11 +1845,10 @@ describe("Workflow", () => {
         const inputs = codegen.inputs({ workflowContext });
 
         const templatingNodeData1 = templatingNodeFactory();
-        const templatingNodeContext1 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData1,
         });
-        workflowContext.addNodeContext(templatingNodeContext1);
 
         const templatingNodeData2 = templatingNodeFactory({
           id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
@@ -1929,18 +1856,16 @@ describe("Workflow", () => {
           sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
           targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
         });
-        const templatingNodeContext2 = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: templatingNodeData2,
         });
-        workflowContext.addNodeContext(templatingNodeContext2);
 
         const mergeNodeData = mergeNodeDataFactory();
-        const mergeNodeContext = await createNodeContext({
+        await createNodeContext({
           workflowContext,
           nodeData: mergeNodeData,
         });
-        workflowContext.addNodeContext(mergeNodeContext);
         const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
         const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
         if (!mergeTargetHandle1 || !mergeTargetHandle2) {

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -108,4 +108,12 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
 
     return toPythonSafeSnakeCase(nodeOutputName, "output");
   }
+
+  /**
+   * Extend this class to perform any additional property generation asynchronously
+   * after the node context has been created.
+   */
+  public buildProperties(): Promise<void> {
+    return Promise.resolve();
+  }
 }

--- a/ee/codegen/src/context/node-context/create-node-context.ts
+++ b/ee/codegen/src/context/node-context/create-node-context.ts
@@ -24,7 +24,7 @@ import {
 } from "src/types/vellum";
 import { assertUnreachable } from "src/utils/typing";
 
-export function createNodeContext(
+function buildNodeContext(
   args: BaseNodeContext.Args<WorkflowDataNode>
 ): BaseNodeContext<WorkflowDataNode> {
   const nodeData = args.nodeData;
@@ -178,4 +178,13 @@ export function createNodeContext(
         `Unsupported node type: ${args.nodeData.type}`
       );
   }
+}
+
+export async function createNodeContext(
+  args: BaseNodeContext.Args<WorkflowDataNode>
+): Promise<BaseNodeContext<WorkflowDataNode>> {
+  const nodeContext = buildNodeContext(args);
+  args.workflowContext.addNodeContext(nodeContext);
+  await nodeContext.buildProperties();
+  return nodeContext;
 }

--- a/ee/codegen/src/context/node-context/create-node-context.ts
+++ b/ee/codegen/src/context/node-context/create-node-context.ts
@@ -1,9 +1,3 @@
-import { VellumError } from "vellum-ai";
-import { DocumentIndexRead, MetricDefinitionHistoryItem } from "vellum-ai/api";
-import { DocumentIndexes as DocumentIndexesClient } from "vellum-ai/api/resources/documentIndexes/client/Client";
-import { MetricDefinitions as MetricDefinitionsClient } from "vellum-ai/api/resources/metricDefinitions/client/Client";
-import { WorkflowDeployments as WorkflowDeploymentsClient } from "vellum-ai/api/resources/workflowDeployments/client/Client";
-
 import { BaseNodeContext } from "./base";
 import { GuardrailNodeContext } from "./guardrail-node";
 import { InlineSubworkflowNodeContext } from "./inline-subworkflow-node";
@@ -22,58 +16,23 @@ import { NoteNodeContext } from "src/context/node-context/note-node";
 import { PromptDeploymentNodeContext } from "src/context/node-context/prompt-deployment-node";
 import { SubworkflowDeploymentNodeContext } from "src/context/node-context/subworkflow-deployment-node";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
-import {
-  EntityNotFoundError,
-  NodeDefinitionGenerationError,
-} from "src/generators/errors";
+import { NodeDefinitionGenerationError } from "src/generators/errors";
 import {
   InlinePromptNode,
-  InlinePromptNodeData,
-  LegacyPromptNodeData,
   WorkflowDataNode,
   WorkflowNodeType,
 } from "src/types/vellum";
 import { assertUnreachable } from "src/utils/typing";
 
-export async function createNodeContext(
+export function createNodeContext(
   args: BaseNodeContext.Args<WorkflowDataNode>
-): Promise<BaseNodeContext<WorkflowDataNode>> {
+): BaseNodeContext<WorkflowDataNode> {
   const nodeData = args.nodeData;
   switch (nodeData.type) {
     case WorkflowNodeType.SEARCH: {
       const searchNodeData = nodeData;
-
-      // Grab the associated document index from api if available to always populate document_index field
-      // with name instead of ID. We can only do this if the document index input is a constant value.
-      let documentIndex: DocumentIndexRead | null = null;
-      const inputValue = searchNodeData.inputs.find(
-        (input) => input.id === searchNodeData.data.documentIndexNodeInputId
-      )?.value;
-
-      const rule = inputValue?.rules?.[0];
-      if (rule?.type === "CONSTANT_VALUE") {
-        if (rule.data.value?.toString()) {
-          try {
-            documentIndex = await new DocumentIndexesClient({
-              apiKey: args.workflowContext.vellumApiKey,
-            }).retrieve(rule.data.value?.toString());
-          } catch (e) {
-            if (e instanceof VellumError && e.statusCode === 404) {
-              args.workflowContext.addError(
-                new EntityNotFoundError(
-                  `Document Index "${rule.data.value?.toString()}" not found.`
-                )
-              );
-            } else {
-              throw e;
-            }
-          }
-        }
-      }
-
       return new TextSearchNodeContext({
         ...args,
-        documentIndex,
         nodeData: searchNodeData,
       });
     }
@@ -89,19 +48,9 @@ export async function createNodeContext(
           });
         }
         case "DEPLOYMENT": {
-          const { releaseTag, workflowDeploymentId } = subworkflowNodeData.data;
-          const workflowDeploymentHistoryItem =
-            await new WorkflowDeploymentsClient({
-              apiKey: args.workflowContext.vellumApiKey,
-            }).workflowDeploymentHistoryItemRetrieve(
-              releaseTag,
-              workflowDeploymentId
-            );
-
           return new SubworkflowDeploymentNodeContext({
             ...args,
             nodeData: subworkflowNodeData,
-            workflowDeploymentHistoryItem,
           });
         }
         default: {
@@ -126,33 +75,9 @@ export async function createNodeContext(
     }
     case WorkflowNodeType.METRIC: {
       const guardrailNodeData = nodeData;
-      let metricDefinitionsHistoryItem:
-        | MetricDefinitionHistoryItem
-        | undefined = undefined;
-
-      try {
-        metricDefinitionsHistoryItem = await new MetricDefinitionsClient({
-          apiKey: args.workflowContext.vellumApiKey,
-        }).metricDefinitionHistoryItemRetrieve(
-          guardrailNodeData.data.releaseTag,
-          guardrailNodeData.data.metricDefinitionId
-        );
-      } catch (e) {
-        if (e instanceof VellumError && e.statusCode === 404) {
-          args.workflowContext.addError(
-            new EntityNotFoundError(
-              `Metric Definition "${guardrailNodeData.data.metricDefinitionId} ${guardrailNodeData.data.releaseTag}" not found.`
-            )
-          );
-        } else {
-          throw e;
-        }
-      }
-
       return new GuardrailNodeContext({
         ...args,
         nodeData: guardrailNodeData,
-        metricDefinitionsHistoryItem,
       });
     }
     case WorkflowNodeType.CODE_EXECUTION: {
@@ -174,32 +99,10 @@ export async function createNodeContext(
           });
         }
         case "LEGACY": {
-          // In the legacy case, we simply convert from LEGACY to INLINE on the fly.
-          const legacyNodeData: LegacyPromptNodeData = promptNodeData.data;
-
-          const promptVersionData =
-            legacyNodeData.sandboxRoutingConfig.promptVersionData;
-          if (!promptVersionData) {
-            throw new NodeDefinitionGenerationError(
-              `Prompt version data not found`
-            );
-          }
-
-          // Dynamically fetch the ML Model's name via API
-          const mlModelName = await args.workflowContext.getMLModelNameById(
-            promptVersionData.mlModelToWorkspaceId
-          );
-
-          const inlinePromptNodeData: InlinePromptNodeData = {
-            ...legacyNodeData,
-            variant: "INLINE",
-            mlModelName,
-            execConfig: promptVersionData.execConfig,
-          };
-
           return new InlinePromptNodeContext({
             ...args,
-            nodeData: { ...promptNodeData, data: inlinePromptNodeData },
+            // This is actually a LegacyPromptNode, but we're converting it to an InlinePromptNode on the fly with `buildProperties`
+            nodeData: promptNodeData as InlinePromptNode,
           });
         }
         case "DEPLOYMENT": {

--- a/ee/codegen/src/context/node-context/inline-prompt-node.ts
+++ b/ee/codegen/src/context/node-context/inline-prompt-node.ts
@@ -1,6 +1,11 @@
 import { BaseNodeContext } from "src/context/node-context/base";
 import { PortContext } from "src/context/port-context";
-import { InlinePromptNode as InlinePromptNodeType } from "src/types/vellum";
+import { NodeDefinitionGenerationError } from "src/generators/errors";
+import {
+  InlinePromptNodeData,
+  InlinePromptNode as InlinePromptNodeType,
+  LegacyPromptNodeData,
+} from "src/types/vellum";
 
 export class InlinePromptNodeContext extends BaseNodeContext<InlinePromptNodeType> {
   baseNodeClassName = "InlinePromptNode";
@@ -24,5 +29,35 @@ export class InlinePromptNodeContext extends BaseNodeContext<InlinePromptNodeTyp
         portId: this.nodeData.data.sourceHandleId,
       }),
     ];
+  }
+
+  async buildProperties(): Promise<void> {
+    // @ts-expect-error In the legacy case, we simply convert from LEGACY to INLINE on the fly after the context is initialized with the legacy node data.
+    if (this.nodeData.data.variant !== "LEGACY") {
+      return;
+    }
+
+    // @ts-expect-error
+    const legacyNodeData: LegacyPromptNodeData = this.nodeData.data;
+
+    const promptVersionData =
+      legacyNodeData.sandboxRoutingConfig.promptVersionData;
+    if (!promptVersionData) {
+      throw new NodeDefinitionGenerationError(`Prompt version data not found`);
+    }
+
+    // Dynamically fetch the ML Model's name via API
+    const mlModelName = await this.workflowContext.getMLModelNameById(
+      promptVersionData.mlModelToWorkspaceId
+    );
+
+    const inlinePromptNodeData: InlinePromptNodeData = {
+      ...legacyNodeData,
+      variant: "INLINE",
+      mlModelName,
+      execConfig: promptVersionData.execConfig,
+    };
+
+    this.nodeData = { ...this.nodeData, data: inlinePromptNodeData };
   }
 }

--- a/ee/codegen/src/context/node-context/text-search-node.ts
+++ b/ee/codegen/src/context/node-context/text-search-node.ts
@@ -1,25 +1,17 @@
 import { DocumentIndexRead } from "vellum-ai/api";
+import { DocumentIndexes as DocumentIndexesClient } from "vellum-ai/api/resources/documentIndexes/client/Client";
+import { VellumError } from "vellum-ai/errors";
 
 import { BaseNodeContext } from "./base";
 
 import { PortContext } from "src/context/port-context";
+import { EntityNotFoundError } from "src/generators/errors";
 import { SearchNode } from "src/types/vellum";
-
-export declare namespace TextSearchNodeContext {
-  interface Args extends BaseNodeContext.Args<SearchNode> {
-    documentIndex: DocumentIndexRead | null;
-  }
-}
 
 export class TextSearchNodeContext extends BaseNodeContext<SearchNode> {
   baseNodeClassName = "SearchNode";
   baseNodeDisplayClassName = "BaseSearchNodeDisplay";
-  documentIndex: DocumentIndexRead | null;
-
-  constructor(args: TextSearchNodeContext.Args) {
-    super(args);
-    this.documentIndex = args.documentIndex;
-  }
+  documentIndex: DocumentIndexRead | null = null;
 
   getNodeOutputNamesById(): Record<string, string> {
     return {
@@ -39,5 +31,37 @@ export class TextSearchNodeContext extends BaseNodeContext<SearchNode> {
         portId: this.nodeData.data.sourceHandleId,
       }),
     ];
+  }
+
+  async buildProperties(): Promise<void> {
+    // Grab the associated document index from api if available to always populate document_index field
+    // with name instead of ID. We can only do this if the document index input is a constant value.
+    let documentIndex: DocumentIndexRead | null = null;
+    const inputValue = this.nodeData.inputs.find(
+      (input) => input.id === this.nodeData.data.documentIndexNodeInputId
+    )?.value;
+
+    const rule = inputValue?.rules?.[0];
+    if (rule?.type === "CONSTANT_VALUE") {
+      if (rule.data.value?.toString()) {
+        try {
+          documentIndex = await new DocumentIndexesClient({
+            apiKey: this.workflowContext.vellumApiKey,
+          }).retrieve(rule.data.value?.toString());
+        } catch (e) {
+          if (e instanceof VellumError && e.statusCode === 404) {
+            this.workflowContext.addError(
+              new EntityNotFoundError(
+                `Document Index "${rule.data.value?.toString()}" not found.`
+              )
+            );
+          } else {
+            throw e;
+          }
+        }
+      }
+    }
+
+    this.documentIndex = documentIndex;
   }
 }

--- a/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
@@ -21,6 +21,12 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
       );
     }
 
+    if (!this.nodeContext.workflowDeploymentHistoryItem) {
+      throw new NodeDefinitionGenerationError(
+        "Workflow Deployment History Item is not set"
+      );
+    }
+
     statements.push(
       python.field({
         name: "deployment",
@@ -60,6 +66,12 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
   }
 
   private generateOutputsClass(): python.Class {
+    if (!this.nodeContext.workflowDeploymentHistoryItem) {
+      throw new NodeDefinitionGenerationError(
+        "Workflow Deployment History Item is not set"
+      );
+    }
+
     const nodeBaseClassRef = this.getNodeBaseClass();
     const outputsClass = python.class_({
       name: OUTPUTS_CLASS_NAME,
@@ -117,6 +129,12 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
   }
 
   protected getOutputDisplay(): python.Field {
+    if (!this.nodeContext.workflowDeploymentHistoryItem) {
+      throw new NodeDefinitionGenerationError(
+        "Workflow Deployment History Item is not set"
+      );
+    }
+
     return python.field({
       name: "output_display",
       initializer: python.TypeInstantiation.dict(

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -349,12 +349,10 @@ ${errors.slice(0, 3).map((err) => {
 
           nodesToGenerate.push(nodeData);
 
-          const nodeContext = createNodeContext({
+          await createNodeContext({
             workflowContext: this.workflowContext,
             nodeData,
           });
-          this.workflowContext.addNodeContext(nodeContext);
-          await nodeContext.buildProperties();
         }
       )
     );

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -349,11 +349,12 @@ ${errors.slice(0, 3).map((err) => {
 
           nodesToGenerate.push(nodeData);
 
-          const nodeContext = await createNodeContext({
+          const nodeContext = createNodeContext({
             workflowContext: this.workflowContext,
             nodeData,
           });
           this.workflowContext.addNodeContext(nodeContext);
+          await nodeContext.buildProperties();
         }
       )
     );


### PR DESCRIPTION
Workflow Sandbox that repro's the issue: http://localhost:3000/workflow-sandboxes/b34abe22-6cc9-4c73-a704-9f7a53489bc7

We had a test for this logic at the `workflow.test.ts` level, but the logic actually lived in `project.ts`. So I added a test to `project.test.ts` to reproduce the bug and proposed a fix.

The most important implementation file to review is `ee/codegen/src/project.ts` and I'd start there. Everything else is logicless downstream implications of that change