### PR TITLE
[SC-4008] Auto-Inherit BaseNodeOutputs in Outputs classes

### DIFF
--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -46,9 +46,17 @@ class BaseNodeMeta(type):
         if "Outputs" in dct:
             outputs_class = dct["Outputs"]
             if not any(issubclass(base, BaseOutputs) for base in outputs_class.__bases__):
+                parent_outputs_class = next(
+                    (base.Outputs for base in bases if hasattr(base, "Outputs")),
+                    BaseOutputs,  # Default to BaseOutputs only if no parent has Outputs
+                )
+
+                # Filter out object from bases while preserving other inheritance
+                filtered_bases = tuple(base for base in outputs_class.__bases__ if base is not object)
+
                 dct["Outputs"] = type(
                     f"{name}.Outputs",
-                    (BaseOutputs,) + outputs_class.__bases__,  # Add BaseOutputs as first base
+                    (parent_outputs_class,) + filtered_bases,
                     {**outputs_class.__dict__, "__module__": dct["__module__"]},
                 )
         else:

--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -43,7 +43,15 @@ class BaseNodeMeta(type):
         # TODO: Inherit the inner Output classes from every base class.
         #   https://app.shortcut.com/vellum/story/4007/support-auto-inheriting-parent-node-outputs
 
-        if "Outputs" not in dct:
+        if "Outputs" in dct:
+            outputs_class = dct["Outputs"]
+            if not any(issubclass(base, BaseOutputs) for base in outputs_class.__bases__):
+                dct["Outputs"] = type(
+                    f"{name}.Outputs",
+                    (BaseOutputs,) + outputs_class.__bases__,  # Add BaseOutputs as first base
+                    {**outputs_class.__dict__, "__module__": dct["__module__"]},
+                )
+        else:
             for base in reversed(bases):
                 if hasattr(base, "Outputs"):
                     dct["Outputs"] = type(

--- a/src/vellum/workflows/nodes/bases/tests/test_base_node.py
+++ b/src/vellum/workflows/nodes/bases/tests/test_base_node.py
@@ -216,8 +216,9 @@ def test_outputs_preserves_non_object_bases():
         def run(self):
             return self.Outputs(foo="bar", bar="baz")  # type: ignore
 
-    # TEST that Outputs **inherits from ExtraMixin**
+    # TEST that Outputs is a subclass of Foo and ParentNode.Outputs
     assert Foo in ChildNode.Outputs.__bases__, "Foo should be preserved in bases"
+    assert ParentNode.Outputs in ChildNode.Outputs.__bases__, "ParentNode.Outputs should be preserved in bases"
     assert object not in ChildNode.Outputs.__bases__, "object should not be in bases"
 
     # TEST that Outputs has the correct attributes

--- a/src/vellum/workflows/nodes/bases/tests/test_base_node.py
+++ b/src/vellum/workflows/nodes/bases/tests/test_base_node.py
@@ -5,6 +5,7 @@ from vellum.client.types.string_vellum_value_request import StringVellumValueReq
 from vellum.core.pydantic_utilities import UniversalBaseModel
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.outputs.base import BaseOutputs
 from vellum.workflows.state.base import BaseState, StateMeta
 
 
@@ -148,3 +149,21 @@ def test_base_node__node_resolution__descriptor_in_fern_pydantic():
     node = SomeNode(state=State(foo="bar"))
 
     assert node.model.value == "bar"
+
+
+def test_base_node__inherit_base_outputs():
+    class MyNode(BaseNode):
+        class Outputs:
+            foo: str
+
+    # TEST that the Outputs class is a subclass of BaseOutputs
+    assert issubclass(MyNode.Outputs, BaseOutputs)
+
+    # TEST that the Outputs class has the correct attributes
+    assert hasattr(MyNode.Outputs, "foo")
+
+    # WHEN the node outputs is initialized
+    outputs = MyNode.Outputs(foo="bar")  # type: ignore
+
+    # THEN the outputs should be correct
+    assert outputs.foo == "bar"

--- a/src/vellum/workflows/nodes/bases/tests/test_base_node.py
+++ b/src/vellum/workflows/nodes/bases/tests/test_base_node.py
@@ -156,14 +156,78 @@ def test_base_node__inherit_base_outputs():
         class Outputs:
             foo: str
 
+        def run(self):
+            return self.Outputs(foo="bar")  # type: ignore
+
     # TEST that the Outputs class is a subclass of BaseOutputs
     assert issubclass(MyNode.Outputs, BaseOutputs)
+
+    # TEST that the Outputs class does not inherit from object
+    assert object not in MyNode.Outputs.__bases__
 
     # TEST that the Outputs class has the correct attributes
     assert hasattr(MyNode.Outputs, "foo")
 
-    # WHEN the node outputs is initialized
-    outputs = MyNode.Outputs(foo="bar")  # type: ignore
+    # WHEN the node is run
+    node = MyNode()
+    outputs = node.run()
 
     # THEN the outputs should be correct
     assert outputs.foo == "bar"
+
+
+def test_child_node__inherits_base_outputs_when_no_parent_outputs():
+    class ParentNode(BaseNode):  # No Outputs class here
+        pass
+
+    class ChildNode(ParentNode):
+        class Outputs:
+            foo: str
+
+        def run(self):
+            return self.Outputs(foo="bar")  # type: ignore
+
+    # TEST that ChildNode.Outputs is a subclass of BaseOutputs (since ParentNode has no Outputs)
+    assert issubclass(ChildNode.Outputs, BaseOutputs)
+
+    # TEST that ChildNode.Outputs has the correct attributes
+    assert hasattr(ChildNode.Outputs, "foo")
+
+    # WHEN the node is run
+    node = ChildNode()
+    outputs = node.run()
+
+    # THEN the outputs should be correct
+    assert outputs.foo == "bar"
+
+
+def test_outputs_preserves_non_object_bases():
+    class ParentNode(BaseNode):
+        class Outputs:
+            foo: str
+
+    class Foo:
+        bar: str
+
+    class ChildNode(ParentNode):
+        class Outputs(ParentNode.Outputs, Foo):
+            pass
+
+        def run(self):
+            return self.Outputs(foo="bar", bar="baz")  # type: ignore
+
+    # TEST that Outputs **inherits from ExtraMixin**
+    assert Foo in ChildNode.Outputs.__bases__, "Foo should be preserved in bases"
+    assert object not in ChildNode.Outputs.__bases__, "object should not be in bases"
+
+    # TEST that Outputs has the correct attributes
+    assert hasattr(ChildNode.Outputs, "foo")
+    assert hasattr(ChildNode.Outputs, "bar")
+
+    # WHEN Outputs is instantiated
+    node = ChildNode()
+    outputs = node.run()
+
+    # THEN the output values should be correct
+    assert outputs.foo == "bar"
+    assert outputs.bar == "baz"


### PR DESCRIPTION
allow users to define class Outputs in Node without inheriting explicitly, should also do the same for workflow output

test:
```py
from vellum.workflows import BaseWorkflow
from vellum.workflows.inputs.base import BaseInputs
from vellum.workflows.nodes.bases.base import BaseNode
from vellum.workflows.state.base import BaseState


class Inputs(BaseInputs):
    input: str


class BasicGenericNode(BaseNode):
    class Outputs:  # no need to inherit
        output = Inputs.input


class BasicGenericNodeWorkflow(BaseWorkflow[Inputs, BaseState]):
    graph = BasicGenericNode

    class Outputs(BaseWorkflow.Outputs):  # still need now
        output = BasicGenericNode.Outputs.output
```

```py
from tests.workflows.basic_generic_node.workflow import BasicGenericNodeWorkflow, Inputs


def test_workflow__happy_path():
    # GIVEN a workflow that just passes through its input to a terminal node
    workflow = BasicGenericNodeWorkflow()

    # WHEN we run the workflow
    terminal_event = workflow.run(inputs=Inputs(input="hello"))

    # THEN the workflow should be fulfilled
    assert terminal_event.name == "workflow.execution.fulfilled", terminal_event
    assert terminal_event.outputs == {"output": "hello"}

```
