### PR TITLE
Introduce an edgesFactory to continue simplifying Graph attribute tests

### DIFF
--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -12,7 +12,6 @@ import {
 
 import { createNodeContext, WorkflowContext } from "src/context";
 import { GraphAttribute } from "src/generators/graph-attribute";
-import { WorkflowEdge } from "src/types/vellum";
 
 describe("Workflow", () => {
   let workflowContext: WorkflowContext;
@@ -60,25 +59,12 @@ describe("Workflow", () => {
         nodeData: templatingNodeData2,
       });
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [entrypointNode, templatingNodeData2],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -113,33 +99,13 @@ describe("Workflow", () => {
         nodeData: templatingNodeData3,
       });
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [entrypointNode, templatingNodeData2],
+          [entrypointNode, templatingNodeData3],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -163,25 +129,12 @@ describe("Workflow", () => {
         nodeData: templatingNodeData2,
       });
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [templatingNodeData1, templatingNodeData2],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -210,47 +163,15 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: mergeNodeData,
       });
-      const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
-      const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
-      if (!mergeTargetHandle1 || !mergeTargetHandle2) {
-        throw new Error("Handle IDs are required");
-      }
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle1,
-        },
-        {
-          id: "edge-4",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData2.id,
-          sourceHandleId: templatingNodeData2.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle2,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [entrypointNode, templatingNodeData2],
+          [templatingNodeData1, [mergeNodeData, 0]],
+          [templatingNodeData2, [mergeNodeData, 1]],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -290,63 +211,17 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: mergeNodeData,
       });
-      const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
-      const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
-      if (!mergeTargetHandle1 || !mergeTargetHandle2) {
-        throw new Error("Handle IDs are required");
-      }
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-        {
-          id: "edge-4",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle1,
-        },
-        {
-          id: "edge-5",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData2.id,
-          sourceHandleId: templatingNodeData2.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle2,
-        },
-        {
-          id: "edge-6",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData3.id,
-          sourceHandleId: templatingNodeData3.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle2,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [entrypointNode, templatingNodeData2],
+          [entrypointNode, templatingNodeData3],
+          [templatingNodeData1, [mergeNodeData, 0]],
+          [templatingNodeData2, [mergeNodeData, 1]],
+          [templatingNodeData3, [mergeNodeData, 1]],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -386,55 +261,16 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: mergeNodeData,
       });
-      const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
-      const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
-      if (!mergeTargetHandle1 || !mergeTargetHandle2) {
-        throw new Error("Handle IDs are required");
-      }
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle1,
-        },
-        {
-          id: "edge-4",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData2.id,
-          sourceHandleId: templatingNodeData2.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle2,
-        },
-        {
-          id: "edge-5",
-          type: "DEFAULT",
-          sourceNodeId: mergeNodeData.id,
-          sourceHandleId: mergeNodeData.data.sourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [entrypointNode, templatingNodeData2],
+          [templatingNodeData1, [mergeNodeData, 0]],
+          [templatingNodeData2, [mergeNodeData, 1]],
+          [mergeNodeData, templatingNodeData3],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -474,55 +310,16 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: mergeNodeData,
       });
-      const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
-      const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
-      if (!mergeTargetHandle1 || !mergeTargetHandle2) {
-        throw new Error("Handle IDs are required");
-      }
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-        {
-          id: "edge-4",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData2.id,
-          sourceHandleId: templatingNodeData2.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle1,
-        },
-        {
-          id: "edge-5",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData3.id,
-          sourceHandleId: templatingNodeData3.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle2,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [entrypointNode, templatingNodeData2],
+          [templatingNodeData1, templatingNodeData3],
+          [templatingNodeData2, [mergeNodeData, 0]],
+          [templatingNodeData3, [mergeNodeData, 1]],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -551,41 +348,14 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: conditionalNodeData,
       });
