### PR TITLE
Allow codegen to be resilient to graph attribute failures in strict mode

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -56,10 +56,9 @@ class TestWorkflow(BaseWorkflow):
 
 exports[`Workflow > write > should handle the workflow generation even if graph attribute fails in non-strict mode 1`] = `
 "from vellum.workflows import BaseWorkflow
-from .nodes.templating_node import TemplatingNode
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = TemplatingNode
+    pass
 "
 `;

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -53,3 +53,13 @@ class TestWorkflow(BaseWorkflow):
     graph = TemplatingNode >> TemplatingNode1TemplatingNode
 "
 `;
+
+exports[`Workflow > write > should handle the workflow generation even if graph attribute fails in non-strict mode 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = TemplatingNode
+"
+`;

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -6,10 +6,11 @@ import { Writer } from "@fern-api/python-ast/core/Writer";
 import { WorkflowGenerationError } from "./errors";
 
 import { PORTS_CLASS_NAME } from "src/constants";
-import { WorkflowContext } from "src/context";
-import { BaseNodeContext } from "src/context/node-context/base";
-import { PortContext } from "src/context/port-context";
-import { WorkflowDataNode, WorkflowEdge } from "src/types/vellum";
+
+import type { WorkflowContext } from "src/context";
+import type { BaseNodeContext } from "src/context/node-context/base";
+import type { PortContext } from "src/context/port-context";
+import type { WorkflowDataNode, WorkflowEdge } from "src/types/vellum";
 
 // Fern's Python AST types are not mutable, so we need to define our own types
 // so that we can mutate the graph as we traverse through the edges.
@@ -61,7 +62,7 @@ export class GraphAttribute extends AstNode {
    * The core assumption made is that `graphMutableAst` is always a valid graph, and
    * adding a single edge to it will always produce another valid graph.
    */
-  private generateGraphMutableAst(): GraphMutableAst {
+  public generateGraphMutableAst(): GraphMutableAst {
     let graphMutableAst: GraphMutableAst = { type: "empty" };
     const edgesQueue = this.workflowContext.getEntrypointNodeEdges();
     const edgesByPortId = this.workflowContext.getEdgesByPortId();

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -7,7 +7,6 @@ import { isNil } from "lodash";
 
 import { BasePersistedFile } from "./base-persisted-file";
 import { WorkflowGenerationError } from "./errors";
-import { GraphAttribute } from "./graph-attribute";
 import { WorkflowOutput } from "./workflow-output";
 
 import {
@@ -18,6 +17,7 @@ import {
 } from "src/constants";
 import { WorkflowContext } from "src/context";
 import { BaseState } from "src/generators/base-state";
+import { GraphAttribute } from "src/generators/graph-attribute";
 import { Inputs } from "src/generators/inputs";
 import { NodeDisplayData } from "src/generators/node-display-data";
 import { WorkflowDisplayData, WorkflowEdge } from "src/types/vellum";

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -5,10 +5,6 @@ import { Type } from "@fern-api/python-ast/Type";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { isNil } from "lodash";
 
-import { BasePersistedFile } from "./base-persisted-file";
-import { WorkflowGenerationError } from "./errors";
-import { WorkflowOutput } from "./workflow-output";
-
 import {
   GENERATED_DISPLAY_MODULE_NAME,
   GENERATED_WORKFLOW_MODULE_NAME,
@@ -16,10 +12,16 @@ import {
   PORTS_CLASS_NAME,
 } from "src/constants";
 import { WorkflowContext } from "src/context";
+import { BasePersistedFile } from "src/generators/base-persisted-file";
 import { BaseState } from "src/generators/base-state";
+import {
+  BaseCodegenError,
+  WorkflowGenerationError,
+} from "src/generators/errors";
 import { GraphAttribute } from "src/generators/graph-attribute";
 import { Inputs } from "src/generators/inputs";
 import { NodeDisplayData } from "src/generators/node-display-data";
+import { WorkflowOutput } from "src/generators/workflow-output";
 import { WorkflowDisplayData, WorkflowEdge } from "src/types/vellum";
 import { isDefined } from "src/utils/typing";
 
@@ -512,14 +514,23 @@ export class Workflow {
       return;
     }
 
-    const graphField = python.field({
-      name: "graph",
-      initializer: new GraphAttribute({
-        workflowContext: this.workflowContext,
-      }),
-    });
+    try {
+      const graphField = python.field({
+        name: "graph",
+        initializer: new GraphAttribute({
+          workflowContext: this.workflowContext,
+        }),
+      });
 
-    workflowClass.add(graphField);
+      workflowClass.add(graphField);
+    } catch (error) {
+      if (error instanceof BaseCodegenError) {
+        this.workflowContext.addError(error);
+        return;
+      }
+
+      throw error;
+    }
   }
 
   public getWorkflowFile(): WorkflowFile {

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -8,6 +8,7 @@ import { Comment } from "@fern-api/python-ast/Comment";
 import { StarImport } from "@fern-api/python-ast/StarImport";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 
+import * as codegen from "./codegen";
 import {
   GENERATED_DISPLAY_MODULE_NAME,
   GENERATED_DISPLAY_NODE_MODULE_PATH,
@@ -28,8 +29,6 @@ import { GuardrailNode } from "./generators/nodes/guardrail-node";
 import { InlineSubworkflowNode } from "./generators/nodes/inline-subworkflow-node";
 import { SearchNode } from "./generators/nodes/search-node";
 import { TemplatingNode } from "./generators/nodes/templating-node";
-
-import { codegen } from "./index";
 
 import { ApiNodeContext } from "src/context/node-context/api-node";
 import { BaseNodeContext } from "src/context/node-context/base";


### PR DESCRIPTION
This makes is such that if there are errors raised in our graph attribute, we could still generate the rest of the project