### PR TITLE
Support graph generation of an edge between sets

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -183,7 +183,36 @@ exports[`Workflow > graph > should define nested sets of nodes without compilati
 "
 `;
 
+exports[`Workflow > graph > should handle loops of conditionals 1`] = `
+"{
+    StartNode.Ports.branch_1 >> TopNode,
+    StartNode.Ports.branch_2,
+} >> Graph.from_set(
+    {
+        LoopCheckNode.Ports.branch_1 >> StartNode,
+        LoopCheckNode.Ports.branch_2 >> FinalOutputNode,
+    }
+)
+"
+`;
+
 exports[`Workflow > graph > should show errors for a node pointing to non-existent node 1`] = `
 "TemplatingNode
+"
+`;
+
+exports[`Workflow > graph > should support an edge between two sets 1`] = `
+"{
+    TopLeftNode
+    >> {
+        TopRightNode,
+        BottomRightNode,
+    },
+    BottomLeftNode
+    >> {
+        TopRightNode,
+        BottomRightNode,
+    },
+}
 "
 `;

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -977,5 +977,120 @@ describe("Workflow", () => {
       );
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("should support an edge between two sets", async () => {
+      const topLeftNode = templatingNodeFactory({ label: "Top Left Node" });
+      await createNodeContext({
+        workflowContext,
+        nodeData: topLeftNode,
+      });
+
+      const topRightNode = finalOutputNodeFactory({
+        id: "7e09927b-6d6f-4829-92c9-54e66bdcaf86",
+        label: "Top Right Node",
+        name: "top-right-node",
+        targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a294e",
+        outputId: "7e09927b-6d6f-4829-92c9-54e66bdcaf86",
+      });
+      await createNodeContext({
+        workflowContext,
+        nodeData: topRightNode,
+      });
+
+      const bottomLeftNode = templatingNodeFactory({
+        id: "7e09927b-6d6f-4829-92c9-54e66bdcaf87",
+        label: "Bottom Left Node",
+        sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
+        targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
+      });
+
+      await createNodeContext({
+        workflowContext,
+        nodeData: bottomLeftNode,
+      });
+
+      const bottomRightNode = finalOutputNodeFactory({
+        id: "7e09927b-6d6f-4829-92c9-54e66bdcaf88",
+        label: "Bottom Right Node",
+        name: "bottom-right-node",
+        targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2950",
+        outputId: "7e09927b-6d6f-4829-92c9-54e66bdcaf88",
+      });
+      await createNodeContext({
+        workflowContext,
+        nodeData: bottomRightNode,
+      });
+
+      const edges: WorkflowEdge[] = [
+        {
+          id: "edge-1",
+          type: "DEFAULT",
+          sourceNodeId: entrypointNode.id,
+          sourceHandleId: entrypointNode.data.sourceHandleId,
+          targetNodeId: topLeftNode.id,
+          targetHandleId: topLeftNode.data.targetHandleId,
+        },
+        {
+          id: "edge-2",
+          type: "DEFAULT",
+          sourceNodeId: entrypointNode.id,
+          sourceHandleId: entrypointNode.data.sourceHandleId,
+          targetNodeId: bottomLeftNode.id,
+          targetHandleId: bottomLeftNode.data.targetHandleId,
+        },
+        {
+          id: "edge-3",
+          type: "DEFAULT",
+          sourceNodeId: topLeftNode.id,
+          sourceHandleId: topLeftNode.data.sourceHandleId,
+          targetNodeId: bottomRightNode.id,
+          targetHandleId: bottomRightNode.data.targetHandleId,
+        },
+        {
+          id: "edge-4",
+          type: "DEFAULT",
+          sourceNodeId: bottomLeftNode.id,
+          sourceHandleId: bottomLeftNode.data.sourceHandleId,
+          targetNodeId: bottomRightNode.id,
+          targetHandleId: bottomRightNode.data.targetHandleId,
+        },
+        {
+          id: "edge-5",
+          type: "DEFAULT",
+          sourceNodeId: topLeftNode.id,
+          sourceHandleId: topLeftNode.data.sourceHandleId,
+          targetNodeId: topRightNode.id,
+          targetHandleId: topRightNode.data.targetHandleId,
+        },
+        {
+          id: "edge-6",
+          type: "DEFAULT",
+          sourceNodeId: bottomLeftNode.id,
+          sourceHandleId: bottomLeftNode.data.sourceHandleId,
+          targetNodeId: topRightNode.id,
+          targetHandleId: topRightNode.data.targetHandleId,
+        },
+      ];
+      workflowContext.addWorkflowEdges(edges);
+
+      new GraphAttribute({ workflowContext }).write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should walmart", async () => {
+      workflowContext.addWorkflowEdges([
+        {
+          id: "edge-1",
+          type: "DEFAULT",
+          sourceNodeId: entrypointNode.id,
+          sourceHandleId: entrypointNode.data.sourceHandleId,
+          targetNodeId: setupFallbackValue.id,
+          targetHandleId: setupFallbackValue.data.targetHandleId,
+        },
+      ]);
+
+      new GraphAttribute({ workflowContext }).write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/constants.ts
+++ b/ee/codegen/src/constants.ts
@@ -8,6 +8,11 @@ export const VELLUM_WORKFLOW_NODE_BASE_TYPES_PATH = [
   "bases",
   "types",
 ] as const;
+export const VELLUM_WORKFLOW_GRAPH_MODULE_PATH = [
+  "vellum",
+  "workflows",
+  "graph",
+] as const;
 /* Class names */
 export const OUTPUTS_CLASS_NAME = "Outputs";
 export const PORTS_CLASS_NAME = "Ports";

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -4,10 +4,7 @@ import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { PORTS_CLASS_NAME } from "src/constants";
-import {
-  NodeNotFoundError,
-  WorkflowGenerationError,
-} from "src/generators/errors";
+import { NodeNotFoundError } from "src/generators/errors";
 import { WorkflowDataNode, WorkflowEdge } from "src/types/vellum";
 
 import type { WorkflowContext } from "src/context";
@@ -68,6 +65,7 @@ export class GraphAttribute extends AstNode {
     let graphMutableAst: GraphMutableAst = { type: "empty" };
     const edgesQueue = this.workflowContext.getEntrypointNodeEdges();
     const edgesByPortId = this.workflowContext.getEdgesByPortId();
+    const entrypointNodeId = this.workflowContext.getEntrypointNode().id;
     const processedEdges = new Set<WorkflowEdge>();
 
     while (edgesQueue.length > 0) {
@@ -77,38 +75,20 @@ export class GraphAttribute extends AstNode {
       }
 
       let sourceNode: BaseNodeContext<WorkflowDataNode> | null;
-      try {
-        sourceNode =
-          edge.sourceNodeId === this.workflowContext.getEntrypointNode().id
-            ? null
-            : this.workflowContext.getNodeContext(edge.sourceNodeId);
-      } catch (error) {
-        if (error instanceof NodeNotFoundError) {
-          const enhancedError = new NodeNotFoundError(
-            `Failed to find source node with ID '${edge.sourceNodeId}' referenced from edge ${edge.id}`
-          );
-          this.workflowContext.addError(enhancedError);
+      if (edge.sourceNodeId === entrypointNodeId) {
+        sourceNode = null;
+      } else {
+        sourceNode = this.resolveNodeId(edge.sourceNodeId, edge.id);
+        if (!sourceNode) {
           processedEdges.add(edge);
           continue;
-        } else {
-          throw error;
         }
       }
 
-      let targetNode: BaseNodeContext<WorkflowDataNode> | null;
-      try {
-        targetNode = this.workflowContext.getNodeContext(edge.targetNodeId);
-      } catch (error) {
-        if (error instanceof NodeNotFoundError) {
-          const enhancedError = new NodeNotFoundError(
-            `Failed to find target node with ID '${edge.targetNodeId}' referenced from edge ${edge.id}`
-          );
-          this.workflowContext.addError(enhancedError);
-          processedEdges.add(edge);
-          continue;
-        } else {
-          throw error;
-        }
+      const targetNode = this.resolveNodeId(edge.targetNodeId, edge.id);
+      if (!targetNode) {
+        processedEdges.add(edge);
+        continue;
       }
 
       const isPlural = (mutableAst: GraphMutableAst): boolean => {
@@ -379,11 +359,6 @@ export class GraphAttribute extends AstNode {
 
           const newRhs = addEdgeToGraph(mutableAst.rhs, lhsTerminal.reference);
           if (newRhs) {
-            if (lhsTerminals.length > 1 && newRhs.type === "set") {
-              throw new WorkflowGenerationError(
-                "Adding an edge between two sets is not supported"
-              );
-            }
             return {
               type: "right_shift",
               lhs: mutableAst.lhs,
@@ -415,6 +390,25 @@ export class GraphAttribute extends AstNode {
     }
 
     return graphMutableAst;
+  }
+
+  private resolveNodeId(
+    nodeId: string,
+    edgeId: string
+  ): BaseNodeContext<WorkflowDataNode> | null {
+    try {
+      return this.workflowContext.getNodeContext(nodeId);
+    } catch (error) {
+      if (error instanceof NodeNotFoundError) {
+        const enhancedError = new NodeNotFoundError(
+          `Failed to find target node with ID '${nodeId}' referenced from edge ${edgeId}`
+        );
+        this.workflowContext.addError(enhancedError);
+        return null;
+      } else {
+        throw error;
+      }
+    }
   }
 
   /**
@@ -726,7 +720,10 @@ export class GraphAttribute extends AstNode {
   /**
    * Translates our mutable graph AST into a Fern-native Python AST node.
    */
-  private getGraphAttributeAstNode(mutableAst: GraphMutableAst): AstNode {
+  private getGraphAttributeAstNode(
+    mutableAst: GraphMutableAst,
+    useWrap: boolean = false
+  ): AstNode {
     if (mutableAst.type === "empty") {
       return python.TypeInstantiation.none();
     }
@@ -749,17 +746,30 @@ export class GraphAttribute extends AstNode {
     }
 
     if (mutableAst.type === "set") {
-      return python.TypeInstantiation.set(
+      const setAst = python.TypeInstantiation.set(
         mutableAst.values.map((ast) => this.getGraphAttributeAstNode(ast)),
         {
           endWithComma: true,
         }
       );
+      if (useWrap) {
+        return new python.MethodInvocation({
+          methodReference: python.reference({
+            name: "Graph.from_set",
+            modulePath: ["vellum", "workflows", "graph"],
+          }),
+          arguments_: [python.methodArgument({ value: setAst })],
+        });
+      }
+      return setAst;
     }
 
     if (mutableAst.type === "right_shift") {
       const lhs = this.getGraphAttributeAstNode(mutableAst.lhs);
-      const rhs = this.getGraphAttributeAstNode(mutableAst.rhs);
+      const rhs = this.getGraphAttributeAstNode(
+        mutableAst.rhs,
+        mutableAst.lhs.type === "set"
+      );
       if (!lhs || !rhs) {
         return python.TypeInstantiation.none();
       }

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -3,7 +3,10 @@ import { OperatorType } from "@fern-api/python-ast/OperatorType";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
-import { PORTS_CLASS_NAME } from "src/constants";
+import {
+  PORTS_CLASS_NAME,
+  VELLUM_WORKFLOW_GRAPH_MODULE_PATH,
+} from "src/constants";
 import { NodeNotFoundError } from "src/generators/errors";
 import { WorkflowDataNode, WorkflowEdge } from "src/types/vellum";
 
@@ -756,7 +759,7 @@ export class GraphAttribute extends AstNode {
         return new python.MethodInvocation({
           methodReference: python.reference({
             name: "Graph.from_set",
-            modulePath: ["vellum", "workflows", "graph"],
+            modulePath: VELLUM_WORKFLOW_GRAPH_MODULE_PATH,
           }),
           arguments_: [python.methodArgument({ value: setAst })],
         });


### PR DESCRIPTION
This one was a doozy 😵 

Essentially, Python doesn't support the `>>` operator between set instances. It's also dangerous for us to override or monkey patch this globally (though maybe there's a way to do so within the context of a Graph class definition...).

The workaround is to use our preexisting `Graph.from_set` helper to be able to workaround compilation errors while still supporting valid graphs that exhibit this behavior