### PR TITLE
Simplify the graph attribute interface to be just workflow context

### DIFF
--- a/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
+++ b/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
@@ -1,3 +1,5 @@
+import { entrypointNodeDataFactory } from "./node-data-factories";
+
 import { WorkflowContext } from "src/context";
 
 export function workflowContextFactory(
@@ -5,6 +7,7 @@ export function workflowContextFactory(
     absolutePathToOutputDirectory,
     moduleName,
     workflowClassName,
+    workflowRawNodes,
     workflowRawEdges,
     codeExecutionNodeCodeRepresentationOverride,
     strict = true,
@@ -12,12 +15,15 @@ export function workflowContextFactory(
     codeExecutionNodeCodeRepresentationOverride: "STANDALONE",
   }
 ): WorkflowContext {
+  const nodes = workflowRawNodes || [entrypointNodeDataFactory()];
+
   return new WorkflowContext({
     absolutePathToOutputDirectory:
       absolutePathToOutputDirectory || "./src/__tests__/",
     moduleName: moduleName || "code",
     workflowClassName: workflowClassName || "TestWorkflow",
     vellumApiKey: "<TEST_API_KEY>",
+    workflowRawNodes: nodes,
     workflowRawEdges: workflowRawEdges || [],
     strict,
     codeExecutionNodeCodeRepresentationOverride,

--- a/ee/codegen/src/generators/nodes/bases/nested-workflow-base.ts
+++ b/ee/codegen/src/generators/nodes/bases/nested-workflow-base.ts
@@ -72,6 +72,7 @@ export abstract class BaseNestedWorkflowNode<
       this.workflowContext.createNestedWorkflowContext({
         parentNode: this,
         workflowClassName: nestedWorkflowClassName,
+        workflowRawNodes: innerWorkflowData.nodes,
         workflowRawEdges: innerWorkflowData.edges,
       });
 


### PR DESCRIPTION
Evaluating our set of customer workflows revealed some pretty gnarly graph generation cases, that has motivated me to want to separate out the set of graph gen cases and build out some more going forward. The first step of that was to make the interface simpler by requiring just the `workflowContext`. This will allow the graph attribute tests to not need to do the same work that `Workflow()` currently does for each case, so that the snapshots are just the graph attribute itself

This ended up being a bigger lift than expected, but doable, so going to start splitting out these PRs to merge them in