### PR TITLE
[SC-6621] Add custom replace filter to Jinja templating and corresponding tests

### DIFF
--- a/src/vellum/utils/templating/constants.py
+++ b/src/vellum/utils/templating/constants.py
@@ -23,7 +23,10 @@ DEFAULT_JINJA_GLOBALS: Dict[str, Any] = {
     "re": re,
     "yaml": yaml,
 }
-DEFAULT_JINJA_CUSTOM_FILTERS: Dict[str, Callable[[Union[str, bytes]], bool]] = {
+
+FilterFunc = Union[Callable[[Union[str, bytes]], bool], Callable[[Any, Any, Any], str]]
+
+DEFAULT_JINJA_CUSTOM_FILTERS: Dict[str, FilterFunc] = {
     "is_valid_json_string": is_valid_json_string,
     "replace": replace,
 }

--- a/src/vellum/utils/templating/constants.py
+++ b/src/vellum/utils/templating/constants.py
@@ -10,7 +10,7 @@ import pydash
 import pytz
 import yaml
 
-from vellum.utils.templating.custom_filters import is_valid_json_string
+from vellum.utils.templating.custom_filters import is_valid_json_string, replace
 
 DEFAULT_JINJA_GLOBALS: Dict[str, Any] = {
     "datetime": datetime,
@@ -25,4 +25,5 @@ DEFAULT_JINJA_GLOBALS: Dict[str, Any] = {
 }
 DEFAULT_JINJA_CUSTOM_FILTERS: Dict[str, Callable[[Union[str, bytes]], bool]] = {
     "is_valid_json_string": is_valid_json_string,
+    "replace": replace,
 }

--- a/src/vellum/utils/templating/custom_filters.py
+++ b/src/vellum/utils/templating/custom_filters.py
@@ -1,5 +1,7 @@
 import json
-from typing import Union
+from typing import Any, Union
+
+from vellum.workflows.state.encoder import DefaultStateEncoder
 
 
 def is_valid_json_string(value: Union[str, bytes]) -> bool:
@@ -10,3 +12,22 @@ def is_valid_json_string(value: Union[str, bytes]) -> bool:
     except ValueError:
         return False
     return True
+
+
+def replace(s: Any, old: Any, new: Any) -> str:
+    def encode_to_str(obj: Any) -> str:
+        """Encode an object for template rendering using DefaultStateEncoder."""
+        try:
+            if isinstance(obj, str):
+                return obj
+            return json.dumps(obj, cls=DefaultStateEncoder)
+        except TypeError:
+            return str(obj)
+
+    if old == "":
+        return encode_to_str(s)
+
+    s_str = encode_to_str(s)
+    old_str = encode_to_str(old)
+    new_str = encode_to_str(new)
+    return s_str.replace(old_str, new_str)

--- a/src/vellum/utils/templating/render.py
+++ b/src/vellum/utils/templating/render.py
@@ -50,10 +50,9 @@ def render_sandboxed_jinja_template(
             "cls": DefaultStateEncoder,
         }
 
+        environment.filters["replace"] = custom_replace
         if jinja_custom_filters:
             environment.filters.update(jinja_custom_filters)
-
-        environment.filters["replace"] = custom_replace
 
         jinja_template = environment.from_string(template)
 

--- a/src/vellum/utils/templating/render.py
+++ b/src/vellum/utils/templating/render.py
@@ -1,8 +1,9 @@
 import json
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from jinja2.sandbox import SandboxedEnvironment
 
+from vellum.utils.templating.constants import FilterFunc
 from vellum.utils.templating.exceptions import JinjaTemplateError
 from vellum.workflows.state.encoder import DefaultStateEncoder
 
@@ -18,7 +19,7 @@ def render_sandboxed_jinja_template(
     *,
     template: str,
     input_values: Dict[str, Any],
-    jinja_custom_filters: Optional[Dict[str, Callable[[Union[str, bytes]], bool]]] = None,
+    jinja_custom_filters: Optional[Dict[str, FilterFunc]] = None,
     jinja_globals: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Render a Jinja template within a sandboxed environment."""

--- a/src/vellum/utils/templating/render.py
+++ b/src/vellum/utils/templating/render.py
@@ -21,7 +21,8 @@ def custom_replace(s, old, new):
 
     def encode(obj):
         try:
-            return json.dumps(obj, cls=DefaultStateEncoder)
+            if not isinstance(s, str):
+                return json.dumps(obj, cls=DefaultStateEncoder)
         except TypeError:
             return str(obj)
 

--- a/src/vellum/utils/templating/render.py
+++ b/src/vellum/utils/templating/render.py
@@ -14,25 +14,6 @@ def finalize(obj: Any) -> str:
     return str(obj)
 
 
-def custom_replace(s, old, new):
-    """
-    Custom replace filter that uses DefaultStateEncoder for conversion
-    """
-
-    def encode(obj):
-        try:
-            if not isinstance(s, str):
-                return json.dumps(obj, cls=DefaultStateEncoder)
-        except TypeError:
-            return str(obj)
-
-    s_str = encode(s)
-    old_str = encode(old)
-    new_str = encode(new)
-
-    return s_str.replace(old_str, new_str)
-
-
 def render_sandboxed_jinja_template(
     *,
     template: str,
@@ -51,7 +32,6 @@ def render_sandboxed_jinja_template(
             "cls": DefaultStateEncoder,
         }
 
-        environment.filters["replace"] = custom_replace
         if jinja_custom_filters:
             environment.filters.update(jinja_custom_filters)
 

--- a/src/vellum/utils/templating/render.py
+++ b/src/vellum/utils/templating/render.py
@@ -14,6 +14,27 @@ def finalize(obj: Any) -> str:
     return str(obj)
 
 
+def custom_replace(s, old, new):
+    """
+    Custom replace filter that uses DefaultStateEncoder for conversion
+    """
+    import json
+
+    from vellum.workflows.state.encoder import DefaultStateEncoder
+
+    def encode(obj):
+        try:
+            return json.dumps(obj, cls=DefaultStateEncoder)
+        except TypeError:
+            return str(obj)
+
+    s_str = encode(s)
+    old_str = encode(old)
+    new_str = encode(new)
+
+    return s_str.replace(old_str, new_str)
+
+
 def render_sandboxed_jinja_template(
     *,
     template: str,
@@ -34,6 +55,8 @@ def render_sandboxed_jinja_template(
 
         if jinja_custom_filters:
             environment.filters.update(jinja_custom_filters)
+
+        environment.filters["replace"] = custom_replace
 
         jinja_template = environment.from_string(template)
 

--- a/src/vellum/utils/templating/render.py
+++ b/src/vellum/utils/templating/render.py
@@ -18,9 +18,6 @@ def custom_replace(s, old, new):
     """
     Custom replace filter that uses DefaultStateEncoder for conversion
     """
-    import json
-
-    from vellum.workflows.state.encoder import DefaultStateEncoder
 
     def encode(obj):
         try:

--- a/src/vellum/utils/templating/tests/test_custom_filters.py
+++ b/src/vellum/utils/templating/tests/test_custom_filters.py
@@ -1,0 +1,19 @@
+import pytest
+
+from vellum.utils.templating.custom_filters import replace
+
+
+@pytest.mark.parametrize(
+    ["input_str", "old", "new", "expected"],
+    [
+        ("foo", "foo", "bar", "bar"),
+        ({"message": "hello"}, "hello", "world", '{"message": "world"}'),
+        ("Value: 123", 123, 456, "Value: 456"),
+        (123, 2, 4, "143"),
+        ("", "", "", ""),
+        ("foo", "", "bar", "foo"),
+    ],
+)
+def test_replace(input_str, old, new, expected):
+    actual = replace(input_str, old, new)
+    assert actual == expected

--- a/src/vellum/workflows/nodes/core/templating_node/node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/node.py
@@ -1,6 +1,6 @@
-from typing import Any, Callable, ClassVar, Dict, Generic, Mapping, Tuple, Type, TypeVar, Union, get_args
+from typing import Any, ClassVar, Dict, Generic, Mapping, Tuple, Type, TypeVar, get_args
 
-from vellum.utils.templating.constants import DEFAULT_JINJA_CUSTOM_FILTERS, DEFAULT_JINJA_GLOBALS
+from vellum.utils.templating.constants import DEFAULT_JINJA_CUSTOM_FILTERS, DEFAULT_JINJA_GLOBALS, FilterFunc
 from vellum.utils.templating.exceptions import JinjaTemplateError
 from vellum.utils.templating.render import render_sandboxed_jinja_template
 from vellum.workflows.errors import WorkflowErrorCode
@@ -54,7 +54,7 @@ class TemplatingNode(BaseNode[StateType], Generic[StateType, _OutputType], metac
     inputs: ClassVar[EntityInputsInterface]
 
     jinja_globals: Dict[str, Any] = DEFAULT_JINJA_GLOBALS
-    jinja_custom_filters: Mapping[str, Callable[[Union[str, bytes]], bool]] = DEFAULT_JINJA_CUSTOM_FILTERS
+    jinja_custom_filters: Mapping[str, FilterFunc] = DEFAULT_JINJA_CUSTOM_FILTERS
 
     class Outputs(BaseNode.Outputs):
         """


### PR DESCRIPTION
this could solve the replace problem, however, while running `re_act_agent` https://app.vellum.ai/workflow-sandboxes/795d7568-bac5-4430-bdf0-e01c97b17110 

there is another err that seems to be related to the map item, since changing `replace` to `tojson` will produce the same err
`Error: WorkflowError(message='list assignment index out of range', code=<WorkflowErrorCode.INTERNAL_ERROR: 'INTERNAL_ERROR'>)`