### PR TITLE
Remove the `nodes` param from codegen.workflow()

### DIFF
--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -84,7 +84,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [searchNodeData],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -135,7 +134,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [templatingNodeData1, templatingNodeData2],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -205,7 +203,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [templatingNodeData1, templatingNodeData2, templatingNodeData3],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -256,7 +253,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [templatingNodeData1, templatingNodeData2],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -334,7 +330,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [templatingNodeData1, templatingNodeData2, mergeNodeData],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -439,12 +434,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [
-          templatingNodeData1,
-          templatingNodeData2,
-          templatingNodeData3,
-          mergeNodeData,
-        ],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -541,12 +530,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [
-          templatingNodeData1,
-          templatingNodeData2,
-          mergeNodeData,
-          templatingNodeData3,
-        ],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -643,12 +626,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [
-          templatingNodeData1,
-          templatingNodeData2,
-          mergeNodeData,
-          templatingNodeData3,
-        ],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -720,7 +697,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [conditionalNodeData, templatingNodeData1, templatingNodeData2],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -790,7 +766,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [templatingNodeData1, templatingNodeData2, templatingNodeData3],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -860,7 +835,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [templatingNodeData1, templatingNodeData2, templatingNodeData3],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -930,7 +904,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [templatingNodeData1, templatingNodeData2, templatingNodeData3],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -1027,12 +1000,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [
-          templatingNodeData1,
-          templatingNodeData2,
-          templatingNodeData3,
-          templatingNodeData4,
-        ],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -1167,14 +1134,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [
-          templatingNodeData1,
-          templatingNodeData2,
-          templatingNodeData3,
-          templatingNodeData4,
-          templatingNodeData5,
-          mergeNodeData,
-        ],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -1246,7 +1205,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [conditionalNodeData, templatingNodeData1, templatingNodeData2],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -1348,12 +1306,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [
-          conditionalNodeData,
-          templatingNodeData1,
-          templatingNodeData2,
-          templatingNodeData3,
-        ],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -1490,14 +1442,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [
-          conditionalNodeData,
-          conditionalNode2Data,
-          templatingNodeData1,
-          templatingNodeData2,
-          templatingNodeData3,
-          templatingNodeData4,
-        ],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -1634,14 +1578,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [
-          conditionalNodeData,
-          templatingNodeData1,
-          templatingNodeData2,
-          templatingNodeData3,
-          templatingNodeData4,
-          templatingNodeData5,
-        ],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -1719,7 +1655,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [templatingNodeData1, templatingNodeData2, mergeNodeData],
       });
 
       workflow.getWorkflowFile().write(writer);

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -52,7 +52,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -65,7 +64,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -94,7 +92,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -146,7 +143,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [searchNodeData],
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -201,7 +197,6 @@ describe("Workflow", () => {
         moduleName,
         workflowContext,
         inputs,
-        nodes: [templatingNodeData1, templatingNodeData2],
       });
 
       workflow.getWorkflowFile().write(writer);

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -20,11 +20,7 @@ import { WorkflowContext } from "src/context";
 import { BaseState } from "src/generators/base-state";
 import { Inputs } from "src/generators/inputs";
 import { NodeDisplayData } from "src/generators/node-display-data";
-import {
-  WorkflowDataNode,
-  WorkflowDisplayData,
-  WorkflowEdge,
-} from "src/types/vellum";
+import { WorkflowDisplayData, WorkflowEdge } from "src/types/vellum";
 import { isDefined } from "src/utils/typing";
 
 export declare namespace Workflow {
@@ -35,8 +31,6 @@ export declare namespace Workflow {
     workflowContext: WorkflowContext;
     /* The inputs for the workflow */
     inputs: Inputs;
-    /* The nodes in the workflow */
-    nodes: WorkflowDataNode[];
     /* The display data for the workflow */
     displayData?: WorkflowDisplayData;
   }
@@ -45,12 +39,10 @@ export declare namespace Workflow {
 export class Workflow {
   public readonly workflowContext: WorkflowContext;
   private readonly inputs: Inputs;
-  private readonly nodes: WorkflowDataNode[];
   private readonly displayData: WorkflowDisplayData | undefined;
-  constructor({ workflowContext, inputs, nodes, displayData }: Workflow.Args) {
+  constructor({ workflowContext, inputs, displayData }: Workflow.Args) {
     this.workflowContext = workflowContext;
     this.inputs = inputs;
-    this.nodes = nodes;
     this.displayData = displayData;
   }
 
@@ -516,7 +508,7 @@ export class Workflow {
   }
 
   private addGraph(workflowClass: python.Class): void {
-    if (this.nodes.length === 0) {
+    if (this.getEdges().length === 0) {
       return;
     }
 

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -372,7 +372,6 @@ ${errors.slice(0, 3).map((err) => {
       moduleName,
       workflowContext: this.workflowContext,
       inputs,
-      nodes: nodesToGenerate,
       displayData: this.workflowVersionExecConfig.workflowRawData.displayData,
     });
 


### PR DESCRIPTION
Workflow and GraphAttribute testing have some redundancy that I'm looking to cleanup to make adding new GraphAttribute test cases easier. The hope is that this continues to also simplify the codegen interfaces themselves.

In this PR, we remove the `nodes` parameter from the `codegen.workflow()` constructor. It was only used to determine whether or not to generate the GraphAttribute, which we could already infer from the `workflowContext`. This removes one unit of redundancy from the Graph Attribute tests