### PR TITLE
Speed up codegen tests by passing disable formatting to workflow context

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -23,11 +23,10 @@ baz = foo + bar
 `;
 
 exports[`WorkflowProjectGenerator > inlude sandbox > should include a sandbox.py file when passed sandboxInputs 1`] = `
-"from vellum import ArrayChatMessageContent, ChatMessage, StringChatMessageContent
-from vellum.workflows.sandbox import WorkflowSandboxRunner
-
-from .inputs import Inputs
+"from vellum.workflows.sandbox import WorkflowSandboxRunner
 from .workflow import Workflow
+from .inputs import Inputs
+from vellum import ChatMessage, StringChatMessageContent, ArrayChatMessageContent
 
 if __name__ != "__main__":
     raise Exception("This file is not meant to be imported")
@@ -71,7 +70,6 @@ runner.run()
 exports[`WorkflowProjectGenerator > nodes with output values > should prioritize terminal node data over output values 1`] = `
 "from vellum.workflows.nodes.displayable import FinalOutputNode
 from vellum.workflows.state import BaseState
-
 from .templating_node import TemplatingNode
 
 

--- a/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
+++ b/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
@@ -1,17 +1,14 @@
 import { WorkflowContext } from "src/context";
 
-export function workflowContextFactory(
-  {
-    absolutePathToOutputDirectory,
-    moduleName,
-    workflowClassName,
-    workflowRawEdges,
-    codeExecutionNodeCodeRepresentationOverride,
-    strict = true,
-  }: Partial<WorkflowContext.Args> = {
-    codeExecutionNodeCodeRepresentationOverride: "STANDALONE",
-  }
-): WorkflowContext {
+export function workflowContextFactory({
+  absolutePathToOutputDirectory,
+  moduleName,
+  workflowClassName,
+  workflowRawEdges,
+  codeExecutionNodeCodeRepresentationOverride = "STANDALONE",
+  strict = true,
+  disableFormatting = true,
+}: Partial<WorkflowContext.Args> = {}): WorkflowContext {
   return new WorkflowContext({
     absolutePathToOutputDirectory:
       absolutePathToOutputDirectory || "./src/__tests__/",
@@ -21,5 +18,6 @@ export function workflowContextFactory(
     workflowRawEdges: workflowRawEdges || [],
     strict,
     codeExecutionNodeCodeRepresentationOverride,
+    disableFormatting,
   });
 }

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -3,13 +3,11 @@
 exports[`InlineSubworkflowNode > basic > inline subworkflow node display file 1`] = `
 "# flake8: noqa: F401, F403
 
-from uuid import UUID
-
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
+from ....nodes.inline_subworkflow_node import InlineSubworkflowNode
+from uuid import UUID
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
-
-from ....nodes.inline_subworkflow_node import InlineSubworkflowNode
 from .nodes import *
 from .workflow import *
 