-      const conditionalIfSourceHandleId =
-        conditionalNodeData.data.conditions[0]?.sourceHandleId;
-      const conditionalElseSourceHandleId =
-        conditionalNodeData.data.conditions[1]?.sourceHandleId;
-      if (!conditionalIfSourceHandleId || !conditionalElseSourceHandleId) {
-        throw new Error("Handle IDs are required");
-      }
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: conditionalNodeData.id,
-          targetHandleId: conditionalNodeData.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalIfSourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalElseSourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, conditionalNodeData],
+          [[conditionalNodeData, "0"], templatingNodeData1],
+          [[conditionalNodeData, "1"], templatingNodeData2],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -620,33 +390,13 @@ describe("Workflow", () => {
         nodeData: templatingNodeData3,
       });
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData2.id,
-          sourceHandleId: templatingNodeData2.data.sourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [templatingNodeData1, templatingNodeData2],
+          [templatingNodeData2, templatingNodeData3],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -681,33 +431,13 @@ describe("Workflow", () => {
         nodeData: templatingNodeData3,
       });
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [templatingNodeData1, templatingNodeData2],
+          [entrypointNode, templatingNodeData3],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -742,33 +472,13 @@ describe("Workflow", () => {
         nodeData: templatingNodeData3,
       });
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [templatingNodeData1, templatingNodeData2],
+          [templatingNodeData1, templatingNodeData3],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -814,49 +524,15 @@ describe("Workflow", () => {
         nodeData: templatingNodeData4,
       });
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-        {
-          id: "edge-4",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData3.id,
-          sourceHandleId: templatingNodeData3.data.sourceHandleId,
-          targetNodeId: templatingNodeData4.id,
-          targetHandleId: templatingNodeData4.data.targetHandleId,
-        },
-        {
-          id: "edge-5",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData2.id,
-          sourceHandleId: templatingNodeData2.data.sourceHandleId,
-          targetNodeId: templatingNodeData4.id,
-          targetHandleId: templatingNodeData4.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [templatingNodeData1, templatingNodeData2],
+          [templatingNodeData1, templatingNodeData3],
+          [templatingNodeData3, templatingNodeData4],
+          [templatingNodeData2, templatingNodeData4],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -918,71 +594,18 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: mergeNodeData,
       });
-      const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
-      const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
-      if (!mergeTargetHandle1 || !mergeTargetHandle2) {
-        throw new Error("Handle IDs are required");
-      }
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-        {
-          id: "edge-4",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData3.id,
-          sourceHandleId: templatingNodeData3.data.sourceHandleId,
-          targetNodeId: templatingNodeData4.id,
-          targetHandleId: templatingNodeData4.data.targetHandleId,
-        },
-        {
-          id: "edge-5",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData4.id,
-          sourceHandleId: templatingNodeData4.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle1,
-        },
-        {
-          id: "edge-6",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData2.id,
-          sourceHandleId: templatingNodeData2.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle2,
-        },
-        {
-          id: "edge-7",
-          type: "DEFAULT",
-          sourceNodeId: mergeNodeData.id,
-          sourceHandleId: mergeNodeData.data.sourceHandleId,
-          targetNodeId: templatingNodeData5.id,
-          targetHandleId: templatingNodeData5.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [entrypointNode, templatingNodeData2],
+          [templatingNodeData1, templatingNodeData3],
+          [templatingNodeData3, templatingNodeData4],
+          [templatingNodeData4, [mergeNodeData, 0]],
+          [templatingNodeData2, [mergeNodeData, 1]],
+          [mergeNodeData, templatingNodeData5],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -1011,41 +634,14 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: conditionalNodeData,
       });
-      const conditionalIfSourceHandleId =
-        conditionalNodeData.data.conditions[0]?.sourceHandleId;
-      const conditionalElseSourceHandleId =
-        conditionalNodeData.data.conditions[1]?.sourceHandleId;
-      if (!conditionalIfSourceHandleId || !conditionalElseSourceHandleId) {
-        throw new Error("Handle IDs are required");
-      }
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: conditionalNodeData.id,
-          targetHandleId: conditionalNodeData.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalIfSourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalIfSourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, conditionalNodeData],
+          [[conditionalNodeData, "0"], templatingNodeData1],
+          [[conditionalNodeData, "0"], templatingNodeData2],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -1096,49 +692,15 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: conditionalNodeData,
       });
-      const conditionalIfSourceHandleId =
-        conditionalNodeData.data.conditions[0]?.sourceHandleId;
-      const conditionalElseSourceHandleId =
-        conditionalNodeData.data.conditions[1]?.sourceHandleId;
-      if (!conditionalIfSourceHandleId || !conditionalElseSourceHandleId) {
-        throw new Error("Handle IDs are required");
-      }
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: conditionalNodeData.id,
-          targetHandleId: conditionalNodeData.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalIfSourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalElseSourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-4",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalElseSourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, conditionalNodeData],
+          [[conditionalNodeData, "0"], templatingNodeData1],
+          [[conditionalNodeData, "1"], templatingNodeData2],
+          [[conditionalNodeData, "1"], templatingNodeData3],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -1189,13 +751,6 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: conditionalNodeData,
       });
