### PR TITLE
Prioritize terminal node data over workflow output values

### DIFF
--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -303,7 +303,10 @@ export class WorkflowContext {
       outputVariableId,
       outputVariableContext
     );
-    this.addUsedOutputVariableName(outputVariableContext.name);
+    // This was added from the workflow output context. We should remove this once terminal node data is removed from data
+    if (!this.outputVariableNames.has(outputVariableContext.name)) {
+      this.addUsedOutputVariableName(outputVariableContext.name);
+    }
   }
 
   public getOutputVariableContextById(

--- a/ee/codegen/src/context/workflow-output-context.ts
+++ b/ee/codegen/src/context/workflow-output-context.ts
@@ -71,13 +71,13 @@ export class WorkflowOutputContext {
     const defaultName = "output_";
 
     let rawOutputVariableName: string;
-    if (this.workflowOutputValue) {
+    if (this.terminalNodeData) {
+      rawOutputVariableName = this.terminalNodeData.data.name;
+    } else if (this.workflowOutputValue) {
       const outputVariable = this.workflowContext.getOutputVariableContextById(
         this.workflowOutputValue.outputVariableId
       );
       rawOutputVariableName = outputVariable.name;
-    } else if (this.terminalNodeData) {
-      rawOutputVariableName = this.terminalNodeData.data.name;
     } else {
       throw new WorkflowOutputGenerationError(
         "Expected either workflow output value or terminal node data to be defined"


### PR DESCRIPTION
Context: We are receiving bad data on output_values from workflows. This was discovered when QAing a customer workflow and the subworkflow was referencing the outer workflow's output variables and not the inner one. This related PR (https://github.com/vellum-ai/vellum/pull/7874) fixes this change for workflows going forward but the current existing workflows are polluted with bad data. This change prioritizes the legacy terminal nodes temporarily so that it points to the right outputs.

This also fixes SC-6545 where the inner subworkflow starts referencing the outer workflow's outputs