### PR TITLE
Clean up expected exceptions in get_node_display_class

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -208,8 +208,8 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
         return uuid4_from_hash(f"{self.node_id}|trigger")
 
     @classmethod
-    def get_from_node_display_registry(cls, node_class: Type[NodeType]) -> Type["BaseNodeDisplay"]:
-        return cls._node_display_registry[node_class]
+    def get_from_node_display_registry(cls, node_class: Type[NodeType]) -> Optional[Type["BaseNodeDisplay"]]:
+        return cls._node_display_registry.get(node_class)
 
     @classmethod
     def infer_node_class(cls) -> Type[NodeType]:

--- a/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
+++ b/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
@@ -10,27 +10,23 @@ if TYPE_CHECKING:
 def get_node_display_class(
     base_class: Type["NodeDisplayType"], node_class: Type[NodeType], root_node_class: Optional[Type[NodeType]] = None
 ) -> Type["NodeDisplayType"]:
-    try:
-        node_display_class = base_class.get_from_node_display_registry(node_class)
-    except KeyError:
-        try:
-            base_node_display_class = get_node_display_class(
-                base_class, node_class.__bases__[0], node_class if root_node_class is None else root_node_class
+    node_display_class = base_class.get_from_node_display_registry(node_class)
+    if node_display_class:
+        if not issubclass(node_display_class, base_class):
+            raise TypeError(
+                f"Expected to find a subclass of '{base_class.__name__}' for node class '{node_class.__name__}'"
             )
 
-            # `base_node_display_class` is always a Generic class, so it's safe to index into it
-            NodeDisplayBaseClass = base_node_display_class[node_class]  # type: ignore[index]
-            NodeDisplayClass = types.new_class(
-                f"{node_class.__name__}Display",
-                bases=(NodeDisplayBaseClass,),
-            )
-            return NodeDisplayClass
-        except IndexError:
-            return base_class
+        return node_display_class
 
-    if not issubclass(node_display_class, base_class):
-        raise TypeError(
-            f"Expected to find a subclass of '{base_class.__name__}' for node class '{node_class.__name__}'"
-        )
+    base_node_display_class = get_node_display_class(
+        base_class, node_class.__bases__[0], node_class if root_node_class is None else root_node_class
+    )
 
-    return node_display_class
+    # `base_node_display_class` is always a Generic class, so it's safe to index into it
+    NodeDisplayBaseClass = base_node_display_class[node_class]  # type: ignore[index]
+    NodeDisplayClass = types.new_class(
+        f"{node_class.__name__}Display",
+        bases=(NodeDisplayBaseClass,),
+    )
+    return NodeDisplayClass


### PR DESCRIPTION
Was debugging the following error:
<img width="1254" alt="Screenshot 2025-01-28 at 11 09 44 PM" src="https://github.com/user-attachments/assets/04301ce2-37ba-4eb4-88fa-bd918d5d051f" />

I never liked the pattern of "expected exceptions" - basically using excpetions to drive conditional logic, but couldn't find a reason why. This is the reason I'm using - clouding up valid code traversals as "`During handling of the above exception, another exception occurred:`"