### PR TITLE
More subworkflow deployment resilience against Output display class generation failure

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
@@ -52,6 +52,32 @@ class SubworkflowNode(SubworkflowDeploymentNode):
 "
 `;
 
+exports[`SubworkflowDeploymentNode > failure > should generate subworkflow deployment node display as much as possible for non strict workflow contexts 1`] = `
+"from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
+from ...nodes.subworkflow_node import SubworkflowNode
+from uuid import UUID
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class SubworkflowNodeDisplay(BaseSubworkflowDeploymentNodeDisplay[SubworkflowNode]):
+    label = "Subworkflow Node"
+    node_id = UUID("c8f2964c-09b8-44e0-a06d-606319fe5e2a")
+    target_handle_id = UUID("f5e6bd33-527a-4ba6-8906-cd5e96a4321c")
+    node_input_ids_by_name = {}
+    port_displays = {
+        SubworkflowNode.Ports.default: PortDisplayOverrides(
+            id=UUID("600efd51-8677-4ba3-a582-b298bebb2868")
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=2239.986322714681, y=484.74458968144046),
+        width=None,
+        height=None,
+    )
+"
+`;
+
 exports[`SubworkflowDeploymentNode > failure > should generate subworkflow deployment nodes as much as possible for non strict workflow contexts 1`] = `
 "from vellum.workflows.nodes.displayable import SubworkflowDeploymentNode
 

--- a/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
@@ -114,5 +114,37 @@ describe("SubworkflowDeploymentNode", () => {
       node.getNodeFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it(`should generate subworkflow deployment node display as much as possible for non strict workflow contexts`, async () => {
+      const workflowContext = workflowContextFactory({
+        strict: false,
+      });
+
+      vi.spyOn(
+        WorkflowDeploymentsClient.prototype,
+        "workflowDeploymentHistoryItemRetrieve"
+      ).mockRejectedValue(
+        new VellumError({
+          body: {
+            detail: "No Workflow Deployment found.",
+          },
+        })
+      );
+
+      const nodeData = subworkflowDeploymentNodeDataFactory();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as SubworkflowDeploymentNodeContext;
+
+      node = new SubworkflowDeploymentNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeDisplayFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -356,9 +356,17 @@ export abstract class BaseNode<
     });
     nodeClass.add(nodeInputIdsByNameField);
 
-    const outputDisplay = this.getOutputDisplay();
-    if (outputDisplay) {
-      nodeClass.add(outputDisplay);
+    try {
+      const outputDisplay = this.getOutputDisplay();
+      if (outputDisplay) {
+        nodeClass.add(outputDisplay);
+      }
+    } catch (error) {
+      if (error instanceof BaseCodegenError) {
+        this.workflowContext.addError(error);
+      } else {
+        throw error;
+      }
     }
 
     const portDisplay = this.getPortDisplay();

--- a/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
@@ -77,7 +77,7 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
     if (!this.nodeContext.workflowDeploymentHistoryItem) {
       this.workflowContext.addError(
         new NodeAttributeGenerationError(
-          `Failed to generate attribute: ${this.nodeData.data.label}.deployment`
+          `Failed to generate ${this.nodeData.data.label}.Outputs class`
         )
       );
       return null;
@@ -144,7 +144,7 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
   protected getOutputDisplay(): python.Field {
     if (!this.nodeContext.workflowDeploymentHistoryItem) {
       throw new NodeDefinitionGenerationError(
-        "Workflow Deployment History Item is not set"
+        `Failed to generate \`output_display\` for ${this.nodeData.data.label}`
       );
     }
 


### PR DESCRIPTION
Now _fully_ allows the code generation of a subworkflow deployment node that is unable to find the deployment history item