### PR TITLE
Fix issue around pulling the same workflow twice creating redundant entries in the Vellum Lockfile

### DIFF
--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -47,6 +47,13 @@ def _resolve_workflow_config(
             pk=workflow_config.workflow_sandbox_id if workflow_config else None,
         )
     elif workflow_sandbox_id:
+        workflow_config = next((w for w in config.workflows if w.workflow_sandbox_id == workflow_sandbox_id), None)
+        if workflow_config:
+            return WorkflowConfigResolutionResult(
+                workflow_config=workflow_config,
+                pk=workflow_sandbox_id,
+            )
+
         workflow_config = WorkflowConfig(
             workflow_sandbox_id=workflow_sandbox_id,
             module=f"workflow_{workflow_sandbox_id.split('-')[0]}",

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -98,7 +98,6 @@ def pull_command(
         workflow_sandbox_id=workflow_sandbox_id,
         workflow_deployment=workflow_deployment,
     )
-    save_lock_file = not module
 
     workflow_config = workflow_config_result.workflow_config
     if not workflow_config:
@@ -190,16 +189,12 @@ Its schema should be considered unstable and subject to change at any time."""
     if include_sandbox:
         if not workflow_config.ignore:
             workflow_config.ignore = "sandbox.py"
-            save_lock_file = True
         elif isinstance(workflow_config.ignore, str) and "sandbox.py" != workflow_config.ignore:
             workflow_config.ignore = [workflow_config.ignore, "sandbox.py"]
-            save_lock_file = True
         elif isinstance(workflow_config.ignore, list) and "sandbox.py" not in workflow_config.ignore:
             workflow_config.ignore.append("sandbox.py")
-            save_lock_file = True
 
-    if save_lock_file:
-        config.save()
+    config.save()
 
     if error_content:
         logger.error(error_content)


### PR DESCRIPTION
When a user pulls from the same workflow with the workflow-sandbox-id param, it would create duplicate issues. This PR fixes
