### PR TITLE
Flesh out fix for api node additional headers contain secrets

### DIFF
--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -136,7 +136,7 @@ describe("ApiNode", () => {
       }
     );
 
-    it.skip("should generate Workspace secrets for header values", async () => {
+    it("should generate Workspace secrets for header values", async () => {
       const workspaceSecretId = uuidv4();
       node = await createNode({
         workspaceSecrets: [{ id: workspaceSecretId, name: "test-secret" }],

--- a/ee/codegen/src/context/node-context/api-node.ts
+++ b/ee/codegen/src/context/node-context/api-node.ts
@@ -75,6 +75,15 @@ export class ApiNodeContext extends BaseNodeContext<ApiNodeType> {
     if (bearerKeyInput) {
       secrets.push(bearerKeyInput);
     }
+
+    this.nodeData.data.additionalHeaders?.forEach((header) => {
+      const headerInputValue = this.nodeData.inputs.find(
+        (input) => input.id === header.headerValueInputId
+      );
+      if (headerInputValue) {
+        secrets.push(headerInputValue);
+      }
+    });
     await Promise.all(
       secrets.map(async (input) => this.processSecretInput(input))
     );


### PR DESCRIPTION
Official support for workspace secrets within the additional headers field of api nodes