### PR TITLE
[Fix] Fix Lazy Reference Imports

### DIFF
--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer.ts
@@ -6,7 +6,7 @@ import { isNil } from "lodash";
 import { NodeInputValuePointerRule } from "./node-input-value-pointer-rules/node-input-value-pointer-rule";
 
 import { BaseNodeContext } from "src/context/node-context/base";
-import { AccessAttribute } from "src/generators/access-attribute";
+import { StaticMethodInvocation } from "src/generators/static-method-invocation";
 import {
   NodeInputValuePointer as NodeInputValuePointerType,
   WorkflowDataNode,
@@ -77,14 +77,10 @@ export class NodeInputValuePointer extends AstNode {
         break;
       }
 
-      const coalesceMethod = python.invokeMethod({
-        methodReference: python.reference({ name: "coalesce" }),
+      expression = new StaticMethodInvocation({
+        reference: expression,
+        methodName: "coalesce",
         arguments_: [python.methodArgument({ value: rule })],
-      });
-
-      expression = new AccessAttribute({
-        lhs: expression,
-        rhs: coalesceMethod,
       });
     }
 

--- a/ee/codegen/src/generators/static-method-invocation.ts
+++ b/ee/codegen/src/generators/static-method-invocation.ts
@@ -4,7 +4,7 @@ import { Writer } from "@fern-api/python-ast/core/Writer";
 import type { python } from "@fern-api/python-ast";
 
 export class StaticMethodInvocation extends AstNode {
-  private reference: python.Reference;
+  private reference: python.AstNode;
   private methodName: string;
   private arguments: python.MethodArgument[];
   constructor({
@@ -12,7 +12,7 @@ export class StaticMethodInvocation extends AstNode {
     arguments_,
     methodName,
   }: {
-    reference: python.Reference;
+    reference: python.AstNode;
     arguments_: python.MethodArgument[];
     methodName: string;
   }) {
@@ -20,6 +20,7 @@ export class StaticMethodInvocation extends AstNode {
     this.reference = reference;
     this.methodName = methodName;
     this.arguments = arguments_;
+
     this.inheritReferences(reference);
     this.arguments.forEach((arg) => {
       this.inheritReferences(arg);


### PR DESCRIPTION
This fixes LazyReference such that we generate valid code.

## Before
```
from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
from vellum.workflows.state import BaseState
from vellum.workflows.references import LazyReference
from  import coalesce
class TemplatingNode(BaseTemplatingNode[BaseState, str]):
    template = """Hello {{ var_1 }}"""
    inputs = {"var_1": LazyReference(lambda: TemplatingNode.Outputs.result.coalesce("World")),}
```

## After
```
from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
from vellum.workflows.references import LazyReference
from vellum.workflows.state import BaseState


class TemplatingNode(BaseTemplatingNode[BaseState, str]):
    template = """Hello {{ var_1 }}"""
    inputs = {
        "var_1": LazyReference(lambda: TemplatingNode.Outputs.result.coalesce("World")),
    }
```