### PR TITLE
[SC-6273] Handle null/notNull operators on search node metadata filters and improve error messages

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
@@ -17,7 +17,7 @@ class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
     target_handle_id = UUID("370d712d-3369-424e-bcf7-f4da1aef3928")
     metadata_filter_input_id_by_operand_id = {
         UUID("a6322ca2-8b65-4d26-b3a1-f926dcada0fa"): UUID(
-            "c539a2e2-0873-43b0-ae21-81790bb1c4cb"
+            "a6322ca2-8b65-4d26-b3a1-f926dcada0fa"
         ),
         UUID("c539a2e2-0873-43b0-ae21-81790bb1c4cb"): UUID(
             "c539a2e2-0873-43b0-ae21-81790bb1c4cb"
@@ -116,22 +116,19 @@ class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
     target_handle_id = UUID("370d712d-3369-424e-bcf7-f4da1aef3928")
     metadata_filter_input_id_by_operand_id = {
         UUID("500ce391-ee26-4588-a5a0-2dfa6b70add5"): UUID(
-            "3321686c-b131-4651-a18c-3e578252abf4"
+            "500ce391-ee26-4588-a5a0-2dfa6b70add5"
         ),
         UUID("3321686c-b131-4651-a18c-3e578252abf4"): UUID(
             "3321686c-b131-4651-a18c-3e578252abf4"
         ),
         UUID("28682e34-ef0c-47fd-a32e-8228a53360b0"): UUID(
-            "65a90810-f26b-4848-9c7f-29f324450e07"
+            "28682e34-ef0c-47fd-a32e-8228a53360b0"
         ),
         UUID("65a90810-f26b-4848-9c7f-29f324450e07"): UUID(
             "65a90810-f26b-4848-9c7f-29f324450e07"
         ),
         UUID("4f88fdee-4bee-40d8-a998-bbbc7255029c"): UUID(
-            "dc1b9237-5fde-4d9f-9648-792475e02cfa"
-        ),
-        UUID("dc1b9237-5fde-4d9f-9648-792475e02cfa"): UUID(
-            "dc1b9237-5fde-4d9f-9648-792475e02cfa"
+            "4f88fdee-4bee-40d8-a998-bbbc7255029c"
         ),
     }
     node_input_ids_by_name = {
@@ -150,7 +147,7 @@ class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
             "65a90810-f26b-4848-9c7f-29f324450e07"
         ),
         "vellum-query-builder-variable-4f88fdee-4bee-40d8-a998-bbbc7255029c": UUID(
-            "dc1b9237-5fde-4d9f-9648-792475e02cfa"
+            "4f88fdee-4bee-40d8-a998-bbbc7255029c"
         ),
     }
     output_display = {
@@ -201,9 +198,7 @@ class SearchNode(BaseSearchNode):
                 MetadataLogicalCondition(
                     lhs_variable="STATUS", operator="=", rhs_variable="1"
                 ),
-                MetadataLogicalCondition(
-                    lhs_variable="DELETED_AT", operator="null", rhs_variable="true"
-                ),
+                MetadataLogicalCondition(lhs_variable="DELETED_AT", operator="null"),
             ],
         ),
     )
@@ -229,7 +224,7 @@ class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
     target_handle_id = UUID("370d712d-3369-424e-bcf7-f4da1aef3928")
     metadata_filter_input_id_by_operand_id = {
         UUID("a6322ca2-8b65-4d26-b3a1-f926dcada0fa"): UUID(
-            "c539a2e2-0873-43b0-ae21-81790bb1c4cb"
+            "a6322ca2-8b65-4d26-b3a1-f926dcada0fa"
         ),
         UUID("c539a2e2-0873-43b0-ae21-81790bb1c4cb"): UUID(
             "c539a2e2-0873-43b0-ae21-81790bb1c4cb"

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -191,22 +191,6 @@ describe("TextSearchNode", () => {
               combinator: "OR",
             },
           },
-          {
-            id: "dc1b9237-5fde-4d9f-9648-792475e02cfa",
-            key: "vellum-query-builder-variable-4f88fdee-4bee-40d8-a998-bbbc7255029c",
-            value: {
-              rules: [
-                {
-                  type: "CONSTANT_VALUE",
-                  data: {
-                    type: "STRING",
-                    value: "true",
-                  },
-                },
-              ],
-              combinator: "OR",
-            },
-          },
         ],
         metadataFilters: {
           type: "LOGICAL_CONDITION_GROUP",

--- a/ee/codegen/src/utils/nodes.ts
+++ b/ee/codegen/src/utils/nodes.ts
@@ -28,3 +28,7 @@ export function getNodeLabel(nodeData: WorkflowNode): string {
       return nodeData.data.label;
   }
 }
+
+export function isUnaryOperator(operator: string): boolean {
+  return operator === "null" || operator === "notNull";
+}

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/nodes/search_node.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/nodes/search_node.py
@@ -12,9 +12,9 @@ class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
     node_id = UUID("e5ff9360-a29c-437b-a9c1-05fc52df2834")
     target_handle_id = UUID("370d712d-3369-424e-bcf7-f4da1aef3928")
     metadata_filter_input_id_by_operand_id = {
-        UUID("a6322ca2-8b65-4d26-b3a1-f926dcada0fa"): UUID("c539a2e2-0873-43b0-ae21-81790bb1c4cb"),
+        UUID("a6322ca2-8b65-4d26-b3a1-f926dcada0fa"): UUID("a6322ca2-8b65-4d26-b3a1-f926dcada0fa"),
         UUID("c539a2e2-0873-43b0-ae21-81790bb1c4cb"): UUID("c539a2e2-0873-43b0-ae21-81790bb1c4cb"),
-        UUID("a89483b6-6850-4105-8c4e-ec0fd197cd43"): UUID("847b8ee0-2c37-4e41-9dea-b4ba3579e2c1"),
+        UUID("a89483b6-6850-4105-8c4e-ec0fd197cd43"): UUID("a89483b6-6850-4105-8c4e-ec0fd197cd43"),
         UUID("847b8ee0-2c37-4e41-9dea-b4ba3579e2c1"): UUID("847b8ee0-2c37-4e41-9dea-b4ba3579e2c1"),
     }
     node_input_ids_by_name = {


### PR DESCRIPTION
Context: This came up from QAing workflows and the data we get from main vellum is that we have a `rhsVariableId` when given a null/notNull operator but no corresponding vellum-query-builder input variable. This PR handles the bad data issue