### PR TITLE
Generic node factory should default to random uuid

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1374,6 +1374,7 @@ export function nodePortFactory(port: Partial<NodePort> = {}): NodePort {
 
 export function genericNodeFactory(
   {
+    id,
     name,
     nodeTrigger,
     nodePorts,
@@ -1381,6 +1382,7 @@ export function genericNodeFactory(
     nodeOutputs,
     adornments,
   }: {
+    id?: string;
     name: string;
     nodeTrigger?: NodeTrigger;
     nodePorts?: NodePort[];
@@ -1392,7 +1394,7 @@ export function genericNodeFactory(
   }
 ): GenericNode {
   const nodeData: GenericNode = {
-    id: "node-1",
+    id: id ?? uuidv4(),
     type: WorkflowNodeType.GENERIC,
     base: {
       module: ["vellum", "workflows", "nodes", "bases", "base"],


### PR DESCRIPTION
Graph attribute and other tests with multiple nodes become easier with random node id generation so that our node context validation doesn't get triggered. We only want hard coded values during display tests, which we could pass in there.