### PR TITLE
Support workflow value descriptors pointing to non node outputs

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -31,6 +31,18 @@ class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
 "
 `;
 
+exports[`Workflow > write > should generate correct code with an output variable mapped to an input variable 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .inputs import Inputs
+from vellum.workflows.state import BaseState
+
+
+class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
+    class Outputs(BaseWorkflow.Outputs):
+        passthrough = Inputs.query
+"
+`;
+
 exports[`Workflow > write > should handle edges pointing to non-existent nodes 1`] = `
 "from vellum.workflows import BaseWorkflow
 from .inputs import Inputs

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -359,7 +359,6 @@ export class WorkflowContext {
     workflowOutputContext: WorkflowOutputContext
   ): void {
     this.workflowOutputContexts.push(workflowOutputContext);
-    this.addUsedOutputVariableName(workflowOutputContext.name);
   }
 
   public isNodeModuleNameUsed(nodeModuleName: string): boolean {

--- a/ee/codegen/src/generators/workflow-output.ts
+++ b/ee/codegen/src/generators/workflow-output.ts
@@ -3,7 +3,8 @@ import { Field } from "@fern-api/python-ast/Field";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
-import { OUTPUTS_CLASS_NAME } from "src/constants";
+import { WorkflowValueDescriptor } from "./workflow-value-descriptor";
+
 import { WorkflowContext } from "src/context";
 import { WorkflowOutputContext } from "src/context/workflow-output-context";
 
@@ -29,16 +30,12 @@ export class WorkflowOutput extends AstNode {
   }
 
   private generateWorkflowOutput(): Field {
-    const terminalNodeId = this.workflowOutputContext.getOutputNodeId();
-    const terminalNodeContext =
-      this.workflowContext.getNodeContext(terminalNodeId);
-
     const workflowOutput = python.field({
       name: this.workflowOutputContext.name,
-      initializer: python.reference({
-        name: terminalNodeContext.nodeClassName,
-        modulePath: terminalNodeContext.nodeModulePath,
-        attribute: [OUTPUTS_CLASS_NAME, "value"],
+      initializer: new WorkflowValueDescriptor({
+        workflowContext: this.workflowContext,
+        workflowValueDescriptor:
+          this.workflowOutputContext.getWorkflowValueDescriptor(),
       }),
     });
 


### PR DESCRIPTION
This PR supports our workflow output values pointing to anything besides node output. It's the use case that helps complete the refactor that we were starting here: https://github.com/vellum-ai/vellum-python-sdks/pull/969