### PR TITLE
Fix test surrounding multiple nodes pointing to nested set of conditional ports

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -176,16 +176,14 @@ exports[`Workflow > graph > should be correct for two branches merging from sets
 
 exports[`Workflow > graph > should be pointing to the correct terminal nodes from a nested set of conditionals 1`] = `
 "{
-    FirstCheckNode.Ports.if_port 
-    >> FirstInnerCheckNode 
-    >> SecondInnerCheckNode
-    >> FinalCheckNode,
-    FirstCheckNode.Ports.else_port
-    >> {
+    FirstCheckNode.Ports.if_port >> FirstInnerCheckNode >> SecondInnerCheckNode,
+    FirstCheckNode.Ports.else_port,
+} >> Graph.from_set(
+    {
         FinalCheckNode.Ports.if_port >> InnerTerminalNode,
         FinalCheckNode.Ports.else_port >> OuterOutputNode,
-    },
-}
+    }
+)
 "
 `;
 

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -688,7 +688,7 @@ describe("Workflow", () => {
       ]);
     });
 
-    it.skip("should be pointing to the correct terminal nodes from a nested set of conditionals", async () => {
+    it("should be pointing to the correct terminal nodes from a nested set of conditionals", async () => {
       const firstCheckNode = genericNodeFactory({
         name: "FirstCheckNode",
         nodePorts: [
@@ -738,20 +738,6 @@ describe("Workflow", () => {
         [[finalCheckNode, "else_port"], outerOutputNode],
         [secondInnerCheckNode, finalCheckNode],
       ]);
-      /**
-       * Currently generating the following:
-{
-    FirstCheckNode.Ports.if_port >> FirstInnerCheckNode >> SecondInnerCheckNode,
-    FirstCheckNode.Ports.else_port
-    >> {
-        FinalCheckNode.Ports.if_port >> InnerTerminalNode,
-        FinalCheckNode.Ports.else_port >> OuterOutputNode,
-    },
-} >> FinalCheckNode
-       * There are two symptoms of the same issues with this graph:
-       * - Hallucinated a InnerTerminalNode >> FinalCheckNode edge
-       * - Hallucinated a OuterOutputNode >> FinalCheckNode edge
-       */
     });
   });
 });


### PR DESCRIPTION
Finally resolves a pretty intricate test case of graph generation that we weren't covering. Had to do with improper splitting of a Graph set