### PR TITLE
EE adornments serialization test fix

### DIFF
--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -81,6 +81,11 @@ def test_serialize_node__retry(serialize_node):
                     },
                     "attributes": [
                         {
+                            "id": "8a07dc58-3fed-41d4-8ca6-31ee0bb86c61",
+                            "name": "delay",
+                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                        },
+                        {
                             "id": "f388e93b-8c68-4f54-8577-bbd0c9091557",
                             "name": "max_attempts",
                             "value": {"type": "CONSTANT_VALUE", "value": {"type": "NUMBER", "value": 3.0}},


### PR DESCRIPTION
Our licensing prevents external contributors from adding to `ee` directory, so just following up with the test fix for this: https://github.com/vellum-ai/vellum-python-sdks/pull/781/commits/68a8e4203a1beb556fcb09279c1ee28e7593736a