### PR TITLE
Move BaseNodeDisplay serialize methods up a level

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -16,15 +16,28 @@ from typing import (
     get_origin,
 )
 
+from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.expressions.between import BetweenExpression
+from vellum.workflows.expressions.is_nil import IsNilExpression
+from vellum.workflows.expressions.is_not_nil import IsNotNilExpression
+from vellum.workflows.expressions.is_not_null import IsNotNullExpression
+from vellum.workflows.expressions.is_not_undefined import IsNotUndefinedExpression
+from vellum.workflows.expressions.is_null import IsNullExpression
+from vellum.workflows.expressions.is_undefined import IsUndefinedExpression
+from vellum.workflows.expressions.not_between import NotBetweenExpression
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference
+from vellum.workflows.references.execution_count import ExecutionCountReference
+from vellum.workflows.references.vellum_secret import VellumSecretReference
+from vellum.workflows.references.workflow_input import WorkflowInputReference
 from vellum.workflows.types.core import JsonObject
 from vellum.workflows.types.generics import NodeType
 from vellum.workflows.types.utils import get_original_base
 from vellum.workflows.utils.names import pascal_to_title_case
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay, PortDisplayOverrides
+from vellum_ee.workflows.display.utils.vellum import convert_descriptor_to_operator, primitive_to_vellum_value
 from vellum_ee.workflows.display.vellum import CodeResourceDefinition
 
 if TYPE_CHECKING:
@@ -174,3 +187,87 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
 
         node_class = cls.infer_node_class()
         cls._node_display_registry[node_class] = cls
+
+    def serialize_condition(self, display_context: "WorkflowDisplayContext", condition: BaseDescriptor) -> JsonObject:
+        if isinstance(
+            condition,
+            (
+                IsNullExpression,
+                IsNotNullExpression,
+                IsNilExpression,
+                IsNotNilExpression,
+                IsUndefinedExpression,
+                IsNotUndefinedExpression,
+            ),
+        ):
+            lhs = self.serialize_value(display_context, condition._expression)
+            return {
+                "type": "UNARY_EXPRESSION",
+                "lhs": lhs,
+                "operator": convert_descriptor_to_operator(condition),
+            }
+        elif isinstance(condition, (BetweenExpression, NotBetweenExpression)):
+            base = self.serialize_value(display_context, condition._value)
+            lhs = self.serialize_value(display_context, condition._start)
+            rhs = self.serialize_value(display_context, condition._end)
+
+            return {
+                "type": "TERNARY_EXPRESSION",
+                "base": base,
+                "operator": convert_descriptor_to_operator(condition),
+                "lhs": lhs,
+                "rhs": rhs,
+            }
+        else:
+            lhs = self.serialize_value(display_context, condition._lhs)  # type: ignore[attr-defined]
+            rhs = self.serialize_value(display_context, condition._rhs)  # type: ignore[attr-defined]
+
+            return {
+                "type": "BINARY_EXPRESSION",
+                "lhs": lhs,
+                "operator": convert_descriptor_to_operator(condition),
+                "rhs": rhs,
+            }
+
+    def serialize_value(self, display_context: "WorkflowDisplayContext", value: BaseDescriptor) -> JsonObject:
+        if isinstance(value, WorkflowInputReference):
+            workflow_input_display = display_context.global_workflow_input_displays[value]
+            return {
+                "type": "WORKFLOW_INPUT",
+                "input_variable_id": str(workflow_input_display.id),
+            }
+
+        if isinstance(value, OutputReference):
+            upstream_node, output_display = display_context.global_node_output_displays[value]
+            upstream_node_display = display_context.global_node_displays[upstream_node]
+
+            return {
+                "type": "NODE_OUTPUT",
+                "node_id": str(upstream_node_display.node_id),
+                "node_output_id": str(output_display.id),
+            }
+
+        if isinstance(value, VellumSecretReference):
+            return {
+                "type": "VELLUM_SECRET",
+                "vellum_secret_name": value.name,
+            }
+
+        if isinstance(value, ExecutionCountReference):
+            node_class_display = display_context.global_node_displays[value.node_class]
+
+            return {
+                "type": "EXECUTION_COUNTER",
+                "node_id": str(node_class_display.node_id),
+            }
+
+        if not isinstance(value, BaseDescriptor):
+            vellum_value = primitive_to_vellum_value(value)
+            return {
+                "type": "CONSTANT_VALUE",
+                "value": vellum_value.dict(),
+            }
+
+        # If it's not any of the references we know about,
+        # then try to serialize it as a nested value
+        return self.serialize_condition(display_context, value)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_node.py
@@ -3,29 +3,15 @@ from typing import Any, Generic, Optional, TypeVar, cast
 
 from vellum.workflows.constants import UNDEF
 from vellum.workflows.descriptors.base import BaseDescriptor
