### PR TITLE
Fix the GH Action triggers to allow for external collaborators

### DIFF
--- a/.github/workflows/ci-codegen.yaml
+++ b/.github/workflows/ci-codegen.yaml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
     types:
+      - opened
+      - reopened
       - synchronize
 
 jobs:

--- a/.github/workflows/ci-codegen.yaml
+++ b/.github/workflows/ci-codegen.yaml
@@ -1,6 +1,12 @@
 name: ci-codegen
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - synchronize
 
 jobs:
   compile:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
     types:
+      - opened
+      - reopened
       - synchronize
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: ci
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - synchronize
+
 jobs:
   compile:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
We now have external [contributors](https://github.com/vellum-ai/vellum-python-sdks/pull/723)! In order to support their development, we need the CI checks to fire on their PRs. These new triggers should enable that.