### PR TITLE
[Codegen] Support for Lazy References of Nodes

### DIFF
--- a/ee/codegen/package-lock.json
+++ b/ee/codegen/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@vellum-ai/vellum-codegen",
       "version": "0.13.21",
       "dependencies": {
-        "@fern-api/python-ast": "^0.0.21",
+        "@fern-api/python-ast": "^0.0.22",
         "@fern-fern/generator-cli-sdk": "file:./stubs/generator-cli-sdk",
         "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
         "lodash": "^4.17.21",
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@fern-api/python-ast": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.21.tgz",
-      "integrity": "sha512-yDTzbaUda+WQM6+8Ced+3XcND+9ImG/a21rzR9B42qhWdGAwuFwukbCyXg0s+XWIJmmvokoBfm+WwOYvQ8ajUQ==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.22.tgz",
+      "integrity": "sha512-Yr5fe/rfCvY4E2oof4Y+pHq1qAMZjkndaXkJAk/Natkf+qBbVXZa18UfSGNBWsu3Kv8ToF71ofCWtAKgxOfHuA==",
       "dependencies": {
         "@fern-api/base-generator": "0.0.6",
         "@fern-api/core-utils": "^0.15.0-rc63",
@@ -6720,9 +6720,9 @@
       }
     },
     "@fern-api/python-ast": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.21.tgz",
-      "integrity": "sha512-yDTzbaUda+WQM6+8Ced+3XcND+9ImG/a21rzR9B42qhWdGAwuFwukbCyXg0s+XWIJmmvokoBfm+WwOYvQ8ajUQ==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@fern-api/python-ast/-/python-ast-0.0.22.tgz",
+      "integrity": "sha512-Yr5fe/rfCvY4E2oof4Y+pHq1qAMZjkndaXkJAk/Natkf+qBbVXZa18UfSGNBWsu3Kv8ToF71ofCWtAKgxOfHuA==",
       "requires": {
         "@fern-api/base-generator": "0.0.6",
         "@fern-api/core-utils": "^0.15.0-rc63",

--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -31,7 +31,7 @@
     "upgrade-codegen-service": "node --loader ts-node/esm --experimental-specifier-resolution=node  scripts/upgrade-codegen-service.mts"
   },
   "dependencies": {
-    "@fern-api/python-ast": "^0.0.21",
+    "@fern-api/python-ast": "^0.0.22",
     "@fern-fern/generator-cli-sdk": "file:./stubs/generator-cli-sdk",
     "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
     "lodash": "^4.17.21",

--- a/ee/codegen/src/generators/access-attribute.ts
+++ b/ee/codegen/src/generators/access-attribute.ts
@@ -1,0 +1,30 @@
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+import { Writer } from "@fern-api/python-ast/core/Writer";
+
+export declare namespace AccessAttribute {
+  interface Args {
+    lhs: AstNode;
+    rhs: AstNode;
+  }
+}
+
+export class AccessAttribute extends AstNode {
+  private readonly lhs: AstNode;
+  private readonly rhs: AstNode;
+
+  constructor({ lhs, rhs }: AccessAttribute.Args) {
+    super();
+
+    this.lhs = lhs;
+    this.inheritReferences(lhs);
+
+    this.rhs = rhs;
+    this.inheritReferences(rhs);
+  }
+
+  public write(writer: Writer): void {
+    this.lhs.write(writer);
+    writer.write(".");
+    this.rhs.write(writer);
+  }
+}

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/base.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/base.ts
@@ -43,6 +43,12 @@ export abstract class BaseNodeInputValuePointerRule<
     }
   }
 
+  public getReferencedNodeContext():
+    | BaseNodeContext<WorkflowDataNode>
+    | undefined {
+    return undefined;
+  }
+
   abstract getAstNode(): AstNode | undefined;
 
   public write(writer: Writer): void {

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.ts
@@ -2,15 +2,18 @@ import { python } from "@fern-api/python-ast";
 
 import { BaseNodeInputValuePointerRule } from "./base";
 
-import { ExecutionCounterPointer } from "src/types/vellum";
+import { BaseNodeContext } from "src/context/node-context/base";
+import { ExecutionCounterPointer, WorkflowDataNode } from "src/types/vellum";
 
 export class ExecutionCounterPointerRule extends BaseNodeInputValuePointerRule<ExecutionCounterPointer> {
-  getAstNode(): python.Reference {
+  getReferencedNodeContext(): BaseNodeContext<WorkflowDataNode> {
     const executionCounterData = this.nodeInputValuePointerRule.data;
 
-    const nodeContext = this.workflowContext.getNodeContext(
-      executionCounterData.nodeId
-    );
+    return this.workflowContext.getNodeContext(executionCounterData.nodeId);
+  }
+
+  getAstNode(): python.Reference {
+    const nodeContext = this.getReferencedNodeContext();
 
     return python.reference({
       name: nodeContext.nodeClassName,

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.ts
@@ -88,6 +88,12 @@ export class NodeInputValuePointerRule extends AstNode {
     }
   }
 
+  public getReferencedNodeContext():
+    | BaseNodeContext<WorkflowDataNode>
+    | undefined {
+    return this.astNode?.getReferencedNodeContext();
+  }
+
   public write(writer: Writer): void {
     if (this.astNode) {
       this.astNode.write(writer);

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
@@ -3,15 +3,22 @@ import { python } from "@fern-api/python-ast";
 import { BaseNodeInputValuePointerRule } from "./base";
 
 import { OUTPUTS_CLASS_NAME } from "src/constants";
-import { NodeOutputPointer } from "src/types/vellum";
+import { BaseNodeContext } from "src/context/node-context/base";
+import { NodeOutputPointer, WorkflowDataNode } from "src/types/vellum";
 
 export class NodeOutputPointerRule extends BaseNodeInputValuePointerRule<NodeOutputPointer> {
+  getReferencedNodeContext(): BaseNodeContext<WorkflowDataNode> {
+    const nodeOutputPointerRuleData = this.nodeInputValuePointerRule.data;
+
+    return this.workflowContext.getNodeContext(
+      nodeOutputPointerRuleData.nodeId
+    );
+  }
+
   getAstNode(): python.Reference | undefined {
     const nodeOutputPointerRuleData = this.nodeInputValuePointerRule.data;
 
-    const nodeContext = this.workflowContext.getNodeContext(
-      nodeOutputPointerRuleData.nodeId
-    );
+    const nodeContext = this.getReferencedNodeContext();
 
     const nodeOutputName = nodeContext.getNodeOutputNameById(
       nodeOutputPointerRuleData.outputId


### PR DESCRIPTION
This upgrades our the fern python generator and adds support for `LazyReference`. I've verified the changes manually and locally and will fast-follow with some tests. Getting this up asap to unblock customer workflows.