### PR TITLE
[SC-6298] Allow codegen to go through even if node inputs are not mapping to anything

### DIFF
--- a/ee/codegen/src/context/node-context/api-node.ts
+++ b/ee/codegen/src/context/node-context/api-node.ts
@@ -11,6 +11,9 @@ export class ApiNodeContext extends BaseNodeContext<ApiNodeType> {
       [this.nodeData.data.jsonOutputId]: "json",
       [this.nodeData.data.statusCodeOutputId]: "status_code",
       [this.nodeData.data.textOutputId]: "text",
+      ...(this.nodeData.data.errorOutputId
+        ? { [this.nodeData.data.errorOutputId]: "error" }
+        : {}),
     };
   }
 

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -110,10 +110,12 @@ export abstract class BaseNode<
     return this.nodeInputsByKey.get(name);
   }
 
-  protected getNodeInputByName(name: string): NodeInput {
+  protected getNodeInputByName(name: string): NodeInput | undefined {
     const nodeInput = this.findNodeInputByName(name);
     if (!nodeInput) {
-      throw new NodeAttributeGenerationError(`No input found named "${name}"`);
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(`No input found named "${name}"`)
+      );
     }
 
     return nodeInput;

--- a/ee/codegen/src/generators/nodes/code-execution-node.ts
+++ b/ee/codegen/src/generators/nodes/code-execution-node.ts
@@ -111,12 +111,16 @@ export class CodeExecutionNode extends BaseSingleFileNode<
       })
     );
 
-    statements.push(
-      python.field({
-        name: "runtime",
-        initializer: this.getNodeInputByName("runtime"),
-      })
-    );
+    const runtime = this.getNodeInputByName("runtime");
+
+    if (runtime) {
+      statements.push(
+        python.field({
+          name: "runtime",
+          initializer: runtime,
+        })
+      );
+    }
 
     statements.push(
       python.field({

--- a/ee/codegen/src/generators/nodes/error-node.ts
+++ b/ee/codegen/src/generators/nodes/error-node.ts
@@ -12,12 +12,16 @@ export class ErrorNode extends BaseSingleFileNode<
 > {
   getNodeClassBodyStatements(): AstNode[] {
     const bodyStatements: AstNode[] = [];
-    bodyStatements.push(
-      python.field({
-        name: "error",
-        initializer: this.getNodeInputByName("error_source_input_id"),
-      })
-    );
+    const errorSourceInputId = this.getNodeInputByName("error_source_input_id");
+
+    if (errorSourceInputId) {
+      bodyStatements.push(
+        python.field({
+          name: "error",
+          initializer: errorSourceInputId,
+        })
+      );
+    }
 
     return bodyStatements;
   }

--- a/ee/codegen/src/generators/nodes/final-output-node.ts
+++ b/ee/codegen/src/generators/nodes/final-output-node.ts
@@ -42,12 +42,15 @@ export class FinalOutputNode extends BaseSingleFileNode<
       ],
     });
 
-    const outputField = python.field({
-      name: "value",
-      initializer: this.getNodeInputByName("node_input"),
-    });
+    const nodeInput = this.getNodeInputByName("node_input");
 
-    outputsClass.add(outputField);
+    if (nodeInput) {
+      const outputField = python.field({
+        name: "value",
+        initializer: nodeInput,
+      });
+      outputsClass.add(outputField);
+    }
 
     return outputsClass;
   }

--- a/ee/codegen/src/generators/nodes/map-node.ts
+++ b/ee/codegen/src/generators/nodes/map-node.ts
@@ -30,11 +30,14 @@ export class MapNode extends BaseNestedWorkflowNode<
   getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 
-    const itemsField = python.field({
-      name: "items",
-      initializer: this.getNodeInputByName("items"),
-    });
-    statements.push(itemsField);
+    const items = this.getNodeInputByName("items");
+    if (items) {
+      const itemsField = python.field({
+        name: "items",
+        initializer: items,
+      });
+      statements.push(itemsField);
+    }
 
     const nestedWorkflowContext = this.getNestedWorkflowContextByName(
       BaseNestedWorkflowNode.subworkflowNestedProjectName

--- a/ee/codegen/src/generators/nodes/search-node.ts
+++ b/ee/codegen/src/generators/nodes/search-node.ts
@@ -33,21 +33,24 @@ export class SearchNode extends BaseSingleFileNode<
   getNodeClassBodyStatements(): AstNode[] {
     const bodyStatements: AstNode[] = [];
 
-    bodyStatements.push(
-      python.field({
-        name: "query",
-        initializer: this.getNodeInputByName("query"),
-      })
-    );
+    const query = this.getNodeInputByName("query");
+    if (query) {
+      bodyStatements.push(
+        python.field({
+          name: "query",
+          initializer: query,
+        })
+      );
+    }
 
     const documentName = this.nodeContext.documentIndex?.name;
-
+    const documentIndex = this.getNodeInputByName("document_index_id");
     bodyStatements.push(
       python.field({
         name: "document_index",
         initializer: documentName
           ? python.TypeInstantiation.str(documentName)
-          : this.getNodeInputByName("document_index_id"),
+          : documentIndex ?? python.TypeInstantiation.none(),
       })
     );
 
@@ -110,13 +113,16 @@ export class SearchNode extends BaseSingleFileNode<
       })
     );
 
-    bodyStatements.push(
-      python.field({
-        name: "chunk_separator",
-        initializer: this.getNodeInputByName("separator"),
-      })
-    );
+    const separator = this.findNodeInputByName("separator");
 
+    if (separator) {
+      bodyStatements.push(
+        python.field({
+          name: "chunk_separator",
+          initializer: separator,
+        })
+      );
+    }
     return bodyStatements;
   }
 


### PR DESCRIPTION
Context: QAing a workflow showed node inputs that were node pointers that pointed to non existent node ids. This PR allows the codegen process to go through and does not block