### PR TITLE
Remove secret references from integration fixtures

### DIFF
--- a/ee/codegen_integration/fixtures/simple_api_node/code/nodes/api_node.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/nodes/api_node.py
@@ -1,6 +1,5 @@
 from vellum.workflows.constants import APIRequestMethod, AuthorizationType
 from vellum.workflows.nodes.displayable import APINode
-from vellum.workflows.references import VellumSecretReference
 
 
 class ApiNode(APINode):
@@ -10,8 +9,8 @@ class ApiNode(APINode):
     method = APIRequestMethod.POST
     json = '"hii"'
     headers = {
-        "test": VellumSecretReference("cecd16a2-4de5-444d-acff-37a5c400600c"),
-        "nom": VellumSecretReference("cecd16a2-4de5-444d-acff-37a5c400600c"),
+        "test": "test-value",
+        "nom": "nom-value",
     }
     api_key_header_key = "nice-key"
     authorization_type = AuthorizationType.API_KEY

--- a/ee/codegen_integration/fixtures/simple_api_node/display_data/simple_api_node.json
+++ b/ee/codegen_integration/fixtures/simple_api_node/display_data/simple_api_node.json
@@ -184,10 +184,10 @@
             "value": {
               "rules": [
                 {
-                  "type": "WORKSPACE_SECRET",
+                  "type": "CONSTANT_VALUE",
                   "data": {
                     "type": "STRING",
-                    "workspace_secret_id": "cecd16a2-4de5-444d-acff-37a5c400600c"
+                    "value": "test-value"
                   }
                 }
               ],
@@ -216,10 +216,10 @@
             "value": {
               "rules": [
                 {
-                  "type": "WORKSPACE_SECRET",
+                  "type": "CONSTANT_VALUE",
                   "data": {
                     "type": "STRING",
-                    "workspace_secret_id": "cecd16a2-4de5-444d-acff-37a5c400600c"
+                    "value": "nom-value"
                   }
                 }
               ],


### PR DESCRIPTION
Causing a test failure here: https://github.com/vellum-ai/vellum-python-sdks/pull/new/vargas/remove-secrets-from-integration

Not worth adding mocks to specific tests based on how these integration fixtures are setup. So just simply replacing the secret references with hard coded strings