### PR TITLE
Error if Fallback Models Are Encountered

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -610,8 +610,10 @@ export function inlinePromptNodeDataLegacyVariantFactory({
 
 export function promptDeploymentNodeDataFactory({
   errorOutputId = undefined,
+  fallbackModels,
 }: {
   errorOutputId?: string;
+  fallbackModels?: string[];
 } = {}): PromptNode {
   return {
     id: "947cc337-9a53-4c12-9a38-4f65c04c6317",
@@ -626,6 +628,7 @@ export function promptDeploymentNodeDataFactory({
       targetHandleId: "e1f8a351-ab12-4167-93ee-d2dd72c8d15c",
       promptDeploymentId: "afd05488-7a25-4ff2-b87b-878e9552474e",
       releaseTag: "LATEST",
+      fallbackModels,
     },
     inputs: [
       {

--- a/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
@@ -13,8 +13,8 @@ describe("PromptDeploymentNode", () => {
   let writer: Writer;
 
   beforeEach(() => {
-    workflowContext = workflowContextFactory();
     writer = new Writer();
+    workflowContext = workflowContextFactory();
   });
 
   describe("basic", () => {
@@ -40,6 +40,30 @@ describe("PromptDeploymentNode", () => {
     it(`getNodeDisplayFile`, async () => {
       node.getNodeDisplayFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+
+  describe("fallback models", () => {
+    beforeEach(async () => {
+      const nodeData = promptDeploymentNodeDataFactory({
+        fallbackModels: ["model1"],
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as PromptDeploymentNodeContext;
+
+      node = new PromptDeploymentNode({
+        workflowContext,
+        nodeContext,
+      });
+    });
+
+    it(`getNodeFile should fail`, async () => {
+      expect(() => node.getNodeFile().write(writer)).toThrowError(
+        "Fallback models not currently support"
+      );
     });
   });
 });

--- a/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
@@ -22,6 +22,15 @@ export class PromptDeploymentNode extends BaseSingleFileNode<
 
     const nodeData: DeploymentPromptNodeData = this.nodeData.data;
 
+    if (
+      this.nodeData.data.fallbackModels &&
+      this.nodeData.data.fallbackModels.length > 0
+    ) {
+      throw new NodeDefinitionGenerationError(
+        "Fallback models not currently supported."
+      );
+    }
+
     statements.push(
       python.field({
         name: "deployment",

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -798,6 +798,10 @@ export const DeploymentPromptNodeDataSerializer: ObjectSchema<
   arrayOutputId: propertySchema("array_output_id", stringSchema()),
   sourceHandleId: propertySchema("source_handle_id", stringSchema()),
   targetHandleId: propertySchema("target_handle_id", stringSchema()),
+  fallbackModels: propertySchema(
+    "fallback_models",
+    listSchema(stringSchema()).optional()
+  ),
 });
 
 export declare namespace DeploymentPromptNodeDataSerializer {
@@ -810,6 +814,7 @@ export declare namespace DeploymentPromptNodeDataSerializer {
     array_output_id: string;
     source_handle_id: string;
     target_handle_id: string;
+    fallback_models?: string[] | null;
   }
 }
 

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -347,6 +347,7 @@ export interface DeploymentPromptNodeData extends BasePromptNodeData {
   variant: "DEPLOYMENT";
   promptDeploymentId: string;
   releaseTag: string;
+  fallbackModels?: string[];
 }
 
 export interface PromptNodeSourceSandbox {


### PR DESCRIPTION
Fallback models aren't yet supported for wSDK Prompt Deployment Nodes.

This'll ensure that we catch this case early and fail.