-      const conditionalIfSourceHandleId =
-        conditionalNodeData.data.conditions[0]?.sourceHandleId;
-      const conditionalElseSourceHandleId =
-        conditionalNodeData.data.conditions[1]?.sourceHandleId;
-      if (!conditionalIfSourceHandleId || !conditionalElseSourceHandleId) {
-        throw new Error("Handle IDs are required");
-      }
 
       const conditionalNode2Data = conditionalNodeFactory({
         id: "b81a4453-7b80-41ea-bd55-c62df8878fd4",
@@ -1208,65 +763,17 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: conditionalNode2Data,
       });
-      const conditional2IfSourceHandleId =
-        conditionalNode2Data.data.conditions[0]?.sourceHandleId;
-      const conditional2ElseSourceHandleId =
-        conditionalNode2Data.data.conditions[1]?.sourceHandleId;
-      if (!conditional2IfSourceHandleId || !conditional2ElseSourceHandleId) {
-        throw new Error("Handle IDs are required");
-      }
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: conditionalNodeData.id,
-          targetHandleId: conditionalNodeData.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalIfSourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalElseSourceHandleId,
-          targetNodeId: conditionalNode2Data.id,
-          targetHandleId: conditionalNode2Data.data.targetHandleId,
-        },
-        {
-          id: "edge-4",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalElseSourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-5",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNode2Data.id,
-          sourceHandleId: conditional2ElseSourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-        {
-          id: "edge-6",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNode2Data.id,
-          sourceHandleId: conditional2ElseSourceHandleId,
-          targetNodeId: templatingNodeData4.id,
-          targetHandleId: templatingNodeData4.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, conditionalNodeData],
+          [[conditionalNodeData, "0"], templatingNodeData1],
+          [[conditionalNodeData, "1"], conditionalNode2Data],
+          [[conditionalNodeData, "1"], templatingNodeData2],
+          [[conditionalNode2Data, "1"], templatingNodeData3],
+          [[conditionalNode2Data, "1"], templatingNodeData4],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -1328,73 +835,18 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: conditionalNodeData,
       });
