### PR TITLE
Support str lookups of node output references only

### DIFF
--- a/tests/workflows/circular_lazy_reference/nodes/first.py
+++ b/tests/workflows/circular_lazy_reference/nodes/first.py
@@ -3,7 +3,7 @@ from vellum.workflows.references.lazy import LazyReference
 
 
 class FirstNode(BaseNode):
-    second = LazyReference[str]("SecondNode.Outputs.value")
+    second = LazyReference[str]("SecondNode.Outputs.value").coalesce("Start")
 
     class Outputs(BaseNode.Outputs):
         value: str

--- a/tests/workflows/circular_lazy_reference/nodes/loop.py
+++ b/tests/workflows/circular_lazy_reference/nodes/loop.py
@@ -1,7 +1,7 @@
 from vellum.workflows.nodes import BaseNode
 from vellum.workflows.ports.port import Port
 
-from tests.workflows.await_all_executions.workflow import SecondNode
+from tests.workflows.circular_lazy_reference.nodes.second import SecondNode
 
 
 class LoopNode(BaseNode):

--- a/tests/workflows/circular_lazy_reference/tests/test_workflow.py
+++ b/tests/workflows/circular_lazy_reference/tests/test_workflow.py
@@ -1,9 +1,6 @@
-import pytest
-
 from tests.workflows.circular_lazy_reference.workflow import CircularLazyReferenceWorkflow
 
 
-@pytest.mark.skip(reason="https://github.com/vellum-ai/vellum/pull/7810")
 def test_workflow__happy_path():
     # GIVEN a workflow definition that contains two nodes that reference each other
     workflow = CircularLazyReferenceWorkflow()
@@ -12,5 +9,5 @@ def test_workflow__happy_path():
     final_event = workflow.run()
 
     # THEN the workflow should return the correct result
-    assert final_event.name == "workflow.execution.fulfilled"
-    assert final_event.outputs.final_value == 2
+    assert final_event.name == "workflow.execution.fulfilled", final_event.body
+    assert final_event.outputs.final_value == "World Hello World Hello Start"

--- a/tests/workflows/circular_lazy_reference/workflow.py
+++ b/tests/workflows/circular_lazy_reference/workflow.py
@@ -15,4 +15,4 @@ class CircularLazyReferenceWorkflow(BaseWorkflow):
     graph = FirstNode >> SecondNode >> LoopNode.Ports.loop >> FirstNode
 
     class Outputs(BaseWorkflow.Outputs):
-        final_value = LoopNode.Execution.count
+        final_value = SecondNode.Outputs.value


### PR DESCRIPTION
Creates a temporary solution for our circular lazy reference problem, full solution specified in method.

Serialization up next