### PR TITLE
Fix the `VellumError` serialization failure

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/error_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/error_node.py
@@ -4,6 +4,7 @@ from typing import Any, ClassVar, Dict, Generic, Optional, TypeVar
 from vellum.workflows.nodes import ErrorNode
 from vellum.workflows.types.core import JsonObject
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
+from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
@@ -21,6 +22,12 @@ class BaseErrorNodeDisplay(BaseNodeVellumDisplay[_ErrorNodeType], Generic[_Error
         node_id = self.node_id
         error_source_input_id = self.node_input_ids_by_name.get("error_source_input_id")
 
+        error_attribute = raise_if_descriptor(self._node.error)
+        input_values_by_name = {
+            "error_source_input_id": error_attribute,
+            **self.error_inputs_by_name,
+        }
+
         node_inputs = [
             create_node_input(
                 node_id=node_id,
@@ -29,7 +36,7 @@ class BaseErrorNodeDisplay(BaseNodeVellumDisplay[_ErrorNodeType], Generic[_Error
                 display_context=display_context,
                 input_id=self.node_input_ids_by_name.get(variable_name),
             )
-            for variable_name, variable_value in self.error_inputs_by_name.items()
+            for variable_name, variable_value in input_values_by_name.items()
         ]
 
         return {

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_error_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_error_node.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, cast
+
+from vellum.client.types.vellum_error import VellumError
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes.core.error_node.node import ErrorNode
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+
+
+def test_error_node_display__serialize_with_vellum_error() -> None:
+    # GIVEN an Error Node with a VellumError
+    class MyNode(ErrorNode):
+        error = VellumError(
+            message="A bad thing happened",
+            code="USER_DEFINED_ERROR",
+        )
+
+    # AND a workflow referencing the two node
+    class MyWorkflow(BaseWorkflow):
+        graph = MyNode
+
+    # WHEN we serialize the workflow
+    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=MyWorkflow)
+    serialized_workflow = cast(Dict[str, Any], workflow_display.serialize())
+
+    # THEN the correct inputs should be serialized on the node
+    serialized_node = next(
+        node for node in serialized_workflow["workflow_raw_data"]["nodes"] if node["id"] == str(MyNode.__id__)
+    )
+    assert serialized_node["inputs"][0]["value"] == {
+        "combinator": "OR",
+        "rules": [
+            {
+                "data": {
+                    "type": "ERROR",
+                    "error": {
+                        "message": "A bad thing happened",
+                        "code": "USER_DEFINED_ERROR",
+                    },
+                },
+                "type": "CONSTANT_VALUE",
+            }
+        ],
+    }

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_error_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_error_node.py
@@ -33,7 +33,7 @@ def test_error_node_display__serialize_with_vellum_error() -> None:
             {
                 "data": {
                     "type": "ERROR",
-                    "error": {
+                    "value": {
                         "message": "A bad thing happened",
                         "code": "USER_DEFINED_ERROR",
                     },

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_error_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_error_node_serialization.py
@@ -88,7 +88,21 @@ def test_serialize_workflow():
         {
             "id": "5cf9c5e3-0eae-4daf-8d73-8b9536258eb9",
             "type": "ERROR",
-            "inputs": [],
+            "inputs": [
+                {
+                    "id": "690d825f-6ffd-493e-8141-c86d384e6150",
+                    "key": "error_source_input_id",
+                    "value": {
+                        "rules": [
+                            {
+                                "type": "CONSTANT_VALUE",
+                                "data": {"type": "STRING", "value": "Input threshold was too low"},
+                            }
+                        ],
+                        "combinator": "OR",
+                    },
+                }
+            ],
             "data": {
                 "name": "error-node",
                 "label": "Fail Node",

--- a/src/vellum/workflows/errors/types.py
+++ b/src/vellum/workflows/errors/types.py
@@ -61,3 +61,24 @@ def workflow_event_error_to_workflow_error(error: WorkflowEventError) -> Workflo
         message=error.message,
         code=_WORKFLOW_EVENT_ERROR_CODE_TO_WORKFLOW_ERROR_CODE.get(error.code, WorkflowErrorCode.INTERNAL_ERROR),
     )
+
+
+_WORKFLOW_ERROR_CODE_TO_VELLUM_ERROR_CODE: Dict[WorkflowErrorCode, VellumErrorCodeEnum] = {
+    WorkflowErrorCode.INVALID_WORKFLOW: "INVALID_REQUEST",
+    WorkflowErrorCode.INVALID_INPUTS: "INVALID_INPUTS",
+    WorkflowErrorCode.INVALID_OUTPUTS: "INVALID_REQUEST",
+    WorkflowErrorCode.INVALID_STATE: "INVALID_REQUEST",
+    WorkflowErrorCode.INVALID_TEMPLATE: "INVALID_INPUTS",
+    WorkflowErrorCode.INTERNAL_ERROR: "INTERNAL_SERVER_ERROR",
+    WorkflowErrorCode.NODE_EXECUTION: "USER_DEFINED_ERROR",
+    WorkflowErrorCode.PROVIDER_ERROR: "PROVIDER_ERROR",
+    WorkflowErrorCode.USER_DEFINED_ERROR: "USER_DEFINED_ERROR",
+    WorkflowErrorCode.WORKFLOW_CANCELLED: "REQUEST_TIMEOUT",
+}
+
+
+def workflow_error_to_vellum_error(error: WorkflowError) -> VellumError:
+    return VellumError(
+        message=error.message,
+        code=_WORKFLOW_ERROR_CODE_TO_VELLUM_ERROR_CODE.get(error.code, "INTERNAL_SERVER_ERROR"),
+    )

--- a/src/vellum/workflows/nodes/displayable/bases/tests/test_utils.py
+++ b/src/vellum/workflows/nodes/displayable/bases/tests/test_utils.py
@@ -1,8 +1,11 @@
 import pytest
 import enum
 
+from pydantic import BaseModel
+
 from vellum.client.types.chat_history_vellum_value import ChatHistoryVellumValue
 from vellum.client.types.chat_message import ChatMessage
+from vellum.client.types.error_vellum_value import ErrorVellumValue
 from vellum.client.types.json_vellum_value import JsonVellumValue
 from vellum.client.types.number_vellum_value import NumberVellumValue
 from vellum.client.types.search_result import SearchResult
@@ -10,11 +13,17 @@ from vellum.client.types.search_result_document import SearchResultDocument
 from vellum.client.types.search_results_vellum_value import SearchResultsVellumValue
 from vellum.client.types.string_vellum_value import StringVellumValue
 from vellum.client.types.string_vellum_value_request import StringVellumValueRequest
+from vellum.client.types.vellum_error import VellumError
+from vellum.workflows.errors.types import WorkflowError, WorkflowErrorCode
 from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value, primitive_to_vellum_value_request
 
 
 class MockEnum(enum.Enum):
     FOO = "foo"
+
+
+class RandomPydanticModel(BaseModel):
+    foo: str
 
 
 @pytest.mark.parametrize(
@@ -51,6 +60,15 @@ class MockEnum(enum.Enum):
         (StringVellumValue(value="hello"), StringVellumValue(value="hello")),
         (StringVellumValueRequest(value="hello"), StringVellumValueRequest(value="hello")),
         ({"foo": "bar"}, JsonVellumValue(value={"foo": "bar"})),
+        (
+            VellumError(message="hello", code="USER_DEFINED_ERROR"),
+            ErrorVellumValue(value=VellumError(message="hello", code="USER_DEFINED_ERROR")),
+        ),
+        (
+            WorkflowError(message="hello", code=WorkflowErrorCode.USER_DEFINED_ERROR),
+            ErrorVellumValue(value=VellumError(message="hello", code="USER_DEFINED_ERROR")),
+        ),
+        (RandomPydanticModel(foo="bar"), JsonVellumValue(value={"foo": "bar"})),
     ],
 )
 def test_primitive_to_vellum_value(value, expected_output):


### PR DESCRIPTION
Currently blocking serialization of a [customer workflow](https://github.com/vellum-ai/workflows-as-code-runner-prototype/pull/602). We can now properly serialize all inputs of `ErrorNode.error`