### PR TITLE
Add interval parameter to RetryNode

### DIFF
--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -20,7 +20,7 @@ class Inputs(BaseInputs):
     input: str
 
 
-@RetryNode.wrap(max_attempts=3)
+@RetryNode.wrap(max_attempts=3, interval=1)
 class InnerRetryGenericNode(BaseNode):
     input = Inputs.input
 
@@ -81,6 +81,11 @@ def test_serialize_node__retry(serialize_node):
                     },
                     "attributes": [
                         {
+                            "id": "6810e294-15c0-48a0-b77c-fa7318fd1c33",
+                            "name": "interval",
+                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "NUMBER", "value": 1.0}},
+                        },
+                        {
                             "id": "f388e93b-8c68-4f54-8577-bbd0c9091557",
                             "name": "max_attempts",
                             "value": {"type": "CONSTANT_VALUE", "value": {"type": "NUMBER", "value": 3.0}},
@@ -114,7 +119,7 @@ def test_serialize_node__retry(serialize_node):
 
 
 def test_serialize_node__retry__no_display():  # GIVEN an adornment node
-    @RetryNode.wrap(max_attempts=5)
+    @RetryNode.wrap(max_attempts=5, interval=1)
     class StartNode(BaseNode):
         pass
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -20,7 +20,7 @@ class Inputs(BaseInputs):
     input: str
 
 
-@RetryNode.wrap(max_attempts=3, interval=1)
+@RetryNode.wrap(max_attempts=3)
 class InnerRetryGenericNode(BaseNode):
     input = Inputs.input
 
@@ -81,11 +81,6 @@ def test_serialize_node__retry(serialize_node):
                     },
                     "attributes": [
                         {
-                            "id": "6810e294-15c0-48a0-b77c-fa7318fd1c33",
-                            "name": "interval",
-                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "NUMBER", "value": 1.0}},
-                        },
-                        {
                             "id": "f388e93b-8c68-4f54-8577-bbd0c9091557",
                             "name": "max_attempts",
                             "value": {"type": "CONSTANT_VALUE", "value": {"type": "NUMBER", "value": 3.0}},
@@ -119,7 +114,7 @@ def test_serialize_node__retry(serialize_node):
 
 
 def test_serialize_node__retry__no_display():  # GIVEN an adornment node
-    @RetryNode.wrap(max_attempts=5, interval=1)
+    @RetryNode.wrap(max_attempts=5)
     class StartNode(BaseNode):
         pass
 

--- a/src/vellum/workflows/nodes/core/retry_node/node.py
+++ b/src/vellum/workflows/nodes/core/retry_node/node.py
@@ -18,13 +18,13 @@ class RetryNode(BaseAdornmentNode[StateType], Generic[StateType]):
     Used to retry a Subworkflow a specified number of times.
 
     max_attempts: int - The maximum number of attempts to retry the Subworkflow
-    interval: float = 0 - The number of seconds to wait between retries
+    delay: float = 0 - The number of seconds to wait between retries
     retry_on_error_code: Optional[VellumErrorCode] = None - The error code to retry on
     subworkflow: Type["BaseWorkflow[SubworkflowInputs, BaseState]"] - The Subworkflow to execute
     """
 
     max_attempts: int
-    interval: float = 0
+    delay: Optional[float] = None
     retry_on_error_code: Optional[WorkflowErrorCode] = None
     retry_on_condition: Optional[BaseDescriptor] = None
 
@@ -75,7 +75,8 @@ Message: {terminal_event.error.message}""",
                     terminal_event.error.message,
                     code=terminal_event.error.code,
                 )
-                time.sleep(self.interval)
+                if self.delay:
+                    time.sleep(self.delay)
 
         raise last_exception
 
@@ -83,7 +84,7 @@ Message: {terminal_event.error.message}""",
     def wrap(
         cls,
         max_attempts: int,
-        interval: float = 0,
+        delay: Optional[float] = None,
         retry_on_error_code: Optional[WorkflowErrorCode] = None,
         retry_on_condition: Optional[BaseDescriptor] = None,
     ) -> Callable[..., Type["RetryNode"]]:
@@ -91,7 +92,7 @@ Message: {terminal_event.error.message}""",
             cls,
             attributes={
                 "max_attempts": max_attempts,
-                "interval": interval,
+                "delay": delay,
                 "retry_on_error_code": retry_on_error_code,
                 "retry_on_condition": retry_on_condition,
             },

--- a/src/vellum/workflows/nodes/core/retry_node/node.py
+++ b/src/vellum/workflows/nodes/core/retry_node/node.py
@@ -18,7 +18,7 @@ class RetryNode(BaseAdornmentNode[StateType], Generic[StateType]):
     Used to retry a Subworkflow a specified number of times.
 
     max_attempts: int - The maximum number of attempts to retry the Subworkflow
