### PR TITLE
Remove entrypoint node edges from the Graph Attribute interface

### DIFF
--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -191,6 +191,13 @@ export class WorkflowContext {
     return this.entrypointNode;
   }
 
+  public getEntrypointNodeEdges(): WorkflowEdge[] {
+    const entrypointNodeId = this.getEntrypointNode().id;
+    return this.workflowRawEdges.filter(
+      (edge) => edge.sourceNodeId === entrypointNodeId
+    );
+  }
+
   public isInputVariableNameUsed(inputVariableName: string): boolean {
     return this.inputVariableNames.has(inputVariableName);
   }

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -37,7 +37,6 @@ type GraphMutableAst =
 
 export declare namespace GraphAttribute {
   interface Args {
-    entrypointNodeEdges: WorkflowEdge[];
     entrypointNodeId: string;
     edgesByPortId: Map<string, WorkflowEdge[]>;
     workflowContext: WorkflowContext;
@@ -47,18 +46,15 @@ export declare namespace GraphAttribute {
 export class GraphAttribute extends AstNode {
   private readonly workflowContext: WorkflowContext;
   private readonly edgesByPortId: Map<string, WorkflowEdge[]>;
-  private readonly entrypointNodeEdges: WorkflowEdge[];
   private readonly entrypointNodeId: string;
   private readonly astNode: python.AstNode;
 
   public constructor({
-    entrypointNodeEdges,
     entrypointNodeId,
     edgesByPortId,
     workflowContext,
   }: GraphAttribute.Args) {
     super();
-    this.entrypointNodeEdges = entrypointNodeEdges;
     this.entrypointNodeId = entrypointNodeId;
     this.workflowContext = workflowContext;
     this.edgesByPortId = edgesByPortId;
@@ -77,7 +73,7 @@ export class GraphAttribute extends AstNode {
    */
   private generateGraphMutableAst(): GraphMutableAst {
     let graphMutableAst: GraphMutableAst = { type: "empty" };
-    const edgesQueue = [...this.entrypointNodeEdges];
+    const edgesQueue = this.workflowContext.getEntrypointNodeEdges();
     const processedEdges = new Set<WorkflowEdge>();
 
     while (edgesQueue.length > 0) {


### PR DESCRIPTION
The ultimate goal is to separate out the Graph Attribute tests by simplifying the Graph Attribute interface: https://github.com/vellum-ai/vellum-python-sdks/pull/711

In this PR, we just remove 1 of the three attributes we're looking to remove from the `GraphAttribute` class: `entrypointNodeEdges`. Instead, this can be inferred from the workflow context