### PR TITLE
[SC-6289] Correctly serialize subworkflow deployment inpud ids

### DIFF
--- a/ee/codegen_integration/conftest.py
+++ b/ee/codegen_integration/conftest.py
@@ -2,9 +2,10 @@ import pytest
 from datetime import datetime
 import glob
 import os
+from uuid import uuid4
 from typing import List, Optional, Set, Tuple
 
-from vellum import WorkspaceSecretRead
+from vellum import DeploymentRead, WorkspaceSecretRead
 
 current_file_path = os.path.abspath(__file__)
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -59,3 +60,18 @@ def workspace_secret_client(vellum_client):
         secret_type="USER_DEFINED",
     )
     vellum_client.workspace_secrets.retrieve.return_value = workspace_secret
+
+
+@pytest.fixture
+def deployment_client(vellum_client):
+    deployment = DeploymentRead(
+        id="e68d6033-f3e6-4681-a7b9-6bfd2828a237",
+        created=datetime.now(),
+        label="Example Deployment",
+        name="example deployment",
+        last_deployed_on=datetime.now(),
+        input_variables=[],
+        active_model_version_ids=[],
+        last_deployed_history_item_id=str(uuid4()),
+    )
+    vellum_client.workflow_deployments.retrieve.return_value = deployment

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa: F401, F403
+
+from .display import *

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa: F401, F403
+
+from .nodes import *
+from .workflow import *

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/__init__.py
@@ -1,0 +1,4 @@
+from .final_output import FinalOutputDisplay
+from .subworkflow_deployment import SubworkflowDeploymentDisplay
+
+__all__ = ["SubworkflowDeploymentDisplay", "FinalOutputDisplay"]

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/final_output.py
@@ -1,0 +1,21 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.final_output import FinalOutput
+
+
+class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
+    label = "Final Output"
+    node_id = UUID("eb72f89e-f831-4fc1-a54f-dec7f429fff9")
+    target_handle_id = UUID("52b9ff71-e090-4c68-a713-fd72d194b992")
+    output_id = UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585")
+    output_name = "final-output"
+    node_input_id = UUID("0d184119-05b8-4551-a01c-418d3b983880")
+    node_input_ids_by_name = {"node_input": UUID("0d184119-05b8-4551-a01c-418d3b983880")}
+    output_display = {
+        FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"), name="value")
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=2750, y=211.25540166204985), width=471, height=234)

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/subworkflow_deployment.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/subworkflow_deployment.py
@@ -1,0 +1,25 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.subworkflow_deployment import SubworkflowDeployment
+
+
+class SubworkflowDeploymentDisplay(BaseSubworkflowDeploymentNodeDisplay[SubworkflowDeployment]):
+    label = "Subworkflow Deployment"
+    node_id = UUID("07d76e33-f3df-4235-8493-07e341208bf5")
+    target_handle_id = UUID("30771282-5c0a-4a98-a3a8-4c7eeda30d23")
+    node_input_ids_by_name = {"test": UUID("97b63d71-5413-417f-9cf5-49e1b4fd56e4")}
+    output_display = {
+        SubworkflowDeployment.Outputs.final_output: NodeOutputDisplay(
+            id=UUID("61759cf7-da3d-45a3-9f73-68d3907207ae"), name="final-output"
+        )
+    }
+    port_displays = {
+        SubworkflowDeployment.Ports.default: PortDisplayOverrides(id=UUID("fc38b3bd-5c08-4729-9e37-211c415637ad"))
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=1873.116343490305, y=239.74958448753466), width=None, height=None
+    )

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
@@ -1,0 +1,58 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.vellum import (
+    EdgeVellumDisplayOverrides,
+    EntrypointVellumDisplayOverrides,
+    NodeDisplayData,
+    NodeDisplayPosition,
+    WorkflowDisplayData,
+    WorkflowDisplayDataViewport,
+    WorkflowInputsVellumDisplayOverrides,
+    WorkflowMetaVellumDisplayOverrides,
+    WorkflowOutputVellumDisplayOverrides,
+)
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+
+from ..inputs import Inputs
+from ..nodes.final_output import FinalOutput
+from ..nodes.subworkflow_deployment import SubworkflowDeployment
+from ..workflow import Workflow
+
+
+class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+    workflow_display = WorkflowMetaVellumDisplayOverrides(
+        entrypoint_node_id=UUID("39a5155a-d137-4a56-be36-d525802df463"),
+        entrypoint_node_source_handle_id=UUID("beddfefc-dc34-483d-b313-f6a2a2e0737e"),
+        entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),
+        display_data=WorkflowDisplayData(
+            viewport=WorkflowDisplayDataViewport(x=-1404.2954545454543, y=51.525595763459876, zoom=0.7965578111209178)
+        ),
+    )
+    inputs_display = {
+        Inputs.test: WorkflowInputsVellumDisplayOverrides(
+            id=UUID("93b9d3fb-251c-4a53-a1d5-4bd8e61947c5"), name="test", required=True
+        )
+    }
+    entrypoint_displays = {
+        SubworkflowDeployment: EntrypointVellumDisplayOverrides(
+            id=UUID("39a5155a-d137-4a56-be36-d525802df463"),
+            edge_display=EdgeVellumDisplayOverrides(id=UUID("fbf75594-70e8-4e03-ae3d-a64f573df51f")),
+        )
+    }
+    edge_displays = {
+        (SubworkflowDeployment.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
+            id=UUID("85970a9b-4ce7-46a5-b539-66aaeef080df")
+        )
+    }
+    output_displays = {
+        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
+            id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"),
+            node_id=UUID("eb72f89e-f831-4fc1-a54f-dec7f429fff9"),
+            name="final-output",
+            label="Final Output",
+            target_handle_id=UUID("52b9ff71-e090-4c68-a713-fd72d194b992"),
+            display_data=NodeDisplayData(
+                position=NodeDisplayPosition(x=2750, y=211.25540166204985), width=471, height=234
+            ),
+        )
+    }

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/inputs.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/inputs.py
@@ -1,0 +1,5 @@
+from vellum.workflows.inputs import BaseInputs
+
+
+class Inputs(BaseInputs):
+    test: str

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/nodes/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/nodes/__init__.py
@@ -1,0 +1,4 @@
+from .final_output import FinalOutput
+from .subworkflow_deployment import SubworkflowDeployment
+
+__all__ = ["SubworkflowDeployment", "FinalOutput"]

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/nodes/final_output.py
@@ -1,0 +1,9 @@
+from vellum.workflows.nodes.displayable import FinalOutputNode
+from vellum.workflows.state import BaseState
+
+from ..inputs import Inputs
+
+
+class FinalOutput(FinalOutputNode[BaseState, str]):
+    class Outputs(FinalOutputNode.Outputs):
+        value = Inputs.test

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/nodes/subworkflow_deployment.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/nodes/subworkflow_deployment.py
@@ -1,0 +1,14 @@
+from vellum.workflows.nodes.displayable import SubworkflowDeploymentNode
+
+from ..inputs import Inputs
+
+
+class SubworkflowDeployment(SubworkflowDeploymentNode):
+    deployment = "deployment-test"
+    release_tag = "LATEST"
+    subworkflow_inputs = {
+        "test": Inputs.test,
+    }
+
+    class Outputs(SubworkflowDeploymentNode.Outputs):
+        final_output: str

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/workflow.py
@@ -1,0 +1,13 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.state import BaseState
+
+from .inputs import Inputs
+from .nodes.final_output import FinalOutput
+from .nodes.subworkflow_deployment import SubworkflowDeployment
+
+
+class Workflow(BaseWorkflow[Inputs, BaseState]):
+    graph = SubworkflowDeployment >> FinalOutput
+
+    class Outputs(BaseWorkflow.Outputs):
+        final_output = FinalOutput.Outputs.value

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/display_data/simple_subworkflow_deployment_node.json
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/display_data/simple_subworkflow_deployment_node.json
@@ -1,0 +1,198 @@
+{
+  "workflow_raw_data": {
+    "nodes": [
+      {
+        "id": "39a5155a-d137-4a56-be36-d525802df463",
+        "type": "ENTRYPOINT",
+        "data": {
+          "label": "Entrypoint Node",
+          "source_handle_id": "beddfefc-dc34-483d-b313-f6a2a2e0737e"
+        },
+        "inputs": [],
+        "display_data": {
+          "position": {
+            "x": 1545,
+            "y": 330
+          },
+          "width": 124,
+          "height": 48
+        },
+        "base": null,
+        "definition": null
+      },
+      {
+        "id": "07d76e33-f3df-4235-8493-07e341208bf5",
+        "type": "SUBWORKFLOW",
+        "data": {
+          "label": "Subworkflow Deployment",
+          "source_handle_id": "fc38b3bd-5c08-4729-9e37-211c415637ad",
+          "target_handle_id": "30771282-5c0a-4a98-a3a8-4c7eeda30d23",
+          "error_output_id": null,
+          "variant": "DEPLOYMENT",
+          "workflow_deployment_id": "e68d6033-f3e6-4681-a7b9-6bfd2828a237",
+          "release_tag": "LATEST"
+        },
+        "inputs": [
+          {
+            "id": "97b63d71-5413-417f-9cf5-49e1b4fd56e4",
+            "key": "test",
+            "value": {
+              "rules": [
+                {
+                  "type": "INPUT_VARIABLE",
+                  "data": {
+                    "input_variable_id": "93b9d3fb-251c-4a53-a1d5-4bd8e61947c5"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          }
+        ],
+        "display_data": {
+          "position": {
+            "x": 1873.116343490305,
+            "y": 239.74958448753466
+          },
+          "width": null,
+          "height": null
+        },
+        "base": {
+          "name": "SubworkflowDeploymentNode",
+          "module": [
+            "vellum",
+            "workflows",
+            "nodes",
+            "displayable",
+            "subworkflow_deployment_node",
+            "node"
+          ]
+        },
+        "definition": {
+          "module": [
+            "codegen_integration",
+            "fixtures",
+            "simple_subworkflow_deployment_node",
+            "code",
+            "nodes",
+            "subworkflow_deployment"
+          ],
+          "name": "SubworkflowDeployment"
+        }
+      },
+      {
+        "id": "eb72f89e-f831-4fc1-a54f-dec7f429fff9",
+        "type": "TERMINAL",
+        "data": {
+          "label": "Final Output",
+          "name": "final-output",
+          "target_handle_id": "52b9ff71-e090-4c68-a713-fd72d194b992",
+          "output_id": "4dc6e13e-92ba-436e-aa35-87e258f2f585",
+          "output_type": "STRING",
+          "node_input_id": "0d184119-05b8-4551-a01c-418d3b983880"
+        },
+        "inputs": [
+          {
+            "id": "0d184119-05b8-4551-a01c-418d3b983880",
+            "key": "node_input",
+            "value": {
+              "rules": [
+                {
+                  "type": "INPUT_VARIABLE",
+                  "data": {
+                    "input_variable_id": "93b9d3fb-251c-4a53-a1d5-4bd8e61947c5"
+                  }
+                }
+              ],
+              "combinator": "OR"
+            }
+          }
+        ],
+        "display_data": {
+          "position": {
+            "x": 2750,
+            "y": 211.25540166204985
+          },
+          "width": 471,
+          "height": 234
+        },
+        "base": {
+          "name": "FinalOutputNode",
+          "module": [
+            "vellum",
+            "workflows",
+            "nodes",
+            "displayable",
+            "final_output_node",
+            "node"
+          ]
+        },
+        "definition": {
+          "module": [
+            "codegen_integration",
+            "fixtures",
+            "simple_subworkflow_deployment_node",
+            "code",
+            "nodes",
+            "final_output"
+          ],
+          "name": "FinalOutput"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "type": "DEFAULT",
+        "id": "fbf75594-70e8-4e03-ae3d-a64f573df51f",
+        "source_node_id": "39a5155a-d137-4a56-be36-d525802df463",
+        "source_handle_id": "beddfefc-dc34-483d-b313-f6a2a2e0737e",
+        "target_node_id": "07d76e33-f3df-4235-8493-07e341208bf5",
+        "target_handle_id": "30771282-5c0a-4a98-a3a8-4c7eeda30d23"
+      },
+      {
+        "type": "DEFAULT",
+        "id": "85970a9b-4ce7-46a5-b539-66aaeef080df",
+        "source_node_id": "07d76e33-f3df-4235-8493-07e341208bf5",
+        "source_handle_id": "fc38b3bd-5c08-4729-9e37-211c415637ad",
+        "target_node_id": "eb72f89e-f831-4fc1-a54f-dec7f429fff9",
+        "target_handle_id": "52b9ff71-e090-4c68-a713-fd72d194b992"
+      }
+    ],
+    "display_data": {
+      "viewport": {
+        "x": -1404.2954545454543,
+        "y": 51.525595763459876,
+        "zoom": 0.7965578111209178
+      }
+    },
+    "definition": {
+      "name": "Workflow",
+      "module": [
+        "codegen_integration",
+        "fixtures",
+        "simple_subworkflow_deployment_node",
+        "code",
+        "workflow"
+      ]
+    }
+  },
+  "input_variables": [
+    {
+      "id": "93b9d3fb-251c-4a53-a1d5-4bd8e61947c5",
+      "key": "test",
+      "type": "STRING",
+      "required": true,
+      "default": null,
+      "extensions": {
+        "color": null
+      }
+    }
+  ],
+  "output_variables": [
+    {
+      "id": "4dc6e13e-92ba-436e-aa35-87e258f2f585",
+      "key": "final-output",
+      "type": "STRING"
+    }
+  ]
+}

--- a/ee/codegen_integration/test_code_to_display.py
+++ b/ee/codegen_integration/test_code_to_display.py
@@ -8,7 +8,7 @@ from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 
-def test_code_to_display_data(code_to_display_fixture_paths, workspace_secret_client):
+def test_code_to_display_data(code_to_display_fixture_paths, workspace_secret_client, deployment_client):
     """Confirms that code representations of workflows are correctly serialized into their display representations."""
 
     expected_display_data_file_path, code_dir = code_to_display_fixture_paths

--- a/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from typing import ClassVar, Dict, Generic, Optional, TypeVar
+from typing import Generic, Optional, TypeVar
 
 from vellum.workflows.nodes import SubworkflowDeploymentNode
 from vellum.workflows.types.core import JsonObject
@@ -15,7 +15,6 @@ _SubworkflowDeploymentNodeType = TypeVar("_SubworkflowDeploymentNodeType", bound
 class BaseSubworkflowDeploymentNodeDisplay(
     BaseNodeVellumDisplay[_SubworkflowDeploymentNodeType], Generic[_SubworkflowDeploymentNodeType]
 ):
-    subworkflow_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
@@ -30,7 +29,7 @@ class BaseSubworkflowDeploymentNodeDisplay(
                 input_name=variable_name,
                 value=variable_value,
                 display_context=display_context,
-                input_id=self.subworkflow_input_ids_by_name.get(variable_name),
+                input_id=self.node_input_ids_by_name.get(variable_name),
             )
             for variable_name, variable_value in subworkflow_inputs.items()
         ]


### PR DESCRIPTION
Before we were using `subworkflow_input_ids_by_name: ClassVar[Dict[str, UUID]] ` in subworkflow deployment serialization but this field was never codegen'd. Now we use `node_input_ids_by_name` field to look up the id for the input given name