### PR TITLE
Support reasonable Workflow Sandbox label inspired default module name on initial pull

### DIFF
--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -31,6 +31,16 @@ class WorkflowConfigResolutionResult(UniversalBaseModel):
     pk: Optional[str] = None
 
 
+class RunnerConfig(UniversalBaseModel):
+    container_image_name: Optional[str] = None
+    container_image_tag: Optional[str] = None
+
+
+class PullContentsMetadata(UniversalBaseModel):
+    label: Optional[str] = None
+    runner_config: Optional[RunnerConfig] = None
+
+
 def _resolve_workflow_config(
     config: VellumCliConfig,
     module: Optional[str] = None,
@@ -65,9 +75,10 @@ def _resolve_workflow_config(
                 pk=workflow_sandbox_id,
             )
 
+        # We use an empty module name to indicate that we want to backfill it once we have the Workflow Sandbox Label
         workflow_config = WorkflowConfig(
             workflow_sandbox_id=workflow_sandbox_id,
-            module=f"workflow_{workflow_sandbox_id.split('-')[0]}",
+            module="",
         )
         config.workflows.append(workflow_config)
         return WorkflowConfigResolutionResult(
@@ -125,7 +136,11 @@ def pull_command(
     if not pk:
         raise ValueError("No workflow sandbox ID found in project to pull from.")
 
-    logger.info(f"Pulling workflow into {workflow_config.module}")
+    if workflow_config.module:
+        logger.info(f"Pulling workflow into {workflow_config.module}...")
+    else:
+        logger.info(f"Pulling workflow from {pk}...")
+
     client = create_vellum_client()
     query_parameters = {}
 
@@ -146,11 +161,30 @@ def pull_command(
     zip_bytes = b"".join(response)
     zip_buffer = io.BytesIO(zip_bytes)
 
-    target_dir = os.path.join(os.getcwd(), *workflow_config.module.split("."))
     error_content = ""
     metadata_json: Optional[dict] = None
 
     with zipfile.ZipFile(zip_buffer) as zip_file:
+        if METADATA_FILE_NAME in zip_file.namelist():
+            with zip_file.open(METADATA_FILE_NAME) as source:
+                metadata_json = json.load(source)
+
+            pull_contents_metadata = PullContentsMetadata.model_validate(metadata_json)
+
+            if pull_contents_metadata.runner_config:
+                workflow_config.container_image_name = pull_contents_metadata.runner_config.container_image_name
+                workflow_config.container_image_tag = pull_contents_metadata.runner_config.container_image_tag
+                if workflow_config.container_image_name and not workflow_config.container_image_tag:
+                    workflow_config.container_image_tag = "latest"
+
+            if not workflow_config.module and pull_contents_metadata.label:
+                workflow_config.module = snake_case(pull_contents_metadata.label)
+
+        if not workflow_config.module:
+            raise ValueError(f"Failed to resolve a module name for Workflow {pk}")
+
+        target_dir = os.path.join(os.getcwd(), *workflow_config.module.split("."))
+
         # Delete files in target_dir that aren't in the zip file
         if os.path.exists(target_dir):
             ignore_patterns = (
@@ -188,15 +222,6 @@ def pull_command(
                 with open(target_file, "w") as target:
                     logger.info(f"Writing to {target_file}...")
                     target.write(content)
-
-    if metadata_json:
-        runner_config = metadata_json.get("runner_config")
-
-        if runner_config:
-            workflow_config.container_image_name = runner_config.get("container_image_name")
-            workflow_config.container_image_tag = runner_config.get("container_image_tag")
-            if workflow_config.container_image_name and not workflow_config.container_image_tag:
-                workflow_config.container_image_tag = "latest"
 
     if include_json:
         logger.warning(

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -162,10 +162,10 @@ def pull_command(
     zip_buffer = io.BytesIO(zip_bytes)
 
     error_content = ""
-    metadata_json: Optional[dict] = None
 
     with zipfile.ZipFile(zip_buffer) as zip_file:
         if METADATA_FILE_NAME in zip_file.namelist():
+            metadata_json: Optional[dict] = None
             with zip_file.open(METADATA_FILE_NAME) as source:
                 metadata_json = json.load(source)
 
@@ -214,7 +214,6 @@ def pull_command(
                     error_content = content
                     continue
                 if file_name == METADATA_FILE_NAME:
-                    metadata_json = json.loads(content)
                     continue
 
                 target_file = os.path.join(target_dir, file_name)

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -117,7 +117,13 @@ def test_pull__sandbox_id_with_no_config(vellum_client):
     workflow_sandbox_id = "87654321-0000-0000-0000-000000000000"
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
+    vellum_client.workflows.pull.return_value = iter(
+        [
+            _zip_file_map(
+                {"workflow.py": "print('hello')", "metadata.json": json.dumps({"label": "Super Cool Workflow"})}
+            )
+        ]
+    )
 
     # AND we are currently in a new directory
     current_dir = os.getcwd()
@@ -134,7 +140,7 @@ def test_pull__sandbox_id_with_no_config(vellum_client):
 
     # AND the pull api is called with the workflow sandbox id
     vellum_client.workflows.pull.assert_called_once()
-    workflow_py = os.path.join(temp_dir, "workflow_87654321", "workflow.py")
+    workflow_py = os.path.join(temp_dir, "super_cool_workflow", "workflow.py")
     assert os.path.exists(workflow_py)
     with open(workflow_py) as f:
         assert f.read() == "print('hello')"
@@ -149,7 +155,7 @@ def test_pull__sandbox_id_with_no_config(vellum_client):
             "workspaces": [],
             "workflows": [
                 {
-                    "module": "workflow_87654321",
+                    "module": "super_cool_workflow",
                     "workflow_sandbox_id": "87654321-0000-0000-0000-000000000000",
                     "ignore": None,
                     "deployments": [],
@@ -169,7 +175,13 @@ def test_pull__sandbox_id_with_other_workflow_configured(vellum_client, mock_mod
     workflow_sandbox_id = "87654321-0000-0000-0000-000000000000"
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
+    vellum_client.workflows.pull.return_value = iter(
+        [
+            _zip_file_map(
+                {"workflow.py": "print('hello')", "metadata.json": json.dumps({"label": "Super Cool Workflow"})}
+            )
+        ]
+    )
 
     # WHEN the user runs the pull command with the new workflow sandbox id
     runner = CliRunner()
@@ -184,7 +196,7 @@ def test_pull__sandbox_id_with_other_workflow_configured(vellum_client, mock_mod
     assert call_args[0] == workflow_sandbox_id
 
     # AND the workflow.py file is written to the module directory
-    workflow_py = os.path.join(temp_dir, "workflow_87654321", "workflow.py")
+    workflow_py = os.path.join(temp_dir, "super_cool_workflow", "workflow.py")
     assert os.path.exists(workflow_py)
     with open(workflow_py) as f:
         assert f.read() == "print('hello')"
@@ -442,8 +454,12 @@ def test_pull__sandbox_id_with_other_workflow_deployment_in_lock(vellum_client, 
             _zip_file_map(
                 {
                     "workflow.py": "print('hello')",
-                    "metadata.json": '{"runner_config": { "container_image_name": "test", '
-                    '"container_image_tag": "1.0" } }',
+                    "metadata.json": json.dumps(
+                        {
+                            "runner_config": {"container_image_name": "test", "container_image_tag": "1.0"},
+                            "label": "Super Cool Workflow",
+                        }
+                    ),
                 }
             )
         ]
@@ -478,7 +494,7 @@ def test_pull__sandbox_id_with_other_workflow_deployment_in_lock(vellum_client, 
                 "workspace": "default",
             },
             {
-                "module": "workflow_87654321",
+                "module": "super_cool_workflow",
                 "workflow_sandbox_id": new_workflow_sandbox_id,
                 "ignore": None,
                 "deployments": [],


### PR DESCRIPTION
Now when you pull `vellum workflows pull --workflow-sandbox-id`, we will pull based on the label instead of `workflow_87654321`. To complete this work, we need to pull down label in our metadata.json