### PR TITLE
Fix array inputs to inline code exec node

### DIFF
--- a/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
@@ -93,14 +93,14 @@ class CodeExecutionNode(BaseNode[StateType], Generic[StateType, _OutputType], me
         log: str
 
     def run(self) -> Outputs:
-        input_values = self._compile_code_inputs()
         output_type = self.__class__.get_output_type()
         code = self._resolve_code()
         if not self.packages and self.runtime == "PYTHON_3_11_6":
-            logs, result = run_code_inline(code, input_values, output_type)
+            logs, result = run_code_inline(code, self.code_inputs, output_type)
             return self.Outputs(result=result, log=logs)
 
         else:
+            input_values = self._compile_code_inputs()
             expected_output_type = primitive_type_to_vellum_variable_type(output_type)
 
             code_execution_result = self._context.vellum_client.execute_code(
@@ -132,7 +132,7 @@ class CodeExecutionNode(BaseNode[StateType], Generic[StateType, _OutputType], me
                 compiled_inputs.append(
                     StringInput(
                         name=input_name,
-                        value=str(input_value),
+                        value=input_value,
                     )
                 )
             elif isinstance(input_value, VellumSecret):
@@ -194,7 +194,7 @@ class CodeExecutionNode(BaseNode[StateType], Generic[StateType, _OutputType], me
                 )
             else:
                 raise NodeException(
-                    message=f"Unrecognized input type for input '{input_name}'",
+                    message=f"Unrecognized input type for input '{input_name}': {input_value.__class__.__name__}",
                     code=WorkflowErrorCode.INVALID_INPUTS,
                 )
 

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
@@ -562,7 +562,7 @@ def main(arg1: List[Dict]) -> float:
     vellum_client.execute_code.assert_not_called()
 
 
-def test_run_node__code_execution_error(vellum_client):
+def test_run_node__code_execution_error():
     # GIVEN a node that will raise an error during execution
     class State(BaseState):
         pass
@@ -588,3 +588,25 @@ def main(arg1: int, arg2: int) -> int:
     # AND the error should contain the execution error details
     assert "name 'arg3' is not defined" in str(exc_info.value)
     assert exc_info.value.code == WorkflowErrorCode.INVALID_CODE
+
+
+def test_run_node__array_of_bools_input():
+    # GIVEN a node that will raise an error during execution
+    class ExampleCodeExecutionNode(CodeExecutionNode[BaseState, int]):
+        code = """\
+def main(arg1: list[bool]) -> int:
+    return len(arg1)
+"""
+        runtime = "PYTHON_3_11_6"
+        code_inputs = {
+            "arg1": [True, False, True],
+        }
+
+    # WHEN we run the node
+    node = ExampleCodeExecutionNode()
+
+    # THEN it should raise a NodeException with the execution error
+    outputs = node.run()
+
+    # AND the error should contain the execution error details
+    assert outputs == {"result": 3, "log": ""}


### PR DESCRIPTION
This was affecting one of our users who had a workflow with arrays feeding into a code node. We used this as an opportunity to isolate the `VellumValue` stuff to just what gets run in Vellum, allowing first class primitive values to be run locally