### PR TITLE
Unskip test to show non-optimal, yet valid graph

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -2,11 +2,16 @@
 
 exports[`Workflow > graph > Should handle an else case within a conditioned set 1`] = `
 "{
-    FirstCheckNode.Ports.if_port >> {
-        SecondInnerCheckNode.Ports.if_port >> FirstOutputNode,
+    {
+        FirstCheckNode.Ports.if_port >> SecondInnerCheckNode.Ports.if_port,
+        FirstCheckNode.Ports.else_port,
+    }
+    >> FirstOutputNode,
+    FirstCheckNode.Ports.if_port
+    >> {
+        SecondInnerCheckNode.Ports.if_port,
         SecondInnerCheckNode.Ports.else_port >> SecondOutputNode,
     },
-    FirstCheckNode.Ports.else_port >> FirstOutputNode,
 }
 "
 `;

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -787,7 +787,7 @@ describe("Workflow", () => {
         */
     });
 
-    it.skip("Should handle an else case within a conditioned set", async () => {
+    it("Should handle an else case within a conditioned set", async () => {
       const firstCheckNode = genericNodeFactory({
         name: "FirstCheckNode",
         nodePorts: nodePortsFactory(),
@@ -806,6 +806,16 @@ describe("Workflow", () => {
         name: "SecondOutputNode",
       });
 
+      /**
+       * This snapshot is not optimal. Ideally, we would generate:
+{
+    FirstCheckNode.Ports.if_port >> {
+        SecondInnerCheckNode.Ports.if_port >> FirstOutputNode,
+        SecondInnerCheckNode.Ports.else_port >> SecondOutputNode,
+    },
+    FirstCheckNode.Ports.else_port >> FirstOutputNode,
+}
+       */
       await runGraphTest([
         [entrypointNode, firstCheckNode],
         [[firstCheckNode, "if_port"], secondCheckNode],

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -296,8 +296,6 @@ export class GraphAttribute extends AstNode {
       return this.addEdgeToRightShift({
         edge,
         mutableAst,
-        // sourceNode,
-        // targetNode,
         graphSourceNode,
       });
     }
@@ -373,8 +371,6 @@ export class GraphAttribute extends AstNode {
    */
   private addEdgeToRightShift({
     edge,
-    // sourceNode,
-    // targetNode,
     mutableAst,
     graphSourceNode,
   }: {


### PR DESCRIPTION
I have the "optimal" solution in draft state for now: https://github.com/vellum-ai/vellum-python-sdks/pull/854

Could be quite a refactor, and I think the current approach could unblock the customer workflow in graph generating. Need to follow up this PR with adding _sdk_ support for creating an edge between a set and Graph