### PR TITLE
Proposal: New Way of Handling Codegen Warnings

### DIFF
--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -5,7 +5,7 @@ import {
 } from "vellum-ai/api";
 import { Deployments as DeploymentsClient } from "vellum-ai/api/resources/deployments/client/Client";
 import { WorkflowDeployments as WorkflowDeploymentsClient } from "vellum-ai/api/resources/workflowDeployments/client/Client";
-import { beforeEach, vi } from "vitest";
+import { beforeEach, expect, vi } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
 import { inputVariableContextFactory } from "src/__test__/helpers/input-variable-context-factory";
@@ -354,7 +354,10 @@ describe("Non-existent Subworkflow Deployment Node referenced by Templating Node
   it("workflow context should have the error logged", async () => {
     const errors = workflowContext.getErrors();
     expect(errors).toHaveLength(1);
-    expect(errors[0]?.message).toContain(
+
+    const error = errors[0];
+    expect(error?.severity).toBe("WARNING");
+    expect(error?.message).toContain(
       "Could not find subworkflow deployment output with id some-non-existent-subworkflow-output-id"
     );
   });

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -106,7 +106,8 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
       ) {
         this.workflowContext.addError(
           new NodeOutputNotFoundError(
-            `Could not find subworkflow deployment output with id ${outputId}`
+            `Could not find subworkflow deployment output with id ${outputId}`,
+            "WARNING"
           )
         );
         return;

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -10,6 +10,7 @@ import { SDK_MODULE_PATHS } from "src/context/workflow-context/types";
 import { WorkflowOutputContext } from "src/context/workflow-output-context";
 import {
   BaseCodegenError,
+  CodegenErrorSeverity,
   NodeDefinitionGenerationError,
   NodeNotFoundError,
   NodePortGenerationError,
@@ -444,8 +445,11 @@ export class WorkflowContext {
   }
 
   public addError(error: BaseCodegenError): void {
-    if (this.strict) {
+    if (this.strict && error.severity === "ERROR") {
       throw error;
+    }
+    if (error.severity === "WARNING") {
+      error.log();
     }
     const errorExists = this.errors.some(
       (existingError) => existingError.message === error.message
@@ -456,8 +460,12 @@ export class WorkflowContext {
     }
   }
 
-  public getErrors(): BaseCodegenError[] {
-    return [...this.errors];
+  public getErrors(severity?: CodegenErrorSeverity): BaseCodegenError[] {
+    const allErrors = [...this.errors];
+    if (!severity) {
+      return allErrors;
+    }
+    return allErrors.filter((error) => error.severity === severity);
   }
 
   public isClassNameUsed(className: string): boolean {

--- a/ee/codegen/src/generators/error-log-file.ts
+++ b/ee/codegen/src/generators/error-log-file.ts
@@ -15,7 +15,7 @@ export class ErrorLogFile extends BasePersistedFile {
   }
 
   public async persist(): Promise<void> {
-    const errors = this.workflowContext.getErrors();
+    const errors = this.workflowContext.getErrors("ERROR");
     if (errors.length === 0) {
       return;
     }

--- a/ee/codegen/src/generators/errors.ts
+++ b/ee/codegen/src/generators/errors.ts
@@ -14,8 +14,26 @@ export type CodegenErrorCode =
   | "POST_PROCESSING_ERROR"
   | "VALUE_GENERATION_ERROR";
 
+export type CodegenErrorSeverity = "ERROR" | "WARNING";
+
 export abstract class BaseCodegenError extends Error {
   abstract code: CodegenErrorCode;
+
+  public readonly severity: CodegenErrorSeverity;
+
+  constructor(message: string, severity?: CodegenErrorSeverity) {
+    super(message);
+
+    this.severity = severity ?? "ERROR";
+  }
+
+  public log() {
+    if (this.severity === "ERROR") {
+      console.error(this.message);
+    } else {
+      console.warn(this.message);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
I find it helpful to collect warnings much like we do hard errors. This way, we can introduce "ultra strict modes" later, or just generally track issues in codegen of various severity levels.

This PR proposes a pattern for doing so that's inspired by log levels.