### PR TITLE
[SC-6587] Do not codegen authorization type input if that field is undefined

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -999,6 +999,7 @@ export type ApiNodeFactoryProps = {
     key: NodeInput;
     value: NodeInput;
   }[];
+  useUndefinedAuthorizationTypeInputId?: boolean;
 };
 
 export function apiNodeFactory({
@@ -1006,6 +1007,7 @@ export function apiNodeFactory({
   bearerToken,
   apiKeyHeaderValue,
   additionalHeaders,
+  useUndefinedAuthorizationTypeInputId = false,
 }: ApiNodeFactoryProps = {}): ApiNode {
   const bearerTokenInput = bearerToken ?? {
     id: "931502c1-23a5-4e2a-a75e-80736c42f3c9",
@@ -1040,6 +1042,9 @@ export function apiNodeFactory({
       combinator: "OR",
     },
   };
+
+  const defaultAuthorizationTypeInputId =
+    "de330dac-05b1-4e78-bee7-7452203af3d5";
 
   const additionalHeaderInputs =
     additionalHeaders ??
@@ -1153,7 +1158,9 @@ export function apiNodeFactory({
       methodInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
       urlInputId: "480a4c12-22d6-4223-a38a-85db5eda118c",
       bodyInputId: "74865eb7-cdaf-4d40-a499-0a6505e72680",
-      authorizationTypeInputId: "de330dac-05b1-4e78-bee7-7452203af3d5",
+      authorizationTypeInputId: useUndefinedAuthorizationTypeInputId
+        ? undefined
+        : defaultAuthorizationTypeInputId,
       bearerTokenValueInputId: bearerTokenInput.id,
       apiKeyHeaderKeyInputId: "96c8343d-cc94-4df0-9001-eb2905a00be7",
       apiKeyHeaderValueInputId: apiKeyHeaderValueInput.id,

--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -231,3 +231,24 @@ class APINode(BaseAPINode):
     bearer_token_value = "<my-bearer-token>"
 "
 `;
+
+exports[`ApiNode > skip authorization type input id field if undefined > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+from vellum.workflows.constants import APIRequestMethod
+from ..inputs import Inputs
+
+
+class APINode(BaseAPINode):
+    url = "fasdfadsf"
+    method = APIRequestMethod.POST
+    json = {}
+    headers = {
+        "foo": Inputs.additional_header_value,
+        "bar": Inputs.additional_header_value_1,
+        "baz": Inputs.additional_header_value_1,
+    }
+    api_key_header_key = None
+    api_key_header_value = "<my-api-value>"
+    bearer_token_value = "<my-bearer-token>"
+"
+`;

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -223,4 +223,27 @@ describe("ApiNode", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });
+
+  describe("skip authorization type input id field if undefined", () => {
+    beforeEach(async () => {
+      const nodeData = apiNodeFactory({
+        useUndefinedAuthorizationTypeInputId: true,
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      node = new ApiNode({
+        workflowContext: workflowContext,
+        nodeContext,
+      });
+    });
+
+    it("getNodeFile", async () => {
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -109,14 +109,14 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
     }
 
     const authTypeEnum = this.convertAuthTypeValueToEnum();
-    statements.push(
-      python.field({
-        name: "authorization_type",
-        initializer: authTypeEnum
-          ? authTypeEnum
-          : python.TypeInstantiation.none(),
-      })
-    );
+    if (authTypeEnum) {
+      statements.push(
+        python.field({
+          name: "authorization_type",
+          initializer: authTypeEnum,
+        })
+      );
+    }
 
     if (this.nodeData.data.apiKeyHeaderValueInputId) {
       const valueInput = this.nodeData.inputs.find(
@@ -452,6 +452,10 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
   }
 
   private convertAuthTypeValueToEnum(): AstNode | undefined {
+    if (isNil(this.nodeData.data.authorizationTypeInputId)) {
+      return undefined;
+    }
+
     const authValue = this.nodeData.inputs
       .find((input) => input.id === this.nodeData.data.authorizationTypeInputId)
       ?.value.rules.find(


### PR DESCRIPTION
Came up from QAing customer workflow, api nodes were not being codegen because this field was undefined causing errors and skipping of this node