-    delay: float = 0 - The number of seconds to wait between retries
+    delay: float - The number of seconds to wait between retries
     retry_on_error_code: Optional[VellumErrorCode] = None - The error code to retry on
     subworkflow: Type["BaseWorkflow[SubworkflowInputs, BaseState]"] - The Subworkflow to execute
     """

--- a/src/vellum/workflows/nodes/core/retry_node/node.py
+++ b/src/vellum/workflows/nodes/core/retry_node/node.py
@@ -1,3 +1,4 @@
+import time
 from typing import Callable, Generic, Optional, Type
 
 from vellum.workflows.descriptors.base import BaseDescriptor
@@ -17,11 +18,13 @@ class RetryNode(BaseAdornmentNode[StateType], Generic[StateType]):
     Used to retry a Subworkflow a specified number of times.
 
     max_attempts: int - The maximum number of attempts to retry the Subworkflow
+    interval: float = 0 - The number of seconds to wait between retries
     retry_on_error_code: Optional[VellumErrorCode] = None - The error code to retry on
     subworkflow: Type["BaseWorkflow[SubworkflowInputs, BaseState]"] - The Subworkflow to execute
     """
 
     max_attempts: int
+    interval: float = 0
     retry_on_error_code: Optional[WorkflowErrorCode] = None
     retry_on_condition: Optional[BaseDescriptor] = None
 
@@ -72,6 +75,7 @@ Message: {terminal_event.error.message}""",
                     terminal_event.error.message,
                     code=terminal_event.error.code,
                 )
+                time.sleep(self.interval)
 
         raise last_exception
 
@@ -79,6 +83,7 @@ Message: {terminal_event.error.message}""",
     def wrap(
         cls,
         max_attempts: int,
+        interval: float = 0,
         retry_on_error_code: Optional[WorkflowErrorCode] = None,
         retry_on_condition: Optional[BaseDescriptor] = None,
     ) -> Callable[..., Type["RetryNode"]]:
