### PR TITLE
Fix circular dependency triggered when importing WorkflowEventDisplayContext

### DIFF
--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -14,11 +14,10 @@ from vellum_ee.workflows.display.base import (
     WorkflowMetaDisplayType,
     WorkflowOutputDisplayType,
 )
-from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
-from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
+    from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay
     from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 NodeDisplayType = TypeVar("NodeDisplayType", bound="BaseNodeDisplay")
@@ -63,32 +62,3 @@ class WorkflowDisplayContext(
     workflow_output_displays: Dict[BaseDescriptor, WorkflowOutputDisplayType] = field(default_factory=dict)
     edge_displays: Dict[Tuple[Port, Type[BaseNode]], EdgeDisplayType] = field(default_factory=dict)
     port_displays: Dict[Port, "PortDisplay"] = field(default_factory=dict)
-
-    def build_event_display_context(self) -> WorkflowEventDisplayContext:
-        workflow_outputs = {
-            output.name: self.workflow_output_displays[output].id for output in self.workflow_output_displays
-        }
-        workflow_inputs = {input.name: self.workflow_input_displays[input].id for input in self.workflow_input_displays}
-        node_displays = {str(node.__id__): self.node_displays[node] for node in self.node_displays}
-        temp_node_displays = {}
-        for node in node_displays:
-            current_node = node_displays[node]
-            input_display = {}
-            if issubclass(current_node.__class__, BaseNodeVellumDisplay):
-                input_display = current_node.node_input_ids_by_name  # type: ignore[attr-defined]
-            node_display_meta = {
-                output.name: current_node.output_display[output].id for output in current_node.output_display
-            }
-            port_display_meta = {port.name: current_node.port_displays[port].id for port in current_node.port_displays}
-
-            temp_node_displays[node] = NodeDisplay(
-                input_display=input_display,
-                output_display=node_display_meta,
-                port_display=port_display_meta,
-            )
-        display_meta = WorkflowEventDisplayContext(
-            workflow_outputs=workflow_outputs,
-            workflow_inputs=workflow_inputs,
-            node_displays=temp_node_displays,
-        )
-        return display_meta

--- a/ee/vellum_ee/workflows/tests/test_server.py
+++ b/ee/vellum_ee/workflows/tests/test_server.py
@@ -1,0 +1,9 @@
+from vellum.client.core.pydantic_utilities import UniversalBaseModel
+
+
+def test_load_workflow_event_display_context():
+    from vellum_ee.workflows.display.types import WorkflowEventDisplayContext
+
+    # We are actually just ensuring there are no circular dependencies when
+    # our Workflow Server imports this class.
+    assert issubclass(WorkflowEventDisplayContext, UniversalBaseModel)


### PR DESCRIPTION
I was making some Workflow Server changes when I kept hitting this running tests locally:

![Screenshot 2025-02-03 at 3 44 19 PM](https://github.com/user-attachments/assets/3528e65c-7551-4e6d-9f94-f07c66e5d567)

Not sure why this is not affecting us in prod. But in any case, repro'd the import error with a test and solved by moving a method
