### PR TITLE
Remove old way of calculating generic node id

### DIFF
--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -3,7 +3,7 @@ import { PortContext } from "src/context/port-context";
 import { NodeOutputNotFoundError } from "src/generators/errors";
 import { WorkflowDataNode } from "src/types/vellum";
 import { toPythonSafeSnakeCase } from "src/utils/casing";
-import { getNodeId, getNodeLabel } from "src/utils/nodes";
+import { getNodeLabel } from "src/utils/nodes";
 import {
   getGeneratedNodeDisplayModulePath,
   getGeneratedNodeModuleInfo,
@@ -83,10 +83,6 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
 
   protected abstract getNodeOutputNamesById(): Record<string, string>;
   protected abstract createPortContexts(): PortContext[];
-
-  public getNodeId(): string {
-    return getNodeId(this.nodeData);
-  }
 
   public getNodeLabel(): string {
     return getNodeLabel(this.nodeData);

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -293,7 +293,7 @@ export class WorkflowContext {
   }
 
   public addNodeContext(nodeContext: BaseNodeContext<WorkflowDataNode>): void {
-    const nodeId = nodeContext.getNodeId();
+    const nodeId = nodeContext.nodeData.id;
 
     if (this.globalNodeContextsByNodeId.get(nodeId)) {
       throw new NodeDefinitionGenerationError(

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -69,7 +69,6 @@ import {
   WorkflowSandboxInputs,
   WorkflowVersionExecConfig,
 } from "src/types/vellum";
-import { getNodeId } from "src/utils/nodes";
 import { assertUnreachable } from "src/utils/typing";
 
 export interface WorkflowProjectGeneratorOptions {
@@ -375,7 +374,7 @@ ${errors.slice(0, 3).map((err) => {
       workflowContext: this.workflowContext,
     });
 
-    const nodeIds = nodesToGenerate.map((nodeData) => getNodeId(nodeData));
+    const nodeIds = nodesToGenerate.map((nodeData) => nodeData.id);
     const nodes = await this.generateNodes(nodeIds);
 
     const workflow = codegen.workflow({

--- a/ee/codegen/src/utils/nodes.ts
+++ b/ee/codegen/src/utils/nodes.ts
@@ -1,24 +1,4 @@
-import { NodeDefinitionGenerationError } from "src/generators/errors";
 import { WorkflowNode } from "src/types/vellum";
-
-export function getNodeId(nodeData: WorkflowNode): string {
-  switch (nodeData.type) {
-    case "GENERIC": {
-      if (!nodeData.definition) {
-        throw new NodeDefinitionGenerationError(
-          "Generic node missing definition"
-        );
-      }
-      const syntheticId = [
-        ...nodeData.definition.module,
-        nodeData.definition.name,
-      ].join(".");
-      return syntheticId;
-    }
-    default:
-      return nodeData.id;
-  }
-}
 
 export function getNodeLabel(nodeData: WorkflowNode): string {
   switch (nodeData.type) {


### PR DESCRIPTION
We initially wanted to operate with no node ids. But we've since pivoted and now all nodes have ids