### PR TITLE
Resolve more chat history model nonsense

### DIFF
--- a/src/vellum/workflows/nodes/displayable/bases/prompt_deployment_node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/prompt_deployment_node.py
@@ -1,6 +1,6 @@
 import json
 from uuid import UUID
-from typing import Any, ClassVar, Dict, Generic, Iterator, List, Optional, Sequence, Union, cast
+from typing import Any, ClassVar, Dict, Generic, Iterator, List, Optional, Sequence, Union
 
 from vellum import (
     ChatHistoryInputRequest,
@@ -95,10 +95,19 @@ class BasePromptDeploymentNode(BasePromptNode, Generic[StateType]):
             elif isinstance(input_value, list) and all(
                 isinstance(message, (ChatMessage, ChatMessageRequest)) for message in input_value
             ):
+                chat_history = [
+                    (
+                        message
+                        if isinstance(message, ChatMessageRequest)
+                        else ChatMessageRequest.model_validate(message.model_dump())
+                    )
+                    for message in input_value
+                    if isinstance(message, (ChatMessage, ChatMessageRequest))
+                ]
                 compiled_inputs.append(
                     ChatHistoryInputRequest(
                         name=input_name,
-                        value=cast(List[ChatMessage], input_value),
+                        value=chat_history,
                     )
                 )
             else:

--- a/src/vellum/workflows/nodes/displayable/prompt_deployment_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/prompt_deployment_node/tests/test_node.py
@@ -1,7 +1,9 @@
+import pytest
 from uuid import uuid4
 from typing import Any, Iterator, List
 
 from vellum.client.types.chat_history_input_request import ChatHistoryInputRequest
+from vellum.client.types.chat_message import ChatMessage
 from vellum.client.types.chat_message_request import ChatMessageRequest
 from vellum.client.types.execute_prompt_event import ExecutePromptEvent
 from vellum.client.types.fulfilled_execute_prompt_event import FulfilledExecutePromptEvent
@@ -11,14 +13,15 @@ from vellum.client.types.string_vellum_value import StringVellumValue
 from vellum.workflows.nodes.displayable.prompt_deployment_node.node import PromptDeploymentNode
 
 
-def test_run_node__chat_history_input(vellum_client):
+@pytest.mark.parametrize("ChatMessageClass", [ChatMessageRequest, ChatMessage])
+def test_run_node__chat_history_input(vellum_client, ChatMessageClass):
     """Confirm that we can successfully invoke a Prompt Deployment Node that uses Chat History Inputs"""
 
     # GIVEN a Prompt Deployment Node
     class ExamplePromptDeploymentNode(PromptDeploymentNode):
         deployment = "example_prompt_deployment"
         prompt_inputs = {
-            "chat_history": [ChatMessageRequest(role="USER", text="Hello, how are you?")],
+            "chat_history": [ChatMessageClass(role="USER", text="Hello, how are you?")],
         }
 
     # AND we know what the Prompt Deployment will respond with

--- a/src/vellum/workflows/nodes/displayable/subworkflow_deployment_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/subworkflow_deployment_node/node.py
@@ -72,10 +72,19 @@ class SubworkflowDeploymentNode(BaseNode[StateType], Generic[StateType]):
             elif isinstance(input_value, list) and all(
                 isinstance(message, (ChatMessage, ChatMessageRequest)) for message in input_value
             ):
+                chat_history = [
+                    (
+                        message
+                        if isinstance(message, ChatMessageRequest)
+                        else ChatMessageRequest.model_validate(message.model_dump())
+                    )
+                    for message in input_value
+                    if isinstance(message, (ChatMessage, ChatMessageRequest))
+                ]
                 compiled_inputs.append(
                     WorkflowRequestChatHistoryInputRequest(
                         name=input_name,
-                        value=cast(List[ChatMessage], input_value),
+                        value=chat_history,
                     )
                 )
             elif isinstance(input_value, dict):

--- a/src/vellum/workflows/nodes/displayable/subworkflow_deployment_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/subworkflow_deployment_node/tests/test_node.py
@@ -1,7 +1,9 @@
+import pytest
 from datetime import datetime
 from uuid import uuid4
 from typing import Any, Iterator, List
 
+from vellum.client.types.chat_message import ChatMessage
 from vellum.client.types.chat_message_request import ChatMessageRequest
 from vellum.client.types.workflow_execution_workflow_result_event import WorkflowExecutionWorkflowResultEvent
 from vellum.client.types.workflow_output_string import WorkflowOutputString
@@ -12,14 +14,15 @@ from vellum.client.types.workflow_stream_event import WorkflowStreamEvent
 from vellum.workflows.nodes.displayable.subworkflow_deployment_node.node import SubworkflowDeploymentNode
 
 
-def test_run_workflow__chat_history_input(vellum_client):
+@pytest.mark.parametrize("ChatMessageClass", [ChatMessageRequest, ChatMessage])
+def test_run_workflow__chat_history_input(vellum_client, ChatMessageClass):
     """Confirm that we can successfully invoke a Subworkflow Deployment Node that uses Chat History Inputs"""
 
     # GIVEN a Subworkflow Deployment Node
     class ExampleSubworkflowDeploymentNode(SubworkflowDeploymentNode):
         deployment = "example_subworkflow_deployment"
         subworkflow_inputs = {
-            "chat_history": [ChatMessageRequest(role="USER", text="Hello, how are you?")],
+            "chat_history": [ChatMessageClass(role="USER", text="Hello, how are you?")],
         }
 
     # AND we know what the Subworkflow Deployment will respond with


### PR DESCRIPTION
I learned two things in this saga:
- We should prioritize getting all of these `*Request` equivalent dataclasses out of our SDK soon after marketing release
- Where there's a usage of `cast`, there will eventually be a bug