### PR TITLE
Remove output display data from workflow output display

### DIFF
--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -473,7 +473,6 @@ export class Workflow {
               let outputId: string;
               let name: string;
               let label: string;
-              let displayData: NodeDisplayDataType | undefined;
 
               // Final output node
               if ("type" in finalOutput) {
@@ -481,7 +480,6 @@ export class Workflow {
                 outputId = finalOutput.data.outputId;
                 name = finalOutput.data.name;
                 label = finalOutput.data.label;
-                displayData = finalOutput.displayData;
               } else {
                 const nodeId =
                   getNodeIdFromNodeOutputWorkflowReference(finalOutput);
@@ -502,7 +500,6 @@ export class Workflow {
                   getNodeOutputIdFromNodeOutputWorkflowReference(finalOutput);
                 name = referencedOutput.name;
                 label = this.getLabel(referencedNode.nodeData);
-                displayData = referencedNode.nodeData.displayData;
               }
 
               return {
@@ -538,13 +535,6 @@ export class Workflow {
                     python.methodArgument({
                       name: "label",
                       value: python.TypeInstantiation.str(label),
-                    }),
-                    python.methodArgument({
-                      name: "display_data",
-                      value: new NodeDisplayData({
-                        nodeDisplayData: displayData,
-                        workflowContext: this.workflowContext,
-                      }),
                     }),
                   ],
                 }),

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -25,7 +25,6 @@ import { Inputs } from "src/generators/inputs";
 import { NodeDisplayData } from "src/generators/node-display-data";
 import { WorkflowOutput } from "src/generators/workflow-output";
 import {
-  NodeDisplayData as NodeDisplayDataType,
   WorkflowDataNode,
   WorkflowDisplayData,
   WorkflowEdge,

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
@@ -110,7 +110,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("f9c5254c-b86d-420d-811a-a1674df273cd"),
             name="answer",
             label="Final Output 2",
-            target_handle_id=UUID("87d73dc6-cafd-4f8b-b2fd-8367baba5d61"),
-            display_data=NodeDisplayData(position=NodeDisplayPosition(x=5134, y=443), width=480, height=271),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -50,6 +50,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("dad01b99-c0b4-4904-a75e-066fa947d256"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=467, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -50,8 +50,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("5bb10d67-efc7-4bd4-9452-4ec2ffbc031d"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(
-                position=NodeDisplayPosition(x=2392.5396121883655, y=235.35180055401668), width=480, height=234
-            ),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -53,6 +53,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("b0d2bd58-fa00-4eea-98fb-bc09ee1427dd"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=464, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -53,6 +53,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("a9455dc7-85f5-43a9-8be7-f131bc5f08e2"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=458, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -44,8 +44,5 @@ class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkfl
             node_id=UUID("f3fe1e6e-5a4a-42d8-9cfe-9ecbcb935f72"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(
-                position=NodeDisplayPosition(x=2750, y=208.7778595317725), width=456, height=233
-            ),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -50,6 +50,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("075932b7-c6ba-4c3a-8c8f-d6b043f8fe48"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=480, height=233),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -60,6 +60,5 @@ class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
             node_id=UUID("d9d29911-dd45-45d5-9ac8-1a06bb596c2f"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=463, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -57,6 +57,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("fa0d5829-f259-4db8-a11a-b12fd7237ea5"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(position=NodeDisplayPosition(x=864, y=58.5), width=454, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -60,8 +60,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(
-                position=NodeDisplayPosition(x=3434.5298476454295, y=174.57146814404433), width=480, height=234
-            ),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -50,8 +50,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("54803ff7-9afd-4eb1-bff3-242345d3443d"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(
-                position=NodeDisplayPosition(x=2761.0242006615217, y=208.9757993384785), width=474, height=234
-            ),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -50,8 +50,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("e39c8f13-d59b-49fc-8c59-03ee7997b9b6"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(
-                position=NodeDisplayPosition(x=2761.0242006615217, y=208.9757993384785), width=474, height=234
-            ),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -53,6 +53,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("ed688426-1976-4d0c-9f3a-2a0b0fae161a"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=480, height=234),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
@@ -50,9 +50,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("eb72f89e-f831-4fc1-a54f-dec7f429fff9"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("52b9ff71-e090-4c68-a713-fd72d194b992"),
-            display_data=NodeDisplayData(
-                position=NodeDisplayPosition(x=2750, y=211.25540166204985), width=471, height=234
-            ),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -44,8 +44,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("f0347fdc-1611-446c-b1da-408511d4181b"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(
-                position=NodeDisplayPosition(x=2752.5214681440443, y=210), width=478, height=234
-            ),
         )
     }

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
@@ -50,8 +50,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("eb72f89e-f831-4fc1-a54f-dec7f429fff9"),
             name="final-output",
             label="Final Output",
-            display_data=NodeDisplayData(
-                position=NodeDisplayPosition(x=2750, y=211.25540166204985), width=471, height=234
-            ),
         )
     }

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -127,7 +127,7 @@ class WorkflowOutputVellumDisplayOverrides(WorkflowOutputDisplay, WorkflowOutput
     name: str
     label: str
     node_id: UUID
-    display_data: NodeDisplayData
+    display_data: Optional[NodeDisplayData] = None
     target_handle_id: Optional[UUID] = None
 
 

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -182,7 +182,9 @@ class VellumWorkflowDisplay(
                     else str(uuid4_from_hash(f"{self.workflow_id}|target_handle_id|{workflow_output_display.name}"))
                 )
                 synthetic_display_data = (
-                    workflow_output_display.display_data.dict() if workflow_output_display.display_data else {}
+                    workflow_output_display.display_data.dict()
+                    if workflow_output_display.display_data
+                    else NodeDisplayData().dict()
                 )
                 nodes.append(
                     {

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -176,6 +176,14 @@ class VellumWorkflowDisplay(
                     except IndexError:
                         source_node_display = None
 
+                synthetic_target_handle_id = (
+                    str(workflow_output_display.target_handle_id)
+                    if workflow_output_display.target_handle_id
+                    else str(uuid4_from_hash(f"{self.workflow_id}|target_handle_id|{workflow_output_display.name}"))
+                )
+                synthetic_display_data = (
+                    workflow_output_display.display_data.dict() if workflow_output_display.display_data else {}
+                )
                 nodes.append(
                     {
                         "id": str(final_output_node_id),
@@ -183,13 +191,13 @@ class VellumWorkflowDisplay(
                         "data": {
                             "label": workflow_output_display.label,
                             "name": workflow_output_display.name,
-                            "target_handle_id": str(workflow_output_display.target_handle_id),
+                            "target_handle_id": synthetic_target_handle_id,
                             "output_id": str(workflow_output_display.id),
                             "output_type": inferred_type,
                             "node_input_id": str(node_input.id),
                         },
                         "inputs": [node_input.dict()],
-                        "display_data": workflow_output_display.display_data.dict(),
+                        "display_data": synthetic_display_data,
                         "base": final_output_node_base,
                         "definition": None,
                     }
@@ -211,7 +219,7 @@ class VellumWorkflowDisplay(
                             "source_node_id": str(source_node_display.node_id),
                             "source_handle_id": str(source_handle_id),
                             "target_node_id": str(workflow_output_display.node_id),
-                            "target_handle_id": str(workflow_output_display.target_handle_id),
+                            "target_handle_id": synthetic_target_handle_id,
                             "type": "DEFAULT",
                         }
                     )
@@ -372,15 +380,12 @@ class VellumWorkflowDisplay(
 
         output_id = uuid4_from_hash(f"{self.workflow_id}|id|{output.name}")
         node_id = uuid4_from_hash(f"{self.workflow_id}|node_id|{output.name}")
-        target_handle_id = uuid4_from_hash(f"{self.workflow_id}|target_handle_id|{output.name}")
 
         return WorkflowOutputVellumDisplay(
             id=output_id,
             node_id=node_id,
             name=output.name,
             label="Final Output",
-            target_handle_id=target_handle_id,
-            display_data=NodeDisplayData(),
         )
 
     def _generate_edge_display(

--- a/ee/vellum_ee/workflows/tests/local_workflow/display/workflow.py
+++ b/ee/vellum_ee/workflows/tests/local_workflow/display/workflow.py
@@ -50,7 +50,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             node_id=UUID("f3ef4b2b-fec9-4026-9cc6-e5eac295307f"),
             name="final-output",
             label="Final Output",
-            target_handle_id=UUID("3ec34f6e-da48-40d5-a65b-a48fefa75763"),
-            display_data=NodeDisplayData(position=NodeDisplayPosition(x=2750, y=210), width=459, height=234),
         )
     }


### PR DESCRIPTION
Was working on this ticket: https://github.com/vellum-ai/vellum-python-sdks/pull/962, but noticed a number of cleanup items

Another related comment thread: https://vellum-ai.slack.com/archives/C06P13ABK0W/p1739411040354899