### PR TITLE
Console warn when receiving bad edge data and not adding errors to workflow context

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -235,11 +235,6 @@ exports[`Workflow > graph > should handle a simple edge of generic nodes 1`] = `
 "
 `;
 
-exports[`Workflow > graph > should show errors for a node pointing to non-existent node 1`] = `
-"TemplatingNode
-"
-`;
-
 exports[`Workflow > graph > should support an edge between two sets 1`] = `
 "{
     TopLeftNode

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -56,12 +56,10 @@ describe("Workflow", () => {
   };
 
   let workflowContext: WorkflowContext;
-  let writer: Writer;
 
   beforeEach(() => {
     workflowContext = workflowContextFactory();
     workflowContext.addEntrypointNode(entrypointNode);
-    writer = new Writer();
   });
 
   describe("graph", () => {
@@ -587,41 +585,6 @@ describe("Workflow", () => {
         [topNode, outputMiddleNode],
         [topNode, outputBottomNode],
       ]);
-    });
-
-    it("should show errors for a node pointing to non-existent node", async () => {
-      // We skip using runGraphTest here because we want to test an error case
-
-      workflowContext = workflowContextFactory({ strict: false });
-      workflowContext.addEntrypointNode(entrypointNode);
-      const templatingNodeData1 = templatingNodeFactory();
-      await createNodeContext({
-        workflowContext,
-        nodeData: templatingNodeData1,
-      });
-
-      const templatingNodeData2 = templatingNodeFactory({
-        id: "non-existent-node-id",
-        label: "Templating Node 2",
-        sourceHandleId: "dd8397b1-5a41-4fa0-8c24-e5dffee4fb99",
-        targetHandleId: "3feb7e71-ec63-4d58-82ba-c3df829a2949",
-      });
-      // No node context created
-
-      workflowContext.addWorkflowEdges(
-        edgesFactory([
-          [entrypointNode, templatingNodeData1],
-          [entrypointNode, templatingNodeData2],
-        ])
-      );
-
-      new GraphAttribute({ workflowContext }).write(writer);
-      const errors = workflowContext.getErrors();
-      expect(errors).toHaveLength(1);
-      expect(errors[0]?.message).toContain(
-        `Failed to find target node with ID 'non-existent-node-id' referenced from edge edge-2`
-      );
-      expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
 
     it("should support an edge between two sets", async () => {

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -359,15 +359,6 @@ class BadNode(TemplatingNode[BaseState, str]):
     template = """foo"""
     inputs = {}
 `);
-
-      const errorLogPath = join(tempDir, project.getModuleName(), "error.log");
-      expect(fs.existsSync(errorLogPath)).toBe(true);
-      expect(fs.readFileSync(errorLogPath, "utf-8")).toBe(`\
-Encountered 2 error(s) while generating code:
-
-- Port context not found for port id: bad-source-handle-id
-- Failed to find node with id 'bad-target'
-`);
     });
   });
   describe("inlude sandbox", () => {

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -117,10 +117,9 @@ export class GraphAttribute extends AstNode {
       return this.workflowContext.getNodeContext(nodeId);
     } catch (error) {
       if (error instanceof NodeNotFoundError) {
-        const enhancedError = new NodeNotFoundError(
+        console.warn(
           `Failed to find target node with ID '${nodeId}' referenced from edge ${edgeId}`
         );
-        this.workflowContext.addError(enhancedError);
         return null;
       } else {
         throw error;

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -17,6 +17,7 @@ import { BaseState } from "src/generators/base-state";
 import {
   BaseCodegenError,
   NodeNotFoundError,
+  NodePortGenerationError,
   WorkflowGenerationError,
 } from "src/generators/errors";
 import { GraphAttribute } from "src/generators/graph-attribute";
@@ -389,7 +390,7 @@ export class Workflow {
             sourcePortContext =
               this.workflowContext.getPortContextById(sourcePortId);
           } catch (e) {
-            if (e instanceof BaseCodegenError) {
+            if (e instanceof NodePortGenerationError) {
               console.warn(e.message);
             } else {
               throw e;

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -16,6 +16,7 @@ import { BasePersistedFile } from "src/generators/base-persisted-file";
 import { BaseState } from "src/generators/base-state";
 import {
   BaseCodegenError,
+  NodeNotFoundError,
   WorkflowGenerationError,
 } from "src/generators/errors";
 import { GraphAttribute } from "src/generators/graph-attribute";
@@ -389,7 +390,7 @@ export class Workflow {
               this.workflowContext.getPortContextById(sourcePortId);
           } catch (e) {
             if (e instanceof BaseCodegenError) {
-              this.workflowContext.addError(e);
+              console.warn(e.message);
             } else {
               throw e;
             }
@@ -402,8 +403,8 @@ export class Workflow {
           try {
             targetNode = this.workflowContext.getNodeContext(targetNodeId);
           } catch (e) {
-            if (e instanceof BaseCodegenError) {
-              this.workflowContext.addError(e);
+            if (e instanceof NodeNotFoundError) {
+              console.warn(e.message);
             } else {
               throw e;
             }


### PR DESCRIPTION
Context: Currently, workflow runs will fail if we have bad edge data since it runs in strict mode. This PR changes the error notification by instead console warning instead of adding to our workflow context errors which is what strict mode checks against. This essentially does the filter at processing time. Longer term, we probably want something similar to our error list for workflow context but with warnings instead. Alternative short term approach to this was to pre-process the edges before but it felt a little redundant