### PR TITLE
Cleanup has wrapped node util

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
@@ -24,9 +24,8 @@ class BaseTryNodeDisplay(BaseNodeVellumDisplay[_TryNodeType], Generic[_TryNodeTy
     def serialize(self, display_context: WorkflowDisplayContext, **kwargs: Any) -> JsonObject:
         node = self._node
 
-        try:
-            inner_node = get_wrapped_node(node)
-        except AttributeError:
+        inner_node = get_wrapped_node(node)
+        if not inner_node:
             subworkflow = raise_if_descriptor(node.subworkflow)
             if not isinstance(subworkflow.graph, type) or not issubclass(subworkflow.graph, BaseNode):
                 raise NotImplementedError(

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -11,7 +11,7 @@ from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.edges import Edge
 from vellum.workflows.expressions.coalesce_expression import CoalesceExpression
 from vellum.workflows.nodes.bases import BaseNode
-from vellum.workflows.nodes.utils import get_wrapped_node, has_wrapped_node
+from vellum.workflows.nodes.utils import get_wrapped_node
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference, WorkflowInputReference
 from vellum.workflows.types.core import JsonObject
@@ -138,8 +138,8 @@ class BaseWorkflowDisplay(
     ):
         """This method recursively adds nodes wrapped in decorators to the node_output_displays dictionary."""
 
-        if has_wrapped_node(node):
-            inner_node = get_wrapped_node(node)
+        inner_node = get_wrapped_node(node)
+        if inner_node:
             inner_node_display = self._get_node_display(inner_node)
             self._enrich_global_node_output_displays(inner_node, inner_node_display, node_output_displays)
 
@@ -159,8 +159,8 @@ class BaseWorkflowDisplay(
     ):
         """This method recursively adds nodes wrapped in decorators to the port_displays dictionary."""
 
-        if has_wrapped_node(node):
-            inner_node = get_wrapped_node(node)
+        inner_node = get_wrapped_node(node)
+        if inner_node:
             inner_node_display = self._get_node_display(inner_node)
             self._enrich_node_port_displays(inner_node, inner_node_display, port_displays)
 
@@ -214,8 +214,8 @@ class BaseWorkflowDisplay(
             global_node_displays[node] = node_display
 
             # Nodes wrapped in a decorator need to be in our node display dictionary for later retrieval
-            if has_wrapped_node(node):
-                inner_node = get_wrapped_node(node)
+            inner_node = get_wrapped_node(node)
+            if inner_node:
                 inner_node_display = self._get_node_display(inner_node)
                 node_displays[inner_node] = inner_node_display
                 global_node_displays[inner_node] = inner_node_display

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -7,7 +7,7 @@ from vellum.workflows.edges import Edge
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
 from vellum.workflows.nodes.displayable.final_output_node import FinalOutputNode
-from vellum.workflows.nodes.utils import get_unadorned_node, get_unadorned_port, get_wrapped_node, has_wrapped_node
+from vellum.workflows.nodes.utils import get_unadorned_node, get_unadorned_port
 from vellum.workflows.ports import Port
 from vellum.workflows.references import WorkflowInputReference
 from vellum.workflows.references.output import OutputReference
@@ -292,11 +292,9 @@ class VellumWorkflowDisplay(
             else uuid4_from_hash(f"{self.workflow_id}|id|{entrypoint_node_id}")
         )
 
-        if has_wrapped_node(entrypoint):
-            entrypoint = get_wrapped_node(entrypoint)
-
-        target_node_id = node_displays[entrypoint].node_id
-        target_handle_id = node_displays[entrypoint].get_target_handle_id()
+        entrypoint_target = get_unadorned_node(entrypoint)
+        target_node_id = node_displays[entrypoint_target].node_id
+        target_handle_id = node_displays[entrypoint_target].get_target_handle_id()
 
         edge_display = self._generate_edge_display_from_source(
             entrypoint_node_id, source_handle_id, target_node_id, target_handle_id, overrides=edge_display_overrides

--- a/src/vellum/workflows/nodes/utils.py
+++ b/src/vellum/workflows/nodes/utils.py
@@ -4,6 +4,7 @@ from types import ModuleType
 from typing import Any, Callable, Optional, Type, TypeVar
 
 from vellum.workflows.nodes import BaseNode
+from vellum.workflows.nodes.bases.base_adornment_node import BaseAdornmentNode
 from vellum.workflows.ports.port import Port
 from vellum.workflows.types.generics import NodeType
 
@@ -12,7 +13,7 @@ ADORNMENT_MODULE_NAME = "<adornment>"
 
 @cache
 def get_unadorned_node(node: Type[BaseNode]) -> Type[BaseNode]:
-    wrapped_node = getattr(node, "__wrapped_node__", None)
+    wrapped_node = get_wrapped_node(node)
     if wrapped_node is not None:
         return get_unadorned_node(wrapped_node)
 
@@ -28,22 +29,11 @@ def get_unadorned_port(port: Port) -> Port:
     return getattr(unadorned_node.Ports, port.name)
 
 
-@cache
-def get_wrapped_node(node: Type[NodeType]) -> Type[BaseNode]:
-    wrapped_node = getattr(node, "__wrapped_node__", None)
-    if wrapped_node is None:
-        raise AttributeError("Wrapped node not found")
+def get_wrapped_node(node: Type[NodeType]) -> Optional[Type[BaseNode]]:
+    if not issubclass(node, BaseAdornmentNode):
+        return None
 
-    return wrapped_node
-
-
-def has_wrapped_node(node: Type[NodeType]) -> bool:
-    try:
-        get_wrapped_node(node)
-    except AttributeError:
-        return False
-
-    return True
+    return node.__wrapped_node__
 
 
 AdornableNode = TypeVar("AdornableNode", bound=BaseNode)


### PR DESCRIPTION
Last of the adornment cleanup PRs I wanted to do for now (prev: https://github.com/vellum-ai/vellum-python-sdks/pull/674). Cleans up a util that didn't add much now that BaseAdornmentNode carries the relevant state