### PR TITLE
Split out GraphAttribute.isPlural

### DIFF
--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -96,13 +96,6 @@ export class GraphAttribute extends AstNode {
         continue;
       }
 
-      const isPlural = (mutableAst: GraphMutableAst): boolean => {
-        return (
-          mutableAst.type === "right_shift" ||
-          (mutableAst.type === "set" && mutableAst.values.every(isPlural))
-        );
-      };
-
       const getAstSources = (
         mutableAst: GraphMutableAst
       ): GraphPortReference[] => {
@@ -289,7 +282,7 @@ export class GraphAttribute extends AstNode {
               type: "set",
               values: [mutableAst, newLhs],
             };
-            if (isPlural(newSetAst)) {
+            if (this.isPlural(newSetAst)) {
               const newAstSources = newSetAst.values.flatMap((value) =>
                 getAstSources(value)
               );
@@ -441,6 +434,16 @@ export class GraphAttribute extends AstNode {
       };
     }
     return;
+  }
+
+  /**
+   * Checks if the AST contains an edge. We consider a `set` to be plural if all of its members are plural.
+   */
+  private isPlural(mutableAst: GraphMutableAst): boolean {
+    return (
+      mutableAst.type === "right_shift" ||
+      (mutableAst.type === "set" && mutableAst.values.every(this.isPlural))
+    );
   }
 
   /**


### PR DESCRIPTION
Context: https://github.com/vellum-ai/vellum-python-sdks/pull/847

Turns out in order to refactor addEdgeToRightShift, we first need to split out all of the nested functions within the main generator method