### PR TITLE
Don't Hard Fail on Missing Subworkflow Deployment Output

### DIFF
--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -350,12 +350,4 @@ describe("Non-existent Subworkflow Deployment Node referenced by Templating Node
     node.getNodeDisplayFile().write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
   });
-
-  it("workflow context should have the error logged", async () => {
-    const errors = workflowContext.getErrors();
-    expect(errors).toHaveLength(1);
-    expect(errors[0]?.message).toContain(
-      "Could not find subworkflow deployment output with id some-non-existent-subworkflow-output-id"
-    );
-  });
 });

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -104,12 +104,10 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
         this.nodeData.type === "SUBWORKFLOW" &&
         this.nodeData.data.variant === "DEPLOYMENT"
       ) {
-        this.workflowContext.addError(
-          new NodeOutputNotFoundError(
-            `Could not find subworkflow deployment output with id ${outputId}`
-          )
+        console.warn(
+          `Could not find subworkflow deployment output with id ${outputId}`
         );
-        return;
+        return undefined;
       }
 
       throw new NodeOutputNotFoundError(


### PR DESCRIPTION
Here we warn instead of error when a downstream Node is pointing to an output on a Subworkflow Deployment Node that no longer exists.