### PR TITLE
Fix graph gen case where there's an edge between sets

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -6,10 +6,12 @@ exports[`Workflow > graph > Should handle an a conditional pointing both ports t
         FirstCheckNode.Ports.if_port,
         FirstCheckNode.Ports.else_port >> FirstOutputNode,
     }
-    >> Graph.from_set({
-        SecondCheckNode.Ports.if_port >> SecondOutputNode,
-        SecondCheckNode.Ports.else_port >> ThirdOutputNode,
-    })
+    >> Graph.from_set(
+        {
+            SecondCheckNode.Ports.if_port >> SecondOutputNode,
+            SecondCheckNode.Ports.else_port >> ThirdOutputNode,
+        }
+    )
     >> FourthOutputNode
 )
 "

--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -1,5 +1,20 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Workflow > graph > Should handle an a conditional pointing both ports to the same conditional node 1`] = `
+"(
+    {
+        FirstCheckNode.Ports.if_port,
+        FirstCheckNode.Ports.else_port >> FirstOutputNode,
+    }
+    >> Graph.from_set({
+        SecondCheckNode.Ports.if_port >> SecondOutputNode,
+        SecondCheckNode.Ports.else_port >> ThirdOutputNode,
+    })
+    >> FourthOutputNode
+)
+"
+`;
+
 exports[`Workflow > graph > Should handle an else case within a conditioned set 1`] = `
 "{
     {

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -787,5 +787,44 @@ describe("Workflow", () => {
         [[secondCheckNode, "else_port"], secondOutputNode],
       ]);
     });
+
+    it("Should handle an a conditional pointing both ports to the same conditional node", async () => {
+      const firstCheckNode = genericNodeFactory({
+        label: "FirstCheckNode",
+        nodePorts: nodePortsFactory(),
+      });
+
+      const firstOutputNode = genericNodeFactory({
+        label: "FirstOutputNode",
+      });
+
+      const secondCheckNode = genericNodeFactory({
+        label: "SecondCheckNode",
+        nodePorts: nodePortsFactory(),
+      });
+
+      const secondOutputNode = genericNodeFactory({
+        label: "SecondOutputNode",
+      });
+
+      const thirdOutputNode = genericNodeFactory({
+        label: "ThirdOutputNode",
+      });
+
+      const fourthOutputNode = genericNodeFactory({
+        label: "FourthOutputNode",
+      });
+
+      await runGraphTest([
+        [entrypointNode, firstCheckNode],
+        [[firstCheckNode, "if_port"], secondCheckNode],
+        [[firstCheckNode, "else_port"], firstOutputNode],
+        [firstOutputNode, secondCheckNode],
+        [[secondCheckNode, "if_port"], secondOutputNode],
+        [[secondCheckNode, "else_port"], thirdOutputNode],
+        [secondOutputNode, fourthOutputNode],
+        [thirdOutputNode, fourthOutputNode],
+      ]);
+    });
   });
 });

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -929,7 +929,7 @@ export class GraphAttribute extends AstNode {
     }
 
     if (mutableAst.type === "right_shift") {
-      const lhs = this.getGraphAttributeAstNode(mutableAst.lhs);
+      const lhs = this.getGraphAttributeAstNode(mutableAst.lhs, useWrap);
       const rhs = this.getGraphAttributeAstNode(
         mutableAst.rhs,
         mutableAst.lhs.type === "set"


### PR DESCRIPTION
This would fail to compile a workflow without `Graph.from_set()`