### PR TITLE
[SC-6508] Add global output variable contexts to nested workflows

### DIFF
--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -186,6 +186,7 @@ export class WorkflowContext {
       workflowClassName: workflowClassName,
       globalInputVariableContextsById: this.globalInputVariableContextsById,
       globalNodeContextsByNodeId: this.globalNodeContextsByNodeId,
+      globalOutputVariableContextsById: this.globalOutputVariableContextsById,
       parentNode,
       workflowsSdkModulePath: this.sdkModulePathNames.WORKFLOWS_MODULE_PATH,
       vellumApiKey: this.vellumApiKey,

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/display_data/simple_inline_subworkflow_node.json
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/display_data/simple_inline_subworkflow_node.json
@@ -328,7 +328,17 @@
                 "subworkflow_node",
                 "workflow"
               ]
-            }
+            },
+            "output_values": [
+                                        {
+                                            "output_variable_id": "6ab3665f-881d-488b-9124-a6da40136c68",
+                                            "value": {
+                                                "type": "NODE_OUTPUT",
+                                                "node_id": "f3fe1e6e-5a4a-42d8-9cfe-9ecbcb935f72",
+                                                "node_output_id": "6ab3665f-881d-488b-9124-a6da40136c68"
+                                            }
+                                        }
+                                    ]
           },
           "input_variables": [],
           "output_variables": [

--- a/ee/codegen_integration/test_code_to_display.py
+++ b/ee/codegen_integration/test_code_to_display.py
@@ -29,7 +29,11 @@ def test_code_to_display_data(code_to_display_fixture_paths, workspace_secret_cl
         significant_digits=6,
         # This is for the input_variables order being out of order sometimes.
         ignore_order=True,
-        exclude_regex_paths=[r"root\['workflow_raw_data'\]\['edges'\]\[\d+\]\['target_handle_id'\]"],
+        exclude_regex_paths=[
+            r"root\['workflow_raw_data'\]\['edges'\]\[\d+\]\['target_handle_id'\]",
+            # This is for output values since this currently isn't serialized yet
+            r"root\['workflow_raw_data'\]\['nodes'\]\[\d+\]\['data'\]\['workflow_raw_data'\]\['output_values'\]",
+        ],
     )
 
 


### PR DESCRIPTION
Context: This is the fix for inline subworkflow nodes not getting codegen'ed discovered from QA'ing customer workflows. This was a regression from the output values I merged in and we did not catch this since we had no output_values on inline subworkflow nodes