### PR TITLE
add serialization example for Retry nodes with generic node

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_node.py
@@ -18,6 +18,7 @@ from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
 from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
+from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.nodes.vellum.utils import convert_descriptor_to_operator
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum_ee.workflows.display.utils.vellum import primitive_to_vellum_value
@@ -50,11 +51,9 @@ class BaseNodeDisplay(BaseNodeVellumDisplay[_BaseNodeType], Generic[_BaseNodeTyp
 
         if has_wrapped_node(node):
             wrapped_node = get_wrapped_node(node)
+            display_class = get_node_display_class(BaseNodeDisplay, wrapped_node)
 
-            class WrappedBaseNodeDisplay(BaseNodeDisplay[wrapped_node]):
-                pass
-
-            adornment = {
+            adornment: JsonObject = {
                 "id": str(node_id),
                 "label": node.__qualname__,
                 "base": self.get_base().dict(),
@@ -62,7 +61,7 @@ class BaseNodeDisplay(BaseNodeVellumDisplay[_BaseNodeType], Generic[_BaseNodeTyp
             }
 
             existing_adornments = adornments if adornments is not None else []
-            return WrappedBaseNodeDisplay().serialize(display_context, adornments=existing_adornments + [adornment])
+            return display_class().serialize(display_context, adornments=existing_adornments + [adornment])
 
         ports: JsonArray = []
         for idx, port in enumerate(node.Ports):

--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_node.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, Generic, Optional, TypeVar, cast
 
 from vellum.workflows.constants import UNDEF
 from vellum.workflows.descriptors.base import BaseDescriptor
@@ -28,7 +28,7 @@ _BaseNodeType = TypeVar("_BaseNodeType", bound=BaseNode)
 
 class BaseNodeDisplay(BaseNodeVellumDisplay[_BaseNodeType], Generic[_BaseNodeType]):
     def serialize(
-        self, display_context: WorkflowDisplayContext, adornments: JsonArray = [], **kwargs: Any
+        self, display_context: WorkflowDisplayContext, adornments: Optional[JsonArray] = None, **kwargs: Any
     ) -> JsonObject:
         node = self._node
         node_id = self.node_id
@@ -61,7 +61,8 @@ class BaseNodeDisplay(BaseNodeVellumDisplay[_BaseNodeType], Generic[_BaseNodeTyp
                 "attributes": attributes,
             }
 
-            return WrappedBaseNodeDisplay().serialize(display_context, adornments=adornments + [adornment])
+            existing_adornments = adornments if adornments is not None else []
+            return WrappedBaseNodeDisplay().serialize(display_context, adornments=existing_adornments + [adornment])
 
         ports: JsonArray = []
         for idx, port in enumerate(node.Ports):

--- a/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
@@ -47,13 +47,16 @@ class BaseMapNodeDisplay(BaseNodeVellumDisplay[_MapNodeType], Generic[_MapNodeTy
 
         # Note: This must match the items input ID for the map node's node input
         items_workflow_input_id = next(
-            input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "items"
+            (input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "items"),
+            None,
         )
         item_workflow_input_id = next(
-            input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "item"
+            (input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "item"),
+            None,
         )
         index_workflow_input_id = next(
-            input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "index"
+            (input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "index"),
+            None,
         )
 
         return {

--- a/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
@@ -47,16 +47,13 @@ class BaseMapNodeDisplay(BaseNodeVellumDisplay[_MapNodeType], Generic[_MapNodeTy
 
         # Note: This must match the items input ID for the map node's node input
         items_workflow_input_id = next(
-            (input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "items"),
-            None,
+            input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "items"
         )
         item_workflow_input_id = next(
-            (input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "item"),
-            None,
+            input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "item"
         )
         index_workflow_input_id = next(
-            (input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "index"),
-            None,
+            input_variable["id"] for input_variable in renamed_input_variables if input_variable["key"] == "index"
         )
 
         return {

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -1,219 +1,50 @@
+from uuid import uuid4
+
 from deepdiff import DeepDiff
 
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode
-from vellum.workflows.nodes.core.map_node.node import MapNode
+from vellum.workflows.nodes.core.retry_node.node import RetryNode
 from vellum.workflows.outputs.base import BaseOutputs
 from vellum.workflows.state.base import BaseState
 from vellum.workflows.workflows.base import BaseWorkflow
-from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.nodes.vellum.base_node import BaseNodeDisplay
+
+from ee.vellum_ee.workflows.display.base import WorkflowInputsDisplay
 
 
 class Inputs(BaseInputs):
-    foo: str
+    input: str
 
 
-class State(BaseState):
-    bar: str
-
-
-@MapNode.wrap(items=[1, 2, 3])
-class MapGenericNode(BaseNode):
-    item = MapNode.SubworkflowInputs.item
-    foo = Inputs.foo
-    bar = State.bar
+@RetryNode.wrap(max_attempts=3)
+class InnerRetryGenericNode(BaseNode):
+    input = Inputs.input
 
     class Outputs(BaseOutputs):
-        value: str
-
-    def run(self) -> Outputs:
-        return self.Outputs(value=f"{self.foo} {self.bar} {self.item}")
+        output: str
 
 
-class MapGenericNodeWorkflow(BaseWorkflow[BaseInputs, BaseState]):
-    graph = {MapGenericNode}
+class InnerRetryGenericNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode.__wrapped_node__]):
+    pass
 
 
-def test_serialize_node__map():
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=MapGenericNodeWorkflow
+class OuterRetryNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode]):
+    pass
+
+
+class InnerRetryGenericNodeWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+    graph = {InnerRetryGenericNode}
+
+
+def test_serialize_node__retry(serialize_node):
+    input_id = uuid4()
+    serialized_node = serialize_node(
+        node_class=InnerRetryGenericNode,
+        global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)},
     )
-    serialized_workflow: dict = workflow_display.serialize()
     assert not DeepDiff(
-        {
-            "workflow_raw_data": {
-                "nodes": [
-                    {
-                        "id": "08de39f4-3019-455a-bc6c-331ae19c6e2a",
-                        "type": "ENTRYPOINT",
-                        "inputs": [],
-                        "data": {
-                            "label": "Entrypoint Node",
-                            "source_handle_id": "9c071b05-0071-4897-a0d8-ba68913de5e1",
-                        },
-                        "display_data": {"position": {"x": 0.0, "y": 0.0}},
-                        "base": None,
-                        "definition": None,
-                    },
-                    {
-                        "id": "527a10bc-30b2-4e36-91d6-91c8e865bac8",
-                        "type": "MAP",
-                        "inputs": [
-                            {
-                                "id": "5771822f-86c8-4f98-a79d-1a8567a1800b",
-                                "key": "items",
-                                "value": {
-                                    "rules": [{"type": "CONSTANT_VALUE", "data": {"type": "JSON", "value": [1, 2, 3]}}],
-                                    "combinator": "OR",
-                                },
-                            }
-                        ],
-                        "data": {
-                            "label": "Map Node",
-                            "error_output_id": None,
-                            "source_handle_id": "c59be5f3-c304-4763-afdc-1d775f9e1a05",
-                            "target_handle_id": "3a702aac-7b68-47d3-92e1-264883e9532c",
-                            "variant": "INLINE",
-                            "workflow_raw_data": {
-                                "nodes": [
-                                    {
-                                        "id": "e9689479-745e-41e0-9516-8c077fdbc7de",
-                                        "type": "ENTRYPOINT",
-                                        "inputs": [],
-                                        "data": {
-                                            "label": "Entrypoint Node",
-                                            "source_handle_id": "4bd5ba28-f0b7-478c-97bc-015c84557557",
-                                        },
-                                        "display_data": {"position": {"x": 0.0, "y": 0.0}},
-                                        "base": None,
-                                        "definition": None,
-                                    },
-                                    {
-                                        "id": "ff5b8b34-dd8b-4900-8b4c-0175ad6489e9",
-                                        "type": "TERMINAL",
-                                        "data": {
-                                            "label": "Final Output",
-                                            "name": "value",
-                                            "target_handle_id": "6fbe546a-d516-47a8-9bad-c4361a0d0911",
-                                            "output_id": "319d604f-e435-45c0-999d-73a5f1d37fd1",
-                                            "output_type": "STRING",
-                                            "node_input_id": "4c4a3b61-8bfe-4803-8f7b-daedae025b32",
-                                        },
-                                        "inputs": [
-                                            {
-                                                "id": "4c4a3b61-8bfe-4803-8f7b-daedae025b32",
-                                                "key": "node_input",
-                                                "value": {
-                                                    "rules": [
-                                                        {
-                                                            "type": "NODE_OUTPUT",
-                                                            "data": {
-                                                                "node_id": "862bbecb-6eb4-4b65-99c2-e8a5d72a742d",
-                                                                "output_id": "6aaf397f-a3e2-4a1d-a2ae-58f945d91ecc",
-                                                            },
-                                                        }
-                                                    ],
-                                                    "combinator": "OR",
-                                                },
-                                            }
-                                        ],
-                                        "display_data": {"position": {"x": 0.0, "y": 0.0}},
-                                        "base": {
-                                            "name": "FinalOutputNode",
-                                            "module": [
-                                                "vellum",
-                                                "workflows",
-                                                "nodes",
-                                                "displayable",
-                                                "final_output_node",
-                                                "node",
-                                            ],
-                                        },
-                                        "definition": None,
-                                    },
-                                ],
-                                "edges": [
-                                    {
-                                        "id": "716c0f7f-7636-40b1-972c-59f9b0200774",
-                                        "source_node_id": "e9689479-745e-41e0-9516-8c077fdbc7de",
-                                        "source_handle_id": "4bd5ba28-f0b7-478c-97bc-015c84557557",
-                                        "target_node_id": "862bbecb-6eb4-4b65-99c2-e8a5d72a742d",
-                                        "target_handle_id": "a568a8fb-fd40-4cd1-bfb6-c829664857de",
-                                        "type": "DEFAULT",
-                                    },
-                                    {
-                                        "id": "dc2ede20-6f04-43d3-b5cd-305814aa9fca",
-                                        "source_node_id": "862bbecb-6eb4-4b65-99c2-e8a5d72a742d",
-                                        "source_handle_id": "c59be5f3-c304-4763-afdc-1d775f9e1a05",
-                                        "target_node_id": "ff5b8b34-dd8b-4900-8b4c-0175ad6489e9",
-                                        "target_handle_id": "6fbe546a-d516-47a8-9bad-c4361a0d0911",
-                                        "type": "DEFAULT",
-                                    },
-                                ],
-                                "display_data": {"viewport": {"x": 0.0, "y": 0.0, "zoom": 1.0}},
-                                "definition": {
-                                    "name": "Subworkflow",
-                                    "module": ["vellum", "workflows", "nodes", "utils"],
-                                },
-                            },
-                            "input_variables": [],
-                            "output_variables": [
-                                {"id": "319d604f-e435-45c0-999d-73a5f1d37fd1", "key": "value", "type": "STRING"}
-                            ],
-                            "concurrency": None,
-                            "items_input_id": None,
-                            "item_input_id": None,
-                            "index_input_id": None,
-                        },
-                        "display_data": {"position": {"x": 0.0, "y": 0.0}},
-                        "base": {
-                            "name": "MapNode",
-                            "module": ["vellum", "workflows", "nodes", "core", "map_node", "node"],
-                        },
-                        "definition": {
-                            "name": "MapNode",
-                            "module": [
-                                "vellum_ee",
-                                "workflows",
-                                "display",
-                                "tests",
-                                "workflow_serialization",
-                                "generic_nodes",
-                                "test_adornments_serialization",
-                                "MapGenericNode",
-                                "<adornment>",
-                            ],
-                        },
-                    },
-                ],
-                "edges": [
-                    {
-                        "id": "c2df60be-be62-4d57-b6b3-6d5b23aa5790",
-                        "source_node_id": "08de39f4-3019-455a-bc6c-331ae19c6e2a",
-                        "source_handle_id": "9c071b05-0071-4897-a0d8-ba68913de5e1",
-                        "target_node_id": "862bbecb-6eb4-4b65-99c2-e8a5d72a742d",
-                        "target_handle_id": "a568a8fb-fd40-4cd1-bfb6-c829664857de",
-                        "type": "DEFAULT",
-                    }
-                ],
-                "display_data": {"viewport": {"x": 0.0, "y": 0.0, "zoom": 1.0}},
-                "definition": {
-                    "name": "MapGenericNodeWorkflow",
-                    "module": [
-                        "vellum_ee",
-                        "workflows",
-                        "display",
-                        "tests",
-                        "workflow_serialization",
-                        "generic_nodes",
-                        "test_adornments_serialization",
-                    ],
-                },
-            },
-            "input_variables": [],
-            "output_variables": [],
-        },
-        serialized_workflow,
+        {},
+        serialized_node,
         ignore_order=True,
     )

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -1,5 +1,3 @@
-import pytest
-
 from deepdiff import DeepDiff
 
 from vellum.workflows.inputs.base import BaseInputs
@@ -7,6 +5,9 @@ from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.map_node.node import MapNode
 from vellum.workflows.outputs.base import BaseOutputs
 from vellum.workflows.state.base import BaseState
+from vellum.workflows.workflows.base import BaseWorkflow
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
 class Inputs(BaseInputs):
@@ -30,38 +31,189 @@ class MapGenericNode(BaseNode):
         return self.Outputs(value=f"{self.foo} {self.bar} {self.item}")
 
 
-@pytest.mark.skip(reason="not implemented")
-def test_serialize_node__try(serialize_node):
-    serialized_node = serialize_node(MapGenericNode)
+class MapGenericNodeWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+    graph = {MapGenericNode}
+
+
+def test_serialize_node__map():
+    workflow_display = get_workflow_display(
+        base_display_class=VellumWorkflowDisplay, workflow_class=MapGenericNodeWorkflow
+    )
+    serialized_workflow: dict = workflow_display.serialize()
     assert not DeepDiff(
         {
-            "id": "c2ed23f7-f6cb-4a56-a91c-2e5f9d8fda7f",
-            "label": "BasicGenericNode",
-            "type": "GENERIC",
-            "display_data": {"position": {"x": 0.0, "y": 0.0}},
-            "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
-            "definition": {
-                "name": "BasicGenericNode",
-                "module": [
-                    "vellum_ee",
-                    "workflows",
-                    "display",
-                    "tests",
-                    "workflow_serialization",
-                    "generic_nodes",
-                    "test_adornments_serialization",
+            "workflow_raw_data": {
+                "nodes": [
+                    {
+                        "id": "08de39f4-3019-455a-bc6c-331ae19c6e2a",
+                        "type": "ENTRYPOINT",
+                        "inputs": [],
+                        "data": {
+                            "label": "Entrypoint Node",
+                            "source_handle_id": "9c071b05-0071-4897-a0d8-ba68913de5e1",
+                        },
+                        "display_data": {"position": {"x": 0.0, "y": 0.0}},
+                        "base": None,
+                        "definition": None,
+                    },
+                    {
+                        "id": "527a10bc-30b2-4e36-91d6-91c8e865bac8",
+                        "type": "MAP",
+                        "inputs": [
+                            {
+                                "id": "5771822f-86c8-4f98-a79d-1a8567a1800b",
+                                "key": "items",
+                                "value": {
+                                    "rules": [{"type": "CONSTANT_VALUE", "data": {"type": "JSON", "value": [1, 2, 3]}}],
+                                    "combinator": "OR",
+                                },
+                            }
+                        ],
+                        "data": {
+                            "label": "Map Node",
+                            "error_output_id": None,
+                            "source_handle_id": "c59be5f3-c304-4763-afdc-1d775f9e1a05",
+                            "target_handle_id": "3a702aac-7b68-47d3-92e1-264883e9532c",
+                            "variant": "INLINE",
+                            "workflow_raw_data": {
+                                "nodes": [
+                                    {
+                                        "id": "e9689479-745e-41e0-9516-8c077fdbc7de",
+                                        "type": "ENTRYPOINT",
+                                        "inputs": [],
+                                        "data": {
+                                            "label": "Entrypoint Node",
+                                            "source_handle_id": "4bd5ba28-f0b7-478c-97bc-015c84557557",
+                                        },
+                                        "display_data": {"position": {"x": 0.0, "y": 0.0}},
+                                        "base": None,
+                                        "definition": None,
+                                    },
+                                    {
+                                        "id": "ff5b8b34-dd8b-4900-8b4c-0175ad6489e9",
+                                        "type": "TERMINAL",
+                                        "data": {
+                                            "label": "Final Output",
+                                            "name": "value",
+                                            "target_handle_id": "6fbe546a-d516-47a8-9bad-c4361a0d0911",
+                                            "output_id": "319d604f-e435-45c0-999d-73a5f1d37fd1",
+                                            "output_type": "STRING",
+                                            "node_input_id": "4c4a3b61-8bfe-4803-8f7b-daedae025b32",
+                                        },
+                                        "inputs": [
+                                            {
+                                                "id": "4c4a3b61-8bfe-4803-8f7b-daedae025b32",
+                                                "key": "node_input",
+                                                "value": {
+                                                    "rules": [
+                                                        {
+                                                            "type": "NODE_OUTPUT",
+                                                            "data": {
+                                                                "node_id": "862bbecb-6eb4-4b65-99c2-e8a5d72a742d",
+                                                                "output_id": "6aaf397f-a3e2-4a1d-a2ae-58f945d91ecc",
+                                                            },
+                                                        }
+                                                    ],
+                                                    "combinator": "OR",
+                                                },
+                                            }
+                                        ],
+                                        "display_data": {"position": {"x": 0.0, "y": 0.0}},
+                                        "base": {
+                                            "name": "FinalOutputNode",
+                                            "module": [
+                                                "vellum",
+                                                "workflows",
+                                                "nodes",
+                                                "displayable",
+                                                "final_output_node",
+                                                "node",
+                                            ],
+                                        },
+                                        "definition": None,
+                                    },
+                                ],
+                                "edges": [
+                                    {
+                                        "id": "716c0f7f-7636-40b1-972c-59f9b0200774",
+                                        "source_node_id": "e9689479-745e-41e0-9516-8c077fdbc7de",
+                                        "source_handle_id": "4bd5ba28-f0b7-478c-97bc-015c84557557",
+                                        "target_node_id": "862bbecb-6eb4-4b65-99c2-e8a5d72a742d",
+                                        "target_handle_id": "a568a8fb-fd40-4cd1-bfb6-c829664857de",
+                                        "type": "DEFAULT",
+                                    },
+                                    {
+                                        "id": "dc2ede20-6f04-43d3-b5cd-305814aa9fca",
+                                        "source_node_id": "862bbecb-6eb4-4b65-99c2-e8a5d72a742d",
+                                        "source_handle_id": "c59be5f3-c304-4763-afdc-1d775f9e1a05",
+                                        "target_node_id": "ff5b8b34-dd8b-4900-8b4c-0175ad6489e9",
+                                        "target_handle_id": "6fbe546a-d516-47a8-9bad-c4361a0d0911",
+                                        "type": "DEFAULT",
+                                    },
+                                ],
+                                "display_data": {"viewport": {"x": 0.0, "y": 0.0, "zoom": 1.0}},
+                                "definition": {
+                                    "name": "Subworkflow",
+                                    "module": ["vellum", "workflows", "nodes", "utils"],
+                                },
+                            },
+                            "input_variables": [],
+                            "output_variables": [
+                                {"id": "319d604f-e435-45c0-999d-73a5f1d37fd1", "key": "value", "type": "STRING"}
+                            ],
+                            "concurrency": None,
+                            "items_input_id": None,
+                            "item_input_id": None,
+                            "index_input_id": None,
+                        },
+                        "display_data": {"position": {"x": 0.0, "y": 0.0}},
+                        "base": {
+                            "name": "MapNode",
+                            "module": ["vellum", "workflows", "nodes", "core", "map_node", "node"],
+                        },
+                        "definition": {
+                            "name": "MapNode",
+                            "module": [
+                                "vellum_ee",
+                                "workflows",
+                                "display",
+                                "tests",
+                                "workflow_serialization",
+                                "generic_nodes",
+                                "test_adornments_serialization",
+                                "MapGenericNode",
+                                "<adornment>",
+                            ],
+                        },
+                    },
                 ],
+                "edges": [
+                    {
+                        "id": "c2df60be-be62-4d57-b6b3-6d5b23aa5790",
+                        "source_node_id": "08de39f4-3019-455a-bc6c-331ae19c6e2a",
+                        "source_handle_id": "9c071b05-0071-4897-a0d8-ba68913de5e1",
+                        "target_node_id": "862bbecb-6eb4-4b65-99c2-e8a5d72a742d",
+                        "target_handle_id": "a568a8fb-fd40-4cd1-bfb6-c829664857de",
+                        "type": "DEFAULT",
+                    }
+                ],
+                "display_data": {"viewport": {"x": 0.0, "y": 0.0, "zoom": 1.0}},
+                "definition": {
+                    "name": "MapGenericNodeWorkflow",
+                    "module": [
+                        "vellum_ee",
+                        "workflows",
+                        "display",
+                        "tests",
+                        "workflow_serialization",
+                        "generic_nodes",
+                        "test_adornments_serialization",
+                    ],
+                },
             },
-            "trigger": {"id": "9d3a1b3d-4a38-4f2e-bbf1-dd8be152bce8", "merge_behavior": "AWAIT_ANY"},
-            "ports": [
-                {
-                    "id": "4fbf0fff-a42e-4410-852a-238b5059198e",
-                    "type": "DEFAULT",
-                }
-            ],
-            "adornments": None,
-            "attributes": [],
+            "input_variables": [],
+            "output_variables": [],
         },
-        serialized_node,
+        serialized_workflow,
         ignore_order=True,
     )

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -6,8 +6,6 @@ from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.retry_node.node import RetryNode
 from vellum.workflows.outputs.base import BaseOutputs
-from vellum.workflows.state.base import BaseState
-from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.base import WorkflowInputsDisplay
 from vellum_ee.workflows.display.nodes.vellum.base_node import BaseNodeDisplay
 
@@ -24,7 +22,7 @@ class InnerRetryGenericNode(BaseNode):
         output: str
 
 
-class InnerRetryGenericNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode.__wrapped_node__]):
+class InnerRetryGenericNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode.__wrapped_node__]):  # type: ignore
     pass
 
 
@@ -32,15 +30,15 @@ class OuterRetryNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode]):
     pass
 
 
-class InnerRetryGenericNodeWorkflow(BaseWorkflow[BaseInputs, BaseState]):
-    graph = {InnerRetryGenericNode}
-
-
 def test_serialize_node__retry(serialize_node):
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=InnerRetryGenericNode,
         global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)},
