### PR TITLE
Create a simple inline subworkflow node test

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1623,3 +1623,31 @@ export function mapNodeDataFactory(): MapNode {
     ],
   };
 }
+
+export function inlineSubworkflowNodeDataFactory(): SubworkflowNode {
+  const entrypoint = entrypointNodeDataFactory();
+  const templatingNode = templatingNodeFactory();
+  return {
+    id: "14fee4a0-ad25-402f-b942-104d3a5a0824",
+    type: "SUBWORKFLOW",
+    data: {
+      variant: "INLINE",
+      label: "Inline Subworkflow Node",
+      workflowRawData: {
+        nodes: [entrypoint, templatingNode],
+        edges: edgesFactory([[entrypoint, templatingNode]]),
+      },
+      inputVariables: [],
+      outputVariables: [
+        {
+          id: "edd5cfd5-6ad8-437d-8775-4b9aeb62a5fb",
+          key: "final-output",
+          type: "STRING",
+        },
+      ],
+      sourceHandleId: "4878f525-d4a3-4e3d-9221-e146f282a96a",
+      targetHandleId: "3fe4b4a6-5ed2-4307-ac1c-02389337c4f2",
+    },
+    inputs: [],
+  };
+}

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -1,0 +1,43 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`InlineSubworkflowNode > basic > inline subworkflow node display file 1`] = `
+"# flake8: noqa: F401, F403
+
+from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ....nodes.inline_subworkflow_node import InlineSubworkflowNode
+from .nodes import *
+from .workflow import *
+
+
+class InlineSubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[InlineSubworkflowNode]):
+    label = "Inline Subworkflow Node"
+    node_id = UUID("14fee4a0-ad25-402f-b942-104d3a5a0824")
+    target_handle_id = UUID("3fe4b4a6-5ed2-4307-ac1c-02389337c4f2")
+    workflow_input_ids_by_name = {}
+    node_input_ids_by_name = {}
+    output_display = {}
+    port_displays = {
+        InlineSubworkflowNode.Ports.default: PortDisplayOverrides(id=UUID("4878f525-d4a3-4e3d-9221-e146f282a96a"))
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None)
+"
+`;
+
+exports[`InlineSubworkflowNode > basic > inline subworkflow node file 1`] = `
+"from vellum.workflows.nodes.displayable import InlineSubworkflowNode as BaseInlineSubworkflowNode
+
+from .workflow import InlineSubworkflowNodeWorkflow
+
+
+class InlineSubworkflowNode(BaseInlineSubworkflowNode):
+    subworkflow = InlineSubworkflowNodeWorkflow
+
+    class Outputs(BaseInlineSubworkflowNode.Outputs):
+        pass
+"
+`;

--- a/ee/codegen/src/__test__/nodes/inline-subworkflow-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-subworkflow-node.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, readFile, rm } from "fs/promises";
+import { join } from "path";
+
+import { beforeEach } from "vitest";
+
+import { workflowContextFactory } from "src/__test__/helpers";
+import { inlineSubworkflowNodeDataFactory } from "src/__test__/helpers/node-data-factories";
+import { makeTempDir } from "src/__test__/helpers/temp-dir";
+import { createNodeContext } from "src/context";
+import { InlineSubworkflowNodeContext } from "src/context/node-context/inline-subworkflow-node";
+import { InlineSubworkflowNode } from "src/generators/nodes/inline-subworkflow-node";
+
+describe("InlineSubworkflowNode", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = makeTempDir("inline-subworkflow-node-test");
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("basic", () => {
+    beforeEach(async () => {
+      const workflowContext = workflowContextFactory({
+        absolutePathToOutputDirectory: tempDir,
+        moduleName: "code",
+      });
+      const nodeData = inlineSubworkflowNodeDataFactory();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as InlineSubworkflowNodeContext;
+
+      const node = new InlineSubworkflowNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      await node.persist();
+    });
+
+    it(`inline subworkflow node file`, async () => {
+      expect(
+        await readFile(
+          join(
+            tempDir,
+            "code",
+            "nodes",
+            "inline_subworkflow_node",
+            "__init__.py"
+          ),
+          "utf-8"
+        )
+      ).toMatchSnapshot();
+    });
+
+    it(`inline subworkflow node display file`, async () => {
+      expect(
+        await readFile(
+          join(
+            tempDir,
+            "code",
+            "display",
+            "nodes",
+            "inline_subworkflow_node",
+            "__init__.py"
+          ),
+          "utf-8"
+        )
+      ).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
 I noticed during the [map node test](https://github.com/vellum-ai/vellum-python-sdks/pull/959) PR, we didn't have one for inline subworkflow nodes. We add one here, to fix some issues I see there too in a followup