### PR TITLE
Fix reproducing multi branch into node test case in graph generation

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -35,7 +35,7 @@ exports[`Workflow > graph > Should handle an else case within a conditioned set 
 
 exports[`Workflow > graph > Should handle two branches from a node to a node 1`] = `
 "(
-    FirstNode 
+    FirstNode
     >> {
         SecondNode >> ThirdNode >> FourthNode,
         FourthNode,

--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -33,6 +33,18 @@ exports[`Workflow > graph > Should handle an else case within a conditioned set 
 "
 `;
 
+exports[`Workflow > graph > Should handle two branches from a node to a node 1`] = `
+"(
+    FirstNode 
+    >> {
+        SecondNode >> ThirdNode >> FourthNode,
+        FourthNode,
+    }
+    >> FifthNode
+)
+"
+`;
+
 exports[`Workflow > graph > should be able to create a proper else edge when there are three ports pointing to a set 1`] = `
 "{
     FirstCheckNode.Ports.if_port

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -826,5 +826,37 @@ describe("Workflow", () => {
         [thirdOutputNode, fourthOutputNode],
       ]);
     });
+
+    it("Should handle two branches from a node to a node", async () => {
+      const firstNode = genericNodeFactory({
+        label: "FirstNode",
+      });
+
+      const secondNode = genericNodeFactory({
+        label: "SecondNode",
+      });
+
+      const thirdNode = genericNodeFactory({
+        label: "ThirdNode",
+      });
+
+      const fourthNode = genericNodeFactory({
+        label: "FourthNode",
+      });
+
+      const fifthNode = genericNodeFactory({
+        label: "FifthNode",
+        nodePorts: nodePortsFactory(),
+      });
+
+      await runGraphTest([
+        [entrypointNode, firstNode],
+        [firstNode, secondNode],
+        [firstNode, fourthNode],
+        [secondNode, thirdNode],
+        [thirdNode, fourthNode],
+        [fourthNode, fifthNode],
+      ]);
+    });
   });
 });


### PR DESCRIPTION
We were previously generating a `None` in this case - this test case and implementation resolves that