### PR TITLE
Fix serialization error that throws when referencing `TryNode.Outputs.error`

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -76,12 +76,12 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
         )
         return node_definition
 
-    def get_node_output_display(self, output: OutputReference) -> NodeOutputDisplay:
+    def get_node_output_display(self, output: OutputReference) -> Tuple[Type[BaseNode], NodeOutputDisplay]:
         explicit_display = self.output_display.get(output)
         if explicit_display:
-            return explicit_display
+            return self._node, explicit_display
 
-        return NodeOutputDisplay(id=uuid4_from_hash(f"{self.node_id}|{output.name}"), name=output.name)
+        return (self._node, NodeOutputDisplay(id=uuid4_from_hash(f"{self.node_id}|{output.name}"), name=output.name))
 
     def get_node_port_display(self, port: Port) -> PortDisplay:
         overrides = self.port_displays.get(port)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_try_node.py
@@ -1,0 +1,37 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.nodes.core.templating_node.node import TemplatingNode
+from vellum.workflows.nodes.core.try_node.node import TryNode
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+
+
+def test_try_node_display__serialize_with_error_output() -> None:
+    # GIVEN a Base Node wrapped with a TryNode
+    @TryNode.wrap()
+    class MyNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            hello = "world"
+
+    # AND a displayable node referencing
+    class OtherNode(TemplatingNode):
+        template = "{{ hello }} {{ error }}"
+        inputs = {
+            "hello": MyNode.Outputs.hello,
+            "error": MyNode.Outputs.error,
+        }
+
+    # AND a workflow referencing the two nodes
+    class MyWorkflow(BaseWorkflow):
+        graph = MyNode >> OtherNode
+
+    # WHEN we serialize the workflow
+    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=MyWorkflow)
+    serialized_workflow = workflow_display.serialize()
+
+    # THEN the correct inputs should be serialized on the node
+    serialized_node = next(node for node in serialized_workflow["nodes"] if node["id"] == str(OtherNode.__id__))
+    hello_input_value = next(input["value"] for input in serialized_node["data"]["inputs"] if input["name"] == "hello")
+    error_input_value = next(input["value"] for input in serialized_node["data"]["inputs"] if input["name"] == "error")
+    assert hello_input_value == {"type": "node_output", "node_id": "my_node", "output_name": "hello"}
+    assert error_input_value == {"type": "node_output", "node_id": "my_node", "output_name": "error"}

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_try_node.py
@@ -55,7 +55,7 @@ def test_try_node_display__serialize_with_error_output() -> None:
             {
                 "data": {
                     "node_id": str(MyNode.__wrapped_node__.__id__),
-                    "output_id": "bd5a9f78-a635-4415-a818-ebcfe504c3b5",
+                    "output_id": "efe6e307-3ea4-4862-a26f-4c4416bb4537",
                 },
                 "type": "NODE_OUTPUT",
             }

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_utils.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_utils.py
@@ -1,13 +1,12 @@
 import pytest
 from uuid import UUID, uuid4
