### PR TITLE
Define a test creating an edge between two generic nodes

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -183,6 +183,11 @@ exports[`Workflow > graph > should define nested sets of nodes without compilati
 "
 `;
 
+exports[`Workflow > graph > should handle a simple edge of generic nodes 1`] = `
+"StartNode >> EndNode
+"
+`;
+
 exports[`Workflow > graph > should show errors for a node pointing to non-existent node 1`] = `
 "TemplatingNode
 "

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -10,6 +10,7 @@ import {
   conditionalNodeFactory,
   entrypointNodeDataFactory,
   finalOutputNodeFactory,
+  genericNodeFactory,
   mergeNodeDataFactory,
   templatingNodeFactory,
 } from "./helpers/node-data-factories";
@@ -668,6 +669,21 @@ describe("Workflow", () => {
         [bottomLeftNode, topRightNode],
         [topLeftNode, bottomRightNode],
         [bottomLeftNode, bottomRightNode],
+      ]);
+    });
+
+    it.skip("should handle a simple edge of generic nodes", async () => {
+      const startNode = genericNodeFactory({
+        name: "StartNode",
+      });
+
+      const endNode = genericNodeFactory({
+        name: "EndNode",
+      });
+
+      await runGraphTest([
+        [entrypointNode, startNode],
+        [startNode, endNode],
       ]);
     });
   });


### PR DESCRIPTION
Discovered that we don't support edges between generic nodes yet (!!)

This PR creates the test, will resolve it on the next PR