### PR TITLE
Remove the need to generate outputs classes for inline subworkflow nodes

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -36,8 +36,5 @@ from .workflow import InlineSubworkflowNodeWorkflow
 
 class InlineSubworkflowNode(BaseInlineSubworkflowNode):
     subworkflow = InlineSubworkflowNodeWorkflow
-
-    class Outputs(BaseInlineSubworkflowNode.Outputs):
-        pass
 "
 `;

--- a/ee/codegen/src/generators/nodes/inline-subworkflow-node.ts
+++ b/ee/codegen/src/generators/nodes/inline-subworkflow-node.ts
@@ -41,9 +41,7 @@ export class InlineSubworkflowNode extends BaseNestedWorkflowNode<
       initializer: nestedWorkflowReference,
     });
 
-    const outputsClass = this.generateOutputsClass();
-
-    return [subworkflowField, outputsClass];
+    return [subworkflowField];
   }
 
   getNodeDisplayClassBodyStatements(): AstNode[] {
@@ -80,41 +78,6 @@ export class InlineSubworkflowNode extends BaseNestedWorkflowNode<
     );
 
     return statements;
-  }
-
-  private generateOutputsClass(): python.Class {
-    const nodeBaseClassRef = this.getNodeBaseClass();
-    const outputsClass = python.class_({
-      name: OUTPUTS_CLASS_NAME,
-      extends_: [
-        python.reference({
-          name: nodeBaseClassRef.name,
-          modulePath: nodeBaseClassRef.modulePath,
-          alias: nodeBaseClassRef.alias,
-          attribute: [OUTPUTS_CLASS_NAME],
-        }),
-      ],
-    });
-
-    const nestedWorkflowContext = this.getNestedWorkflowContextByName(
-      BaseNestedWorkflowNode.subworkflowNestedProjectName
-    );
-
-    nestedWorkflowContext.workflowOutputContexts.forEach((outputContext) => {
-      const outputName = outputContext.name;
-      const outputField = python.field({
-        name: outputName,
-        initializer: python.reference({
-          name: nestedWorkflowContext.workflowClassName,
-          modulePath: nestedWorkflowContext.modulePath,
-          attribute: [OUTPUTS_CLASS_NAME, outputName],
-        }),
-      });
-
-      outputsClass.add(outputField);
-    });
-
-    return outputsClass;
   }
 
   protected getOutputDisplay(): python.Field {

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/nodes/subworkflow_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/nodes/subworkflow_node/__init__.py
@@ -5,6 +5,3 @@ from .workflow import SubworkflowNodeWorkflow
 
 class SubworkflowNode(InlineSubworkflowNode):
     subworkflow = SubworkflowNodeWorkflow
-
-    class Outputs(InlineSubworkflowNode.Outputs):
-        final_output = SubworkflowNodeWorkflow.Outputs.final_output


### PR DESCRIPTION
Now that Inline Subworkflow Nodes have dynamic [outputs classes](https://github.com/vellum-ai/vellum-python-sdks/pull/780), we no longer need to generate them