### PR TITLE
Support contains in workflow error

### DIFF
--- a/src/vellum/workflows/descriptors/tests/test_utils.py
+++ b/src/vellum/workflows/descriptors/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from vellum.workflows.descriptors.utils import resolve_value
+from vellum.workflows.errors.types import WorkflowError, WorkflowErrorCode
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.references.constant import ConstantValueReference
 from vellum.workflows.state.base import BaseState
@@ -77,6 +78,24 @@ class DummyNode(BaseNode[FixtureState]):
         (FixtureState.zeta["foo"], "bar"),
         (ConstantValueReference(1), 1),
         (FixtureState.theta[0], "baz"),
+        (
+            ConstantValueReference(
+                WorkflowError(
+                    message="This is a test",
+                    code=WorkflowErrorCode.USER_DEFINED_ERROR,
+                )
+            ).contains("test"),
+            True,
+        ),
+        (
+            ConstantValueReference(
+                WorkflowError(
+                    message="This is a test",
+                    code=WorkflowErrorCode.USER_DEFINED_ERROR,
+                )
+            ).does_not_contain("test"),
+            False,
+        ),
     ],
     ids=[
         "or",
@@ -122,6 +141,8 @@ class DummyNode(BaseNode[FixtureState]):
         "accessor",
         "constants",
         "list_index",
+        "error_contains",
+        "error_does_not_contain",
     ],
 )
 def test_resolve_value__happy_path(descriptor, expected_value):

--- a/src/vellum/workflows/errors/types.py
+++ b/src/vellum/workflows/errors/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict
+from typing import Any, Dict
 
 from vellum.client.types.vellum_error import VellumError
 from vellum.client.types.vellum_error_code_enum import VellumErrorCodeEnum
@@ -25,6 +25,9 @@ class WorkflowErrorCode(Enum):
 class WorkflowError:
     message: str
     code: WorkflowErrorCode
+
+    def __contains__(self, item: Any) -> bool:
+        return item in self.message
 
 
 _VELLUM_ERROR_CODE_TO_WORKFLOW_ERROR_CODE: Dict[VellumErrorCodeEnum, WorkflowErrorCode] = {

--- a/src/vellum/workflows/expressions/contains.py
+++ b/src/vellum/workflows/expressions/contains.py
@@ -4,6 +4,7 @@ from vellum.workflows.constants import undefined
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.descriptors.exceptions import InvalidExpressionException
 from vellum.workflows.descriptors.utils import resolve_value
+from vellum.workflows.errors.types import WorkflowError
 from vellum.workflows.state.base import BaseState
 
 LHS = TypeVar("LHS")
@@ -28,7 +29,7 @@ class ContainsExpression(BaseDescriptor[bool], Generic[LHS, RHS]):
         # assumes that lack of is also false
         if lhs is undefined:
             return False
-        if not isinstance(lhs, (list, tuple, set, dict, str)):
+        if not isinstance(lhs, (list, tuple, set, dict, str, WorkflowError)):
             raise InvalidExpressionException(
                 f"Expected a LHS that supported `contains`, got `{lhs.__class__.__name__}`"
             )

--- a/src/vellum/workflows/expressions/does_not_contain.py
+++ b/src/vellum/workflows/expressions/does_not_contain.py
@@ -3,6 +3,7 @@ from typing import Generic, TypeVar, Union
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.descriptors.exceptions import InvalidExpressionException
 from vellum.workflows.descriptors.utils import resolve_value
+from vellum.workflows.errors.types import WorkflowError
 from vellum.workflows.state.base import BaseState
 
 LHS = TypeVar("LHS")
@@ -24,7 +25,7 @@ class DoesNotContainExpression(BaseDescriptor[bool], Generic[LHS, RHS]):
         # Support any type that implements the not in operator
         # https://app.shortcut.com/vellum/story/4658
         lhs = resolve_value(self._lhs, state)
-        if not isinstance(lhs, (list, tuple, set, dict, str)):
+        if not isinstance(lhs, (list, tuple, set, dict, str, WorkflowError)):
             raise InvalidExpressionException(
                 f"Expected a LHS that supported `contains`, got `{lhs.__class__.__name__}`"
             )


### PR DESCRIPTION
This helps support conditions that say `Error contains "Example Error Message"`