### PR TITLE
Avoid auto formatting of user provided scripts in Code Execution Nodes

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -1,5 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`WorkflowProjectGenerator > code execution node at project level > should not autoformat the script file 1`] = `
+"import foo, bar
+baz = foo + bar
+"
+`;
+
 exports[`WorkflowProjectGenerator > inlude sandbox > should include a sandbox.py file when passed sandboxInputs 1`] = `
 "from vellum import ArrayChatMessageContent, ChatMessage, StringChatMessageContent
 from vellum.workflows.sandbox import WorkflowSandboxRunner

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -219,7 +219,7 @@ ${errors.slice(0, 3).map((err) => {
 
     await new Promise((resolve, reject) => {
       exec(
-        `${isortCmd} --sp ${setupCfgPath} ${this.workflowContext.absolutePathToOutputDirectory}`,
+        `${isortCmd} --sp ${setupCfgPath} --skip script.py ${this.workflowContext.absolutePathToOutputDirectory}`,
         (error: Error | null) => {
           if (error) {
             reject(error);


### PR DESCRIPTION
We want to minimize user's code diffs as much as possible, and we don't have autoformatting in our code execution nodes