### PR TITLE
Fix release related triggers on our CI actions

### DIFF
--- a/.github/workflows/ci-codegen.yaml
+++ b/.github/workflows/ci-codegen.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    tags:
   pull_request:
     types:
       - opened

--- a/.github/workflows/ci-workflow-server.yaml
+++ b/.github/workflows/ci-workflow-server.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    tags:
 jobs:
   publish:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    tags:
   pull_request:
     types:
       - opened


### PR DESCRIPTION
When we switched from `on: [push]` to `on: push: branches:`, we forgot to include the tag pushes it was previously listening to, which is what previously triggered our release.

I'll note that there's also a `on: release: created` that we should likely use instead, but I rather go with what we know worked for now, and experiment with a new trigger later