-from vellum.workflows.expressions.between import BetweenExpression
-from vellum.workflows.expressions.is_nil import IsNilExpression
-from vellum.workflows.expressions.is_not_nil import IsNotNilExpression
-from vellum.workflows.expressions.is_not_null import IsNotNullExpression
-from vellum.workflows.expressions.is_not_undefined import IsNotUndefinedExpression
-from vellum.workflows.expressions.is_null import IsNullExpression
-from vellum.workflows.expressions.is_undefined import IsUndefinedExpression
-from vellum.workflows.expressions.not_between import NotBetweenExpression
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.utils import get_wrapped_node
-from vellum.workflows.references.execution_count import ExecutionCountReference
-from vellum.workflows.references.output import OutputReference
-from vellum.workflows.references.vellum_secret import VellumSecretReference
-from vellum.workflows.references.workflow_input import WorkflowInputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
 from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
-from vellum_ee.workflows.display.nodes.vellum.utils import convert_descriptor_to_operator
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum_ee.workflows.display.utils.vellum import primitive_to_vellum_value
 from vellum_ee.workflows.display.vellum import GenericNodeDisplayData
 
 _BaseNodeType = TypeVar("_BaseNodeType", bound=BaseNode)
@@ -129,87 +115,3 @@ class BaseNodeDisplay(BaseNodeVellumDisplay[_BaseNodeType], Generic[_BaseNodeTyp
     def get_generic_node_display_data(self) -> GenericNodeDisplayData:
         explicit_value = self._get_explicit_node_display_attr("display_data", GenericNodeDisplayData)
         return explicit_value if explicit_value else GenericNodeDisplayData()
-
-    def serialize_condition(self, display_context: WorkflowDisplayContext, condition: BaseDescriptor) -> JsonObject:
-        if isinstance(
-            condition,
-            (
-                IsNullExpression,
-                IsNotNullExpression,
-                IsNilExpression,
-                IsNotNilExpression,
-                IsUndefinedExpression,
-                IsNotUndefinedExpression,
-            ),
-        ):
-            lhs = self.serialize_value(display_context, condition._expression)
-            return {
-                "type": "UNARY_EXPRESSION",
-                "lhs": lhs,
-                "operator": convert_descriptor_to_operator(condition),
-            }
-        elif isinstance(condition, (BetweenExpression, NotBetweenExpression)):
-            base = self.serialize_value(display_context, condition._value)
-            lhs = self.serialize_value(display_context, condition._start)
-            rhs = self.serialize_value(display_context, condition._end)
-
-            return {
-                "type": "TERNARY_EXPRESSION",
-                "base": base,
-                "operator": convert_descriptor_to_operator(condition),
-                "lhs": lhs,
-                "rhs": rhs,
-            }
-        else:
-            lhs = self.serialize_value(display_context, condition._lhs)  # type: ignore[attr-defined]
-            rhs = self.serialize_value(display_context, condition._rhs)  # type: ignore[attr-defined]
-
-            return {
-                "type": "BINARY_EXPRESSION",
-                "lhs": lhs,
-                "operator": convert_descriptor_to_operator(condition),
-                "rhs": rhs,
-            }
-
-    def serialize_value(self, display_context: WorkflowDisplayContext, value: BaseDescriptor) -> JsonObject:
-        if isinstance(value, WorkflowInputReference):
-            workflow_input_display = display_context.global_workflow_input_displays[value]
-            return {
-                "type": "WORKFLOW_INPUT",
-                "input_variable_id": str(workflow_input_display.id),
-            }
-
-        if isinstance(value, OutputReference):
-            upstream_node, output_display = display_context.global_node_output_displays[value]
-            upstream_node_display = display_context.global_node_displays[upstream_node]
-
-            return {
-                "type": "NODE_OUTPUT",
-                "node_id": str(upstream_node_display.node_id),
-                "node_output_id": str(output_display.id),
-            }
-
-        if isinstance(value, VellumSecretReference):
-            return {
-                "type": "VELLUM_SECRET",
-                "vellum_secret_name": value.name,
-            }
-
-        if isinstance(value, ExecutionCountReference):
-            node_class_display = display_context.global_node_displays[value.node_class]
-
-            return {
-                "type": "EXECUTION_COUNTER",
-                "node_id": str(node_class_display.node_id),
-            }
-
-        if not isinstance(value, BaseDescriptor):
-            vellum_value = primitive_to_vellum_value(value)
-            return {
-                "type": "CONSTANT_VALUE",
-                "value": vellum_value.dict(),
-            }
-
-        # If it's not any of the references we know about,
-        # then try to serialize it as a nested value
-        return self.serialize_condition(display_context, value)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/conditional_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/conditional_node.py
@@ -17,8 +17,9 @@ from vellum.workflows.nodes.displayable import ConditionalNode
 from vellum.workflows.types.core import ConditionType, JsonObject
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
-from vellum_ee.workflows.display.nodes.vellum.utils import convert_descriptor_to_operator, create_node_input
+from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
+from vellum_ee.workflows.display.utils.vellum import convert_descriptor_to_operator
 from vellum_ee.workflows.display.vellum import NodeInput
 
 _ConditionalNodeType = TypeVar("_ConditionalNodeType", bound=ConditionalNode)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/utils.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/utils.py
@@ -2,31 +2,7 @@ from uuid import UUID
 from typing import Any, List, Optional, Type, Union, cast
 
 from vellum.workflows.descriptors.base import BaseDescriptor
-from vellum.workflows.expressions.and_ import AndExpression
-from vellum.workflows.expressions.begins_with import BeginsWithExpression
-from vellum.workflows.expressions.between import BetweenExpression
 from vellum.workflows.expressions.coalesce_expression import CoalesceExpression
-from vellum.workflows.expressions.contains import ContainsExpression
-from vellum.workflows.expressions.does_not_begin_with import DoesNotBeginWithExpression
-from vellum.workflows.expressions.does_not_contain import DoesNotContainExpression
-from vellum.workflows.expressions.does_not_end_with import DoesNotEndWithExpression
-from vellum.workflows.expressions.does_not_equal import DoesNotEqualExpression
-from vellum.workflows.expressions.ends_with import EndsWithExpression
-from vellum.workflows.expressions.equals import EqualsExpression
-from vellum.workflows.expressions.greater_than import GreaterThanExpression
-from vellum.workflows.expressions.greater_than_or_equal_to import GreaterThanOrEqualToExpression
-from vellum.workflows.expressions.in_ import InExpression
-from vellum.workflows.expressions.is_nil import IsNilExpression
-from vellum.workflows.expressions.is_not_nil import IsNotNilExpression
-from vellum.workflows.expressions.is_not_null import IsNotNullExpression
-from vellum.workflows.expressions.is_not_undefined import IsNotUndefinedExpression
-from vellum.workflows.expressions.is_null import IsNullExpression
-from vellum.workflows.expressions.is_undefined import IsUndefinedExpression
-from vellum.workflows.expressions.less_than import LessThanExpression
-from vellum.workflows.expressions.less_than_or_equal_to import LessThanOrEqualToExpression
-from vellum.workflows.expressions.not_between import NotBetweenExpression
-from vellum.workflows.expressions.not_in import NotInExpression
-from vellum.workflows.expressions.or_ import OrExpression
 from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
 from vellum.workflows.references import NodeReference
 from vellum.workflows.utils.uuids import uuid4_from_hash
@@ -124,48 +100,3 @@ def create_pointer(
         return ConstantValuePointer(type="CONSTANT_VALUE", data=vellum_variable_value)
     else:
         raise ValueError(f"Pointer type {pointer_type} not supported")
-
-
-def convert_descriptor_to_operator(descriptor: BaseDescriptor) -> str:
-    if isinstance(descriptor, EqualsExpression):
-        return "="
-    elif isinstance(descriptor, DoesNotEqualExpression):
-        return "!="
-    elif isinstance(descriptor, LessThanExpression):
-        return "<"
-    elif isinstance(descriptor, GreaterThanExpression):
-        return ">"
-    elif isinstance(descriptor, LessThanOrEqualToExpression):
-        return "<="
-    elif isinstance(descriptor, GreaterThanOrEqualToExpression):
-        return ">="
-    elif isinstance(descriptor, ContainsExpression):
-        return "contains"
-    elif isinstance(descriptor, BeginsWithExpression):
-        return "beginsWith"
-    elif isinstance(descriptor, EndsWithExpression):
-        return "endsWith"
-    elif isinstance(descriptor, DoesNotContainExpression):
-        return "doesNotContain"
-    elif isinstance(descriptor, DoesNotBeginWithExpression):
-        return "doesNotBeginWith"
-    elif isinstance(descriptor, DoesNotEndWithExpression):
-        return "doesNotEndWith"
-    elif isinstance(descriptor, (IsNullExpression, IsNilExpression, IsUndefinedExpression)):
-        return "null"
-    elif isinstance(descriptor, (IsNotNullExpression, IsNotNilExpression, IsNotUndefinedExpression)):
-        return "notNull"
-    elif isinstance(descriptor, InExpression):
-        return "in"
-    elif isinstance(descriptor, NotInExpression):
-        return "notIn"
-    elif isinstance(descriptor, BetweenExpression):
-        return "between"
-    elif isinstance(descriptor, NotBetweenExpression):
-        return "notBetween"
-    elif isinstance(descriptor, AndExpression):
-        return "and"
-    elif isinstance(descriptor, OrExpression):
-        return "or"
-    else:
-        raise ValueError(f"Unsupported descriptor type: {descriptor}")

--- a/ee/vellum_ee/workflows/display/utils/vellum.py
+++ b/ee/vellum_ee/workflows/display/utils/vellum.py
@@ -1,7 +1,32 @@
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
+from vellum.client.types.logical_operator import LogicalOperator
 from vellum.client.types.vellum_variable_type import VellumVariableType
 from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.expressions.and_ import AndExpression
+from vellum.workflows.expressions.begins_with import BeginsWithExpression
+from vellum.workflows.expressions.between import BetweenExpression
+from vellum.workflows.expressions.contains import ContainsExpression
+from vellum.workflows.expressions.does_not_begin_with import DoesNotBeginWithExpression
+from vellum.workflows.expressions.does_not_contain import DoesNotContainExpression
+from vellum.workflows.expressions.does_not_end_with import DoesNotEndWithExpression
+from vellum.workflows.expressions.does_not_equal import DoesNotEqualExpression
+from vellum.workflows.expressions.ends_with import EndsWithExpression
+from vellum.workflows.expressions.equals import EqualsExpression
+from vellum.workflows.expressions.greater_than import GreaterThanExpression
+from vellum.workflows.expressions.greater_than_or_equal_to import GreaterThanOrEqualToExpression
+from vellum.workflows.expressions.in_ import InExpression
+from vellum.workflows.expressions.is_nil import IsNilExpression
+from vellum.workflows.expressions.is_not_nil import IsNotNilExpression
+from vellum.workflows.expressions.is_not_null import IsNotNullExpression
+from vellum.workflows.expressions.is_not_undefined import IsNotUndefinedExpression
+from vellum.workflows.expressions.is_null import IsNullExpression
+from vellum.workflows.expressions.is_undefined import IsUndefinedExpression
+from vellum.workflows.expressions.less_than import LessThanExpression
+from vellum.workflows.expressions.less_than_or_equal_to import LessThanOrEqualToExpression
+from vellum.workflows.expressions.not_between import NotBetweenExpression
+from vellum.workflows.expressions.not_in import NotInExpression
+from vellum.workflows.expressions.or_ import OrExpression
 from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
 from vellum.workflows.references import OutputReference, WorkflowInputReference
 from vellum.workflows.references.execution_count import ExecutionCountReference
@@ -9,7 +34,6 @@ from vellum.workflows.references.node import NodeReference
 from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
 from vellum.workflows.vellum_client import create_vellum_client
-from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum_ee.workflows.display.vellum import (
     ConstantValuePointer,
     ExecutionCounterData,
@@ -23,7 +47,8 @@ from vellum_ee.workflows.display.vellum import (
     WorkspaceSecretPointer,
 )
 
-_T = TypeVar("_T")
+if TYPE_CHECKING:
+    from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
 
 def infer_vellum_variable_type(value: Any) -> VellumVariableType:
@@ -47,7 +72,7 @@ def infer_vellum_variable_type(value: Any) -> VellumVariableType:
 
 
 def create_node_input_value_pointer_rule(
-    value: Any, display_context: WorkflowDisplayContext
+    value: Any, display_context: "WorkflowDisplayContext"
 ) -> NodeInputValuePointerRule:
     if isinstance(value, OutputReference):
         upstream_node, output_display = display_context.global_node_output_displays[value]
@@ -82,3 +107,48 @@ def create_node_input_value_pointer_rule(
         return ConstantValuePointer(type="CONSTANT_VALUE", data=vellum_value)
 
     raise ValueError(f"Unsupported descriptor type: {value.__class__.__name__}")
+
+
+def convert_descriptor_to_operator(descriptor: BaseDescriptor) -> LogicalOperator:
+    if isinstance(descriptor, EqualsExpression):
+        return "="
+    elif isinstance(descriptor, DoesNotEqualExpression):
+        return "!="
+    elif isinstance(descriptor, LessThanExpression):
+        return "<"
+    elif isinstance(descriptor, GreaterThanExpression):
+        return ">"
+    elif isinstance(descriptor, LessThanOrEqualToExpression):
+        return "<="
+    elif isinstance(descriptor, GreaterThanOrEqualToExpression):
+        return ">="
+    elif isinstance(descriptor, ContainsExpression):
+        return "contains"
+    elif isinstance(descriptor, BeginsWithExpression):
+        return "beginsWith"
+    elif isinstance(descriptor, EndsWithExpression):
+        return "endsWith"
+    elif isinstance(descriptor, DoesNotContainExpression):
+        return "doesNotContain"
+    elif isinstance(descriptor, DoesNotBeginWithExpression):
+        return "doesNotBeginWith"
+    elif isinstance(descriptor, DoesNotEndWithExpression):
+        return "doesNotEndWith"
+    elif isinstance(descriptor, (IsNullExpression, IsNilExpression, IsUndefinedExpression)):
+        return "null"
+    elif isinstance(descriptor, (IsNotNullExpression, IsNotNilExpression, IsNotUndefinedExpression)):
+        return "notNull"
+    elif isinstance(descriptor, InExpression):
+        return "in"
+    elif isinstance(descriptor, NotInExpression):
+        return "notIn"
+    elif isinstance(descriptor, BetweenExpression):
+        return "between"
+    elif isinstance(descriptor, NotBetweenExpression):
+        return "notBetween"
+    elif isinstance(descriptor, AndExpression):
+        return "and"
+    elif isinstance(descriptor, OrExpression):
+        return "or"
+    else:
+        raise ValueError(f"Unsupported descriptor type: {descriptor}")


### PR DESCRIPTION
Thread for Context: https://github.com/vellum-ai/vellum-python-sdks/pull/681#discussion_r1927667314

We have to `BaseNodeDisplay`s, but the original was intended to be the one we used for GenericNode's. Consolidation was descoped originally, but will play a big role during adornment support so we are moving to consolidate now.

This PR only hoists up the two `serialize_[condition|value]` methods. It also moves around other methods needed to avoid circ deps. No logic changes in the PR