### PR TITLE
Simplify workflowContextFactory usage

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Workflow Sandbox > write > should generate correct and same code for snake and camel casing of input names 1`] = `
 "from vellum.workflows.sandbox import WorkflowSandboxRunner
-from .workflow import Workflow
+from .workflow import TestWorkflow
 from .inputs import Inputs
 
 if __name__ != "__main__":
@@ -10,7 +10,7 @@ if __name__ != "__main__":
 
 
 runner = WorkflowSandboxRunner(
-    workflow=Workflow(),
+    workflow=TestWorkflow(),
     inputs=[
         Inputs(some_foo="some-value"),
         Inputs(some_bar="some-value"),
@@ -23,7 +23,7 @@ runner.run()
 
 exports[`Workflow Sandbox > write > should generate correct code given inputs 1`] = `
 "from vellum.workflows.sandbox import WorkflowSandboxRunner
-from .workflow import Workflow
+from .workflow import TestWorkflow
 from .inputs import Inputs
 
 if __name__ != "__main__":
@@ -31,7 +31,7 @@ if __name__ != "__main__":
 
 
 runner = WorkflowSandboxRunner(
-    workflow=Workflow(),
+    workflow=TestWorkflow(),
     inputs=[
         Inputs(some_foo="some-value"),
         Inputs(some_bar="some-value"),

--- a/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
+++ b/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
@@ -16,7 +16,7 @@ export function workflowContextFactory(
     absolutePathToOutputDirectory:
       absolutePathToOutputDirectory || "./src/__tests__/",
     moduleName: moduleName || "code",
-    workflowClassName: workflowClassName || "Workflow",
+    workflowClassName: workflowClassName || "TestWorkflow",
     vellumApiKey: "<TEST_API_KEY>",
     workflowRawEdges: workflowRawEdges || [],
     strict,

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -31,9 +31,7 @@ describe("Workflow", () => {
       mockDocumentIndexFactory() as unknown as DocumentIndexRead
     );
 
-    workflowContext = workflowContextFactory({
-      workflowClassName: "TestWorkflow",
-    });
+    workflowContext = workflowContextFactory();
     workflowContext.addEntrypointNode(entrypointNode);
 
     const nodeData = terminalNodeDataFactory();


### PR DESCRIPTION
The ultimate goal is to separate out the Graph Attribute tests by simplifying the Graph Attribute interface: https://github.com/vellum-ai/vellum-python-sdks/pull/711

In this PR, we just simplify the workflowContextFactory usage such that the default was the same across the two test files that use it