### PR TITLE
Fix issue in lockfile where we lose an entry if there are multiple with the same module name

### DIFF
--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -646,3 +646,44 @@ def test_pull__module_not_in_config(vellum_client, mock_module):
                 "workspace": "default",
             }
         ]
+
+
+def test_pull__multiple_instances_of_same_module__keep_when_pulling_another_module(vellum_client, mock_module):
+    # GIVEN a module on the user's filesystem
+    module = mock_module.module
+    temp_dir = mock_module.temp_dir
+    workflow_sandbox_id = mock_module.workflow_sandbox_id
+
+    # AND the vellum lock file has two instances of some other module
+    lock_data = {
+        "workflows": [
+            {
+                "module": "some_other_module",
+                "workflow_sandbox_id": str(uuid4()),
+                "workspace": "default",
+            },
+            {
+                "module": "some_other_module",
+                "workflow_sandbox_id": str(uuid4()),
+                "workspace": "other",
+            },
+        ]
+    }
+    lock_json = os.path.join(temp_dir, "vellum.lock.json")
+    with open(lock_json, "w") as f:
+        json.dump(lock_data, f)
+
+    # AND the workflow pull API call returns a zip file
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
+
+    # WHEN the user runs the pull command on the new module
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["workflows", "pull", module, "--workflow-sandbox-id", workflow_sandbox_id])
+
+    # THEN the command returns successfully
+    assert result.exit_code == 0, (result.output, result.exception)
+
+    # AND the lockfile should have all three entries
+    with open(lock_json) as f:
+        lock_data = json.load(f)
+        assert len(lock_data["workflows"]) == 3

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -428,7 +428,7 @@ def test_pull__sandbox_id_with_other_workflow_deployment_in_lock(vellum_client, 
                 "workflows": [
                     {
                         "module": module,
-                        "workflow_sandbox_id": "0edc07cd-45b9-43e8-99bc-1f181972a857",
+                        "workflow_sandbox_id": workflow_sandbox_id,
                         "ignore": "tests/*",
                         "deployments": [
                             {


### PR DESCRIPTION
Pushing to other workspaces means we now have to be able to handle multiple workflows of the same module name. We were previously using module name as the PK during merge logic, but we can no longer do so.

Long term, the plan is to have an identifier called `remote` be the identifier. But even then, I want to see if we could get away with that being an opt-in flag, and continue uniqueness logic off the combined pk of module name + sandbox id