### PR TITLE
Fix serialization of CoalesceExpression, ConstantValueReference, and LazyReference

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -340,10 +340,7 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
 
     def serialize_value(self, display_context: "WorkflowDisplayContext", value: BaseDescriptor) -> JsonObject:
         if isinstance(value, ConstantValueReference):
-            return {
-                "type": "CONSTANT_VALUE",
-                "value": value._value,
-            }
+            return self.serialize_value(display_context, value._value)
 
         if isinstance(value, LazyReference):
             return self.serialize_value(display_context, value._get())

--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -31,6 +31,7 @@ from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.utils import get_wrapped_node
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference
+from vellum.workflows.references.constant import ConstantValueReference
 from vellum.workflows.references.execution_count import ExecutionCountReference
 from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.references.workflow_input import WorkflowInputReference
@@ -337,6 +338,12 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
             }
 
     def serialize_value(self, display_context: "WorkflowDisplayContext", value: BaseDescriptor) -> JsonObject:
+        if isinstance(value, ConstantValueReference):
+            return {
+                "type": "CONSTANT_VALUE",
+                "value": value._value,
+            }
+
         if isinstance(value, WorkflowInputReference):
             workflow_input_display = display_context.global_workflow_input_displays[value]
             return {

--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -33,6 +33,7 @@ from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference
 from vellum.workflows.references.constant import ConstantValueReference
 from vellum.workflows.references.execution_count import ExecutionCountReference
+from vellum.workflows.references.lazy import LazyReference
 from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.references.workflow_input import WorkflowInputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
@@ -343,6 +344,9 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
                 "type": "CONSTANT_VALUE",
                 "value": value._value,
             }
+
+        if isinstance(value, LazyReference):
+            return self.serialize_value(display_context, value._get())
 
         if isinstance(value, WorkflowInputReference):
             workflow_input_display = display_context.global_workflow_input_displays[value]

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
@@ -4,6 +4,7 @@ from deepdiff import DeepDiff
 
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.references.constant import ConstantValueReference
 from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum_ee.workflows.display.base import WorkflowInputsDisplay
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
@@ -19,11 +20,7 @@ class ConstantValueGenericNode(BaseNode):
 
 
 def test_serialize_node__constant_value(serialize_node):
-    input_id = uuid4()
-    serialized_node = serialize_node(
-        node_class=ConstantValueGenericNode,
-        global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)},
-    )
+    serialized_node = serialize_node(ConstantValueGenericNode)
 
     assert not DeepDiff(
         {
@@ -58,6 +55,49 @@ def test_serialize_node__constant_value(serialize_node):
                             "value": "hello",
                         },
                     },