+        global_node_displays={
+            InnerRetryGenericNode.__wrapped_node__: InnerRetryGenericNodeDisplay,
+            InnerRetryGenericNode: OuterRetryNodeDisplay,
+        },
     )
 
     assert not DeepDiff(

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -8,9 +8,8 @@ from vellum.workflows.nodes.core.retry_node.node import RetryNode
 from vellum.workflows.outputs.base import BaseOutputs
 from vellum.workflows.state.base import BaseState
 from vellum.workflows.workflows.base import BaseWorkflow
+from vellum_ee.workflows.display.base import WorkflowInputsDisplay
 from vellum_ee.workflows.display.nodes.vellum.base_node import BaseNodeDisplay
-
-from ee.vellum_ee.workflows.display.base import WorkflowInputsDisplay
 
 
 class Inputs(BaseInputs):

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -43,8 +43,66 @@ def test_serialize_node__retry(serialize_node):
         node_class=InnerRetryGenericNode,
         global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)},
     )
+
     assert not DeepDiff(
-        {},
+        {
+            "id": "f2a95e79-7d4b-47ad-b986-4f648297ec65",
+            "label": "InnerRetryGenericNode",
+            "type": "GENERIC",
+            "display_data": {"position": {"x": 0.0, "y": 0.0}},
+            "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
+            "definition": {
+                "name": "InnerRetryGenericNode",
+                "module": [
+                    "vellum_ee",
+                    "workflows",
+                    "display",
+                    "tests",
+                    "workflow_serialization",
+                    "generic_nodes",
+                    "test_adornments_serialization",
+                ],
+            },
+            "trigger": {"id": "af9ba01c-4cde-4632-9aa1-7673b42e7bd8", "merge_behavior": "AWAIT_ANY"},
+            "ports": [{"id": "55d46900-e558-4264-8802-a5c5fe7226fe", "name": "default", "type": "DEFAULT"}],
+            "adornments": [
+                {
+                    "id": "5be7d260-74f7-4734-b31b-a46a94539586",
+                    "label": "RetryNode",
+                    "base": {
+                        "name": "RetryNode",
+                        "module": ["vellum", "workflows", "nodes", "core", "retry_node", "node"],
+                    },
+                    "attributes": [
+                        {
+                            "id": "f388e93b-8c68-4f54-8577-bbd0c9091557",
+                            "name": "max_attempts",
+                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "NUMBER", "value": 3.0}},
+                        },
+                        {
+                            "id": "c91782e3-140f-4938-9c23-d2a7b85dcdd8",
+                            "name": "retry_on_error_code",
+                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                        },
+                        {
+                            "id": "73a02e62-4535-4e1f-97b5-1264ca8b1d71",
+                            "name": "retry_on_condition",
+                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                        },
+                    ],
+                }
+            ],
+            "attributes": [
+                {
+                    "id": "c363daa7-9482-4c0e-aee8-faa080602ee3",
+                    "name": "input",
+                    "value": {"type": "WORKFLOW_INPUT", "input_variable_id": str(input_id)},
+                }
+            ],
+            "outputs": [
+                {"id": "8aaf6cd8-3fa5-4f17-a60f-ec7da5ec6498", "name": "output", "type": "STRING", "value": None}
+            ],
+        },
         serialized_node,
         ignore_order=True,
     )

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -207,11 +207,13 @@ class BaseWorkflowDisplay(
         # TODO: We should still serialize nodes that are in the workflow's directory but aren't used in the graph.
         # https://app.shortcut.com/vellum/story/5394
         for node in self._workflow.get_nodes():
-            if node in global_node_displays:
-                continue
             node_display = self._get_node_display(node)
-            node_displays[node] = node_display
-            global_node_displays[node] = node_display
+
+            if node not in node_displays:
+                node_displays[node] = node_display
+
+            if node not in global_node_displays:
+                global_node_displays[node] = node_display
 
             # Nodes wrapped in a decorator need to be in our node display dictionary for later retrieval
             if has_wrapped_node(node):


### PR DESCRIPTION
This is the first example of a serialized adornment using Retry nodes. I will add it for Try nodes next.