### PR TITLE
Fix the output display for inline subworkflow nodes to drive off of output variable context's

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1627,6 +1627,7 @@ export function mapNodeDataFactory(): MapNode {
 export function inlineSubworkflowNodeDataFactory(): SubworkflowNode {
   const entrypoint = entrypointNodeDataFactory();
   const templatingNode = templatingNodeFactory();
+  const outputVariableId = "edd5cfd5-6ad8-437d-8775-4b9aeb62a5fb";
   return {
     id: "14fee4a0-ad25-402f-b942-104d3a5a0824",
     type: "SUBWORKFLOW",
@@ -1636,11 +1637,21 @@ export function inlineSubworkflowNodeDataFactory(): SubworkflowNode {
       workflowRawData: {
         nodes: [entrypoint, templatingNode],
         edges: edgesFactory([[entrypoint, templatingNode]]),
+        outputValues: [
+          {
+            outputVariableId,
+            value: {
+              type: "NODE_OUTPUT",
+              nodeId: templatingNode.id,
+              nodeOutputId: templatingNode.data.outputId,
+            },
+          },
+        ],
       },
       inputVariables: [],
       outputVariables: [
         {
-          id: "edd5cfd5-6ad8-437d-8775-4b9aeb62a5fb",
+          id: outputVariableId,
           key: "final-output",
           type: "STRING",
         },

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -6,7 +6,7 @@ exports[`InlineSubworkflowNode > basic > inline subworkflow node display file 1`
 from uuid import UUID
 
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
-from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ....nodes.inline_subworkflow_node import InlineSubworkflowNode
@@ -20,7 +20,11 @@ class InlineSubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[InlineSubwor
     target_handle_id = UUID("3fe4b4a6-5ed2-4307-ac1c-02389337c4f2")
     workflow_input_ids_by_name = {}
     node_input_ids_by_name = {}
-    output_display = {}
+    output_display = {
+        InlineSubworkflowNode.Outputs.final_output: NodeOutputDisplay(
+            id=UUID("edd5cfd5-6ad8-437d-8775-4b9aeb62a5fb"), name="final-output"
+        )
+    }
     port_displays = {
         InlineSubworkflowNode.Ports.default: PortDisplayOverrides(id=UUID("4878f525-d4a3-4e3d-9221-e146f282a96a"))
     }

--- a/ee/codegen/src/context/output-variable-context.ts
+++ b/ee/codegen/src/context/output-variable-context.ts
@@ -1,18 +1,28 @@
+import { isNil, isEmpty } from "lodash";
 import { VellumVariable } from "vellum-ai/api/types";
+
+import { WorkflowContext } from "src/context/workflow-context";
+import { toPythonSafeSnakeCase } from "src/utils/casing";
 
 export declare namespace OutputVariableContext {
   export type Args = {
     outputVariableData: VellumVariable;
+    workflowContext: WorkflowContext;
   };
 }
 
 export class OutputVariableContext {
+  private readonly workflowContext: WorkflowContext;
   private readonly outputVariableData: VellumVariable;
   public readonly name: string;
 
-  constructor({ outputVariableData }: OutputVariableContext.Args) {
+  constructor({
+    outputVariableData,
+    workflowContext,
+  }: OutputVariableContext.Args) {
+    this.workflowContext = workflowContext;
     this.outputVariableData = outputVariableData;
-    this.name = outputVariableData.key;
+    this.name = this.generateSanitizedOutputVariableName();
   }
 
   public getOutputVariableId(): string {
@@ -25,5 +35,27 @@ export class OutputVariableContext {
 
   public getRawName(): string {
     return this.outputVariableData.key;
+  }
+
+  private generateSanitizedOutputVariableName(): string {
+    const defaultName = "output_";
+
+    const rawOutputVariableName = this.outputVariableData.key;
+    const initialOutputVariableName =
+      !isNil(rawOutputVariableName) && !isEmpty(rawOutputVariableName)
+        ? toPythonSafeSnakeCase(rawOutputVariableName, "output")
+        : defaultName;
+
+    // Deduplicate the output variable name if it's already in use
+    let sanitizedName = initialOutputVariableName;
+    let numRenameAttempts = 0;
+    while (this.workflowContext.isOutputVariableNameUsed(sanitizedName)) {
+      sanitizedName = `${initialOutputVariableName}${
+        initialOutputVariableName.endsWith("_") ? "" : "_"
+      }${numRenameAttempts + 1}`;
+      numRenameAttempts += 1;
+    }
+
+    return sanitizedName;
   }
 }

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -304,10 +304,9 @@ export class WorkflowContext {
       outputVariableId,
       outputVariableContext
     );
+
     // This was added from the workflow output context. We should remove this once terminal node data is removed from data
-    if (!this.outputVariableNames.has(outputVariableContext.name)) {
-      this.addUsedOutputVariableName(outputVariableContext.name);
-    }
+    this.addUsedOutputVariableName(outputVariableContext.name);
   }
 
   public getOutputVariableContextById(

--- a/ee/codegen/src/context/workflow-output-context.ts
+++ b/ee/codegen/src/context/workflow-output-context.ts
@@ -77,28 +77,15 @@ export class WorkflowOutputContext {
       const outputVariable = this.workflowContext.getOutputVariableContextById(
         this.workflowOutputValue.outputVariableId
       );
-      rawOutputVariableName = outputVariable.name;
+      return outputVariable.name;
     } else {
       throw new WorkflowOutputGenerationError(
         "Expected either workflow output value or terminal node data to be defined"
       );
     }
 
-    const initialOutputVariableName =
-      !isNil(rawOutputVariableName) && !isEmpty(rawOutputVariableName)
-        ? toPythonSafeSnakeCase(rawOutputVariableName, "output")
-        : defaultName;
-
-    // Deduplicate the output variable name if it's already in use
-    let sanitizedName = initialOutputVariableName;
-    let numRenameAttempts = 0;
-    while (this.workflowContext.isOutputVariableNameUsed(sanitizedName)) {
-      sanitizedName = `${initialOutputVariableName}${
-        initialOutputVariableName.endsWith("_") ? "" : "_"
-      }${numRenameAttempts + 1}`;
-      numRenameAttempts += 1;
-    }
-
-    return sanitizedName;
+    return !isNil(rawOutputVariableName) && !isEmpty(rawOutputVariableName)
+      ? toPythonSafeSnakeCase(rawOutputVariableName, "output")
+      : defaultName;
   }
 }

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -362,6 +362,14 @@ ${errors.slice(0, 3).map((err) => {
       this.workflowContext.addInputVariableContext(inputVariableContext);
     });
 
+    this.workflowVersionExecConfig.outputVariables.forEach((outputVariable) => {
+      const outputVariableContext = new OutputVariableContext({
+        outputVariableData: outputVariable,
+        workflowContext: this.workflowContext,
+      });
+      this.workflowContext.addOutputVariableContext(outputVariableContext);
+    });
+
     const entrypointNodes =
       this.workflowVersionExecConfig.workflowRawData.nodes.filter(
         (n): n is EntrypointNode => n.type === "ENTRYPOINT"
@@ -423,13 +431,6 @@ ${errors.slice(0, 3).map((err) => {
 
     const inputs = codegen.inputs({
       workflowContext: this.workflowContext,
-    });
-
-    this.workflowVersionExecConfig.outputVariables.forEach((outputVariable) => {
-      const outputVariableContext = new OutputVariableContext({
-        outputVariableData: outputVariable,
-      });
-      this.workflowContext.addOutputVariableContext(outputVariableContext);
     });
 
     const nodeIds = nodesToGenerate.map((nodeData) => nodeData.id);

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
@@ -19,7 +19,7 @@ class SubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[SubworkflowNode]):
     node_input_ids_by_name = {}
     output_display = {
         SubworkflowNode.Outputs.final_output: NodeOutputDisplay(
-            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final_output"
+            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final-output"
         )
     }
     port_displays = {


### PR DESCRIPTION
Continuing work started here: https://github.com/vellum-ai/vellum-python-sdks/pull/968

I noticed that we were using the wrong output variable id's when defining subworkflow node output displays (for both subworkflow and map node outputs). So I started with the expected snapshot and worked backwards. In doing so that we have redundancy between `output-variable-context` and `workflow-output-context`s, so this cleanup will eventually remove the latter