### PR TITLE
Support for referencing generic node outputs

### DIFF
--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
@@ -66,6 +66,22 @@ class MyCustomNode(BaseNode):
 "
 `;
 
+exports[`GenericNode > basic with generic node output as attribute > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import BaseNode
+from .my_custom_node import ReferencedNode
+
+
+class MyCustomNode(BaseNode):
+    default_attribute = ReferencedNode.Outputs.output
+
+    class NodeTrigger(BaseNode.Trigger):
+        merge_behavior = "AWAIT_ALL"
+
+    class Outputs(BaseNode.Outputs):
+        output = "default-value"
+"
+`;
+
 exports[`GenericNode > basic with node output as attribute > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseNodeDisplay
 from ...nodes.my_custom_node import MyCustomNode

--- a/ee/codegen/src/context/node-context/generic-node.ts
+++ b/ee/codegen/src/context/node-context/generic-node.ts
@@ -7,7 +7,9 @@ export class GenericNodeContext extends BaseNodeContext<GenericNodeType> {
   baseNodeDisplayClassName = "BaseNodeDisplay";
 
   getNodeOutputNamesById(): Record<string, string> {
-    return {};
+    return Object.fromEntries(
+      this.nodeData.outputs.map((output) => [output.id, output.name])
+    );
   }
 
   createPortContexts(): PortContext[] {


### PR DESCRIPTION
Noticed while implementing [lazy string references](https://github.com/vellum-ai/vellum-python-sdks/pull/907/files) that we were not supporting output references to generic nodes. Now we do