### PR TITLE
Ignore node output reference pointers to non-existent subworkflow deployment outputs

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -655,9 +655,8 @@ export function templatingNodeFactory({
   sourceHandleId,
   targetHandleId,
   errorOutputId,
-  inputRules,
   outputType = VellumVariableType.String,
-  inputReferences,
+  inputs,
   template,
 }: {
   id?: string;
@@ -665,12 +664,8 @@ export function templatingNodeFactory({
   sourceHandleId?: string;
   targetHandleId?: string;
   errorOutputId?: string;
-  inputRules?: NodeInputValuePointerRule[];
   outputType?: VellumVariableType;
-  inputReferences?: Array<{
-    referenceId: string;
-    referenceNodeId: string;
-  }>;
+  inputs?: NodeInput[];
   template?: ConstantValuePointer;
 } = {}): TemplatingNode {
   const defaultTemplate: ConstantValuePointer = {
@@ -681,41 +676,21 @@ export function templatingNodeFactory({
     },
   };
 
-  const inputs: NodeInput[] = [];
+  const nodeInputs: NodeInput[] = inputs ?? [];
 
-  inputs.push({
-    id: "9feb7b5e-5947-496d-b56f-1e2627730796",
-    key: "text",
-    value: {
-      rules: inputReferences
-        ? inputReferences.map((ref) => ({
-            type: "NODE_OUTPUT" as const,
-            data: {
-              nodeId: ref.referenceNodeId,
-              outputId: ref.referenceId,
-            },
-          }))
-        : inputRules ?? [
-            {
-              type: "CONSTANT_VALUE",
-              data: {
-                type: "STRING",
-                value: "Hello, world!",
-              },
-            },
-          ],
-      combinator: "OR" as const,
-    },
-  });
-
-  inputs.push({
-    id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
-    key: "template",
-    value: {
-      rules: [template ?? defaultTemplate],
-      combinator: "OR",
-    },
-  });
+  const templateInputExists = nodeInputs.some(
+    (input) => input.key === "template"
+  );
+  if (!templateInputExists) {
+    nodeInputs.push({
+      id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
+      key: "template",
+      value: {
+        rules: [template ?? defaultTemplate],
+        combinator: "OR",
+      },
+    });
+  }
 
   const nodeData: TemplatingNode = {
     id: id ?? "46e221ab-a749-41a2-9242-b1f5bf31f3a5",
@@ -729,7 +704,7 @@ export function templatingNodeFactory({
       templateNodeInputId: "7b8af68b-cf60-4fca-9c57-868042b5b616",
       outputType: outputType,
     },
-    inputs,
+    inputs: nodeInputs,
   };
   return nodeData;
 }

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -657,8 +657,7 @@ export function templatingNodeFactory({
   errorOutputId,
   inputRules,
   outputType = VellumVariableType.String,
-  inputReferenceId,
-  inputReferenceNodeId,
+  inputReferences,
   template,
 }: {
   id?: string;
@@ -668,17 +667,55 @@ export function templatingNodeFactory({
   errorOutputId?: string;
   inputRules?: NodeInputValuePointerRule[];
   outputType?: VellumVariableType;
-  inputReferenceId?: string;
-  inputReferenceNodeId?: string;
-  template?: NodeInputValuePointerRule;
+  inputReferences?: Array<{
+    referenceId: string;
+    referenceNodeId: string;
+  }>;
+  template?: ConstantValuePointer;
 } = {}): TemplatingNode {
-  const defaultTemplate: NodeInputValuePointerRule = {
+  const defaultTemplate: ConstantValuePointer = {
     type: "CONSTANT_VALUE",
     data: {
       type: "STRING",
       value: "Hello, World!",
     },
   };
+
+  const inputs: NodeInput[] = [];
+
+  inputs.push({
+    id: "9feb7b5e-5947-496d-b56f-1e2627730796",
+    key: "text",
+    value: {
+      rules: inputReferences
+        ? inputReferences.map((ref) => ({
+            type: "NODE_OUTPUT" as const,
+            data: {
+              nodeId: ref.referenceNodeId,
+              outputId: ref.referenceId,
+            },
+          }))
+        : inputRules ?? [
+            {
+              type: "CONSTANT_VALUE",
+              data: {
+                type: "STRING",
+                value: "Hello, world!",
+              },
+            },
+          ],
+      combinator: "OR" as const,
+    },
+  });
+
+  inputs.push({
+    id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
+    key: "template",
+    value: {
+      rules: [template ?? defaultTemplate],
+      combinator: "OR",
+    },
+  });
 
   const nodeData: TemplatingNode = {
     id: id ?? "46e221ab-a749-41a2-9242-b1f5bf31f3a5",
@@ -692,43 +729,7 @@ export function templatingNodeFactory({
       templateNodeInputId: "7b8af68b-cf60-4fca-9c57-868042b5b616",
       outputType: outputType,
     },
-    inputs: [
-      {
-        id: "9feb7b5e-5947-496d-b56f-1e2627730796",
-        key: "text",
-        value: {
-          rules:
-            inputReferenceId && inputReferenceNodeId
-              ? [
-                  {
-                    type: "NODE_OUTPUT",
-                    data: {
-                      nodeId: inputReferenceNodeId,
-                      outputId: inputReferenceId,
-                    },
-                  },
-                ]
-              : inputRules ?? [
-                  {
-                    type: "CONSTANT_VALUE",
-                    data: {
-                      type: "STRING",
-                      value: "Hello, world!",
-                    },
-                  },
-                ],
-          combinator: "OR",
-        },
-      },
-      {
-        id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
-        key: "template",
-        value: {
-          rules: [template ?? defaultTemplate],
-          combinator: "OR",
-        },
-      },
-    ],
+    inputs,
   };
   return nodeData;
 }

--- a/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
@@ -121,6 +121,56 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
 "
 `;
 
+exports[`Non-existent Subworkflow Deployment Node referenced by Templating Node > getNodeDisplayFile 1`] = `
+"from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from ...nodes.templating_node import TemplatingNode
+from uuid import UUID
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
+    label = "Templating Node"
+    node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
+    target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
+    template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
+    node_input_ids_by_name = {
+        "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
+        "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),
+    }
+    output_display = {
+        TemplatingNode.Outputs.result: NodeOutputDisplay(
+            id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="result"
+        )
+    }
+    port_displays = {
+        TemplatingNode.Ports.default: PortDisplayOverrides(
+            id=UUID("6ee2c814-d0a5-4ec9-83b6-45156e2f22c4")
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=0, y=0), width=None, height=None
+    )
+"
+`;
+
+exports[`Non-existent Subworkflow Deployment Node referenced by Templating Node > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
+from vellum.workflows.state import BaseState
+from .prompt_node import PromptNode
+
+
+class TemplatingNode(BaseTemplatingNode[BaseState, str]):
+    template = """{{ output[0].type }}"""
+    inputs = {
+        "text": PromptNode.Outputs.results,
+    }
+"
+`;
+
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDisplayFile with 'takes array output id' 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from ...nodes.conditional_node import ConditionalNode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
@@ -116,7 +116,7 @@ from .prompt_node import PromptNode
 class TemplatingNode(BaseTemplatingNode[BaseState, str]):
     template = """{{ output[0].type }}"""
     inputs = {
-        "text": PromptNode.Outputs.results,
+        "text": PromptNode.Outputs.text,
     }
 "
 `;
@@ -166,7 +166,7 @@ from .prompt_node import PromptNode
 class TemplatingNode(BaseTemplatingNode[BaseState, str]):
     template = """{{ output[0].type }}"""
     inputs = {
-        "text": PromptNode.Outputs.results,
+        "text": PromptNode.Outputs.text,
     }
 "
 `;

--- a/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
@@ -22,7 +22,7 @@ class PromptDeploymentNodeDisplay(
     prompt_input_ids_by_name = {
         "my_var_1": UUID("3911bd2e-eaaf-4805-9ffc-e5d6a71c91a7")
     }
-    node_input_ids_by_name = {"my_var_1": UUID("3911bd2e-eaaf-4805-9ffc-e5d6a71c91a7")}
+    node_input_ids_by_name = {}
     output_display = {
         PromptDeploymentNode.Outputs.text: NodeOutputDisplay(
             id=UUID("fa015382-7e5b-404e-b073-1c5f01832169"), name="text"
@@ -53,8 +53,6 @@ exports[`PromptDeploymentNode > basic > getNodeFile 1`] = `
 class PromptDeploymentNode(BasePromptDeploymentNode):
     deployment = "afd05488-7a25-4ff2-b87b-878e9552474e"
     release_tag = "LATEST"
-    prompt_inputs = {
-        "my_var_1": None,
-    }
+    prompt_inputs = {}
 "
 `;

--- a/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
@@ -15,7 +15,7 @@ class SubworkflowNodeDisplay(BaseSubworkflowDeploymentNodeDisplay[SubworkflowNod
     label = "Subworkflow Node"
     node_id = UUID("c8f2964c-09b8-44e0-a06d-606319fe5e2a")
     target_handle_id = UUID("f5e6bd33-527a-4ba6-8906-cd5e96a4321c")
-    node_input_ids_by_name = {"input": UUID("f62b7511-dd69-4dff-a4fc-718a9db3ceba")}
+    node_input_ids_by_name = {}
     output_display = {
         SubworkflowNode.Outputs.output_1: NodeOutputDisplay(
             id=UUID("1"), name="output-1"
@@ -44,9 +44,7 @@ exports[`SubworkflowDeploymentNode > basic > getNodeFile 1`] = `
 class SubworkflowNode(SubworkflowDeploymentNode):
     deployment = "test-deployment"
     release_tag = "LATEST"
-    subworkflow_inputs = {
-        "input": None,
-    }
+    subworkflow_inputs = {}
 
     class Outputs(SubworkflowDeploymentNode.Outputs):
         output_1: str

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -16,10 +16,7 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
     target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
     template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
-    node_input_ids_by_name = {
-        "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
-        "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),
-    }
+    node_input_ids_by_name = {"template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         TemplatingNode.Outputs.result: NodeOutputDisplay(
             id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="result"
@@ -43,9 +40,7 @@ from vellum.workflows.state import BaseState
 
 class TemplatingNode(BaseTemplatingNode[BaseState, str]):
     template = """Hello, World!"""
-    inputs = {
-        "text": "Hello, world!",
-    }
+    inputs = {}
 "
 `;
 
@@ -65,10 +60,7 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
     target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
     template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
-    node_input_ids_by_name = {
-        "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
-        "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),
-    }
+    node_input_ids_by_name = {"template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         TemplatingNode.Outputs.result: NodeOutputDisplay(
             id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="result"
@@ -93,9 +85,7 @@ from vellum.workflows.types.core import Json
 
 class TemplatingNode(BaseTemplatingNode[BaseState, Json]):
     template = """Hello, World!"""
-    inputs = {
-        "text": "Hello, world!",
-    }
+    inputs = {}
 "
 `;
 
@@ -119,10 +109,7 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
     target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
     template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
-    node_input_ids_by_name = {
-        "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
-        "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),
-    }
+    node_input_ids_by_name = {"template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         TemplatingNode.Outputs.result: NodeOutputDisplay(
             id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="result"
@@ -148,8 +135,6 @@ from vellum.workflows.nodes.core import TryNode
 @TryNode.wrap()
 class TemplatingNode(BaseTemplatingNode[BaseState, str]):
     template = """Hello, World!"""
-    inputs = {
-        "text": "Hello, world!",
-    }
+    inputs = {}
 "
 `;

--- a/ee/codegen/src/__test__/nodes/base-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/base-node.test.ts
@@ -74,7 +74,7 @@ describe("BaseNode", () => {
         });
       }).toThrow(
         new NodeAttributeGenerationError(
-          "Failed to generate attribute 'TemplatingNode2.inputs.text': Failed to find output with id '90abcdef-90ab-cdef-90ab-cdef90abcdef'"
+          "Failed to generate attribute 'TemplatingNode2.inputs.text': Failed to find output value on TemplatingNode.Outputs given id '90abcdef-90ab-cdef-90ab-cdef90abcdef'"
         )
       );
     });

--- a/ee/codegen/src/__test__/nodes/base-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/base-node.test.ts
@@ -11,12 +11,37 @@ describe("BaseNode", () => {
       const workflowContext = workflowContextFactory();
 
       const templatingNodeData = templatingNodeFactory({
-        inputRules: [
+        inputs: [
           {
-            type: "NODE_OUTPUT",
-            data: {
-              nodeId: "12345678-1234-5678-1234-567812345678",
-              outputId: "90abcdef-90ab-cdef-90ab-cdef90abcdef",
+            id: "9feb7b5e-5947-496d-b56f-1e2627730796",
+            key: "text",
+            value: {
+              rules: [
+                {
+                  type: "NODE_OUTPUT",
+                  data: {
+                    nodeId: "12345678-1234-5678-1234-567812345678",
+                    outputId: "90abcdef-90ab-cdef-90ab-cdef90abcdef",
+                  },
+                },
+              ],
+              combinator: "OR",
+            },
+          },
+          {
+            id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
+            key: "template",
+            value: {
+              rules: [
+                {
+                  type: "CONSTANT_VALUE",
+                  data: {
+                    type: "STRING",
+                    value: "Hello, World!",
+                  },
+                },
+              ],
+              combinator: "OR",
             },
           },
         ],
@@ -52,12 +77,37 @@ describe("BaseNode", () => {
         id: "12345678-1234-5678-1234-567812345678",
         sourceHandleId: "12345678-1234-5678-1234-567812345679",
         targetHandleId: "12345678-1234-5678-1234-56781234567a",
-        inputRules: [
+        inputs: [
           {
-            type: "NODE_OUTPUT",
-            data: {
-              nodeId: templatingNodeData.id,
-              outputId: "90abcdef-90ab-cdef-90ab-cdef90abcdef",
+            id: "9feb7b5e-5947-496d-b56f-1e2627730796",
+            key: "text",
+            value: {
+              rules: [
+                {
+                  type: "NODE_OUTPUT",
+                  data: {
+                    nodeId: templatingNodeData.id,
+                    outputId: "90abcdef-90ab-cdef-90ab-cdef90abcdef",
+                  },
+                },
+              ],
+              combinator: "OR",
+            },
+          },
+          {
+            id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
+            key: "template",
+            value: {
+              rules: [
+                {
+                  type: "CONSTANT_VALUE",
+                  data: {
+                    type: "STRING",
+                    value: "Hello, World!",
+                  },
+                },
+              ],
+              combinator: "OR",
             },
           },
         ],
@@ -74,7 +124,7 @@ describe("BaseNode", () => {
         });
       }).toThrow(
         new NodeAttributeGenerationError(
-          "Failed to generate attribute 'TemplatingNode2.inputs.text': Failed to find output value on TemplatingNode.Outputs given id '90abcdef-90ab-cdef-90ab-cdef90abcdef'"
+          "Failed to generate attribute 'TemplatingNode2.inputs.text': Failed to find output value TemplatingNode.Outputs given id '90abcdef-90ab-cdef-90ab-cdef90abcdef'"
         )
       );
     });

--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -283,4 +283,12 @@ describe("Non-existent Subworkflow Deployment Node referenced by Templating Node
     node.getNodeDisplayFile().write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
   });
+
+  it("workflow context should have the error logged", async () => {
+    const errors = workflowContext.getErrors();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toContain(
+      "Could not find subworkflow deployment output with id some-non-existent-subworkflow-output-id"
+    );
+  });
 });

--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -18,7 +18,6 @@ import { InlinePromptNodeContext } from "src/context/node-context/inline-prompt-
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import { ConditionalNode } from "src/generators/nodes/conditional-node";
 import { TemplatingNode } from "src/generators/nodes/templating-node";
-import { ConstantValuePointer } from "src/types/vellum";
 
 describe("InlinePromptNode referenced by Conditional Node", () => {
   let workflowContext: WorkflowContext;
@@ -170,22 +169,44 @@ describe("InlinePromptNode referenced by Templating Node", () => {
       nodeData: promptNode,
     })) as InlinePromptNodeContext;
 
-    const template: ConstantValuePointer = {
-      type: "CONSTANT_VALUE",
-      data: {
-        type: "STRING",
-        value: "{{ output[0].type }}",
-      },
-    };
-
     const templatingNode = templatingNodeFactory({
-      inputReferences: [
+      id: "46e221ab-a749-41a2-9242-b1f5bf31f3a5",
+      sourceHandleId: "6ee2c814-d0a5-4ec9-83b6-45156e2f22c4",
+      targetHandleId: "3960c8e1-9baa-4b9c-991d-e399d16a45aa",
+      inputs: [
         {
-          referenceId: promptNode.data.arrayOutputId,
-          referenceNodeId: promptNode.id,
+          id: "9feb7b5e-5947-496d-b56f-1e2627730796",
+          key: "text",
+          value: {
+            rules: [
+              {
+                type: "NODE_OUTPUT",
+                data: {
+                  nodeId: promptNode.id,
+                  outputId: promptNode.data.outputId,
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
+          key: "template",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "{{ output[0].type }}",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
         },
       ],
-      template: template,
     });
 
     const templatingNodeContext = (await createNodeContext({
@@ -241,26 +262,60 @@ describe("Non-existent Subworkflow Deployment Node referenced by Templating Node
       nodeData: promptNode,
     });
 
-    const template: ConstantValuePointer = {
-      type: "CONSTANT_VALUE",
-      data: {
-        type: "STRING",
-        value: "{{ output[0].type }}",
-      },
-    };
-
     const templatingNode = templatingNodeFactory({
-      inputReferences: [
+      id: "46e221ab-a749-41a2-9242-b1f5bf31f3a5",
+      sourceHandleId: "6ee2c814-d0a5-4ec9-83b6-45156e2f22c4",
+      targetHandleId: "3960c8e1-9baa-4b9c-991d-e399d16a45aa",
+      inputs: [
         {
-          referenceId: promptNode.data.arrayOutputId,
-          referenceNodeId: promptNode.id,
+          id: "9feb7b5e-5947-496d-b56f-1e2627730796",
+          key: "text",
+          value: {
+            rules: [
+              {
+                type: "NODE_OUTPUT",
+                data: {
+                  nodeId: promptNode.id,
+                  outputId: promptNode.data.outputId,
+                },
+              },
+            ],
+            combinator: "OR",
+          },
         },
         {
-          referenceId: "some-non-existent-subworkflow-output-id",
-          referenceNodeId: subworkflowNodeData.id,
+          id: "9feb7b5e-5947-496d-b56f-1e2627730796",
+          key: "output",
+          value: {
+            rules: [
+              {
+                type: "NODE_OUTPUT",
+                data: {
+                  nodeId: subworkflowNodeData.id,
+                  outputId: "some-non-existent-subworkflow-output-id",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "7b8af68b-cf60-4fca-9c57-868042b5b616",
+          key: "template",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "{{ output[0].type }}",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
         },
       ],
-      template: template,
     });
 
     const templatingNodeContext = (await createNodeContext({

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -100,7 +100,7 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
 
     const nodeOutputName = this.nodeOutputNamesById[outputId];
     if (!nodeOutputName) {
-      // Edge case where the node reference is to a non existent subworkflow deployment
+      // This handles an edge case where the node references a non-existent subworkflow deployment
       if (
         this.nodeData.type === "SUBWORKFLOW" &&
         this.nodeData.data.variant === "DEPLOYMENT"
@@ -114,7 +114,7 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
       }
 
       throw new NodeOutputNotFoundError(
-        `Failed to find output value on ${this.nodeClassName}.Outputs given id '${outputId}'`
+        `Failed to find output value ${this.nodeClassName}.Outputs given id '${outputId}'`
       );
     }
 

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -377,8 +377,13 @@ export class WorkflowContext {
     if (this.strict) {
       throw error;
     }
+    const errorExists = this.errors.some(
+      (existingError) => existingError.message === error.message
+    );
 
-    this.errors.push(error);
+    if (!errorExists) {
+      this.errors.push(error);
+    }
   }
 
   public getErrors(): BaseCodegenError[] {

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/base.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/base.ts
@@ -21,7 +21,7 @@ export abstract class BaseNodeInputValuePointerRule<
   public readonly workflowContext: WorkflowContext;
   public readonly nodeInputValuePointerRule: T;
   public readonly iterableConfig?: IterableConfig;
-  private astNode: AstNode;
+  private astNode: AstNode | undefined;
 
   constructor({
     workflowContext,
@@ -34,12 +34,16 @@ export abstract class BaseNodeInputValuePointerRule<
     this.nodeInputValuePointerRule = nodeInputValuePointerRule;
 
     this.astNode = this.getAstNode();
-    this.inheritReferences(this.astNode);
+    if (this.astNode) {
+      this.inheritReferences(this.astNode);
+    }
   }
 
-  abstract getAstNode(): AstNode;
+  abstract getAstNode(): AstNode | undefined;
 
   public write(writer: Writer): void {
-    this.astNode.write(writer);
+    if (this.astNode) {
+      this.astNode.write(writer);
+    }
   }
 }

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.ts
@@ -25,7 +25,9 @@ export declare namespace NodeInputValuePointerRule {
 
 export class NodeInputValuePointerRule extends AstNode {
   private workflowContext: WorkflowContext;
-  private astNode: BaseNodeInputValuePointerRule<NodeInputValuePointerRuleType>;
+  public astNode:
+    | BaseNodeInputValuePointerRule<NodeInputValuePointerRuleType>
+    | undefined;
   public readonly ruleType: NodeInputValuePointerRuleType["type"];
   private iterableConfig?: IterableConfig;
 
@@ -36,12 +38,14 @@ export class NodeInputValuePointerRule extends AstNode {
     this.iterableConfig = args.iterableConfig;
 
     this.astNode = this.getAstNode(args.nodeInputValuePointerRuleData);
-    this.inheritReferences(this.astNode);
+    if (this.astNode) {
+      this.inheritReferences(this.astNode);
+    }
   }
 
   private getAstNode(
     nodeInputValuePointerRuleData: NodeInputValuePointerRuleType
-  ): BaseNodeInputValuePointerRule<NodeInputValuePointerRuleType> {
+  ): BaseNodeInputValuePointerRule<NodeInputValuePointerRuleType> | undefined {
     const ruleType = nodeInputValuePointerRuleData.type;
 
     switch (ruleType) {
@@ -51,11 +55,17 @@ export class NodeInputValuePointerRule extends AstNode {
           nodeInputValuePointerRule: nodeInputValuePointerRuleData,
           iterableConfig: this.iterableConfig,
         });
-      case "NODE_OUTPUT":
-        return new NodeOutputPointerRule({
+      case "NODE_OUTPUT": {
+        const rule = new NodeOutputPointerRule({
           workflowContext: this.workflowContext,
           nodeInputValuePointerRule: nodeInputValuePointerRuleData,
         });
+        if (rule.getAstNode()) {
+          return rule;
+        } else {
+          return undefined;
+        }
+      }
       case "INPUT_VARIABLE":
         return new InputVariablePointerRule({
           workflowContext: this.workflowContext,
@@ -78,6 +88,8 @@ export class NodeInputValuePointerRule extends AstNode {
   }
 
   public write(writer: Writer): void {
-    this.astNode.write(writer);
+    if (this.astNode) {
+      this.astNode.write(writer);
+    }
   }
 }

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
@@ -6,7 +6,7 @@ import { OUTPUTS_CLASS_NAME } from "src/constants";
 import { NodeOutputPointer } from "src/types/vellum";
 
 export class NodeOutputPointerRule extends BaseNodeInputValuePointerRule<NodeOutputPointer> {
-  getAstNode(): python.Reference {
+  getAstNode(): python.Reference | undefined {
     const nodeOutputPointerRuleData = this.nodeInputValuePointerRule.data;
 
     const nodeContext = this.workflowContext.getNodeContext(
@@ -17,10 +17,13 @@ export class NodeOutputPointerRule extends BaseNodeInputValuePointerRule<NodeOut
       nodeOutputPointerRuleData.outputId
     );
 
-    return python.reference({
-      name: nodeContext.nodeClassName,
-      modulePath: nodeContext.nodeModulePath,
-      attribute: [OUTPUTS_CLASS_NAME, nodeOutputName],
-    });
+    if (nodeOutputName) {
+      return python.reference({
+        name: nodeContext.nodeClassName,
+        modulePath: nodeContext.nodeModulePath,
+        attribute: [OUTPUTS_CLASS_NAME, nodeOutputName],
+      });
+    }
+    return undefined;
   }
 }

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer.ts
@@ -17,7 +17,7 @@ export declare namespace NodeInputValuePointer {
 export class NodeInputValuePointer extends AstNode {
   private workflowContext: WorkflowContext;
   private nodeInputValuePointerData: NodeInputValuePointerType;
-  private rules: NodeInputValuePointerRule[];
+  public rules: NodeInputValuePointerRule[];
 
   public constructor(args: NodeInputValuePointer.Args) {
     super();

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer.ts
@@ -1,5 +1,6 @@
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
+import { isNil } from "lodash";
 
 import { NodeInputValuePointerRule } from "./node-input-value-pointer-rules/node-input-value-pointer-rule";
 
@@ -28,14 +29,19 @@ export class NodeInputValuePointer extends AstNode {
   }
 
   private generateRules(): NodeInputValuePointerRule[] {
-    return this.nodeInputValuePointerData.rules.map((ruleData) => {
-      const rule = new NodeInputValuePointerRule({
-        workflowContext: this.workflowContext,
-        nodeInputValuePointerRuleData: ruleData,
-      });
-      this.inheritReferences(rule);
-      return rule;
-    });
+    return this.nodeInputValuePointerData.rules
+      .map((ruleData) => {
+        const rule = new NodeInputValuePointerRule({
+          workflowContext: this.workflowContext,
+          nodeInputValuePointerRuleData: ruleData,
+        });
+        if (rule.astNode) {
+          this.inheritReferences(rule);
+          return rule;
+        }
+        return undefined;
+      })
+      .filter((rule) => !isNil(rule));
   }
 
   write(writer: Writer): void {

--- a/ee/codegen/src/generators/node-inputs/node-input.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input.ts
@@ -16,7 +16,7 @@ export declare namespace NodeInput {
 export class NodeInput extends AstNode {
   private workflowContext: WorkflowContext;
   nodeInputData: NodeInputType;
-  private nodeInputValuePointer: NodeInputValuePointer;
+  public nodeInputValuePointer: NodeInputValuePointer;
 
   public constructor(args: NodeInput.Args) {
     super();

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -19,6 +19,7 @@ import {
   NodeDisplayData as NodeDisplayDataType,
   WorkflowDataNode,
 } from "src/types/vellum";
+import { isNilOrEmpty } from "src/utils/typing";
 
 export declare namespace BaseNode {
   interface Args<T extends WorkflowDataNode, V extends BaseNodeContext<T>> {
@@ -159,8 +160,10 @@ export abstract class BaseNode<
           nodeInputData,
         });
 
-        nodeInputsByKey.set(nodeInputData.key, nodeInput);
-        nodeInputsById.set(nodeInputData.id, nodeInput);
+        if (!isNilOrEmpty(nodeInput.nodeInputValuePointer.rules)) {
+          nodeInputsByKey.set(nodeInputData.key, nodeInput);
+          nodeInputsById.set(nodeInputData.id, nodeInput);
+        }
       } catch (error) {
         if (error instanceof BaseCodegenError) {
           const nodeAttributeGenerationError = new NodeAttributeGenerationError(

--- a/ee/codegen/src/generators/nodes/guardrail-node.ts
+++ b/ee/codegen/src/generators/nodes/guardrail-node.ts
@@ -110,6 +110,11 @@ export class GuardrailNode extends BaseSingleFileNode<
         ).map((output) => {
           const name = this.nodeContext.getNodeOutputNameById(output.id);
 
+          if (!name) {
+            throw new NodeAttributeGenerationError(
+              `Could not find output name for ${this.nodeContext.nodeClassName}.Outputs.${output.key} given output id ${output.id}`
+            );
+          }
           return {
             key: python.reference({
               name: this.nodeContext.nodeClassName,


### PR DESCRIPTION
Context: Came up from qa'ing customer workflow and this PR just skips generation of that reference as discussed