### PR TITLE
Remove label from push API to be cherry picked on the Release PR bc of the breaking change the push API

### DIFF
--- a/ee/vellum_cli/push.py
+++ b/ee/vellum_cli/push.py
@@ -12,7 +12,6 @@ from dotenv import load_dotenv
 from vellum.client.core.api_error import ApiError
 from vellum.resources.workflows.client import OMIT
 from vellum.types import WorkflowPushDeploymentConfigRequest
-from vellum.workflows.utils.names import snake_to_title_case
 from vellum.workflows.vellum_client import create_vellum_client
 from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_cli.config import DEFAULT_WORKSPACE_CONFIG, WorkflowConfig, WorkflowDeploymentConfig, load_vellum_cli_config
@@ -111,8 +110,6 @@ def push_command(
         "container_image_name": workflow_config.container_image_name,
     }
 
-    label = snake_to_title_case(workflow_config.module.split(".")[-1])
-
     deployment_config: WorkflowPushDeploymentConfigRequest = OMIT
     deployment_config_serialized: str = OMIT
     if deploy:
@@ -158,7 +155,6 @@ def push_command(
             # Remove this once we could serialize using the artifact in Vembda
             # https://app.shortcut.com/vellum/story/5585
             exec_config=json.dumps(exec_config),
-            label=label,
             workflow_sandbox_id=workflow_config.workflow_sandbox_id or workflow_sandbox_id,
             artifact=artifact,
             # We should check with fern if we could auto-serialize typed object fields for us
@@ -230,7 +226,7 @@ def push_command(
         )  # type: ignore[attr-defined]
     else:
         logger.info(
-            f"""Successfully pushed {label} to Vellum!
+            f"""Successfully pushed {workflow_config.module} to Vellum!
 Visit at: https://app.vellum.ai/workflow-sandboxes/{response.workflow_sandbox_id}"""
         )
 

--- a/ee/vellum_cli/tests/test_push.py
+++ b/ee/vellum_cli/tests/test_push.py
@@ -119,14 +119,12 @@ def test_push__happy_path(mock_module, vellum_client, base_command):
     assert result.exit_code == 0
 
     # Get the last part of the module path and format it
-    expected_label = mock_module.module.split(".")[-1].replace("_", " ").title()
     expected_artifact_name = f"{mock_module.module.replace('.', '__')}.tar.gz"
 
     # AND we should have called the push API with the correct args
     vellum_client.workflows.push.assert_called_once()
     call_args = vellum_client.workflows.push.call_args.kwargs
     assert json.loads(call_args["exec_config"])["workflow_raw_data"]["definition"]["name"] == "ExampleWorkflow"
-    assert call_args["label"] == expected_label
     assert is_valid_uuid(call_args["workflow_sandbox_id"])
     assert call_args["artifact"].name == expected_artifact_name
     assert "deplyment_config" not in call_args
@@ -165,14 +163,12 @@ def test_push__workflow_sandbox_option__existing_id(mock_module, vellum_client, 
     assert result.exit_code == 0
 
     # Get the last part of the module path and format it
-    expected_label = mock_module.module.split(".")[-1].replace("_", " ").title()
     expected_artifact_name = f"{mock_module.module.replace('.', '__')}.tar.gz"
 
     # AND we should have called the push API with the correct args
     vellum_client.workflows.push.assert_called_once()
     call_args = vellum_client.workflows.push.call_args.kwargs
     assert json.loads(call_args["exec_config"])["workflow_raw_data"]["definition"]["name"] == "ExampleWorkflow"
-    assert call_args["label"] == expected_label
     assert call_args["workflow_sandbox_id"] == existing_workflow_sandbox_id
     assert call_args["artifact"].name == expected_artifact_name
     assert "deplyment_config" not in call_args
@@ -216,14 +212,12 @@ def test_push__workflow_sandbox_option__existing_no_module(mock_module, vellum_c
     assert result.exit_code == 0
 
     # Get the last part of the module path and format it
-    expected_label = second_module.split(".")[-1].replace("_", " ").title()
     expected_artifact_name = f"{second_module.replace('.', '__')}.tar.gz"
 
     # AND we should have called the push API with the correct args
     vellum_client.workflows.push.assert_called_once()
     call_args = vellum_client.workflows.push.call_args.kwargs
     assert json.loads(call_args["exec_config"])["workflow_raw_data"]["definition"]["name"] == "ExampleWorkflow"
-    assert call_args["label"] == expected_label
     assert call_args["workflow_sandbox_id"] == second_workflow_sandbox_id
     assert call_args["artifact"].name == expected_artifact_name
     assert "deplyment_config" not in call_args
@@ -297,14 +291,12 @@ def test_push__deployment(mock_module, vellum_client, base_command):
     assert result.exit_code == 0
 
     # Get the last part of the module path and format it
-    expected_label = mock_module.module.split(".")[-1].replace("_", " ").title()
     expected_artifact_name = f"{mock_module.module.replace('.', '__')}.tar.gz"
 
     # AND we should have called the push API with the correct args
     vellum_client.workflows.push.assert_called_once()
     call_args = vellum_client.workflows.push.call_args.kwargs
     assert json.loads(call_args["exec_config"])["workflow_raw_data"]["definition"]["name"] == "ExampleWorkflow"
-    assert call_args["label"] == expected_label
     assert is_valid_uuid(call_args["workflow_sandbox_id"])
     assert call_args["artifact"].name == expected_artifact_name
     assert call_args["deployment_config"] == "{}"


### PR DESCRIPTION
In hindsight, I should make `label` nullable next time before then removing. This won't affect any live sdk usage though