-from typing import List, cast
+from typing import List
 
 from vellum.client.types.string_vellum_value import StringVellumValue
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.inputs import BaseInputs
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.outputs import BaseOutputs
-from vellum.workflows.references import OutputReference, WorkflowInputReference
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input_value_pointer_rules
@@ -92,12 +91,12 @@ def test_create_node_input_value_pointer_rules(
                 entrypoint_node_display=NodeDisplayData(),
             ),
             global_workflow_input_displays={
-                cast(WorkflowInputReference, Inputs.example_workflow_input): WorkflowInputsVellumDisplayOverrides(
+                Inputs.example_workflow_input: WorkflowInputsVellumDisplayOverrides(
                     id=UUID("a154c29d-fac0-4cd0-ba88-bc52034f5470"),
                 ),
             },
             global_node_output_displays={
-                cast(OutputReference, MyNodeA.Outputs.output): (
+                MyNodeA.Outputs.output: (
                     MyNodeA,
                     NodeOutputDisplay(id=UUID("4b16a629-11a1-4b3f-a965-a57b872d13b8"), name="output"),
                 ),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
@@ -1,15 +1,17 @@
 from uuid import UUID
-from typing import Any, Callable, ClassVar, Generic, Optional, Type, TypeVar, cast
+from typing import Any, Callable, ClassVar, Generic, Optional, Tuple, Type, TypeVar, cast
 
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.try_node.node import TryNode
 from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME, get_wrapped_node
+from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonObject
 from vellum.workflows.types.utils import get_original_base
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
@@ -18,6 +20,9 @@ _TryNodeType = TypeVar("_TryNodeType", bound=TryNode)
 
 class BaseTryNodeDisplay(BaseNodeVellumDisplay[_TryNodeType], Generic[_TryNodeType]):
     error_output_id: ClassVar[Optional[UUID]] = None
+
+    def _get_error_output_id(self) -> UUID:
+        return self.error_output_id or uuid4_from_hash(f"{self.node_id}|error_output_id")
 
     def serialize(self, display_context: WorkflowDisplayContext, **kwargs: Any) -> JsonObject:
         node = self._node
@@ -56,6 +61,19 @@ class BaseTryNodeDisplay(BaseNodeVellumDisplay[_TryNodeType], Generic[_TryNodeTy
                 serialized_node_definition["name"] = node.__name__
 
         return serialized_node
+
+    def get_node_output_display(self, output: OutputReference) -> Tuple[Type[BaseNode], NodeOutputDisplay]:
+        inner_node = self._node.__wrapped_node__
+        if not inner_node:
+            return super().get_node_output_display(output)
+
+        if output.name == "error":
+            return inner_node, NodeOutputDisplay(id=self._get_error_output_id(), name="error")
+
+        inner_output = getattr(inner_node.Outputs, output.name)
+        node_display_class = get_node_display_class(BaseNodeVellumDisplay, inner_node)
+        node_display = node_display_class()
+        return node_display.get_node_output_display(inner_output)
 
     @classmethod
     def wrap(cls, error_output_id: Optional[UUID] = None) -> Callable[..., Type["BaseTryNodeDisplay"]]:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/utils.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/utils.py
@@ -28,8 +28,7 @@ from vellum.workflows.expressions.not_between import NotBetweenExpression
 from vellum.workflows.expressions.not_in import NotInExpression
 from vellum.workflows.expressions.or_ import OrExpression
 from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
-from vellum.workflows.nodes.utils import get_wrapped_node, has_wrapped_node
-from vellum.workflows.references import NodeReference, OutputReference
+from vellum.workflows.references import NodeReference
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum_ee.workflows.display.utils.vellum import create_node_input_value_pointer_rule
@@ -56,15 +55,6 @@ def create_node_input(
     pointer_type: Optional[Type[NodeInputValuePointerRule]] = ConstantValuePointer,
 ) -> NodeInput:
     input_id = str(input_id) if input_id else str(uuid4_from_hash(f"{node_id}|{input_name}"))
-    if (
-        isinstance(value, OutputReference)
-        and value.outputs_class._node_class
-        and has_wrapped_node(value.outputs_class._node_class)
-    ):
-        wrapped_node = get_wrapped_node(value.outputs_class._node_class)
-        if wrapped_node._is_wrapped_node:
-            value = getattr(wrapped_node.Outputs, value.name)
-
     rules = create_node_input_value_pointer_rules(value, display_context, pointer_type=pointer_type)
     return NodeInput(
         id=input_id,

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
@@ -685,8 +685,7 @@ def test_serialize_workflow__try_wrapped():
                 "display_data": {"position": {"x": 0.0, "y": 0.0}},
             },
         ],
-        final_output_nodes,
-        ignore_order=True,
+        sorted(final_output_nodes, key=lambda x: x["id"], reverse=True),
     )
 
     # AND each edge should be serialized correctly

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -150,7 +150,7 @@ class BaseWorkflowDisplay(
 
             # TODO: Make sure this output ID matches the workflow output ID of the subworkflow node's workflow
             # https://app.shortcut.com/vellum/story/5660/fix-output-id-in-subworkflow-nodes
-            node_output_displays[node_output] = node, node_display.get_node_output_display(node_output)
+            node_output_displays[node_output] = node_display.get_node_output_display(node_output)
 
     def _enrich_node_port_displays(
         self,

--- a/src/vellum/plugins/vellum_mypy.py
+++ b/src/vellum/plugins/vellum_mypy.py
@@ -19,6 +19,7 @@ from mypy.plugin import AttributeContext, ClassDefContext, FunctionSigContext, M
 from mypy.types import AnyType, CallableType, FunctionLike, Instance, Type as MypyType, TypeAliasType, UnionType
 
 TypeResolver = Callable[[str, List[MypyType]], MypyType]
+NODE_ATTRIBUTE_REGEX = r"^[a-z].*$"
 
 DESCRIPTOR_PATHS: list[tuple[str, str, str]] = [
     (
@@ -49,7 +50,7 @@ DESCRIPTOR_PATHS: list[tuple[str, str, str]] = [
     (
         "vellum.workflows.nodes.bases.base.BaseNode",
         "vellum.workflows.references.node.NodeReference",
-        r"^[a-z].*$",
+        NODE_ATTRIBUTE_REGEX,
     ),
 ]
 
@@ -239,8 +240,11 @@ class VellumMypyPlugin(Plugin):
         the original defined type, and the descriptor version of the type.
         """
 
-        for sym in ctx.cls.info.names.values():
+        for key, sym in ctx.cls.info.names.items():
             if not isinstance(sym.node, Var):
+                continue
+
+            if not re.match(NODE_ATTRIBUTE_REGEX, key):
                 continue
 
             type_ = sym.node.type


### PR DESCRIPTION
This is blocking us from running the headspace workflow. Adornments continue to be the gift that keep on giving.

Thankfully, we have a ton of testing around it all that I feel motivated to do a few minor cleanups after this PR