### PR TITLE
Reuse new node port factory in generic node factory

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1342,7 +1342,7 @@ export function errorNodeDataFactory({
   };
 }
 
-export function nodePortFactory(port: Partial<NodePort>): NodePort {
+export function nodePortFactory(port: Partial<NodePort> = {}): NodePort {
   const portType = port.type ?? "DEFAULT";
   const portId = port.id ?? uuidv4();
   const portName = port.name ?? `${portType.toLowerCase()}_port`;
@@ -1406,13 +1406,7 @@ export function genericNodeFactory(
       id: "trigger-1",
       mergeBehavior: "AWAIT_ALL",
     },
-    ports: nodePorts ?? [
-      {
-        type: "DEFAULT",
-        id: "port-1",
-        name: "default-port",
-      },
-    ],
+    ports: nodePorts ?? [nodePortFactory()],
     attributes: nodeAttributes ?? [
       {
         id: "attr-1",


### PR DESCRIPTION
Context: https://github.com/vellum-ai/vellum-python-sdks/pull/818