-      const conditionalIfSourceHandleId =
-        conditionalNodeData.data.conditions[0]?.sourceHandleId;
-      const conditionalElseSourceHandleId =
-        conditionalNodeData.data.conditions[1]?.sourceHandleId;
-      if (!conditionalIfSourceHandleId || !conditionalElseSourceHandleId) {
-        throw new Error("Handle IDs are required");
-      }
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: conditionalNodeData.id,
-          targetHandleId: conditionalNodeData.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalIfSourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: conditionalNodeData.id,
-          sourceHandleId: conditionalElseSourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-        {
-          id: "edge-4",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-        {
-          id: "edge-5",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData2.id,
-          sourceHandleId: templatingNodeData2.data.sourceHandleId,
-          targetNodeId: templatingNodeData3.id,
-          targetHandleId: templatingNodeData3.data.targetHandleId,
-        },
-        {
-          id: "edge-6",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData3.id,
-          sourceHandleId: templatingNodeData3.data.sourceHandleId,
-          targetNodeId: templatingNodeData4.id,
-          targetHandleId: templatingNodeData4.data.targetHandleId,
-        },
-        {
-          id: "edge-7",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData5.id,
-          targetHandleId: templatingNodeData5.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, conditionalNodeData],
+          [[conditionalNodeData, "0"], templatingNodeData1],
+          [[conditionalNodeData, "1"], templatingNodeData2],
+          [templatingNodeData1, templatingNodeData3],
+          [templatingNodeData2, templatingNodeData3],
+          [templatingNodeData3, templatingNodeData4],
+          [templatingNodeData1, templatingNodeData5],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -1423,47 +875,15 @@ describe("Workflow", () => {
         workflowContext,
         nodeData: mergeNodeData,
       });
-      const mergeTargetHandle1 = mergeNodeData.data.targetHandles[0]?.id;
-      const mergeTargetHandle2 = mergeNodeData.data.targetHandles[1]?.id;
-      if (!mergeTargetHandle1 || !mergeTargetHandle2) {
-        throw new Error("Handle IDs are required");
-      }
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle1,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData2.id,
-          sourceHandleId: templatingNodeData2.data.sourceHandleId,
-          targetNodeId: mergeNodeData.id,
-          targetHandleId: mergeTargetHandle2,
-        },
-        {
-          id: "edge-4",
-          type: "DEFAULT",
-          sourceNodeId: templatingNodeData1.id,
-          sourceHandleId: templatingNodeData1.data.sourceHandleId,
-          targetNodeId: templatingNodeData2.id,
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [templatingNodeData1, [mergeNodeData, 0]],
+          [templatingNodeData2, [mergeNodeData, 1]],
+          [templatingNodeData1, templatingNodeData2],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
@@ -1512,41 +932,14 @@ describe("Workflow", () => {
         nodeData: outputBottomNode,
       });
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: topNode.id,
-          targetHandleId: topNode.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: topNode.id,
-          sourceHandleId: topNode.data.sourceHandleId,
-          targetNodeId: outputTopNode.id,
-          targetHandleId: outputTopNode.data.targetHandleId,
-        },
-        {
-          id: "edge-3",
-          type: "DEFAULT",
-          sourceNodeId: topNode.id,
-          sourceHandleId: topNode.data.sourceHandleId,
-          targetNodeId: outputMiddleNode.id,
-          targetHandleId: outputMiddleNode.data.targetHandleId,
-        },
-        {
-          id: "edge-4",
-          type: "DEFAULT",
-          sourceNodeId: topNode.id,
-          sourceHandleId: topNode.data.sourceHandleId,
-          targetNodeId: outputBottomNode.id,
-          targetHandleId: outputBottomNode.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, topNode],
+          [topNode, outputTopNode],
+          [topNode, outputMiddleNode],
+          [topNode, outputBottomNode],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -955,35 +955,19 @@ describe("Workflow", () => {
       });
 
       const templatingNodeData2 = templatingNodeFactory({
-        id: "7e09927b-6d6f-4829-92c9-54e66bdcaf81",
+        id: "non-existent-node-id",
         label: "Templating Node 2",
         sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
         targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
       });
