### PR TITLE
Fix templating node output as a list of dataclasses

### DIFF
--- a/src/vellum/utils/templating/render.py
+++ b/src/vellum/utils/templating/render.py
@@ -9,7 +9,7 @@ from vellum.workflows.state.encoder import DefaultStateEncoder
 
 
 def finalize(obj: Any) -> str:
-    if isinstance(obj, dict):
+    if isinstance(obj, (dict, list)):
         return json.dumps(obj, cls=DefaultStateEncoder)
 
     return str(obj)

--- a/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
@@ -220,3 +220,17 @@ def test_templating_node__replace_filter():
             },
         }
     ]
+
+
+def test_templating_node__last_chat_message():
+    # GIVEN a templating node that outputs a complex object
+    class LastChatMessageTemplateNode(TemplatingNode[BaseState, List[ChatMessage]]):
+        template = """{{ chat_history[:-1] }}"""
+        inputs = {"chat_history": [ChatMessage(role="USER", text="Hello"), ChatMessage(role="ASSISTANT", text="World")]}
+
+    # WHEN the node is run
+    node = LastChatMessageTemplateNode()
+    outputs = node.run()
+
+    # THEN the output is the expected JSON
+    assert outputs.result == [ChatMessage(role="USER", text="Hello")]


### PR DESCRIPTION
This was failing one of the customer workflows that we were qaing