### PR TITLE
Support int inputs in code executor nodes

### DIFF
--- a/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
@@ -170,11 +170,11 @@ class CodeExecutionNode(BaseNode[StateType], Generic[StateType, _OutputType], me
                         value=cast(Dict[str, Any], input_value),
                     )
                 )
-            elif isinstance(input_value, float):
+            elif isinstance(input_value, (float, int)):
                 compiled_inputs.append(
                     NumberInput(
                         name=input_name,
-                        value=input_value,
+                        value=float(input_value),
                     )
                 )
             elif isinstance(input_value, FunctionCall):

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
@@ -6,6 +6,7 @@ from vellum import CodeExecutorResponse, NumberVellumValue, StringInput
 from vellum.client.types.code_execution_package import CodeExecutionPackage
 from vellum.client.types.code_executor_secret_input import CodeExecutorSecretInput
 from vellum.client.types.function_call import FunctionCall
+from vellum.client.types.number_input import NumberInput
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.displayable.code_execution_node import CodeExecutionNode
@@ -13,7 +14,7 @@ from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.state.base import BaseState, StateMeta
 
 
-def test_run_workflow__happy_path(vellum_client):
+def test_run_node__happy_path(vellum_client):
     """Confirm that CodeExecutionNodes output the expected text and results when run."""
 
     # GIVEN a node that subclasses CodeExecutionNode
@@ -79,7 +80,7 @@ def main(word: str) -> int:
     )
 
 
-def test_run_workflow__code_attribute(vellum_client):
+def test_run_node__code_attribute(vellum_client):
     """Confirm that CodeExecutionNodes can use the `code` attribute to specify the code to execute."""
 
     # GIVEN a node that subclasses CodeExecutionNode
@@ -147,7 +148,7 @@ def main(word: str) -> int:
     )
 
 
-def test_run_workflow__code_and_filepath_defined(vellum_client):
+def test_run_node__code_and_filepath_defined(vellum_client):
     """Confirm that CodeExecutionNodes raise an error if both `code` and `filepath` are defined."""
 
     # GIVEN a node that subclasses CodeExecutionNode
@@ -198,7 +199,7 @@ def main(word: str) -> int:
     assert exc_info.value.message == "Cannot specify both `code` and `filepath` for a CodeExecutionNode"
 
 
-def test_run_workflow__code_and_filepath_not_defined(vellum_client):
+def test_run_node__code_and_filepath_not_defined(vellum_client):
     """Confirm that CodeExecutionNodes raise an error if neither `code` nor `filepath` are defined."""
 
     # GIVEN a node that subclasses CodeExecutionNode
@@ -241,7 +242,7 @@ def test_run_workflow__code_and_filepath_not_defined(vellum_client):
     assert exc_info.value.message == "Must specify either `code` or `filepath` for a CodeExecutionNode"
 
 
-def test_run_workflow__vellum_secret(vellum_client):
+def test_run_node__vellum_secret(vellum_client):
     """Confirm that CodeExecutionNodes can use Vellum Secrets"""
 
     # GIVEN a node that subclasses CodeExecutionNode that references a Vellum Secret
@@ -303,7 +304,53 @@ def main(word: str) -> int:
     )
 
 
-def test_run_workflow__run_inline(vellum_client):
+def test_run_node__int_input(vellum_client):
+    """Confirm that CodeExecutionNodes can use int's as inputs"""
+
+    # GIVEN a node that subclasses CodeExecutionNode that references an int
+    class State(BaseState):
+        pass
+
+    fixture = os.path.abspath(os.path.join(__file__, "../fixtures/main.py"))
+
+    class ExampleCodeExecutionNode(CodeExecutionNode[State, int]):
+        filepath = fixture
+        runtime = "PYTHON_3_11_6"
+        packages = [
+            CodeExecutionPackage(
+                name="openai",
+                version="1.0.0",
+            )
+        ]
+
+        code_inputs = {
+            "counter": 1,
+        }
+
+    # AND we know what the Code Execution Node will respond with
+    mock_code_execution = CodeExecutorResponse(
+        log="",
+        output=NumberVellumValue(value=0),
+    )
+    vellum_client.execute_code.return_value = mock_code_execution
+
+    # WHEN we run the node
+    node = ExampleCodeExecutionNode(state=State())
+    outputs = node.run()
+
+    # THEN the node should have produced the outputs we expect
+    assert outputs == {"result": 0, "log": ""}
+
+    # AND we should have invoked the Code with the correct inputs
+    assert vellum_client.execute_code.call_args_list[0].kwargs["input_values"] == [
+        NumberInput(
+            name="counter",
+            value=1,
+        )
+    ]
+
+
+def test_run_node__run_inline(vellum_client):
     """Confirm that CodeExecutionNodes run the code inline instead of through Vellum under certain conditions."""
 
     # GIVEN a node that subclasses CodeExecutionNode
@@ -330,7 +377,7 @@ def main(word: str) -> int:
     vellum_client.execute_code.assert_not_called()
 
 
-def test_run_workflow__run_inline__incorrect_output_type():
+def test_run_node__run_inline__incorrect_output_type():
     """Confirm that CodeExecutionNodes raise an error if the output type is incorrect during inline execution."""
 
     # GIVEN a node that subclasses CodeExecutionNode that returns a string but is defined to return an int
@@ -354,7 +401,7 @@ def main(word: str) -> int:
     assert exc_info.value.message == "Expected an output of type 'int', but received 'str'"
 
 
-def test_run_workflow__run_inline__valid_dict_to_pydantic():
+def test_run_node__run_inline__valid_dict_to_pydantic():
     """Confirm that CodeExecutionNodes can convert a dict to a Pydantic model during inline execution."""
 
     # GIVEN a node that subclasses CodeExecutionNode that returns a dict matching a Pydantic model
@@ -380,7 +427,7 @@ def main(word: str) -> int:
     assert outputs == {"result": FunctionCall(name="hello", arguments={}), "log": ""}
 
 
-def test_run_workflow__run_inline__invalid_dict_to_pydantic():
+def test_run_node__run_inline__invalid_dict_to_pydantic():
     """Confirm that CodeExecutionNodes raise an error if the Pydantic validation fails during inline execution."""
 
     # GIVEN a node that subclasses CodeExecutionNode that returns a dict not matching a Pydantic model
@@ -416,7 +463,7 @@ name
     )
 
 
-def test_run_workflow__run_inline__valid_dict_to_pydantic_any_type():
+def test_run_node__run_inline__valid_dict_to_pydantic_any_type():
     """Confirm that CodeExecutionNodes can convert a dict to a Pydantic model during inline execution."""
 
     # GIVEN a node that subclasses CodeExecutionNode that returns a dict matching Any

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
@@ -345,7 +345,7 @@ def test_run_node__int_input(vellum_client):
     assert vellum_client.execute_code.call_args_list[0].kwargs["input_values"] == [
         NumberInput(
             name="counter",
-            value=1,
+            value=1.0,
         )
     ]
 


### PR DESCRIPTION
Was failing any code node that tried to use ints (like execution count. This PR resolves