-      await createNodeContext({
-        workflowContext,
-        nodeData: templatingNodeData2,
-      });
+      // No node context created
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData1.id,
-          targetHandleId: templatingNodeData1.data.targetHandleId,
-        },
-        {
-          id: "edge-2",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: "non-existent-node-id",
-          targetHandleId: templatingNodeData2.data.targetHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([
+          [entrypointNode, templatingNodeData1],
+          [entrypointNode, templatingNodeData2],
+        ])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       const errors = workflowContext.getErrors();

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -1,6 +1,7 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { workflowContextFactory } from "./helpers";
+import { edgesFactory } from "./helpers/edge-data-factories";
 import {
   conditionalNodeFactory,
   entrypointNodeDataFactory,
@@ -33,17 +34,9 @@ describe("Workflow", () => {
         nodeData: templatingNodeData,
       });
 
-      const edges: WorkflowEdge[] = [
-        {
-          id: "edge-1",
-          type: "DEFAULT",
-          sourceNodeId: entrypointNode.id,
-          sourceHandleId: entrypointNode.data.sourceHandleId,
-          targetNodeId: templatingNodeData.id,
-          targetHandleId: templatingNodeData.data.sourceHandleId,
-        },
-      ];
-      workflowContext.addWorkflowEdges(edges);
+      workflowContext.addWorkflowEdges(
+        edgesFactory([[entrypointNode, templatingNodeData]])
+      );
 
       new GraphAttribute({ workflowContext }).write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();

--- a/ee/codegen/src/__test__/helpers/edge-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/edge-data-factories.ts
@@ -15,6 +15,15 @@ const getSourceHandleId = (
       return id;
     }
 
+    if (actualNode.type === "CONDITIONAL") {
+      const id = actualNode.data.conditions[Number(portName)]?.sourceHandleId;
+      if (!id) {
+        throw new Error("Conditional node has no source handle id");
+      }
+
+      return id;
+    }
+
     return getSourceHandleId(actualNode);
   }
 

--- a/ee/codegen/src/__test__/helpers/edge-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/edge-data-factories.ts
@@ -1,0 +1,91 @@
+import { WorkflowEdge, WorkflowNode } from "src/types/vellum";
+
+const getSourceHandleId = (
+  node: WorkflowNode | [WorkflowNode, string]
+): string => {
+  if (Array.isArray(node)) {
+    const [actualNode, portName] = node;
+
+    if (actualNode.type === "GENERIC") {
+      const id = actualNode.ports.find((port) => port.name === portName)?.id;
+      if (!id) {
+        throw new Error(`Port not found: ${portName}`);
+      }
+
+      return id;
+    }
+
+    return getSourceHandleId(actualNode);
+  }
+
+  if (node.type === "GENERIC") {
+    const port = node.ports[0];
+    if (!port) {
+      throw new Error("Generic node has no ports");
+    }
+
+    return port.id;
+  }
+
+  if (
+    node.type == "TERMINAL" ||
+    node.type === "NOTE" ||
+    node.type === "ERROR"
+  ) {
+    throw new Error(`${node.type} nodes have no source handle id`);
+  }
+
+  if (node.type === "CONDITIONAL") {
+    throw new Error("Conditional nodes must include a port name");
+  }
+
+  return node.data.sourceHandleId;
+};
+
+const getTargetHandleId = (
+  node: WorkflowNode | [WorkflowNode, number]
+): string => {
+  if (Array.isArray(node)) {
+    const [actualNode, targetIndex] = node;
+    if (actualNode.type === "MERGE") {
+      const id = actualNode.data.targetHandles[targetIndex]?.id;
+      if (!id) {
+        throw new Error(`Target handle not found: ${targetIndex}`);
+      }
+
+      return id;
+    }
+
+    return getTargetHandleId(actualNode);
+  }
+
+  if (node.type === "GENERIC") {
+    return node.trigger.id;
+  }
+
+  if (node.type === "MERGE") {
+    throw new Error("Merge nodes must include target handle index");
+  }
+
+  if (node.type === "ENTRYPOINT" || node.type === "NOTE") {
+    throw new Error(`${node.type} nodes have no target handle id`);
+  }
+
+  return node.data.targetHandleId;
+};
+
+export function edgesFactory(
+  nodePairs: [
+    WorkflowNode | [WorkflowNode, string],
+    WorkflowNode | [WorkflowNode, number]
+  ][]
+): WorkflowEdge[] {
+  return nodePairs.map(([sourceNode, targetNode], index) => ({
+    id: `edge-${index + 1}`,
+    type: "DEFAULT",
+    sourceNodeId: Array.isArray(sourceNode) ? sourceNode[0].id : sourceNode.id,
+    sourceHandleId: getSourceHandleId(sourceNode),
+    targetNodeId: Array.isArray(targetNode) ? targetNode[0].id : targetNode.id,
+    targetHandleId: getTargetHandleId(targetNode),
+  }));
+}

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1361,6 +1361,7 @@ export function genericNodeFactory(
   }
 ): GenericNode {
   const nodeData: GenericNode = {
+    id: "node-1",
     type: WorkflowNodeType.GENERIC,
     base: {
       module: ["vellum", "workflows", "nodes", "bases", "base"],

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -1864,6 +1864,7 @@ export const GenericNodeSerializer: ObjectSchema<
   GenericNodeSerializer.Raw,
   Omit<GenericNode, "type">
 > = objectSchema({
+  id: stringSchema(),
   displayData: propertySchema(
     "display_data",
     GenericNodeDisplayDataSerializer.optional()
@@ -1879,6 +1880,7 @@ export const GenericNodeSerializer: ObjectSchema<
 
 export declare namespace GenericNodeSerializer {
   interface Raw extends BaseWorkflowNodeSerializer.Raw {
+    id: string;
     base: CodeResourceDefinitionSerializer.Raw;
     display_data?: {
       position?: {

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -661,6 +661,7 @@ export interface NodeOutput {
 }
 
 export interface GenericNode extends BaseWorkflowNode {
+  id: string;
   type: "GENERIC";
   displayData?: GenericNodeDisplayData;
   base: CodeResourceDefinition;


### PR DESCRIPTION
I decided that each new graph attribute test case that comes up, going to pre-empt it with one change to simplify defining these graph generation tests to make each one easier to add. This PR focuses on defining edges, using a new `edgesFactory` to eliminate about ~700 lines of fluff