### PR TITLE
Remove WorkflowOutputVellumDisplayOverrides.node_id

### DIFF
--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -468,14 +468,12 @@ export class Workflow {
             (workflowOutputContext) => {
               const finalOutput =
                 workflowOutputContext.getFinalOutputNodeData();
-              let outputNodeId: string;
               let outputId: string;
               let name: string;
               let label: string;
 
               // Final output node
               if ("type" in finalOutput) {
-                outputNodeId = finalOutput.id;
                 outputId = finalOutput.data.outputId;
                 name = finalOutput.data.name;
                 label = finalOutput.data.label;
@@ -494,7 +492,6 @@ export class Workflow {
                   this.workflowContext.getOutputVariableContextById(
                     finalOutput.outputVariableId
                   );
-                outputNodeId = referencedNode.nodeData.id;
                 outputId =
                   getNodeOutputIdFromNodeOutputWorkflowReference(finalOutput);
                 name = referencedOutput.name;
@@ -518,10 +515,6 @@ export class Workflow {
                     python.methodArgument({
                       name: "id",
                       value: python.TypeInstantiation.uuid(outputId),
-                    }),
-                    python.methodArgument({
-                      name: "node_id",
-                      value: python.TypeInstantiation.uuid(outputNodeId),
                     }),
                     python.methodArgument({
                       name: "name",

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
@@ -107,7 +107,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     output_displays = {
         Workflow.Outputs.answer: WorkflowOutputVellumDisplayOverrides(
             id=UUID("8c6e5464-8916-4039-b911-cf707855d372"),
-            node_id=UUID("f9c5254c-b86d-420d-811a-a1674df273cd"),
             name="answer",
             label="Final Output 2",
         )

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -46,9 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62"),
-            node_id=UUID("dad01b99-c0b4-4904-a75e-066fa947d256"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -46,9 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("87760362-25b9-4dcb-8034-b49dc9e033ab"),
-            node_id=UUID("5bb10d67-efc7-4bd4-9452-4ec2ffbc031d"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("87760362-25b9-4dcb-8034-b49dc9e033ab"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -49,9 +49,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("d8381526-1225-4843-8c22-eec7747445e4"),
-            node_id=UUID("b0d2bd58-fa00-4eea-98fb-bc09ee1427dd"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("d8381526-1225-4843-8c22-eec7747445e4"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -49,9 +49,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("493cfa4b-5235-4b71-99ef-270955f35fcb"),
-            node_id=UUID("a9455dc7-85f5-43a9-8be7-f131bc5f08e2"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("493cfa4b-5235-4b71-99ef-270955f35fcb"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -40,9 +40,6 @@ class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkfl
     }
     output_displays = {
         SubworkflowNodeWorkflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"),
-            node_id=UUID("f3fe1e6e-5a4a-42d8-9cfe-9ecbcb935f72"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -46,9 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6"),
-            node_id=UUID("075932b7-c6ba-4c3a-8c8f-d6b043f8fe48"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -56,9 +56,6 @@ class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
     }
     output_displays = {
         MapNodeWorkflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("bffc4749-00b8-44db-90ee-db655cbc7e62"),
-            node_id=UUID("d9d29911-dd45-45d5-9ac8-1a06bb596c2f"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("bffc4749-00b8-44db-90ee-db655cbc7e62"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -53,9 +53,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("d9269719-a7a2-4388-9b85-73e329a78d16"),
-            node_id=UUID("fa0d5829-f259-4db8-a11a-b12fd7237ea5"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("d9269719-a7a2-4388-9b85-73e329a78d16"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -56,9 +56,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"),
-            node_id=UUID("7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -46,9 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("f1eca494-a7dc-41c0-9c74-9658a64955e6"),
-            node_id=UUID("54803ff7-9afd-4eb1-bff3-242345d3443d"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("f1eca494-a7dc-41c0-9c74-9658a64955e6"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -46,9 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("aed7279d-59cd-4c15-b82c-21de48129ba3"),
-            node_id=UUID("e39c8f13-d59b-49fc-8c59-03ee7997b9b6"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("aed7279d-59cd-4c15-b82c-21de48129ba3"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -49,9 +49,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("43e128f4-24fe-4484-9d08-948a4a390707"),
-            node_id=UUID("ed688426-1976-4d0c-9f3a-2a0b0fae161a"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("43e128f4-24fe-4484-9d08-948a4a390707"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
@@ -47,7 +47,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
             id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"),
-            node_id=UUID("eb72f89e-f831-4fc1-a54f-dec7f429fff9"),
             name="final-output",
             label="Final Output",
         )

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -40,9 +40,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"),
-            node_id=UUID("f0347fdc-1611-446c-b1da-408511d4181b"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"), name="final-output", label="Final Output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
@@ -46,9 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"),
-            node_id=UUID("eb72f89e-f831-4fc1-a54f-dec7f429fff9"),
-            name="final-output",
-            label="Final Output",
+            id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"), name="final-output", label="Final Output"
         )
     }

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -126,7 +126,7 @@ class EntrypointVellumDisplay(EntrypointVellumDisplayOverrides):
 class WorkflowOutputVellumDisplayOverrides(WorkflowOutputDisplay, WorkflowOutputDisplayOverrides):
     name: str
     label: str
-    node_id: UUID
+    node_id: Optional[UUID] = None
     display_data: Optional[NodeDisplayData] = None
     target_handle_id: Optional[UUID] = None
 

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -144,7 +144,9 @@ class VellumWorkflowDisplay(
 
         # Add a synthetic Terminal Node and track the Workflow's output variables for each Workflow output
         for workflow_output, workflow_output_display in self.display_context.workflow_output_displays.items():
-            final_output_node_id = workflow_output_display.node_id
+            final_output_node_id = workflow_output_display.node_id or uuid4_from_hash(
+                f"{self.workflow_id}|node_id|{workflow_output.name}"
+            )
             inferred_type = infer_vellum_variable_type(workflow_output)
 
             # Remove the terminal node output from the unreferenced set
@@ -220,7 +222,7 @@ class VellumWorkflowDisplay(
                             "id": str(uuid4_from_hash(f"{self.workflow_id}|edge_id|{workflow_output_display.name}")),
                             "source_node_id": str(source_node_display.node_id),
                             "source_handle_id": str(source_handle_id),
-                            "target_node_id": str(workflow_output_display.node_id),
+                            "target_node_id": str(final_output_node_id),
                             "target_handle_id": synthetic_target_handle_id,
                             "type": "DEFAULT",
                         }
@@ -381,11 +383,9 @@ class VellumWorkflowDisplay(
             )
 
         output_id = uuid4_from_hash(f"{self.workflow_id}|id|{output.name}")
-        node_id = uuid4_from_hash(f"{self.workflow_id}|node_id|{output.name}")
 
         return WorkflowOutputVellumDisplay(
             id=output_id,
-            node_id=node_id,
             name=output.name,
             label="Final Output",
         )

--- a/ee/vellum_ee/workflows/tests/local_workflow/display/workflow.py
+++ b/ee/vellum_ee/workflows/tests/local_workflow/display/workflow.py
@@ -47,7 +47,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
             id=UUID("5469b810-6ea6-4362-9e79-e360d44a1405"),
-            node_id=UUID("f3ef4b2b-fec9-4026-9cc6-e5eac295307f"),
             name="final-output",
             label="Final Output",
         )


### PR DESCRIPTION
Context: https://github.com/vellum-ai/vellum-python-sdks/pull/966

Going to incrementally start simplifying our display classes to eventually conlidate:
- BaseWorkflowDisplay and VellumWorkflowDisplay -> BaseWorkflowDisplay
- `XDisplay`, `XDisplayOverrides`, `XVellumDisplay`, `XVellumDisplayOverrides` -> `XDisplay`

This PR removes `WorkflowOutputVellumDisplayOverrides.node_id` on the pursuit to eventually reach the above consolidation