### PR TITLE
Support pulling workflows without needing a `pyproject.toml` config defined.

### DIFF
--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -42,6 +42,17 @@ def _resolve_workflow_config(
 
     if module:
         workflow_config = next((w for w in config.workflows if w.module == module), None)
+        if not workflow_config and workflow_sandbox_id:
+            workflow_config = WorkflowConfig(
+                workflow_sandbox_id=workflow_sandbox_id,
+                module=module,
+            )
+            config.workflows.append(workflow_config)
+            return WorkflowConfigResolutionResult(
+                workflow_config=workflow_config,
+                pk=workflow_sandbox_id,
+            )
+
         return WorkflowConfigResolutionResult(
             workflow_config=workflow_config,
             pk=workflow_config.workflow_sandbox_id if workflow_config else None,


### PR DESCRIPTION
This PR supports the ability to do the following without any configuration in advance:

```bash
vellum workflows pull my_awesome_workflow --workflow-sandbox-id 1234
```

There are two more PRs in this series I want to support after this one:
- `vellum workflows pull --workflow-sandbox-id 1234` - and a reasonable-ish module will be generated instead of `workflow_12345678`
- `vellum workflows pull my_awesome_workflow --workflow-sandbox-id 1234 --path src/workflows` will pull the workflow in the `src/workflows` directory. eg, `src/workflows/my_awesome_workflow/workflow.py`