+                }
+            ],
+            "outputs": [],
+        },
+        serialized_node,
+        ignore_order=True,
+    )
+
+
+class ConstantValueReferenceGenericNode(BaseNode):
+    attr: str = ConstantValueReference("hello")
+
+
+def test_serialize_node__constant_value_reference(serialize_node):
+    serialized_node = serialize_node(ConstantValueReferenceGenericNode)
+
+    assert not DeepDiff(
+        {
+            "id": "9271e2b1-f47e-47a4-95ae-51299dedb62f",
+            "label": "ConstantValueReferenceGenericNode",
+            "type": "GENERIC",
+            "display_data": {"position": {"x": 0.0, "y": 0.0}},
+            "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
+            "definition": {
+                "name": "ConstantValueReferenceGenericNode",
+                "module": [
+                    "vellum_ee",
+                    "workflows",
+                    "display",
+                    "tests",
+                    "workflow_serialization",
+                    "generic_nodes",
+                    "test_attributes_serialization",
+                ],
+            },
+            "trigger": {"id": "8cc0b4c4-4ae4-4248-8fd5-bfb2e658eb51", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "fe696d84-47c2-4325-8020-34a1c586a759", "name": "default", "type": "DEFAULT"}],
+            "adornments": None,
+            "attributes": [
+                {
+                    "id": "460aeb68-7369-43d2-9d3d-37caa425611f",
+                    "name": "attr",
+                    "value": {"type": "CONSTANT_VALUE", "value": "hello"},
                 }
             ],
             "outputs": [],

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
@@ -5,6 +5,7 @@ from deepdiff import DeepDiff
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.references.constant import ConstantValueReference
+from vellum.workflows.references.lazy import LazyReference
 from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum_ee.workflows.display.base import WorkflowInputsDisplay
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
@@ -98,6 +99,49 @@ def test_serialize_node__constant_value_reference(serialize_node):
                     "id": "460aeb68-7369-43d2-9d3d-37caa425611f",
                     "name": "attr",
                     "value": {"type": "CONSTANT_VALUE", "value": "hello"},
+                }
+            ],
+            "outputs": [],
+        },
+        serialized_node,
+        ignore_order=True,
+    )
+
+
+class LazyReferenceGenericNode(BaseNode):
+    attr: str = LazyReference(lambda: "hello")
+
+
+def test_serialize_node__lazy_reference(serialize_node):
+    serialized_node = serialize_node(LazyReferenceGenericNode)
+
+    assert not DeepDiff(
+        {
+            "id": "29563b11-bd4d-47b0-b017-372f78aeaef5",
+            "label": "LazyReferenceGenericNode",
+            "type": "GENERIC",
+            "display_data": {"position": {"x": 0.0, "y": 0.0}},
+            "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
+            "definition": {
+                "name": "LazyReferenceGenericNode",
+                "module": [
+                    "vellum_ee",
+                    "workflows",
+                    "display",
+                    "tests",
+                    "workflow_serialization",
+                    "generic_nodes",
+                    "test_attributes_serialization",
+                ],
+            },
+            "trigger": {"id": "56e9791a-078a-4bb7-90bc-a26c3991c70f", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "acb761a0-fcc2-4d21-bc8c-d0d560912c04", "name": "default", "type": "DEFAULT"}],
+            "adornments": None,
+            "attributes": [
+                {
+                    "id": "4370b381-9165-4fb4-881e-480507abe069",
+                    "name": "attr",
+                    "value": {"type": "CONSTANT_VALUE", "value": {"type": "STRING", "value": "hello"}},
                 }
             ],
             "outputs": [],

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
@@ -109,7 +109,7 @@ def test_serialize_node__constant_value_reference(serialize_node):
 
 
 class LazyReferenceGenericNode(BaseNode):
-    attr: str = LazyReference(lambda: "hello")
+    attr: str = LazyReference(lambda: ConstantValueReference("hello"))
 
 
 def test_serialize_node__lazy_reference(serialize_node):

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
@@ -98,7 +98,7 @@ def test_serialize_node__constant_value_reference(serialize_node):
                 {
                     "id": "460aeb68-7369-43d2-9d3d-37caa425611f",
                     "name": "attr",
-                    "value": {"type": "CONSTANT_VALUE", "value": "hello"},
+                    "value": {"type": "CONSTANT_VALUE", "value": {"type": "STRING", "value": "hello"}},
                 }
             ],
             "outputs": [],

--- a/ee/vellum_ee/workflows/display/utils/vellum.py
+++ b/ee/vellum_ee/workflows/display/utils/vellum.py
@@ -6,6 +6,7 @@ from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.expressions.and_ import AndExpression
 from vellum.workflows.expressions.begins_with import BeginsWithExpression
 from vellum.workflows.expressions.between import BetweenExpression
+from vellum.workflows.expressions.coalesce_expression import CoalesceExpression
 from vellum.workflows.expressions.contains import ContainsExpression
 from vellum.workflows.expressions.does_not_begin_with import DoesNotBeginWithExpression
 from vellum.workflows.expressions.does_not_contain import DoesNotContainExpression
@@ -150,5 +151,7 @@ def convert_descriptor_to_operator(descriptor: BaseDescriptor) -> LogicalOperato
         return "and"
     elif isinstance(descriptor, OrExpression):
         return "or"
+    elif isinstance(descriptor, CoalesceExpression):
+        return "coalesce"
     else:
         raise ValueError(f"Unsupported descriptor type: {descriptor}")


### PR DESCRIPTION
The problem with `ConstantValueReference` is that our data model can't tell the difference between `attr = 1` and `attr = ConstantValueReference(1)`. Probably not a big deal. 

Should we even allow users to directly use `ConstantValueReference`?