### PR TITLE
Try fixing tags gha triggers for tag pushes (take 2)

### DIFF
--- a/.github/workflows/ci-codegen.yaml
+++ b/.github/workflows/ci-codegen.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     tags:
+      - '*'
   pull_request:
     types:
       - opened

--- a/.github/workflows/ci-workflow-server.yaml
+++ b/.github/workflows/ci-workflow-server.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     tags:
+      - '*'
 jobs:
   publish:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     tags:
+      - '*'
   pull_request:
     types:
       - opened


### PR DESCRIPTION
0.13.17 didn't hit our workflow files. If this doesn't work, going straight to `release` triggers