### PR TITLE
[Part 1] Plumb Through Node Contexts

### DIFF
--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/constant-value-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/constant-value-pointer.test.ts
@@ -1,15 +1,15 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
-import { workflowContextFactory } from "src/__test__/helpers";
-import { WorkflowContext } from "src/context";
+import { nodeContextFactory } from "src/__test__/helpers";
+import { BaseNodeContext } from "src/context/node-context/base";
 import { ConstantValuePointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/constant-value-pointer";
-import { ConstantValuePointer } from "src/types/vellum";
+import { ConstantValuePointer, WorkflowDataNode } from "src/types/vellum";
 
 describe("ConstantValuePointer", () => {
-  let workflowContext: WorkflowContext;
+  let nodeContext: BaseNodeContext<WorkflowDataNode>;
 
-  beforeEach(() => {
-    workflowContext = workflowContextFactory();
+  beforeEach(async () => {
+    nodeContext = await nodeContextFactory();
   });
 
   it("should generate correct AST for STRING constant value", async () => {
@@ -22,7 +22,7 @@ describe("ConstantValuePointer", () => {
     };
 
     const rule = new ConstantValuePointerRule({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerRule: constantValuePointer,
     });
 

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.test.ts
@@ -29,10 +29,13 @@ describe("ExecutionCounterPointer", () => {
     const workflowContext = workflowContextFactory();
 
     const node = searchNodeDataFactory();
-    await nodeContextFactory({ workflowContext, nodeData: node });
+    const nodeContext = await nodeContextFactory({
+      workflowContext,
+      nodeData: node,
+    });
 
     const executionCounterPointer = new ExecutionCounterPointerRule({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerRule: {
         type: "EXECUTION_COUNTER",
         data: {

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/input-variable-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/input-variable-pointer.test.ts
@@ -1,6 +1,9 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
-import { workflowContextFactory } from "src/__test__/helpers";
+import {
+  nodeContextFactory,
+  workflowContextFactory,
+} from "src/__test__/helpers";
 import { inputVariableContextFactory } from "src/__test__/helpers/input-variable-context-factory";
 import { InputVariablePointerRule } from "src/generators/node-inputs";
 
@@ -28,8 +31,10 @@ describe("InputVariablePointer", () => {
       })
     );
 
+    const nodeContext = await nodeContextFactory({ workflowContext });
+
     const inputVariablePointer = new InputVariablePointerRule({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerRule: {
         type: "INPUT_VARIABLE",
         data: {
@@ -45,9 +50,10 @@ describe("InputVariablePointer", () => {
 
   it("should handle when it's referencing an input variable that no longer exists", async () => {
     const workflowContext = workflowContextFactory();
+    const nodeContext = await nodeContextFactory({ workflowContext });
 
     const inputVariablePointer = new InputVariablePointerRule({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerRule: {
         type: "INPUT_VARIABLE",
         data: {

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.test.ts
@@ -1,6 +1,9 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
-import { workflowContextFactory } from "src/__test__/helpers";
+import {
+  nodeContextFactory,
+  workflowContextFactory,
+} from "src/__test__/helpers";
 import { inputVariableContextFactory } from "src/__test__/helpers/input-variable-context-factory";
 import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
@@ -13,10 +16,12 @@ import {
 describe("NodeInputValuePointerRule", () => {
   let writer: Writer;
   let workflowContext: WorkflowContext;
+  let nodeContext: BaseNodeContext<WorkflowDataNode>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     writer = new Writer();
     workflowContext = workflowContextFactory();
+    nodeContext = await nodeContextFactory({ workflowContext });
   });
 
   it("should generate correct AST for CONSTANT_VALUE pointer", async () => {
@@ -29,7 +34,7 @@ describe("NodeInputValuePointerRule", () => {
     };
 
     const rule = new NodeInputValuePointerRule({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerRuleData: constantValuePointer,
     });
 
@@ -38,7 +43,7 @@ describe("NodeInputValuePointerRule", () => {
   });
 
   it("should generate correct AST for NODE_OUTPUT pointer", async () => {
-    vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
+    vi.spyOn(nodeContext.workflowContext, "getNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
       getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),
@@ -53,7 +58,7 @@ describe("NodeInputValuePointerRule", () => {
     };
 
     const rule = new NodeInputValuePointerRule({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerRuleData: nodeOutputPointer,
     });
 
@@ -81,7 +86,7 @@ describe("NodeInputValuePointerRule", () => {
     };
 
     const rule = new NodeInputValuePointerRule({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerRuleData: inputVariablePointer,
     });
 

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-output-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-output-pointer.test.ts
@@ -1,6 +1,9 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
-import { workflowContextFactory } from "src/__test__/helpers";
+import {
+  nodeContextFactory,
+  workflowContextFactory,
+} from "src/__test__/helpers";
 import { BaseNodeContext } from "src/context/node-context/base";
 import { NodeOutputPointerRule } from "src/generators/node-inputs";
 import { WorkflowDataNode } from "src/types/vellum";
@@ -24,8 +27,10 @@ describe("NodeOutputPointer", () => {
       getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),
     } as unknown as BaseNodeContext<WorkflowDataNode>);
 
+    const nodeContext = await nodeContextFactory({ workflowContext });
+
     const nodeOutputPointer = new NodeOutputPointerRule({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerRule: {
         type: "NODE_OUTPUT",
         data: {

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.test.ts
@@ -1,13 +1,17 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
-import { workflowContextFactory } from "src/__test__/helpers";
+import { nodeContextFactory } from "src/__test__/helpers";
+import { BaseNodeContext } from "src/context/node-context/base";
 import { WorkspaceSecretPointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer";
+import { WorkflowDataNode } from "src/types/vellum";
 
 describe("WorkspaceSecretPointer", () => {
   let writer: Writer;
+  let nodeContext: BaseNodeContext<WorkflowDataNode>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     writer = new Writer();
+    nodeContext = await nodeContextFactory();
   });
 
   afterEach(() => {
@@ -15,10 +19,8 @@ describe("WorkspaceSecretPointer", () => {
   });
 
   it("should generate correct Python code", async () => {
-    const workflowContext = workflowContextFactory();
-
     const workspaceSecretPointer = new WorkspaceSecretPointerRule({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerRule: {
         type: "WORKSPACE_SECRET",
         data: {
@@ -33,10 +35,8 @@ describe("WorkspaceSecretPointer", () => {
   });
 
   it("should handle the the case where the workspace secret isn't yet specified", async () => {
-    const workflowContext = workflowContextFactory();
-
     const workspaceSecretPointer = new WorkspaceSecretPointerRule({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerRule: {
         type: "WORKSPACE_SECRET",
         data: {

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer.test.ts
@@ -1,7 +1,10 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
 import { describe, it, expect, beforeEach } from "vitest";
 
-import { workflowContextFactory } from "src/__test__/helpers";
+import {
+  nodeContextFactory,
+  workflowContextFactory,
+} from "src/__test__/helpers";
 import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
 import { NodeInputValuePointer } from "src/generators/node-inputs/node-input-value-pointer";
@@ -11,12 +14,14 @@ import {
 } from "src/types/vellum";
 
 describe("NodeInputValuePointer", () => {
-  let workflowContext: WorkflowContext;
   let writer: Writer;
+  let workflowContext: WorkflowContext;
+  let nodeContext: BaseNodeContext<WorkflowDataNode>;
 
-  beforeEach(() => {
-    workflowContext = workflowContextFactory();
+  beforeEach(async () => {
     writer = new Writer();
+    workflowContext = workflowContextFactory();
+    nodeContext = await nodeContextFactory({ workflowContext });
   });
 
   it("should handle a single constant value rule", async () => {
@@ -34,7 +39,7 @@ describe("NodeInputValuePointer", () => {
     };
 
     const nodeInputValuePointer = new NodeInputValuePointer({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerData,
     });
 
@@ -44,7 +49,7 @@ describe("NodeInputValuePointer", () => {
   });
 
   it("should handle three node output pointer rules", async () => {
-    vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
+    vi.spyOn(nodeContext.workflowContext, "getNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
       getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),
@@ -78,7 +83,7 @@ describe("NodeInputValuePointer", () => {
     };
 
     const nodeInputValuePointer = new NodeInputValuePointer({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerData,
     });
 
@@ -88,7 +93,7 @@ describe("NodeInputValuePointer", () => {
   });
 
   it("should handle two node output pointers and one constant value", async () => {
-    vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
+    vi.spyOn(nodeContext.workflowContext, "getNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
       getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),
@@ -122,7 +127,7 @@ describe("NodeInputValuePointer", () => {
     };
 
     const nodeInputValuePointer = new NodeInputValuePointer({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerData,
     });
 
@@ -132,7 +137,7 @@ describe("NodeInputValuePointer", () => {
   });
 
   it("should handle two node output pointers with a constant value in between", async () => {
-    vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
+    vi.spyOn(nodeContext.workflowContext, "getNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
       getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),
@@ -166,7 +171,7 @@ describe("NodeInputValuePointer", () => {
     };
 
     const nodeInputValuePointer = new NodeInputValuePointer({
-      workflowContext: workflowContext,
+      nodeContext,
       nodeInputValuePointerData,
     });
 

--- a/ee/codegen/src/__test__/node-inputs/node-input.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input.test.ts
@@ -1,17 +1,23 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
-import { workflowContextFactory } from "src/__test__/helpers";
+import {
+  nodeContextFactory,
+  workflowContextFactory,
+} from "src/__test__/helpers";
 import * as codegen from "src/codegen";
 import { WorkflowContext } from "src/context";
-import { NodeInput as NodeInputType } from "src/types/vellum";
+import { BaseNodeContext } from "src/context/node-context/base";
+import { NodeInput as NodeInputType, WorkflowDataNode } from "src/types/vellum";
 
 describe("NodeInput", () => {
   let writer: Writer;
   let workflowContext: WorkflowContext;
+  let nodeContext: BaseNodeContext<WorkflowDataNode>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     writer = new Writer();
     workflowContext = workflowContextFactory();
+    nodeContext = await nodeContextFactory({ workflowContext });
   });
 
   it("should generate correct Python code", async () => {
@@ -33,7 +39,8 @@ describe("NodeInput", () => {
     };
 
     const nodeInput = codegen.nodeInput({
-      workflowContext: workflowContext,
+      nodeContext,
+      workflowContext,
       nodeInputData,
     });
 

--- a/ee/codegen/src/__test__/node-inputs/node-input.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input.test.ts
@@ -1,23 +1,17 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
-import {
-  nodeContextFactory,
-  workflowContextFactory,
-} from "src/__test__/helpers";
+import { nodeContextFactory } from "src/__test__/helpers";
 import * as codegen from "src/codegen";
-import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
 import { NodeInput as NodeInputType, WorkflowDataNode } from "src/types/vellum";
 
 describe("NodeInput", () => {
   let writer: Writer;
-  let workflowContext: WorkflowContext;
   let nodeContext: BaseNodeContext<WorkflowDataNode>;
 
   beforeEach(async () => {
     writer = new Writer();
-    workflowContext = workflowContextFactory();
-    nodeContext = await nodeContextFactory({ workflowContext });
+    nodeContext = await nodeContextFactory();
   });
 
   it("should generate correct Python code", async () => {
@@ -40,7 +34,6 @@ describe("NodeInput", () => {
 
     const nodeInput = codegen.nodeInput({
       nodeContext,
-      workflowContext,
       nodeInputData,
     });
 

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -17,7 +17,7 @@ export declare namespace BaseNodeContext {
 }
 
 export abstract class BaseNodeContext<T extends WorkflowDataNode> {
-  protected workflowContext: WorkflowContext;
+  public readonly workflowContext: WorkflowContext;
   public readonly nodeModulePath: string[];
   public readonly nodeModuleName: string;
   public readonly nodeFileName: string;

--- a/ee/codegen/src/generators/conditional-node-port.ts
+++ b/ee/codegen/src/generators/conditional-node-port.ts
@@ -203,7 +203,6 @@ export class ConditionalNodePort extends AstNode {
           },
         };
         rhs = codegen.nodeInput({
-          workflowContext: this.portContext.workflowContext,
           nodeContext: this.portContext.nodeContext,
           nodeInputData: castedRhs,
         });

--- a/ee/codegen/src/generators/conditional-node-port.ts
+++ b/ee/codegen/src/generators/conditional-node-port.ts
@@ -204,6 +204,7 @@ export class ConditionalNodePort extends AstNode {
         };
         rhs = codegen.nodeInput({
           workflowContext: this.portContext.workflowContext,
+          nodeContext: this.portContext.nodeContext,
           nodeInputData: castedRhs,
         });
       }

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/base.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/base.ts
@@ -2,14 +2,16 @@ import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { WorkflowContext } from "src/context";
+import { BaseNodeContext } from "src/context/node-context/base";
 import {
   IterableConfig,
   NodeInputValuePointerRule as NodeInputValuePointerRuleType,
+  WorkflowDataNode,
 } from "src/types/vellum";
 
 export declare namespace BaseNodeInputValuePointerRule {
   export interface Args<T extends NodeInputValuePointerRuleType> {
-    workflowContext: WorkflowContext;
+    nodeContext: BaseNodeContext<WorkflowDataNode>;
     nodeInputValuePointerRule: T;
     iterableConfig?: IterableConfig;
   }
@@ -18,18 +20,20 @@ export declare namespace BaseNodeInputValuePointerRule {
 export abstract class BaseNodeInputValuePointerRule<
   T extends NodeInputValuePointerRuleType
 > extends AstNode {
+  private readonly nodeContext: BaseNodeContext<WorkflowDataNode>;
   public readonly workflowContext: WorkflowContext;
   public readonly nodeInputValuePointerRule: T;
   public readonly iterableConfig?: IterableConfig;
   private astNode: AstNode | undefined;
 
   constructor({
-    workflowContext,
+    nodeContext,
     nodeInputValuePointerRule,
     iterableConfig,
   }: BaseNodeInputValuePointerRule.Args<T>) {
     super();
-    this.workflowContext = workflowContext;
+    this.nodeContext = nodeContext;
+    this.workflowContext = nodeContext.workflowContext;
     this.iterableConfig = iterableConfig;
     this.nodeInputValuePointerRule = nodeInputValuePointerRule;
 

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/constant-value-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/constant-value-pointer.ts
@@ -1,13 +1,17 @@
 import { BaseNodeInputValuePointerRule } from "./base";
 
 import * as codegen from "src/codegen";
-import { WorkflowContext } from "src/context";
+import { BaseNodeContext } from "src/context/node-context/base";
 import { VellumValue } from "src/generators";
-import { ConstantValuePointer, IterableConfig } from "src/types/vellum";
+import {
+  ConstantValuePointer,
+  IterableConfig,
+  WorkflowDataNode,
+} from "src/types/vellum";
 
 export declare namespace ConstantValuePointerRule {
   interface Args {
-    workflowContext: WorkflowContext;
+    nodeContext: BaseNodeContext<WorkflowDataNode>;
     nodeInputValuePointerRule: ConstantValuePointer;
     iterableConfig?: IterableConfig;
   }

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.ts
@@ -6,25 +6,26 @@ import { ConstantValuePointerRule } from "./constant-value-pointer";
 import { InputVariablePointerRule } from "./input-variable-pointer";
 import { NodeOutputPointerRule } from "./node-output-pointer";
 
-import { WorkflowContext } from "src/context";
+import { BaseNodeContext } from "src/context/node-context/base";
 import { ExecutionCounterPointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/execution-counter-pointer";
 import { WorkspaceSecretPointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer";
 import {
   IterableConfig,
   NodeInputValuePointerRule as NodeInputValuePointerRuleType,
+  WorkflowDataNode,
 } from "src/types/vellum";
 import { assertUnreachable } from "src/utils/typing";
 
 export declare namespace NodeInputValuePointerRule {
   export interface Args {
-    workflowContext: WorkflowContext;
+    nodeContext: BaseNodeContext<WorkflowDataNode>;
     nodeInputValuePointerRuleData: NodeInputValuePointerRuleType;
     iterableConfig?: IterableConfig;
   }
 }
 
 export class NodeInputValuePointerRule extends AstNode {
-  private workflowContext: WorkflowContext;
+  private nodeContext: BaseNodeContext<WorkflowDataNode>;
   public astNode:
     | BaseNodeInputValuePointerRule<NodeInputValuePointerRuleType>
     | undefined;
@@ -33,7 +34,7 @@ export class NodeInputValuePointerRule extends AstNode {
 
   public constructor(args: NodeInputValuePointerRule.Args) {
     super();
-    this.workflowContext = args.workflowContext;
+    this.nodeContext = args.nodeContext;
     this.ruleType = args.nodeInputValuePointerRuleData.type;
     this.iterableConfig = args.iterableConfig;
 
@@ -51,13 +52,13 @@ export class NodeInputValuePointerRule extends AstNode {
     switch (ruleType) {
       case "CONSTANT_VALUE":
         return new ConstantValuePointerRule({
-          workflowContext: this.workflowContext,
+          nodeContext: this.nodeContext,
           nodeInputValuePointerRule: nodeInputValuePointerRuleData,
           iterableConfig: this.iterableConfig,
         });
       case "NODE_OUTPUT": {
         const rule = new NodeOutputPointerRule({
-          workflowContext: this.workflowContext,
+          nodeContext: this.nodeContext,
           nodeInputValuePointerRule: nodeInputValuePointerRuleData,
         });
         if (rule.getAstNode()) {
@@ -68,17 +69,17 @@ export class NodeInputValuePointerRule extends AstNode {
       }
       case "INPUT_VARIABLE":
         return new InputVariablePointerRule({
-          workflowContext: this.workflowContext,
+          nodeContext: this.nodeContext,
           nodeInputValuePointerRule: nodeInputValuePointerRuleData,
         });
       case "WORKSPACE_SECRET":
         return new WorkspaceSecretPointerRule({
-          workflowContext: this.workflowContext,
+          nodeContext: this.nodeContext,
           nodeInputValuePointerRule: nodeInputValuePointerRuleData,
         });
       case "EXECUTION_COUNTER":
         return new ExecutionCounterPointerRule({
-          workflowContext: this.workflowContext,
+          nodeContext: this.nodeContext,
           nodeInputValuePointerRule: nodeInputValuePointerRuleData,
         });
       default: {

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer.ts
@@ -4,25 +4,28 @@ import { isNil } from "lodash";
 
 import { NodeInputValuePointerRule } from "./node-input-value-pointer-rules/node-input-value-pointer-rule";
 
-import { WorkflowContext } from "src/context";
-import { NodeInputValuePointer as NodeInputValuePointerType } from "src/types/vellum";
+import { BaseNodeContext } from "src/context/node-context/base";
+import {
+  NodeInputValuePointer as NodeInputValuePointerType,
+  WorkflowDataNode,
+} from "src/types/vellum";
 
 export declare namespace NodeInputValuePointer {
   export interface Args {
-    workflowContext: WorkflowContext;
+    nodeContext: BaseNodeContext<WorkflowDataNode>;
     nodeInputValuePointerData: NodeInputValuePointerType;
   }
 }
 
 export class NodeInputValuePointer extends AstNode {
-  private workflowContext: WorkflowContext;
+  private nodeContext: BaseNodeContext<WorkflowDataNode>;
   private nodeInputValuePointerData: NodeInputValuePointerType;
   public rules: NodeInputValuePointerRule[];
 
   public constructor(args: NodeInputValuePointer.Args) {
     super();
 
-    this.workflowContext = args.workflowContext;
+    this.nodeContext = args.nodeContext;
     this.nodeInputValuePointerData = args.nodeInputValuePointerData;
 
     this.rules = this.generateRules();
@@ -32,7 +35,7 @@ export class NodeInputValuePointer extends AstNode {
     return this.nodeInputValuePointerData.rules
       .map((ruleData) => {
         const rule = new NodeInputValuePointerRule({
-          workflowContext: this.workflowContext,
+          nodeContext: this.nodeContext,
           nodeInputValuePointerRuleData: ruleData,
         });
         if (rule.astNode) {

--- a/ee/codegen/src/generators/node-inputs/node-input.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input.ts
@@ -3,21 +3,18 @@ import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { NodeInputValuePointer } from "./node-input-value-pointer";
 
-import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
 import { NodeInput as NodeInputType, WorkflowDataNode } from "src/types/vellum";
 
 export declare namespace NodeInput {
   export interface Args {
     nodeContext: BaseNodeContext<WorkflowDataNode>;
-    workflowContext: WorkflowContext;
     nodeInputData: NodeInputType;
   }
 }
 
 export class NodeInput extends AstNode {
   private nodeContext: BaseNodeContext<WorkflowDataNode>;
-  private workflowContext: WorkflowContext;
   public nodeInputData: NodeInputType;
   public nodeInputValuePointer: NodeInputValuePointer;
 
@@ -25,7 +22,6 @@ export class NodeInput extends AstNode {
     super();
 
     this.nodeContext = args.nodeContext;
-    this.workflowContext = args.workflowContext;
     this.nodeInputData = args.nodeInputData;
 
     this.nodeInputValuePointer = this.generateNodeInputValuePointer();
@@ -33,7 +29,7 @@ export class NodeInput extends AstNode {
 
   private generateNodeInputValuePointer(): NodeInputValuePointer {
     const nodeInputValuePointer = new NodeInputValuePointer({
-      workflowContext: this.workflowContext,
+      nodeContext: this.nodeContext,
       nodeInputValuePointerData: this.nodeInputData.value,
     });
     this.inheritReferences(nodeInputValuePointer);

--- a/ee/codegen/src/generators/node-inputs/node-input.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input.ts
@@ -4,23 +4,27 @@ import { Writer } from "@fern-api/python-ast/core/Writer";
 import { NodeInputValuePointer } from "./node-input-value-pointer";
 
 import { WorkflowContext } from "src/context";
-import { NodeInput as NodeInputType } from "src/types/vellum";
+import { BaseNodeContext } from "src/context/node-context/base";
+import { NodeInput as NodeInputType, WorkflowDataNode } from "src/types/vellum";
 
 export declare namespace NodeInput {
   export interface Args {
+    nodeContext: BaseNodeContext<WorkflowDataNode>;
     workflowContext: WorkflowContext;
     nodeInputData: NodeInputType;
   }
 }
 
 export class NodeInput extends AstNode {
+  private nodeContext: BaseNodeContext<WorkflowDataNode>;
   private workflowContext: WorkflowContext;
-  nodeInputData: NodeInputType;
+  public nodeInputData: NodeInputType;
   public nodeInputValuePointer: NodeInputValuePointer;
 
   public constructor(args: NodeInput.Args) {
     super();
 
+    this.nodeContext = args.nodeContext;
     this.workflowContext = args.workflowContext;
     this.nodeInputData = args.nodeInputData;
 

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -65,12 +65,10 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
               }
               const key = new NodeInput({
                 nodeContext: this.nodeContext,
-                workflowContext: this.workflowContext,
                 nodeInputData: keyInput,
               });
               const value = new NodeInput({
                 nodeContext: this.nodeContext,
-                workflowContext: this.workflowContext,
                 nodeInputData: valueInput,
               });
 
@@ -289,7 +287,6 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
               }
               const key = new NodeInput({
                 nodeContext: this.nodeContext,
-                workflowContext: this.workflowContext,
                 nodeInputData: nodeInput,
               });
 
@@ -320,7 +317,6 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
               }
               const key = new NodeInput({
                 nodeContext: this.nodeContext,
-                workflowContext: this.workflowContext,
                 nodeInputData: nodeInput,
               });
 

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -64,10 +64,12 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
                 );
               }
               const key = new NodeInput({
+                nodeContext: this.nodeContext,
                 workflowContext: this.workflowContext,
                 nodeInputData: keyInput,
               });
               const value = new NodeInput({
+                nodeContext: this.nodeContext,
                 workflowContext: this.workflowContext,
                 nodeInputData: valueInput,
               });
@@ -286,6 +288,7 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
                 );
               }
               const key = new NodeInput({
+                nodeContext: this.nodeContext,
                 workflowContext: this.workflowContext,
                 nodeInputData: nodeInput,
               });
@@ -316,6 +319,7 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
                 );
               }
               const key = new NodeInput({
+                nodeContext: this.nodeContext,
                 workflowContext: this.workflowContext,
                 nodeInputData: nodeInput,
               });

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -157,7 +157,6 @@ export abstract class BaseNode<
       try {
         const nodeInput = codegen.nodeInput({
           nodeContext: this.nodeContext,
-          workflowContext: this.workflowContext,
           nodeInputData,
         });
 

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -156,6 +156,7 @@ export abstract class BaseNode<
     this.nodeData.inputs.forEach((nodeInputData) => {
       try {
         const nodeInput = codegen.nodeInput({
+          nodeContext: this.nodeContext,
           workflowContext: this.workflowContext,
           nodeInputData,
         });


### PR DESCRIPTION
In order to support `LazyReference`, we need to know which node we're currently operating on. For this, we need `nodeContext`.

This PR simply passes `nodeContext` everywhere we need it, and simplify the call signature by removing `workflowContext` since that can be derived from `nodeContext`.

Next Steps:
- Make use of this plumbing to actually detect self-references and use `LazyReference`
- Do the same for Workflow Value Descriptors once everything is proven out for legacy Node Inputs