### PR TITLE
Remove `entrypointNodeId` from the GraphAttribute constructor interface

### DIFF
--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -37,22 +37,16 @@ type GraphMutableAst =
 
 export declare namespace GraphAttribute {
   interface Args {
-    entrypointNodeId: string;
     workflowContext: WorkflowContext;
   }
 }
 
 export class GraphAttribute extends AstNode {
   private readonly workflowContext: WorkflowContext;
-  private readonly entrypointNodeId: string;
   private readonly astNode: python.AstNode;
 
-  public constructor({
-    entrypointNodeId,
-    workflowContext,
-  }: GraphAttribute.Args) {
+  public constructor({ workflowContext }: GraphAttribute.Args) {
     super();
-    this.entrypointNodeId = entrypointNodeId;
     this.workflowContext = workflowContext;
 
     this.astNode = this.generateGraphAttribute();
@@ -80,7 +74,7 @@ export class GraphAttribute extends AstNode {
       }
 
       const sourceNode =
-        edge.sourceNodeId === this.entrypointNodeId
+        edge.sourceNodeId === this.workflowContext.getEntrypointNode().id
           ? null
           : this.workflowContext.getNodeContext(edge.sourceNodeId);
 

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -47,13 +47,11 @@ export class Workflow {
   private readonly inputs: Inputs;
   private readonly nodes: WorkflowDataNode[];
   private readonly displayData: WorkflowDisplayData | undefined;
-  private readonly entrypointNodeId: string;
   constructor({ workflowContext, inputs, nodes, displayData }: Workflow.Args) {
     this.workflowContext = workflowContext;
     this.inputs = inputs;
     this.nodes = nodes;
     this.displayData = displayData;
-    this.entrypointNodeId = this.workflowContext.getEntrypointNode().id;
   }
 
   private generateParentWorkflowClass(): python.Reference {
@@ -525,7 +523,6 @@ export class Workflow {
     const graphField = python.field({
       name: "graph",
       initializer: new GraphAttribute({
-        entrypointNodeId: this.entrypointNodeId,
         workflowContext: this.workflowContext,
       }),
     });


### PR DESCRIPTION
The ultimate goal is to separate out the Graph Attribute tests by simplifying the Graph Attribute interface: https://github.com/vellum-ai/vellum-python-sdks/pull/711

In this PR, we remove the last argument from the GraphAttribute constructor. After splitting out the bits I needed, I realized that I could now split out the tests into its own file and not necessarily implement the rest of the above linked PR