### PR TITLE
[SC-6275] Make target handle id optional in workflow output vellum display override

### DIFF
--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -503,12 +503,6 @@ export class Workflow {
                       ),
                     }),
                     python.methodArgument({
-                      name: "target_handle_id",
-                      value: python.TypeInstantiation.uuid(
-                        terminalNodeData.data.targetHandleId
-                      ),
-                    }),
-                    python.methodArgument({
                       name: "display_data",
                       value: new NodeDisplayData({
                         nodeDisplayData: terminalNodeData.displayData,

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -50,7 +50,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("dad01b99-c0b4-4904-a75e-066fa947d256"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("2d005e2b-e8bb-404a-9702-8faf10c2213d"),
             display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=467, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -50,7 +50,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("5bb10d67-efc7-4bd4-9452-4ec2ffbc031d"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("ab9dd41a-5c7b-484a-bcd5-d55658ea849c"),
             display_data=NodeDisplayData(
                 position=NodeDisplayPosition(x=2392.5396121883655, y=235.35180055401668), width=480, height=234
             ),

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -53,7 +53,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("b0d2bd58-fa00-4eea-98fb-bc09ee1427dd"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("ddb7fe0e-0500-4862-8d0d-b05645283c28"),
             display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=464, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -53,7 +53,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("a9455dc7-85f5-43a9-8be7-f131bc5f08e2"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("0ef13a41-8905-45ad-9aee-09c201368981"),
             display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=458, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -44,7 +44,6 @@ class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkfl
             node_id=UUID("f3fe1e6e-5a4a-42d8-9cfe-9ecbcb935f72"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("20aa0107-742b-4662-941f-4f146b3c5565"),
             display_data=NodeDisplayData(
                 position=NodeDisplayPosition(x=2750, y=208.7778595317725), width=456, height=233
             ),

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -50,7 +50,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("075932b7-c6ba-4c3a-8c8f-d6b043f8fe48"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("abf4fec7-4053-417c-bf17-21819155d4d1"),
             display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=480, height=233),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -60,7 +60,6 @@ class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
             node_id=UUID("d9d29911-dd45-45d5-9ac8-1a06bb596c2f"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("8ff89a09-6ff0-4b02-bba7-eb8456a9c865"),
             display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=463, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -57,7 +57,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("fa0d5829-f259-4db8-a11a-b12fd7237ea5"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("8e19172a-4f87-4c21-8c91-ccdfb3e74c16"),
             display_data=NodeDisplayData(position=NodeDisplayPosition(x=864, y=58.5), width=454, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -60,7 +60,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("8a2df326-df6a-4a5e-81a3-12da082e468c"),
             display_data=NodeDisplayData(
                 position=NodeDisplayPosition(x=3434.5298476454295, y=174.57146814404433), width=480, height=234
             ),

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -50,7 +50,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("54803ff7-9afd-4eb1-bff3-242345d3443d"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("6bf50c29-d2f5-4a4f-a63b-907c9053833d"),
             display_data=NodeDisplayData(
                 position=NodeDisplayPosition(x=2761.0242006615217, y=208.9757993384785), width=474, height=234
             ),

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -50,7 +50,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("e39c8f13-d59b-49fc-8c59-03ee7997b9b6"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("77ab6d0c-7fea-441e-8e22-7afc62b3555b"),
             display_data=NodeDisplayData(
                 position=NodeDisplayPosition(x=2761.0242006615217, y=208.9757993384785), width=474, height=234
             ),

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -53,7 +53,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("ed688426-1976-4d0c-9f3a-2a0b0fae161a"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("b28439f6-0c1e-44c0-87b1-b7fa3c7408b2"),
             display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=480, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -44,7 +44,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("f0347fdc-1611-446c-b1da-408511d4181b"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("f3ad283c-d092-4973-91e0-996e5859002a"),
             display_data=NodeDisplayData(
                 position=NodeDisplayPosition(x=2752.5214681440443, y=210), width=478, height=234
             ),

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -113,8 +113,8 @@ class WorkflowOutputVellumDisplayOverrides(WorkflowOutputDisplay, WorkflowOutput
     name: str
     label: str
     node_id: UUID
-    target_handle_id: UUID
     display_data: NodeDisplayData
+    target_handle_id: Optional[UUID] = None
 
 
 @dataclass


### PR DESCRIPTION
From this comment:
https://github.com/vellum-ai/vellum-python-sdks/pull/786#discussion_r1941283637