### PR TITLE
Deprecate the other four workflow output displays

### DIFF
--- a/ee/codegen/src/constants.ts
+++ b/ee/codegen/src/constants.ts
@@ -19,6 +19,12 @@ export const VELLUM_WORKFLOW_CONSTANTS_PATH = [
   "references",
   "constant",
 ] as const;
+export const VELLUM_WORKFLOWS_DISPLAY_BASE_PATH = [
+  "vellum_ee",
+  "workflows",
+  "display",
+  "base",
+] as const;
 /* Class names */
 export const OUTPUTS_CLASS_NAME = "Outputs";
 export const PORTS_CLASS_NAME = "Ports";

--- a/ee/codegen/src/context/workflow-output-context.ts
+++ b/ee/codegen/src/context/workflow-output-context.ts
@@ -1,3 +1,5 @@
+import { OutputVariableContext } from "./output-variable-context";
+
 import { WorkflowContext } from "src/context/workflow-context";
 import { WorkflowOutputGenerationError } from "src/generators/errors";
 import {
@@ -18,7 +20,6 @@ export class WorkflowOutputContext {
   private readonly workflowContext: WorkflowContext;
   private readonly terminalNodeData?: FinalOutputNodeType;
   private readonly workflowOutputValue?: WorkflowOutputValueType;
-  public readonly name: string;
 
   constructor({
     workflowContext,
@@ -28,10 +29,9 @@ export class WorkflowOutputContext {
     this.workflowContext = workflowContext;
     this.terminalNodeData = terminalNodeData;
     this.workflowOutputValue = workflowOutputValue;
-    this.name = this.getOutputVariableName();
   }
 
-  public getOutputVariableId(): string {
+  private getOutputVariableId(): string {
     if (this.workflowOutputValue) {
       return this.workflowOutputValue.outputVariableId;
     } else if (this.terminalNodeData) {
@@ -59,10 +59,8 @@ export class WorkflowOutputContext {
     }
   }
 
-  private getOutputVariableName(): string {
+  public getOutputVariable(): OutputVariableContext {
     const outputVariableId = this.getOutputVariableId();
-    const outputVariable =
-      this.workflowContext.getOutputVariableContextById(outputVariableId);
-    return outputVariable.name;
+    return this.workflowContext.getOutputVariableContextById(outputVariableId);
   }
 }

--- a/ee/codegen/src/context/workflow-output-context.ts
+++ b/ee/codegen/src/context/workflow-output-context.ts
@@ -31,13 +31,11 @@ export class WorkflowOutputContext {
     this.name = this.getOutputVariableName();
   }
 
-  public getFinalOutputNodeData():
-    | FinalOutputNodeType
-    | WorkflowOutputValueType {
+  public getOutputVariableId(): string {
     if (this.workflowOutputValue) {
-      return this.workflowOutputValue;
+      return this.workflowOutputValue.outputVariableId;
     } else if (this.terminalNodeData) {
-      return this.terminalNodeData;
+      return this.terminalNodeData.data.outputId;
     } else {
       throw new WorkflowOutputGenerationError(
         "Expected either workflow output value or terminal node data to be defined"
@@ -62,20 +60,9 @@ export class WorkflowOutputContext {
   }
 
   private getOutputVariableName(): string {
-    if (this.terminalNodeData) {
-      const outputVariable = this.workflowContext.getOutputVariableContextById(
-        this.terminalNodeData.data.outputId
-      );
-      return outputVariable.name;
-    } else if (this.workflowOutputValue) {
-      const outputVariable = this.workflowContext.getOutputVariableContextById(
-        this.workflowOutputValue.outputVariableId
-      );
-      return outputVariable.name;
-    } else {
-      throw new WorkflowOutputGenerationError(
-        "Expected either workflow output value or terminal node data to be defined"
-      );
-    }
+    const outputVariableId = this.getOutputVariableId();
+    const outputVariable =
+      this.workflowContext.getOutputVariableContextById(outputVariableId);
+    return outputVariable.name;
   }
 }

--- a/ee/codegen/src/generators/workflow-output.ts
+++ b/ee/codegen/src/generators/workflow-output.ts
@@ -31,7 +31,7 @@ export class WorkflowOutput extends AstNode {
 
   private generateWorkflowOutput(): Field {
     const workflowOutput = python.field({
-      name: this.workflowOutputContext.name,
+      name: this.workflowOutputContext.getOutputVariable().name,
       initializer: new WorkflowValueDescriptor({
         workflowContext: this.workflowContext,
         workflowValueDescriptor:

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -10,6 +10,7 @@ import {
   GENERATED_WORKFLOW_MODULE_NAME,
   OUTPUTS_CLASS_NAME,
   PORTS_CLASS_NAME,
+  VELLUM_WORKFLOWS_DISPLAY_BASE_PATH,
 } from "src/constants";
 import { WorkflowContext } from "src/context";
 import { BasePersistedFile } from "src/generators/base-persisted-file";
@@ -472,9 +473,7 @@ export class Workflow {
                 value: python.instantiateClass({
                   classReference: python.reference({
                     name: "WorkflowOutputDisplay",
-                    modulePath:
-                      this.workflowContext.sdkModulePathNames
-                        .VELLUM_TYPES_MODULE_PATH,
+                    modulePath: VELLUM_WORKFLOWS_DISPLAY_BASE_PATH,
                   }),
                   arguments_: [
                     python.methodArgument({

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -462,13 +462,13 @@ export class Workflow {
         initializer: python.TypeInstantiation.dict(
           this.workflowContext.workflowOutputContexts.map(
             (workflowOutputContext) => {
-              const outputId = workflowOutputContext.getOutputVariableId();
+              const outputVariable = workflowOutputContext.getOutputVariable();
 
               return {
                 key: python.reference({
                   name: this.workflowContext.workflowClassName,
                   modulePath: this.workflowContext.modulePath,
-                  attribute: [OUTPUTS_CLASS_NAME, workflowOutputContext.name],
+                  attribute: [OUTPUTS_CLASS_NAME, outputVariable.name],
                 }),
                 value: python.instantiateClass({
                   classReference: python.reference({
@@ -478,14 +478,16 @@ export class Workflow {
                   arguments_: [
                     python.methodArgument({
                       name: "id",
-                      value: python.TypeInstantiation.uuid(outputId),
+                      value: python.TypeInstantiation.uuid(
+                        outputVariable.getOutputVariableId()
+                      ),
                     }),
                     python.methodArgument({
                       name: "name",
                       value: python.TypeInstantiation.str(
                         // Intentionally use the raw name from the terminal node
                         // Rather than the sanitized name from the output context
-                        workflowOutputContext.name
+                        outputVariable.getRawName()
                       ),
                     }),
                   ],

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -9,7 +10,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -45,7 +45,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62"), name="final_output"
+            id=UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -45,7 +45,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("87760362-25b9-4dcb-8034-b49dc9e033ab"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("87760362-25b9-4dcb-8034-b49dc9e033ab"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("87760362-25b9-4dcb-8034-b49dc9e033ab"), name="final_output"
+            id=UUID("87760362-25b9-4dcb-8034-b49dc9e033ab"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -9,7 +10,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -48,7 +48,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("d8381526-1225-4843-8c22-eec7747445e4"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("d8381526-1225-4843-8c22-eec7747445e4"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -9,7 +10,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -49,6 +49,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("d8381526-1225-4843-8c22-eec7747445e4"), name="final_output"
+            id=UUID("d8381526-1225-4843-8c22-eec7747445e4"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -49,6 +49,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("493cfa4b-5235-4b71-99ef-270955f35fcb"), name="final_output"
+            id=UUID("493cfa4b-5235-4b71-99ef-270955f35fcb"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -9,7 +10,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -48,7 +48,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("493cfa4b-5235-4b71-99ef-270955f35fcb"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("493cfa4b-5235-4b71-99ef-270955f35fcb"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -40,6 +40,6 @@ class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkfl
     }
     output_displays = {
         SubworkflowNodeWorkflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final_output"
+            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -8,7 +8,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -39,7 +39,7 @@ class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkfl
         )
     }
     output_displays = {
-        SubworkflowNodeWorkflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final-output"
+        SubworkflowNodeWorkflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -8,7 +9,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -9,7 +10,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -45,7 +45,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6"), name="final_output"
+            id=UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -9,7 +10,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -56,6 +56,6 @@ class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
     }
     output_displays = {
         MapNodeWorkflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("bffc4749-00b8-44db-90ee-db655cbc7e62"), name="final_output"
+            id=UUID("bffc4749-00b8-44db-90ee-db655cbc7e62"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -55,7 +55,7 @@ class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
         ),
     }
     output_displays = {
-        MapNodeWorkflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("bffc4749-00b8-44db-90ee-db655cbc7e62"), name="final-output"
+        MapNodeWorkflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("bffc4749-00b8-44db-90ee-db655cbc7e62"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -9,7 +10,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -52,7 +52,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         ),
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("d9269719-a7a2-4388-9b85-73e329a78d16"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("d9269719-a7a2-4388-9b85-73e329a78d16"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -53,6 +53,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("d9269719-a7a2-4388-9b85-73e329a78d16"), name="final_output"
+            id=UUID("d9269719-a7a2-4388-9b85-73e329a78d16"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -8,7 +8,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -55,7 +55,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         ),
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -56,6 +56,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"), name="final_output"
+            id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -8,7 +9,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -45,7 +45,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("f1eca494-a7dc-41c0-9c74-9658a64955e6"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("f1eca494-a7dc-41c0-9c74-9658a64955e6"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -9,7 +10,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("f1eca494-a7dc-41c0-9c74-9658a64955e6"), name="final_output"
+            id=UUID("f1eca494-a7dc-41c0-9c74-9658a64955e6"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -9,7 +10,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("aed7279d-59cd-4c15-b82c-21de48129ba3"), name="final_output"
+            id=UUID("aed7279d-59cd-4c15-b82c-21de48129ba3"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -45,7 +45,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("aed7279d-59cd-4c15-b82c-21de48129ba3"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("aed7279d-59cd-4c15-b82c-21de48129ba3"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -49,6 +49,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("43e128f4-24fe-4484-9d08-948a4a390707"), name="final_output"
+            id=UUID("43e128f4-24fe-4484-9d08-948a4a390707"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -9,7 +10,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -48,7 +48,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("43e128f4-24fe-4484-9d08-948a4a390707"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("43e128f4-24fe-4484-9d08-948a4a390707"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -8,7 +8,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -39,7 +39,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"), name="final_output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -8,7 +9,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -40,6 +40,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"), name="final_output"
+            id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -9,7 +10,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
@@ -46,6 +46,6 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
-            id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"), name="final_output"
+            id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
+    WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -45,7 +45,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"), name="final-output"
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"), name="final_output"
         )
     }

--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -74,14 +74,15 @@ EntrypointDisplayOverridesType = TypeVar("EntrypointDisplayOverridesType", bound
 
 
 @dataclass
-class WorkflowOutputDisplayOverrides:
+class WorkflowOutputDisplay:
     id: UUID
+    name: str
 
 
 @dataclass
-class WorkflowOutputDisplay(WorkflowOutputDisplayOverrides):
+class WorkflowOutputDisplayOverrides(WorkflowOutputDisplay):
+    """
+    DEPRECATED: Use WorkflowOutputDisplay instead. Will be removed in 0.15.0
+    """
+
     pass
-
-
-WorkflowOutputDisplayType = TypeVar("WorkflowOutputDisplayType", bound=WorkflowOutputDisplay)
-WorkflowOutputDisplayOverridesType = TypeVar("WorkflowOutputDisplayOverridesType", bound=WorkflowOutputDisplayOverrides)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_subworkflow_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_subworkflow_node.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from typing import ClassVar, Dict, Generic, List, Optional, Tuple, Type, TypeVar, cast
+from typing import ClassVar, Dict, Generic, List, Optional, Tuple, Type, TypeVar
 
 from vellum import VellumVariable
 from vellum.workflows.inputs.base import BaseInputs
@@ -10,7 +10,7 @@ from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum_ee.workflows.display.utils.vellum import infer_vellum_variable_type
-from vellum_ee.workflows.display.vellum import NodeInput, WorkflowOutputVellumDisplay
+from vellum_ee.workflows.display.vellum import NodeInput
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 _InlineSubworkflowNodeType = TypeVar("_InlineSubworkflowNodeType", bound=InlineSubworkflowNode)
@@ -110,9 +110,7 @@ class BaseInlineSubworkflowNodeDisplay(
     ) -> List[VellumVariable]:
         workflow_outputs: List[VellumVariable] = []
         for output_descriptor in raise_if_descriptor(node.subworkflow).Outputs:  # type: ignore[union-attr]
-            workflow_output_display = cast(
-                WorkflowOutputVellumDisplay, display_context.workflow_output_displays[output_descriptor]
-            )
+            workflow_output_display = display_context.workflow_output_displays[output_descriptor]
             output_type = infer_vellum_variable_type(output_descriptor)
             workflow_outputs.append(
                 VellumVariable(id=str(workflow_output_display.id), key=workflow_output_display.name, type=output_type)

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -13,7 +13,7 @@ from vellum_ee.workflows.display.base import (
     StateValueDisplayType,
     WorkflowInputsDisplayType,
     WorkflowMetaDisplayType,
-    WorkflowOutputDisplayType,
+    WorkflowOutputDisplay,
 )
 
 if TYPE_CHECKING:
@@ -45,7 +45,6 @@ class WorkflowDisplayContext(
         StateValueDisplayType,
         NodeDisplayType,
         EntrypointDisplayType,
-        WorkflowOutputDisplayType,
         EdgeDisplayType,
     ]
 ):
@@ -63,6 +62,6 @@ class WorkflowDisplayContext(
         default_factory=dict
     )
     entrypoint_displays: Dict[Type[BaseNode], EntrypointDisplayType] = field(default_factory=dict)
-    workflow_output_displays: Dict[BaseDescriptor, WorkflowOutputDisplayType] = field(default_factory=dict)
+    workflow_output_displays: Dict[BaseDescriptor, WorkflowOutputDisplay] = field(default_factory=dict)
     edge_displays: Dict[Tuple[Port, Type[BaseNode]], EdgeDisplayType] = field(default_factory=dict)
     port_displays: Dict[Port, "PortDisplay"] = field(default_factory=dict)

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -20,7 +20,6 @@ from vellum_ee.workflows.display.base import (
     WorkflowInputsDisplayOverrides,
     WorkflowMetaDisplay,
     WorkflowMetaDisplayOverrides,
-    WorkflowOutputDisplay,
     WorkflowOutputDisplayOverrides,
 )
 
@@ -123,8 +122,11 @@ class EntrypointVellumDisplay(EntrypointVellumDisplayOverrides):
 
 
 @dataclass
-class WorkflowOutputVellumDisplayOverrides(WorkflowOutputDisplay, WorkflowOutputDisplayOverrides):
-    name: str
+class WorkflowOutputVellumDisplayOverrides(WorkflowOutputDisplayOverrides):
+    """
+    DEPRECATED: Use WorkflowOutputDisplay instead. Will be removed in 0.15.0
+    """
+
     label: Optional[str] = None
     node_id: Optional[UUID] = None
     display_data: Optional[NodeDisplayData] = None
@@ -133,6 +135,10 @@ class WorkflowOutputVellumDisplayOverrides(WorkflowOutputDisplay, WorkflowOutput
 
 @dataclass
 class WorkflowOutputVellumDisplay(WorkflowOutputVellumDisplayOverrides):
+    """
+    DEPRECATED: Use WorkflowOutputDisplay instead. Will be removed in 0.15.0
+    """
+
     pass
 
 

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -31,8 +31,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplay,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplay,
-    WorkflowOutputVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.base_workflow_display import BaseWorkflowDisplay
 
@@ -53,8 +51,6 @@ class VellumWorkflowDisplay(
         EntrypointVellumDisplayOverrides,
         EdgeVellumDisplay,
         EdgeVellumDisplayOverrides,
-        WorkflowOutputVellumDisplay,
-        WorkflowOutputVellumDisplayOverrides,
     ]
 ):
     node_display_base_class = BaseNodeDisplay
@@ -144,9 +140,7 @@ class VellumWorkflowDisplay(
 
         # Add a synthetic Terminal Node and track the Workflow's output variables for each Workflow output
         for workflow_output, workflow_output_display in self.display_context.workflow_output_displays.items():
-            final_output_node_id = workflow_output_display.node_id or uuid4_from_hash(
-                f"{self.workflow_id}|node_id|{workflow_output.name}"
-            )
+            final_output_node_id = uuid4_from_hash(f"{self.workflow_id}|node_id|{workflow_output.name}")
             inferred_type = infer_vellum_variable_type(workflow_output)
 
             # Remove the terminal node output from the unreferenced set
@@ -178,19 +172,11 @@ class VellumWorkflowDisplay(
                     except IndexError:
                         source_node_display = None
 
-                synthetic_target_handle_id = (
-                    str(workflow_output_display.target_handle_id)
-                    if workflow_output_display.target_handle_id
-                    else str(uuid4_from_hash(f"{self.workflow_id}|target_handle_id|{workflow_output_display.name}"))
+                synthetic_target_handle_id = str(
+                    uuid4_from_hash(f"{self.workflow_id}|target_handle_id|{workflow_output_display.name}")
                 )
-                synthetic_display_data = (
-                    workflow_output_display.display_data.dict()
-                    if workflow_output_display.display_data
-                    else NodeDisplayData().dict()
-                )
-                synthetic_node_label = (
-                    workflow_output_display.label if workflow_output_display.label is not None else "Final Output"
-                )
+                synthetic_display_data = NodeDisplayData().dict()
+                synthetic_node_label = "Final Output"
                 nodes.append(
                     {
                         "id": str(final_output_node_id),
@@ -369,28 +355,6 @@ class VellumWorkflowDisplay(
         )
 
         return EntrypointVellumDisplay(id=entrypoint_id, edge_display=edge_display)
-
-    def _generate_workflow_output_display(
-        self,
-        output: BaseDescriptor,
-        overrides: Optional[WorkflowOutputVellumDisplayOverrides] = None,
-    ) -> WorkflowOutputVellumDisplay:
-        if overrides:
-            return WorkflowOutputVellumDisplay(
-                id=overrides.id,
-                name=overrides.name,
-                label=overrides.label,
-                node_id=overrides.node_id,
-                target_handle_id=overrides.target_handle_id,
-                display_data=overrides.display_data,
-            )
-
-        output_id = uuid4_from_hash(f"{self.workflow_id}|id|{output.name}")
-
-        return WorkflowOutputVellumDisplay(
-            id=output_id,
-            name=output.name,
-        )
 
     def _generate_edge_display(
         self,


### PR DESCRIPTION
Going to incrementally start simplifying our display classes to eventually conlidate:
- BaseWorkflowDisplay and VellumWorkflowDisplay -> BaseWorkflowDisplay
- `XDisplay`, `XDisplayOverrides`, `XVellumDisplay`, `XVellumDisplayOverrides` -> `XDisplay`

This PR deprecates the redundant classes of `WorkflowOutputDisplay` and finishes the consolidation on this first example