### PR TITLE
Remove workflow output node label

### DIFF
--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -470,13 +470,11 @@ export class Workflow {
                 workflowOutputContext.getFinalOutputNodeData();
               let outputId: string;
               let name: string;
-              let label: string;
 
               // Final output node
               if ("type" in finalOutput) {
                 outputId = finalOutput.data.outputId;
                 name = finalOutput.data.name;
-                label = finalOutput.data.label;
               } else {
                 const nodeId =
                   getNodeIdFromNodeOutputWorkflowReference(finalOutput);
@@ -495,7 +493,6 @@ export class Workflow {
                 outputId =
                   getNodeOutputIdFromNodeOutputWorkflowReference(finalOutput);
                 name = referencedOutput.name;
-                label = this.getLabel(referencedNode.nodeData);
               }
 
               return {
@@ -523,10 +520,6 @@ export class Workflow {
                         // Rather than the sanitized name from the output context
                         name
                       ),
-                    }),
-                    python.methodArgument({
-                      name: "label",
-                      value: python.TypeInstantiation.str(label),
                     }),
                   ],
                 }),

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
@@ -108,6 +108,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         Workflow.Outputs.answer: WorkflowOutputVellumDisplayOverrides(
             id=UUID("8c6e5464-8916-4039-b911-cf707855d372"),
             name="answer",
-            label="Final Output 2",
         )
     }

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62"), name="final-output", label="Final Output"
+            id=UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("87760362-25b9-4dcb-8034-b49dc9e033ab"), name="final-output", label="Final Output"
+            id=UUID("87760362-25b9-4dcb-8034-b49dc9e033ab"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -49,6 +49,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("d8381526-1225-4843-8c22-eec7747445e4"), name="final-output", label="Final Output"
+            id=UUID("d8381526-1225-4843-8c22-eec7747445e4"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -49,6 +49,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("493cfa4b-5235-4b71-99ef-270955f35fcb"), name="final-output", label="Final Output"
+            id=UUID("493cfa4b-5235-4b71-99ef-270955f35fcb"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -40,6 +40,6 @@ class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkfl
     }
     output_displays = {
         SubworkflowNodeWorkflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final-output", label="Final Output"
+            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6"), name="final-output", label="Final Output"
+            id=UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -56,6 +56,6 @@ class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
     }
     output_displays = {
         MapNodeWorkflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("bffc4749-00b8-44db-90ee-db655cbc7e62"), name="final-output", label="Final Output"
+            id=UUID("bffc4749-00b8-44db-90ee-db655cbc7e62"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -53,6 +53,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("d9269719-a7a2-4388-9b85-73e329a78d16"), name="final-output", label="Final Output"
+            id=UUID("d9269719-a7a2-4388-9b85-73e329a78d16"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -56,6 +56,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"), name="final-output", label="Final Output"
+            id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("f1eca494-a7dc-41c0-9c74-9658a64955e6"), name="final-output", label="Final Output"
+            id=UUID("f1eca494-a7dc-41c0-9c74-9658a64955e6"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("aed7279d-59cd-4c15-b82c-21de48129ba3"), name="final-output", label="Final Output"
+            id=UUID("aed7279d-59cd-4c15-b82c-21de48129ba3"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -49,6 +49,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("43e128f4-24fe-4484-9d08-948a4a390707"), name="final-output", label="Final Output"
+            id=UUID("43e128f4-24fe-4484-9d08-948a4a390707"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
@@ -48,6 +48,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
             id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"),
             name="final-output",
-            label="Final Output",
         )
     }

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -40,6 +40,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"), name="final-output", label="Final Output"
+            id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"), name="final-output", label="Final Output"
+            id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"), name="final-output"
         )
     }

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -125,7 +125,7 @@ class EntrypointVellumDisplay(EntrypointVellumDisplayOverrides):
 @dataclass
 class WorkflowOutputVellumDisplayOverrides(WorkflowOutputDisplay, WorkflowOutputDisplayOverrides):
     name: str
-    label: str
+    label: Optional[str] = None
     node_id: Optional[UUID] = None
     display_data: Optional[NodeDisplayData] = None
     target_handle_id: Optional[UUID] = None

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -188,12 +188,15 @@ class VellumWorkflowDisplay(
                     if workflow_output_display.display_data
                     else NodeDisplayData().dict()
                 )
+                synthetic_node_label = (
+                    workflow_output_display.label if workflow_output_display.label is not None else "Final Output"
+                )
                 nodes.append(
                     {
                         "id": str(final_output_node_id),
                         "type": "TERMINAL",
                         "data": {
-                            "label": workflow_output_display.label,
+                            "label": synthetic_node_label,
                             "name": workflow_output_display.name,
                             "target_handle_id": synthetic_target_handle_id,
                             "output_id": str(workflow_output_display.id),
@@ -387,7 +390,6 @@ class VellumWorkflowDisplay(
         return WorkflowOutputVellumDisplay(
             id=output_id,
             name=output.name,
-            label="Final Output",
         )
 
     def _generate_edge_display(

--- a/ee/vellum_ee/workflows/tests/local_workflow/display/workflow.py
+++ b/ee/vellum_ee/workflows/tests/local_workflow/display/workflow.py
@@ -48,6 +48,5 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
             id=UUID("5469b810-6ea6-4362-9e79-e360d44a1405"),
             name="final-output",
-            label="Final Output",
         )
     }


### PR DESCRIPTION
Context: https://github.com/vellum-ai/vellum-python-sdks/pull/984

Going to incrementally start simplifying our display classes to eventually conlidate:
- BaseWorkflowDisplay and VellumWorkflowDisplay -> BaseWorkflowDisplay
- `XDisplay`, `XDisplayOverrides`, `XVellumDisplay`, `XVellumDisplayOverrides` -> `XDisplay`

This PR removes `WorkflowOutputVellumDisplayOverrides.label` on the pursuit to eventually reach the above consolidation