### PR TITLE
Run the postinstall script after adding a new version of the package

### DIFF
--- a/ee/codegen/scripts/upgrade-codegen-service.mts
+++ b/ee/codegen/scripts/upgrade-codegen-service.mts
@@ -31,6 +31,7 @@ const main = async () => {
       stdio: "inherit",
     }
   );
+  execSync(`npm run postinstall`, { stdio: "inherit" });
 
   // Generate our codegen module lookup function. If we generate all if cases instead of
   // passing in a variable version to the async imports this will cause static type checking


### PR DESCRIPTION
I learned that `postinstall` is not run automatically for individual installs, so this should resolve the latest codegen-service failure: https://github.com/vellum-ai/vellum-python-sdks/actions/runs/13101647560/job/36550650973