### PR TITLE
Make BaseNode.Outputs._node_class non-Optional

### DIFF
--- a/ee/vellum_ee/workflows/display/utils/vellum.py
+++ b/ee/vellum_ee/workflows/display/utils/vellum.py
@@ -79,10 +79,7 @@ def create_node_input_value_pointer_rule(
     if isinstance(value, OutputReference):
         if value not in display_context.global_node_output_displays:
             if issubclass(value.outputs_class, BaseNode.Outputs):
-                if value.outputs_class._node_class:
-                    raise ValueError(
-                        f"Reference to node '{value.outputs_class._node_class.__name__}' not found in graph."
-                    )
+                raise ValueError(f"Reference to node '{value.outputs_class._node_class.__name__}' not found in graph.")
 
         upstream_node, output_display = display_context.global_node_output_displays[value]
         upstream_node_display = display_context.global_node_displays[upstream_node]

--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -1,3 +1,4 @@
+from dataclasses import field
 from functools import cached_property, reduce
 import inspect
 from types import MappingProxyType
@@ -230,7 +231,7 @@ class BaseNode(Generic[StateType], metaclass=BaseNodeMeta):
     #   "Outputs" class inherits from "BaseOutputs" and do so automatically.
     #   https://app.shortcut.com/vellum/story/4008/auto-inherit-basenodeoutputs-in-outputs-classes
     class Outputs(BaseOutputs):
-        _node_class: Optional[Type["BaseNode"]] = None
+        _node_class: Type["BaseNode"] = field(init=False)
 
     class Ports(NodePorts):
         default = Port(default=True)


### PR DESCRIPTION
We set it in the metaclass, so we are guaranteed existence

Context: https://github.com/vellum-ai/vellum-python-sdks/pull/830