### PR TITLE
Build more resiliency in our Subworkflow Deployment node codegen

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/base-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/base-node.test.ts.snap
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`BaseNode > failures > should generate base nodes as much as possible for non strict workflow contexts 1`] = `
+"from vellum.workflows.nodes.displayable import BaseNode
+
+
+class MyCustomNode(BaseNode):
+    pass
+"
+`;

--- a/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
@@ -58,8 +58,6 @@ exports[`SubworkflowDeploymentNode > failure > should generate subworkflow deplo
 
 class SubworkflowNode(SubworkflowDeploymentNode):
     release_tag = "LATEST"
-    subworkflow_inputs = {
-        "input": None,
-    }
+    subworkflow_inputs = {}
 "
 `;

--- a/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
@@ -51,3 +51,15 @@ class SubworkflowNode(SubworkflowDeploymentNode):
         output_2: float
 "
 `;
+
+exports[`SubworkflowDeploymentNode > failure > should generate subworkflow deployment nodes as much as possible for non strict workflow contexts 1`] = `
+"from vellum.workflows.nodes.displayable import SubworkflowDeploymentNode
+
+
+class SubworkflowNode(SubworkflowDeploymentNode):
+    release_tag = "LATEST"
+    subworkflow_inputs = {
+        "input": None,
+    }
+"
+`;

--- a/ee/codegen/src/__test__/nodes/base-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/base-node.test.ts
@@ -143,7 +143,9 @@ describe("BaseNode", () => {
       vi.spyOn(
         GenericNode.prototype,
         "getNodeClassBodyStatements"
-      ).mockRejectedValue(new NodeDefinitionGenerationError("test"));
+      ).mockImplementation(() => {
+        throw new NodeDefinitionGenerationError("test");
+      });
 
       const workflowContext = workflowContextFactory({
         strict: false,

--- a/ee/codegen/src/__test__/nodes/base-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/base-node.test.ts
@@ -1,8 +1,18 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+
 import { workflowContextFactory } from "src/__test__/helpers";
-import { templatingNodeFactory } from "src/__test__/helpers/node-data-factories";
+import {
+  genericNodeFactory,
+  templatingNodeFactory,
+} from "src/__test__/helpers/node-data-factories";
 import { createNodeContext } from "src/context";
+import { GenericNodeContext } from "src/context/node-context/generic-node";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
-import { NodeAttributeGenerationError } from "src/generators/errors";
+import {
+  NodeAttributeGenerationError,
+  NodeDefinitionGenerationError,
+} from "src/generators/errors";
+import { GenericNode } from "src/generators/nodes/generic-node";
 import { TemplatingNode } from "src/generators/nodes/templating-node";
 
 describe("BaseNode", () => {
@@ -127,6 +137,33 @@ describe("BaseNode", () => {
           "Failed to generate attribute 'TemplatingNode2.inputs.text': Failed to find output value TemplatingNode.Outputs given id '90abcdef-90ab-cdef-90ab-cdef90abcdef'"
         )
       );
+    });
+
+    it(`should generate base nodes as much as possible for non strict workflow contexts`, async () => {
+      vi.spyOn(
+        GenericNode.prototype,
+        "getNodeClassBodyStatements"
+      ).mockRejectedValue(new NodeDefinitionGenerationError("test"));
+
+      const workflowContext = workflowContextFactory({
+        strict: false,
+      });
+      const writer = new Writer();
+
+      const nodeData = genericNodeFactory();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as GenericNodeContext;
+
+      const node = new GenericNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });
 });

--- a/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
@@ -82,5 +82,37 @@ describe("SubworkflowDeploymentNode", () => {
         new NodeDefinitionGenerationError("No Workflow Deployment found.")
       );
     });
+
+    it(`should generate subworkflow deployment nodes as much as possible for non strict workflow contexts`, async () => {
+      const workflowContext = workflowContextFactory({
+        strict: false,
+      });
+
+      vi.spyOn(
+        WorkflowDeploymentsClient.prototype,
+        "workflowDeploymentHistoryItemRetrieve"
+      ).mockRejectedValue(
+        new VellumError({
+          body: {
+            detail: "No Workflow Deployment found.",
+          },
+        })
+      );
+
+      const nodeData = subworkflowDeploymentNodeDataFactory();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as SubworkflowDeploymentNodeContext;
+
+      node = new SubworkflowDeploymentNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/context/node-context/create-node-context.ts
+++ b/ee/codegen/src/context/node-context/create-node-context.ts
@@ -16,7 +16,10 @@ import { NoteNodeContext } from "src/context/node-context/note-node";
 import { PromptDeploymentNodeContext } from "src/context/node-context/prompt-deployment-node";
 import { SubworkflowDeploymentNodeContext } from "src/context/node-context/subworkflow-deployment-node";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
-import { NodeDefinitionGenerationError } from "src/generators/errors";
+import {
+  BaseCodegenError,
+  NodeDefinitionGenerationError,
+} from "src/generators/errors";
 import {
   InlinePromptNode,
   WorkflowDataNode,
@@ -185,6 +188,14 @@ export async function createNodeContext(
 ): Promise<BaseNodeContext<WorkflowDataNode>> {
   const nodeContext = buildNodeContext(args);
   args.workflowContext.addNodeContext(nodeContext);
-  await nodeContext.buildProperties();
+  try {
+    await nodeContext.buildProperties();
+  } catch (error) {
+    if (error instanceof BaseCodegenError) {
+      args.workflowContext.addError(error);
+    } else {
+      throw error;
+    }
+  }
   return nodeContext;
 }

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -292,13 +292,10 @@ export abstract class BaseNode<
     });
 
     try {
-      console.log("BaseNode generateNodeClass");
-      this.getNodeClassBodyStatements().forEach((statement) => {
-        console.log("BaseNode generateNodeClass 2", statement);
-        nodeClass.add(statement);
-      });
+      this.getNodeClassBodyStatements().forEach((statement) =>
+        nodeClass.add(statement)
+      );
     } catch (error) {
-      console.log("BaseNode generateNodeClass 3", error);
       if (error instanceof BaseCodegenError) {
         this.workflowContext.addError(error);
       } else {

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -291,9 +291,20 @@ export abstract class BaseNode<
       decorators: this.getNodeDecorators(),
     });
 
-    this.getNodeClassBodyStatements().forEach((statement) =>
-      nodeClass.add(statement)
-    );
+    try {
+      console.log("BaseNode generateNodeClass");
+      this.getNodeClassBodyStatements().forEach((statement) => {
+        console.log("BaseNode generateNodeClass 2", statement);
+        nodeClass.add(statement);
+      });
+    } catch (error) {
+      console.log("BaseNode generateNodeClass 3", error);
+      if (error instanceof BaseCodegenError) {
+        this.workflowContext.addError(error);
+      } else {
+        throw error;
+      }
+    }
 
     return nodeClass;
   }

--- a/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
@@ -25,19 +25,21 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
     }
 
     if (!this.nodeContext.workflowDeploymentHistoryItem) {
-      throw new NodeDefinitionGenerationError(
-        "Workflow Deployment History Item is not set"
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          `Failed to generate attribute: ${this.nodeData.data.label}.deployment`
+        )
+      );
+    } else {
+      statements.push(
+        python.field({
+          name: "deployment",
+          initializer: python.TypeInstantiation.str(
+            this.nodeContext.workflowDeploymentHistoryItem.name
+          ),
+        })
       );
     }
-
-    statements.push(
-      python.field({
-        name: "deployment",
-        initializer: python.TypeInstantiation.str(
-          this.nodeContext.workflowDeploymentHistoryItem.name
-        ),
-      })
-    );
 
     statements.push(
       python.field({
@@ -63,16 +65,22 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
       })
     );
 
-    statements.push(this.generateOutputsClass());
+    const outputsClass = this.generateOutputsClass();
+    if (outputsClass) {
+      statements.push(outputsClass);
+    }
 
     return statements;
   }
 
-  private generateOutputsClass(): python.Class {
+  private generateOutputsClass(): python.Class | null {
     if (!this.nodeContext.workflowDeploymentHistoryItem) {
-      throw new NodeDefinitionGenerationError(
-        "Workflow Deployment History Item is not set"
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          `Failed to generate attribute: ${this.nodeData.data.label}.deployment`
+        )
       );
+      return null;
     }
 
     const nodeBaseClassRef = this.getNodeBaseClass();


### PR DESCRIPTION
Codegen is currently 400ing early and not codegenning far enough in the case of a workflow deployment retrieve failure. This PR helps us get farther, with an additional test case for generic nodes