### PR TITLE
[SC-6285] Update search node to use weights attribute if present and not default weights value

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
@@ -97,7 +97,8 @@ class BaseSearchNodeDisplay(BaseNodeVellumDisplay[_SearchNodeType], Generic[_Sea
         result_merging = options.result_merging if options else None
         result_merging_enabled = True if result_merging and result_merging.enabled else False
 
-        weights = options.weights if options else None
+        raw_weights = raise_if_descriptor(node.weights)
+        weights = raw_weights if raw_weights is not None else options.weights if options is not None else None
 
         node_input_names_and_values = [
             ("query", node.query),

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_search_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_search_node_serialization.py
@@ -84,7 +84,12 @@ def test_serialize_workflow():
                 "id": "983f2b7f-ad86-45cf-b04b-08724af27236",
                 "key": "weights",
                 "value": {
-                    "rules": [{"type": "CONSTANT_VALUE", "data": {"type": "JSON", "value": None}}],
+                    "rules": [
+                        {
+                            "type": "CONSTANT_VALUE",
+                            "data": {"type": "JSON", "value": {"keywords": 0.45, "semantic_similarity": 0.55}},
+                        }
+                    ],
                     "combinator": "OR",
                 },
             },

--- a/tests/workflows/basic_search_node/workflow.py
+++ b/tests/workflows/basic_search_node/workflow.py
@@ -1,6 +1,7 @@
 from vellum import (
     SearchFiltersRequest,
     SearchRequestOptionsRequest,
+    SearchWeightsRequest,
     StringVellumValueRequest,
     VellumValueLogicalConditionGroupRequest,
     VellumValueLogicalConditionRequest,
@@ -18,6 +19,7 @@ class Inputs(BaseInputs):
 class SimpleSearchNode(SearchNode):
     query = Inputs.query
     document_index = "name"
+    weights = SearchWeightsRequest(semantic_similarity=0.55, keywords=0.45)
     options = SearchRequestOptionsRequest(
         filters=SearchFiltersRequest(
             external_ids=None,


### PR DESCRIPTION
This PR fixes search node to use weights attribute if present and not default weights value. This came up from QAing trust center workflow