@@ -86,6 +91,7 @@ Message: {terminal_event.error.message}""",
             cls,
             attributes={
                 "max_attempts": max_attempts,
+                "interval": interval,
                 "retry_on_error_code": retry_on_error_code,
                 "retry_on_condition": retry_on_condition,
             },

--- a/tests/workflows/basic_retry_node_delay/testing/test_workflow.py
+++ b/tests/workflows/basic_retry_node_delay/testing/test_workflow.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 
-from tests.workflows.basic_retry_node_interval.workflow import SimpleRetryExample
+from tests.workflows.basic_retry_node_delay.workflow import SimpleRetryExample
 
 
 def test_run_workflow__happy_path():
-    # GIVEN a workflow that references a Retry example with interval
+    # GIVEN a workflow that references a Retry example with delay
     workflow = SimpleRetryExample()
 
     # WHEN the workflow is run
@@ -17,5 +17,5 @@ def test_run_workflow__happy_path():
     # AND the output should match the environment variable
     assert terminal_event.outputs == {"final_value": 3}
 
-    # AND the duration should be (retry - 1) * interval
+    # AND the duration should be (retry - 1) * delay
     assert terminal_event.timestamp - datetime_start > timedelta(seconds=0.2)

--- a/tests/workflows/basic_retry_node_delay_annotation/tests/test_workflow.py
+++ b/tests/workflows/basic_retry_node_delay_annotation/tests/test_workflow.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 
-from tests.workflows.basic_retry_node_interval_annotation.workflow import SimpleRetryExample
+from tests.workflows.basic_retry_node_delay_annotation.workflow import SimpleRetryExample
 
 
 def test_run_workflow__happy_path():
-    # GIVEN a workflow that references a Retry example with interval
+    # GIVEN a workflow that references a Retry example with delay
     workflow = SimpleRetryExample()
 
     # WHEN the workflow is run
@@ -17,5 +17,5 @@ def test_run_workflow__happy_path():
     # AND the output should match the environment variable
     assert terminal_event.outputs == {"final_value": 3}
 
-    # AND the duration should be (retry - 1) * interval
+    # AND the duration should be (retry - 1) * delay
     assert terminal_event.timestamp - datetime_start > timedelta(seconds=0.2)

--- a/tests/workflows/basic_retry_node_delay_annotation/workflow.py
+++ b/tests/workflows/basic_retry_node_delay_annotation/workflow.py
@@ -1,10 +1,10 @@
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.core.retry_node import RetryNode
-from vellum.workflows.state import BaseState
 
 
-class StartNode(BaseNode):
+@RetryNode.wrap(max_attempts=3, delay=0.1)
+class RetryableNode(BaseNode):
     attempt_number = RetryNode.SubworkflowInputs.attempt_number
 
     class Outputs(BaseNode.Outputs):
@@ -15,22 +15,6 @@ class StartNode(BaseNode):
             raise Exception("This is a retryable node")
 
         return self.Outputs(execution_count=self.attempt_number)
-
-
-class Subworkflow(BaseWorkflow[RetryNode.SubworkflowInputs, BaseState]):
-    graph = StartNode
-
-    class Outputs(StartNode.Outputs):
-        pass
-
-
-class RetryableNode(RetryNode):
-    max_attempts = 3
-    interval = 0.1  # 0.1 second between retries
-    subworkflow = Subworkflow
-
-    class Outputs(Subworkflow.Outputs):
-        pass
 
 
 class SimpleRetryExample(BaseWorkflow):

--- a/tests/workflows/basic_retry_node_interval/testing/test_workflow.py
+++ b/tests/workflows/basic_retry_node_interval/testing/test_workflow.py
@@ -1,0 +1,21 @@
+from datetime import datetime, timedelta
+
+from tests.workflows.basic_retry_node_interval.workflow import SimpleRetryExample
+
+
+def test_run_workflow__happy_path():
+    # GIVEN a workflow that references a Retry example with interval
+    workflow = SimpleRetryExample()
+
+    # WHEN the workflow is run
+    datetime_start = datetime.now()
+    terminal_event = workflow.run()
+
+    # THEN the workflow should complete successfully
+    assert terminal_event.name == "workflow.execution.fulfilled", terminal_event
+
+    # AND the output should match the environment variable
+    assert terminal_event.outputs == {"final_value": 3}
+
+    # AND the duration should be (retry - 1) * interval
+    assert terminal_event.timestamp - datetime_start > timedelta(seconds=0.2)

--- a/tests/workflows/basic_retry_node_interval/workflow.py
+++ b/tests/workflows/basic_retry_node_interval/workflow.py
@@ -1,0 +1,40 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes.bases import BaseNode
+from vellum.workflows.nodes.core.retry_node import RetryNode
+from vellum.workflows.state import BaseState
+
+
+class StartNode(BaseNode):
+    attempt_number = RetryNode.SubworkflowInputs.attempt_number
+
+    class Outputs(BaseNode.Outputs):
+        execution_count: int
+
+    def run(self) -> Outputs:
+        if self.attempt_number < 3:
+            raise Exception("This is a retryable node")
+
+        return self.Outputs(execution_count=self.attempt_number)
+
+
+class Subworkflow(BaseWorkflow[RetryNode.SubworkflowInputs, BaseState]):
+    graph = StartNode
+
+    class Outputs(StartNode.Outputs):
+        pass
+
+
+class RetryableNode(RetryNode):
+    max_attempts = 3
+    interval = 0.1  # 0.1 second between retries
+    subworkflow = Subworkflow
+
+    class Outputs(Subworkflow.Outputs):
+        pass
+
+
+class SimpleRetryExample(BaseWorkflow):
+    graph = RetryableNode
+
+    class Outputs(BaseWorkflow.Outputs):
+        final_value = RetryableNode.Outputs.execution_count

--- a/tests/workflows/basic_retry_node_interval_annotation/tests/test_workflow.py
+++ b/tests/workflows/basic_retry_node_interval_annotation/tests/test_workflow.py
@@ -1,0 +1,21 @@
+from datetime import datetime, timedelta
+
+from tests.workflows.basic_retry_node_interval_annotation.workflow import SimpleRetryExample
+
+
+def test_run_workflow__happy_path():
+    # GIVEN a workflow that references a Retry example with interval
+    workflow = SimpleRetryExample()
+
+    # WHEN the workflow is run
+    datetime_start = datetime.now()
+    terminal_event = workflow.run()
+
+    # THEN the workflow should complete successfully
+    assert terminal_event.name == "workflow.execution.fulfilled", terminal_event
+
+    # AND the output should match the environment variable
+    assert terminal_event.outputs == {"final_value": 3}
+
+    # AND the duration should be (retry - 1) * interval
+    assert terminal_event.timestamp - datetime_start > timedelta(seconds=0.2)

--- a/tests/workflows/basic_retry_node_interval_annotation/workflow.py
+++ b/tests/workflows/basic_retry_node_interval_annotation/workflow.py
@@ -1,0 +1,24 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes.bases import BaseNode
+from vellum.workflows.nodes.core.retry_node import RetryNode
+
+
+@RetryNode.wrap(max_attempts=3, interval=0.1)
+class RetryableNode(BaseNode):
+    attempt_number = RetryNode.SubworkflowInputs.attempt_number
+
+    class Outputs(BaseNode.Outputs):
+        execution_count: int
+
+    def run(self) -> Outputs:
+        if self.attempt_number < 3:
+            raise Exception("This is a retryable node")
+
+        return self.Outputs(execution_count=self.attempt_number)
+
+
+class SimpleRetryExample(BaseWorkflow):
+    graph = RetryableNode
+
+    class Outputs(BaseWorkflow.Outputs):
+        final_value = RetryableNode.Outputs.execution_count


### PR DESCRIPTION
Closes #746 

- uses float seconds to match with `time.sleep`