### PR TITLE
Fix flaky expensive emitter test

### DIFF
--- a/tests/workflows/background_emitter/workflow.py
+++ b/tests/workflows/background_emitter/workflow.py
@@ -8,17 +8,26 @@ from vellum.workflows.state.base import BaseState
 
 
 class ExpensiveEmitter(BaseWorkflowEmitter):
-    delay = 0.02
+    delay = 0.2
+    _has_slept: bool
+
+    def __init__(self):
+        self._has_slept = False
 
     def _emit(self) -> None:
         pass
 
+    def _sleep(self) -> None:
+        if not self._has_slept:
+            time.sleep(self.delay)
+            self._has_slept = True
+
     def emit_event(self, event: WorkflowEvent) -> None:
         self._emit()
-        time.sleep(self.delay)
+        self._sleep()
 
     def snapshot_state(self, state: BaseState) -> None:
-        time.sleep(self.delay)
+        self._sleep()
 
 
 class StartNode(BaseNode):


### PR DESCRIPTION
This test failed three times on another pr: https://github.com/vellum-ai/vellum-python-sdks/actions/runs/13313436086/job/37181988700

Bumping up the sleep time but making sure it only does it once so as to not slow down tests