### PR TITLE
[SC-6284] Safe cast search node limit param to int if it is valid string

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -29,6 +29,7 @@ import {
   NodeAttribute,
   NodeOutput,
   AdornmentNode,
+  ConstantValuePointer,
 } from "src/types/vellum";
 
 export function entrypointNodeDataFactory(): EntrypointNode {
@@ -98,6 +99,7 @@ export function searchNodeDataFactory(args?: {
   metadataFilters?: VellumLogicalConditionGroup;
   metadataFilterInputs?: NodeInput[];
   errorOutputId?: string;
+  limitInput?: ConstantValuePointer;
 }): SearchNode {
   const errorOutputId = args?.errorOutputId;
 
@@ -232,7 +234,7 @@ export function searchNodeDataFactory(args?: {
         key: "limit",
         value: {
           rules: [
-            {
+            args?.limitInput ?? {
               type: "CONSTANT_VALUE",
               data: {
                 type: "NUMBER",

--- a/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
@@ -99,6 +99,105 @@ class SearchNode(BaseSearchNode):
 "
 `;
 
+exports[`TextSearchNode > limit param should cast string to int > getNodeDisplayFile 1`] = `
+"from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
+from ...nodes.search_node import SearchNode
+from uuid import UUID
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
+    label = "Search Node"
+    node_id = UUID("search")
+    target_handle_id = UUID("370d712d-3369-424e-bcf7-f4da1aef3928")
+    metadata_filter_input_id_by_operand_id = {
+        UUID("a6322ca2-8b65-4d26-b3a1-f926dcada0fa"): UUID(
+            "a6322ca2-8b65-4d26-b3a1-f926dcada0fa"
+        ),
+        UUID("c539a2e2-0873-43b0-ae21-81790bb1c4cb"): UUID(
+            "c539a2e2-0873-43b0-ae21-81790bb1c4cb"
+        ),
+    }
+    node_input_ids_by_name = {
+        "query": UUID("f3a0d8b9-7772-4db6-8e28-f49f8c4d9e2a"),
+        "document_index_id": UUID("b49bc1ab-2ad5-4cf2-8966-5cc87949900d"),
+        "weights": UUID("1daf3180-4b92-472a-8665-a7703c84a94e"),
+        "limit": UUID("161d264e-d04e-4c37-8e50-8bbb4c90c46e"),
+        "separator": UUID("4eddefc0-90d5-422a-aec2-bc94c8f1d83c"),
+        "result_merging_enabled": UUID("dc9f880b-81bc-4644-b025-8f7d5db23a48"),
+        "external_id_filters": UUID("61933e79-b0c2-4e3c-bf07-e2d93b9d9c54"),
+        "metadata_filters": UUID("7c43b315-d1f2-4727-9540-6cc3fd4641f3"),
+        "vellum-query-builder-variable-a6322ca2-8b65-4d26-b3a1-f926dcada0fa": UUID(
+            "a6322ca2-8b65-4d26-b3a1-f926dcada0fa"
+        ),
+        "vellum-query-builder-variable-c539a2e2-0873-43b0-ae21-81790bb1c4cb": UUID(
+            "c539a2e2-0873-43b0-ae21-81790bb1c4cb"
+        ),
+    }
+    output_display = {
+        SearchNode.Outputs.results: NodeOutputDisplay(
+            id=UUID("77839b3c-fe1c-4dcb-9c61-2fac827f729b"), name="results"
+        ),
+        SearchNode.Outputs.text: NodeOutputDisplay(
+            id=UUID("d56d7c49-7b45-4933-9779-2bd7f82c2141"), name="text"
+        ),
+    }
+    port_displays = {
+        SearchNode.Ports.default: PortDisplayOverrides(
+            id=UUID("e4dedb66-0638-4f0c-9941-6420bfe353b2")
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=0, y=0), width=None, height=None
+    )
+"
+`;
+
+exports[`TextSearchNode > limit param should cast string to int > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
+from ..inputs import Inputs
+from vellum import SearchWeightsRequest, SearchResultMergingRequest
+from vellum.workflows.nodes.displayable.bases.types import (
+    SearchFilters,
+    MetadataLogicalConditionGroup,
+    MetadataLogicalCondition,
+)
+
+
+class SearchNode(BaseSearchNode):
+    query = Inputs.query
+    document_index = "my-sweet-document"
+    limit = 8
+    weights = SearchWeightsRequest(semantic_similarity=0.8, keywords=0.2)
+    result_merging = SearchResultMergingRequest(enabled=True)
+    filters = SearchFilters(
+        external_ids=None,
+        metadata=MetadataLogicalConditionGroup(
+            combinator="AND",
+            negated=False,
+            conditions=[
+                MetadataLogicalConditionGroup(
+                    combinator="AND",
+                    negated=False,
+                    conditions=[
+                        MetadataLogicalCondition(
+                            lhs_variable=Inputs.var1,
+                            operator="=",
+                            rhs_variable=Inputs.var1,
+                        )
+                    ],
+                )
+            ],
+        ),
+    )
+    chunk_separator = "\\n\\n#####\\n\\n"
+"
+`;
+
 exports[`TextSearchNode > metadata filters > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from ...nodes.search_node import SearchNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
@@ -99,64 +99,6 @@ class SearchNode(BaseSearchNode):
 "
 `;
 
-exports[`TextSearchNode > limit param should cast string to int > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
-from ...nodes.search_node import SearchNode
-from uuid import UUID
-from vellum_ee.workflows.display.nodes.types import (
-    NodeOutputDisplay,
-    PortDisplayOverrides,
-)
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
-
-
-class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
-    label = "Search Node"
-    node_id = UUID("search")
-    target_handle_id = UUID("370d712d-3369-424e-bcf7-f4da1aef3928")
-    metadata_filter_input_id_by_operand_id = {
-        UUID("a6322ca2-8b65-4d26-b3a1-f926dcada0fa"): UUID(
-            "a6322ca2-8b65-4d26-b3a1-f926dcada0fa"
-        ),
-        UUID("c539a2e2-0873-43b0-ae21-81790bb1c4cb"): UUID(
-            "c539a2e2-0873-43b0-ae21-81790bb1c4cb"
-        ),
-    }
-    node_input_ids_by_name = {
-        "query": UUID("f3a0d8b9-7772-4db6-8e28-f49f8c4d9e2a"),
-        "document_index_id": UUID("b49bc1ab-2ad5-4cf2-8966-5cc87949900d"),
-        "weights": UUID("1daf3180-4b92-472a-8665-a7703c84a94e"),
-        "limit": UUID("161d264e-d04e-4c37-8e50-8bbb4c90c46e"),
-        "separator": UUID("4eddefc0-90d5-422a-aec2-bc94c8f1d83c"),
-        "result_merging_enabled": UUID("dc9f880b-81bc-4644-b025-8f7d5db23a48"),
-        "external_id_filters": UUID("61933e79-b0c2-4e3c-bf07-e2d93b9d9c54"),
-        "metadata_filters": UUID("7c43b315-d1f2-4727-9540-6cc3fd4641f3"),
-        "vellum-query-builder-variable-a6322ca2-8b65-4d26-b3a1-f926dcada0fa": UUID(
-            "a6322ca2-8b65-4d26-b3a1-f926dcada0fa"
-        ),
-        "vellum-query-builder-variable-c539a2e2-0873-43b0-ae21-81790bb1c4cb": UUID(
-            "c539a2e2-0873-43b0-ae21-81790bb1c4cb"
-        ),
-    }
-    output_display = {
-        SearchNode.Outputs.results: NodeOutputDisplay(
-            id=UUID("77839b3c-fe1c-4dcb-9c61-2fac827f729b"), name="results"
-        ),
-        SearchNode.Outputs.text: NodeOutputDisplay(
-            id=UUID("d56d7c49-7b45-4933-9779-2bd7f82c2141"), name="text"
-        ),
-    }
-    port_displays = {
-        SearchNode.Ports.default: PortDisplayOverrides(
-            id=UUID("e4dedb66-0638-4f0c-9941-6420bfe353b2")
-        )
-    }
-    display_data = NodeDisplayData(
-        position=NodeDisplayPosition(x=0, y=0), width=None, height=None
-    )
-"
-`;
-
 exports[`TextSearchNode > limit param should cast string to int > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
 from ..inputs import Inputs

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -291,12 +291,45 @@ describe("TextSearchNode", () => {
       });
     });
 
+    it("should throw ValueGenerationError when trying to parse non-integer string", async () => {
+      await expect(async () => {
+        node.getNodeFile().write(writer);
+        await writer.toStringFormatted();
+      }).rejects.toThrow(
+        'Failed to parse search node limit value "not-a-number" as an integer'
+      );
+    });
+  });
+
+  describe("limit param should throw exception if not a constant value of type number", () => {
+    beforeEach(async () => {
+      const nodeData = searchNodeDataFactory({
+        limitInput: {
+          type: "CONSTANT_VALUE",
+          data: {
+            type: "JSON",
+            value: "{}",
+          },
+        },
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as TextSearchNodeContext;
+
+      node = new SearchNode({
+        workflowContext,
+        nodeContext,
+      });
+    });
+
     it("should throw NodeAttributeGenerationError when trying to parse non-integer string", async () => {
       await expect(async () => {
         node.getNodeFile().write(writer);
         await writer.toStringFormatted();
       }).rejects.toThrow(
-        'Failed to parse search node limit value "not-a-number" to integer'
+        "Limit param input should be a CONSTANT_VALUE and of type NUMBER, got JSON instead"
       );
     });
   });

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -10,6 +10,10 @@ import { inputVariableContextFactory } from "src/__test__/helpers/input-variable
 import { searchNodeDataFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { TextSearchNodeContext } from "src/context/node-context/text-search-node";
+import {
+  NodeAttributeGenerationError,
+  ValueGenerationError,
+} from "src/generators/errors";
 import { SearchNode } from "src/generators/nodes/search-node";
 
 describe("TextSearchNode", () => {
@@ -291,12 +295,14 @@ describe("TextSearchNode", () => {
       });
     });
 
-    it("should throw ValueGenerationError when trying to parse non-integer string", async () => {
+    it("should throw ValueGenerationError", async () => {
       await expect(async () => {
         node.getNodeFile().write(writer);
         await writer.toStringFormatted();
       }).rejects.toThrow(
-        'Failed to parse search node limit value "not-a-number" as an integer'
+        new ValueGenerationError(
+          'Failed to parse search node limit value "not-a-number" as an integer'
+        )
       );
     });
   });
@@ -324,12 +330,14 @@ describe("TextSearchNode", () => {
       });
     });
 
-    it("should throw NodeAttributeGenerationError when trying to parse non-integer string", async () => {
+    it("should throw NodeAttributeGenerationError", async () => {
       await expect(async () => {
         node.getNodeFile().write(writer);
         await writer.toStringFormatted();
       }).rejects.toThrow(
-        "Limit param input should be a CONSTANT_VALUE and of type NUMBER, got JSON instead"
+        new NodeAttributeGenerationError(
+          "Limit param input should be a CONSTANT_VALUE and of type NUMBER, got JSON instead"
+        )
       );
     });
   });

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -266,11 +266,6 @@ describe("TextSearchNode", () => {
       node.getNodeFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-
-    it("getNodeDisplayFile", async () => {
-      node.getNodeDisplayFile().write(writer);
-      expect(await writer.toStringFormatted()).toMatchSnapshot();
-    });
   });
 
   describe("limit param should throw exception if casting string that is not an int", () => {

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -239,6 +239,73 @@ describe("TextSearchNode", () => {
     });
   });
 
+  describe("limit param should cast string to int", () => {
+    beforeEach(async () => {
+      const nodeData = searchNodeDataFactory({
+        limitInput: {
+          type: "CONSTANT_VALUE",
+          data: {
+            type: "STRING",
+            value: "8",
+          },
+        },
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as TextSearchNodeContext;
+
+      node = new SearchNode({
+        workflowContext,
+        nodeContext,
+      });
+    });
+
+    it("getNodeFile", async () => {
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("getNodeDisplayFile", async () => {
+      node.getNodeDisplayFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+
+  describe("limit param should throw exception if casting string that is not an int", () => {
+    beforeEach(async () => {
+      const nodeData = searchNodeDataFactory({
+        limitInput: {
+          type: "CONSTANT_VALUE",
+          data: {
+            type: "STRING",
+            value: "not-a-number",
+          },
+        },
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as TextSearchNodeContext;
+
+      node = new SearchNode({
+        workflowContext,
+        nodeContext,
+      });
+    });
+
+    it("should throw NodeAttributeGenerationError when trying to parse non-integer string", async () => {
+      await expect(async () => {
+        node.getNodeFile().write(writer);
+        await writer.toStringFormatted();
+      }).rejects.toThrow(
+        'Failed to parse search node limit value "not-a-number" to integer'
+      );
+    });
+  });
+
   describe("404 error handling", () => {
     beforeEach(async () => {
       workflowContext = workflowContextFactory({ strict: false });

--- a/ee/codegen/src/generators/nodes/search-node.ts
+++ b/ee/codegen/src/generators/nodes/search-node.ts
@@ -62,7 +62,7 @@ export class SearchNode extends BaseSingleFileNode<
           const parsedInt = parseInt(limitValue.data.value);
           if (isNaN(parsedInt)) {
             throw new ValueGenerationError(
-              `Failed to parse search node limit value "${limitValue.data.value}" to integer`
+              `Failed to parse search node limit value "${limitValue.data.value}" as an integer`
             );
           }
           bodyStatements.push(
@@ -72,6 +72,13 @@ export class SearchNode extends BaseSingleFileNode<
             })
           );
         }
+      } else if (
+        limitValue?.type === "CONSTANT_VALUE" &&
+        limitValue.data.type !== "NUMBER"
+      ) {
+        throw new NodeAttributeGenerationError(
+          `Limit param input should be a CONSTANT_VALUE and of type NUMBER, got ${limitValue.data.type} instead`
+        );
       } else {
         bodyStatements.push(
           python.field({

--- a/ee/codegen/src/generators/nodes/search-node.ts
+++ b/ee/codegen/src/generators/nodes/search-node.ts
@@ -10,7 +10,10 @@ import {
 } from "src/constants";
 import { TextSearchNodeContext } from "src/context/node-context/text-search-node";
 import { NodeInput } from "src/generators";
-import { NodeAttributeGenerationError } from "src/generators/errors";
+import {
+  NodeAttributeGenerationError,
+  ValueGenerationError,
+} from "src/generators/errors";
 import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base";
 import { VellumValueLogicalExpressionSerializer } from "src/serializers/vellum";
 import {
@@ -50,12 +53,33 @@ export class SearchNode extends BaseSingleFileNode<
 
     const limitInput = this.findNodeInputByName("limit");
     if (limitInput) {
-      bodyStatements.push(
-        python.field({
-          name: "limit",
-          initializer: limitInput,
-        })
-      );
+      const limitValue = limitInput.nodeInputData?.value.rules[0];
+      if (
+        limitValue?.type === "CONSTANT_VALUE" &&
+        limitValue.data.type === "STRING"
+      ) {
+        if (limitValue.data.value != null) {
+          const parsedInt = parseInt(limitValue.data.value);
+          if (isNaN(parsedInt)) {
+            throw new ValueGenerationError(
+              `Failed to parse search node limit value "${limitValue.data.value}" to integer`
+            );
+          }
+          bodyStatements.push(
+            python.field({
+              name: "limit",
+              initializer: python.TypeInstantiation.int(parsedInt),
+            })
+          );
+        }
+      } else {
+        bodyStatements.push(
+          python.field({
+            name: "limit",
+            initializer: limitInput,
+          })
+        );
+      }
     }
 
     bodyStatements.push(


### PR DESCRIPTION
This PR tries a safe cast on limit param if the value happens to be a string that represents an int. This came up from QA of trust center workflow