@@ -34,7 +32,6 @@ class InlineSubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[InlineSubwor
 
 exports[`InlineSubworkflowNode > basic > inline subworkflow node file 1`] = `
 "from vellum.workflows.nodes.displayable import InlineSubworkflowNode as BaseInlineSubworkflowNode
-
 from .workflow import InlineSubworkflowNodeWorkflow
 
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/map-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/map-node.test.ts.snap
@@ -3,13 +3,11 @@
 exports[`MapNode > basic > map node display file 1`] = `
 "# flake8: noqa: F401, F403
 
-from uuid import UUID
-
 from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
+from ....nodes.map_node import MapNode
+from uuid import UUID
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
-
-from ....nodes.map_node import MapNode
 from .nodes import *
 from .workflow import *
 
@@ -31,7 +29,6 @@ class MapNodeDisplay(BaseMapNodeDisplay[MapNode]):
 
 exports[`MapNode > basic > map node file 1`] = `
 "from vellum.workflows.nodes.displayable import MapNode as BaseMapNode
-
 from .workflow import MapNodeWorkflow
 
 
@@ -49,13 +46,11 @@ class MapNode(BaseMapNode):
 exports[`MapNode > with additional output > map node display file 1`] = `
 "# flake8: noqa: F401, F403
 
-from uuid import UUID
-
 from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
+from ....nodes.map_node import MapNode
+from uuid import UUID
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
-
-from ....nodes.map_node import MapNode
 from .nodes import *
 from .workflow import *
 
@@ -80,7 +75,6 @@ class MapNodeDisplay(BaseMapNodeDisplay[MapNode]):
 
 exports[`MapNode > with additional output > map node file 1`] = `
 "from vellum.workflows.nodes.displayable import MapNode as BaseMapNode
-
 from .workflow import MapNodeWorkflow
 
 

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -207,6 +207,9 @@ describe("WorkflowProjectGenerator", () => {
         workflowVersionExecConfigData: displayData,
         moduleName: "code",
         vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
       });
 
       await project.generateCode();
@@ -250,6 +253,9 @@ Encountered 1 error(s) while generating code:
         workflowVersionExecConfigData: displayData,
         moduleName: "code",
         vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
         strict: true,
       });
 
@@ -332,6 +338,9 @@ Encountered 1 error(s) while generating code:
         workflowVersionExecConfigData: displayData,
         moduleName: "code",
         vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
       });
 
       await project.generateCode();
@@ -452,6 +461,9 @@ class BadNode(TemplatingNode[BaseState, str]):
         workflowVersionExecConfigData: displayData,
         moduleName: "code",
         vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
         sandboxInputs: [
           [
             {
@@ -593,6 +605,9 @@ class BadNode(TemplatingNode[BaseState, str]):
         workflowVersionExecConfigData: displayData,
         moduleName: "code",
         vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
       });
 
       await project.generateCode();
@@ -710,6 +725,9 @@ class BadNode(TemplatingNode[BaseState, str]):
         workflowVersionExecConfigData: displayData,
         moduleName: "code",
         vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
       });
 
       await project.generateCode();
@@ -807,6 +825,9 @@ baz = foo + bar
         workflowVersionExecConfigData: displayData,
         moduleName: "code",
         vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
         strict: true,
       });
 
@@ -928,6 +949,9 @@ baz = foo + bar
         workflowVersionExecConfigData: displayData,
         moduleName: "code",
         vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
         strict: false,
       });
 
@@ -1071,6 +1095,9 @@ baz = foo + bar
         workflowVersionExecConfigData: displayData,
         moduleName: "code",
         vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
         strict: true,
       });
 

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -47,8 +47,9 @@ export declare namespace WorkflowContext {
     portContextByName?: PortContextById;
     vellumApiKey: string;
     workflowRawEdges: WorkflowEdge[];
-    strict?: boolean;
-    codeExecutionNodeCodeRepresentationOverride?: "STANDALONE" | "INLINE";
+    strict: boolean;
+    codeExecutionNodeCodeRepresentationOverride: "STANDALONE" | "INLINE";
+    disableFormatting: boolean;
   };
 }
 
@@ -113,8 +114,9 @@ export class WorkflowContext {
 
   public readonly codeExecutionNodeCodeRepresentationOverride:
     | "STANDALONE"
-    | "INLINE"
-    | undefined;
+    | "INLINE";
+
+  public readonly disableFormatting: boolean;
 
   // Track what class names are used within this workflow so that we can ensure name uniqueness
   private readonly classNames: Set<string> = new Set();
@@ -131,8 +133,9 @@ export class WorkflowContext {
     portContextByName,
     vellumApiKey,
     workflowRawEdges,
-    strict = false,
+    strict,
     codeExecutionNodeCodeRepresentationOverride,
+    disableFormatting,
   }: WorkflowContext.Args) {
     this.absolutePathToOutputDirectory = absolutePathToOutputDirectory;
     this.moduleName = moduleName;
@@ -165,6 +168,8 @@ export class WorkflowContext {
     this.codeExecutionNodeCodeRepresentationOverride =
       codeExecutionNodeCodeRepresentationOverride;
 
+    this.disableFormatting = disableFormatting;
+
     this.outputVariableContextsById = new Map();
     this.globalOutputVariableContextsById =
       globalOutputVariableContextsById ?? new Map();
@@ -194,6 +199,7 @@ export class WorkflowContext {
       codeExecutionNodeCodeRepresentationOverride:
         this.codeExecutionNodeCodeRepresentationOverride,
       strict: this.strict,
+      disableFormatting: this.disableFormatting,
     });
   }
 

--- a/ee/codegen/src/generators/nodes/code-execution-node.ts
+++ b/ee/codegen/src/generators/nodes/code-execution-node.ts
@@ -21,10 +21,7 @@ export class CodeExecutionNode extends BaseSingleFileNode<
 > {
   public declare readonly nodeContext: CodeExecutionContext;
   private readonly scriptFileContents: string;
-  private readonly codeRepresentationOverride:
-    | "STANDALONE"
-    | "INLINE"
-    | undefined;
+  private readonly codeRepresentationOverride: "STANDALONE" | "INLINE";
 
   constructor({
     workflowContext,

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -186,9 +186,11 @@ ${errors.slice(0, 3).map((err) => {
         workflowClassName,
         vellumApiKey,
         workflowRawEdges: rawEdges,
-        strict: rest.strict,
+        strict: rest.strict ?? false,
         codeExecutionNodeCodeRepresentationOverride:
-          rest.options?.codeExecutionNodeCodeRepresentationOverride,
+          rest.options?.codeExecutionNodeCodeRepresentationOverride ??
+          "STANDALONE",
+        disableFormatting: rest.options?.disableFormatting ?? false,
       });
       this.sandboxInputs = rest.sandboxInputs;
       this.options = rest.options;
@@ -241,7 +243,7 @@ ${errors.slice(0, 3).map((err) => {
     // collects errors raised by the rest of the codegen process
     await this.generateErrorLogFile().persist();
 
-    if (!this.options?.disableFormatting) {
+    if (!this.workflowContext.disableFormatting) {
       const setupCfgPath = this.resolvePythonConfigFilePath();
       const isortCmd = process.env.ISORT_CMD ?? "isort";
 


### PR DESCRIPTION
Before:
![Screenshot 2025-02-12 at 11 56 48 PM](https://github.com/user-attachments/assets/e8dc4322-0531-4f19-ada7-0d47db47ff9c)

After:
![Screenshot 2025-02-12 at 11 55 40 PM](https://github.com/user-attachments/assets/803345c4-17a1-43d9-a410-67d5902ae195)

The main source of the speedup is not running isort. We could get this down further if we stopped running `isort` in the batch of `project.test.ts` tests, but these affect our python files which we want to keep sorted. Am bullish on eventually removing this from `project.ts` and running this sort of python proc in django as @m-abboud has advised previously, and also just doing an initial isort pass in typescript which doesn't seem too bad