### PR TITLE
Remove the edgesByPortId constructor param from GraphAttribute

### DIFF
--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -198,6 +198,17 @@ export class WorkflowContext {
     );
   }
 
+  public getEdgesByPortId(): Map<string, WorkflowEdge[]> {
+    const edgesByPortId = new Map<string, WorkflowEdge[]>();
+    this.workflowRawEdges.forEach((edge) => {
+      const portId = edge.sourceHandleId;
+      const edges = edgesByPortId.get(portId) ?? [];
+      edges.push(edge);
+      edgesByPortId.set(portId, edges);
+    });
+    return edgesByPortId;
+  }
+
   public isInputVariableNameUsed(inputVariableName: string): boolean {
     return this.inputVariableNames.has(inputVariableName);
   }

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -38,26 +38,22 @@ type GraphMutableAst =
 export declare namespace GraphAttribute {
   interface Args {
     entrypointNodeId: string;
-    edgesByPortId: Map<string, WorkflowEdge[]>;
     workflowContext: WorkflowContext;
   }
 }
 
 export class GraphAttribute extends AstNode {
   private readonly workflowContext: WorkflowContext;
-  private readonly edgesByPortId: Map<string, WorkflowEdge[]>;
   private readonly entrypointNodeId: string;
   private readonly astNode: python.AstNode;
 
   public constructor({
     entrypointNodeId,
-    edgesByPortId,
     workflowContext,
   }: GraphAttribute.Args) {
     super();
     this.entrypointNodeId = entrypointNodeId;
     this.workflowContext = workflowContext;
-    this.edgesByPortId = edgesByPortId;
 
     this.astNode = this.generateGraphAttribute();
   }
@@ -74,6 +70,7 @@ export class GraphAttribute extends AstNode {
   private generateGraphMutableAst(): GraphMutableAst {
     let graphMutableAst: GraphMutableAst = { type: "empty" };
     const edgesQueue = this.workflowContext.getEntrypointNodeEdges();
+    const edgesByPortId = this.workflowContext.getEdgesByPortId();
     const processedEdges = new Set<WorkflowEdge>();
 
     while (edgesQueue.length > 0) {
@@ -407,7 +404,7 @@ export class GraphAttribute extends AstNode {
 
       graphMutableAst = newMutableAst;
       targetNode.portContextsById.forEach((portContext) => {
-        const edges = this.edgesByPortId.get(portContext.portId);
+        const edges = edgesByPortId.get(portContext.portId);
         edges?.forEach((edge) => {
           if (processedEdges.has(edge) || edgesQueue.includes(edge)) {
             return;


### PR DESCRIPTION
The ultimate goal is to separate out the Graph Attribute tests by simplifying the Graph Attribute interface: https://github.com/vellum-ai/vellum-python-sdks/pull/711

In this PR, we remove the `edgesByPortId` from the `GraphAttribute` class, by always inferring `edgesByPortId` from the `workflowContext`. We only read from this state in one spot outside of `GraphAttribute`, so perf impact should be negligible