### PR TITLE
Remove the  `_is_wrapped_node` attribute from BaseNode

### DIFF
--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -144,9 +144,8 @@ class BaseWorkflowDisplay(
 
             if has_wrapped_node(node):
                 inner_node = get_wrapped_node(node)
-                if inner_node._is_wrapped_node:
-                    inner_node_display = self._get_node_display(inner_node)
-                    self._enrich_global_node_output_displays(inner_node, inner_node_display, node_output_displays)
+                inner_node_display = self._get_node_display(inner_node)
+                self._enrich_global_node_output_displays(inner_node, inner_node_display, node_output_displays)
 
             # TODO: Make sure this output ID matches the workflow output ID of the subworkflow node's workflow
             # https://app.shortcut.com/vellum/story/5660/fix-output-id-in-subworkflow-nodes
@@ -166,9 +165,8 @@ class BaseWorkflowDisplay(
 
             if has_wrapped_node(node):
                 inner_node = get_wrapped_node(node)
-                if inner_node._is_wrapped_node:
-                    inner_node_display = self._get_node_display(inner_node)
-                    self._enrich_node_port_displays(inner_node, inner_node_display, port_displays)
+                inner_node_display = self._get_node_display(inner_node)
+                self._enrich_node_port_displays(inner_node, inner_node_display, port_displays)
 
             port_displays[port] = node_display.get_node_port_display(port)
 
@@ -219,10 +217,8 @@ class BaseWorkflowDisplay(
             if has_wrapped_node(node):
                 inner_node = get_wrapped_node(node)
                 inner_node_display = self._get_node_display(inner_node)
-
-                if inner_node._is_wrapped_node:
-                    node_displays[inner_node] = inner_node_display
-                    global_node_displays[inner_node] = inner_node_display
+                node_displays[inner_node] = inner_node_display
+                global_node_displays[inner_node] = inner_node_display
 
             self._enrich_global_node_output_displays(node, node_display, global_node_output_displays)
             self._enrich_node_port_displays(node, node_display, port_displays)

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -95,11 +95,8 @@ class VellumWorkflowDisplay(
         )
 
         # Add all the nodes in the workflow
-        for node, node_display in self.display_context.node_displays.items():
-            if getattr(node, "_is_wrapped_node") is True:
-                # Nodes that are wrapped or decorated by other nodes are not serialized here
-                # They are instead serialized by the wrapper node
-                continue
+        for node in self._workflow.get_nodes():
+            node_display = self.display_context.node_displays[node]
 
             try:
                 serialized_node = node_display.serialize(self.display_context)
@@ -296,9 +293,7 @@ class VellumWorkflowDisplay(
         )
 
         if has_wrapped_node(entrypoint):
-            wrapped_node = get_wrapped_node(entrypoint)
-            if wrapped_node._is_wrapped_node:
-                entrypoint = wrapped_node
+            entrypoint = get_wrapped_node(entrypoint)
 
         target_node_id = node_displays[entrypoint].node_id
         target_handle_id = node_displays[entrypoint].get_target_handle_id()

--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -222,7 +222,6 @@ class BaseNode(Generic[StateType], metaclass=BaseNodeMeta):
     state: StateType
     _context: WorkflowContext
     _inputs: MappingProxyType[NodeReference, Any]
-    _is_wrapped_node: bool = False
 
     class ExternalInputs(BaseInputs):
         __descriptor_class__ = ExternalInputReference

--- a/src/vellum/workflows/nodes/utils.py
+++ b/src/vellum/workflows/nodes/utils.py
@@ -57,8 +57,6 @@ def create_adornment(
         # https://app.shortcut.com/vellum/story/4116
         from vellum.workflows import BaseWorkflow
 
-        inner_cls._is_wrapped_node = True
-
         class Subworkflow(BaseWorkflow):
             graph = inner_cls
 


### PR DESCRIPTION
`BaseNode._is_wrapped_node` is redundant with `BaseAdornmentNode.__wrapped_node__`. Ideally, a child node doesn't care what context it's executing/serializing in, so we opt to have adornment state driven by the adornment node rather than the wrapped node, allowing us to remove `BaseNode._is_wrapped_node` entirely.

First in a series of cleanups after doing https://github.com/vellum-ai/vellum-python-sdks/pull/672