### PR TITLE
Fix lazy reference serialization for legacy nodes

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_node.py
@@ -1,0 +1,52 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes import BaseNode
+from vellum.workflows.nodes.displayable.inline_prompt_node.node import InlinePromptNode
+from vellum.workflows.references.lazy import LazyReference
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+
+
+def test_serialize_node__lazy_reference_in_prompt_inputs():
+    # GIVEN a prompt node with a lazy reference in the prompt inputs
+    class LazyReferencePromptNode(InlinePromptNode):
+        prompt_inputs = {"attr": LazyReference[str]("OtherNode.Outputs.result")}
+        blocks = []
+        ml_model = "gpt-4o"
+
+    class OtherNode(BaseNode):
+        class Outputs:
+            result: str
+
+    # AND a workflow with both nodes
+    class Workflow(BaseWorkflow):
+        graph = LazyReferencePromptNode >> OtherNode
+
+    # WHEN the workflow is serialized
+    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=Workflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    # THEN the node should properly serialize the attribute reference
+    lazy_reference_node = next(
+        node
+        for node in serialized_workflow["workflow_raw_data"]["nodes"]
+        if node["id"] == str(LazyReferencePromptNode.__id__)
+    )
+
+    assert lazy_reference_node["inputs"] == [
+        {
+            "id": "fba6a4d5-835a-4e99-afb7-f6a4aed15110",
+            "key": "attr",
+            "value": {
+                "combinator": "OR",
+                "rules": [
+                    {
+                        "type": "NODE_OUTPUT",
+                        "data": {
+                            "node_id": str(OtherNode.__id__),
+                            "output_id": "7f377cb8-4eca-4f1c-9239-9925f9495d84",
+                        },
+                    }
+                ],
+            },
+        }
+    ]

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -1,0 +1,26 @@
+from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.references.lazy import LazyReference
+from vellum_ee.workflows.display.types import WorkflowDisplayContext
+
+
+def get_child_descriptor(value: LazyReference, display_context: WorkflowDisplayContext) -> BaseDescriptor:
+    if isinstance(value._get, str):
+        reference_parts = value._get.split(".")
+        if len(reference_parts) < 3:
+            raise Exception(f"Failed to parse lazy reference: {value._get}. Only Node Output references are supported.")
+
+        output_name = reference_parts[-1]
+        nested_class_name = reference_parts[-2]
+        if nested_class_name != "Outputs":
+            raise Exception(
+                f"Failed to parse lazy reference: {value._get}. Outputs are the only node reference supported."
+            )
+
+        node_class_name = ".".join(reference_parts[:-2])
+        for node in display_context.node_displays.keys():
+            if node.__name__ == node_class_name:
+                return getattr(node.Outputs, output_name)
+
+        raise Exception(f"Failed to parse lazy reference: {value._get}")
+
+    return value._get()

--- a/ee/vellum_ee/workflows/display/utils/vellum.py
+++ b/ee/vellum_ee/workflows/display/utils/vellum.py
@@ -32,10 +32,12 @@ from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
 from vellum.workflows.references import OutputReference, WorkflowInputReference
 from vellum.workflows.references.execution_count import ExecutionCountReference
+from vellum.workflows.references.lazy import LazyReference
 from vellum.workflows.references.node import NodeReference
 from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
 from vellum.workflows.vellum_client import create_vellum_client
+from vellum_ee.workflows.display.utils.expressions import get_child_descriptor
 from vellum_ee.workflows.display.vellum import (
     ConstantValuePointer,
     ExecutionCounterData,
@@ -88,6 +90,9 @@ def create_node_input_value_pointer_rule(
         return NodeOutputPointer(
             data=NodeOutputData(node_id=str(upstream_node_display.node_id), output_id=str(output_display.id)),
         )
+    if isinstance(value, LazyReference):
+        child_descriptor = get_child_descriptor(value, display_context)
+        return create_node_input_value_pointer_rule(child_descriptor, display_context)
     if isinstance(value, WorkflowInputReference):
         workflow_input_display = display_context.global_workflow_input_displays[value]
         return InputVariablePointer(data=InputVariableData(input_variable_id=str(workflow_input_display.id)))


### PR DESCRIPTION
I was QAing a customer workflow, and noticed that we missed a case on push for LazyReference:

![Screenshot 2025-02-11 at 4 32 29 PM](https://github.com/user-attachments/assets/2cb22acf-9cb2-49d5-9ef6-4a9eb26cf94d)
