### PR TITLE
Codegen Nodes Not in Graph

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -73,7 +73,29 @@ baz = foo + bar
 "
 `;
 
-exports[`WorkflowProjectGenerator > inlude sandbox > should include a sandbox.py file when passed sandboxInputs 1`] = `
+exports[`WorkflowProjectGenerator > failure cases > should generate code even if a node fails to find invalid ports and target nodes 1`] = `
+"from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+
+
+class BadNode(TemplatingNode[BaseState, str]):
+    template = """foo"""
+    inputs = {}
+"
+`;
+
+exports[`WorkflowProjectGenerator > failure cases > should generate code even if a node fails to generate 1`] = `
+"from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+
+
+class BadNode(TemplatingNode[BaseState, str]):
+    template = """foo"""
+    inputs = {}
+"
+`;
+
+exports[`WorkflowProjectGenerator > include sandbox > should include a sandbox.py file when passed sandboxInputs 1`] = `
 "from vellum.workflows.sandbox import WorkflowSandboxRunner
 from .workflow import Workflow
 from .inputs import Inputs
@@ -127,5 +149,15 @@ from .templating_node import TemplatingNode
 class FinalOutput(FinalOutputNode[BaseState, str]):
     class Outputs(FinalOutputNode.Outputs):
         value = TemplatingNode.Outputs.result
+"
+`;
+
+exports[`WorkflowProjectGenerator > runner config with no container image > should handle a runner config with no container image 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.templating_node import TemplatingNode
+
+
+class Workflow(BaseWorkflow):
+    graph = TemplatingNode
 "
 `;

--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -1,5 +1,56 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`WorkflowProjectGenerator > Nodes present but not in graph > should still generate a file for the second node 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .nodes.first_node import FirstNode
+
+
+class Workflow(BaseWorkflow):
+    graph = FirstNode
+"
+`;
+
+exports[`WorkflowProjectGenerator > Nodes present but not in graph > should still generate a file for the second node 2`] = `
+"from vellum.workflows.nodes.displayable import BaseNode
+
+
+class SecondNode(BaseNode):
+    class NodeTrigger(BaseNode.Trigger):
+        merge_behavior = "AWAIT_ATTRIBUTES"
+
+    class Outputs(BaseNode.Outputs):
+        output: str
+"
+`;
+
+exports[`WorkflowProjectGenerator > Nodes present but not in graph > should still generate a file for the second node 3`] = `
+"from vellum_ee.workflows.display.nodes import BaseNodeDisplay
+from ...nodes.second_node import SecondNode
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+
+class SecondNodeDisplay(BaseNodeDisplay[SecondNode]):
+    node_input_ids_by_name = {}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None)
+"
+`;
+
+exports[`WorkflowProjectGenerator > Nodes present but not in graph > should still generate a file for the second node 4`] = `
+"from .first_node import FirstNode
+from .second_node import SecondNode
+
+__all__ = ["FirstNode", "SecondNode"]
+"
+`;
+
+exports[`WorkflowProjectGenerator > Nodes present but not in graph > should still generate a file for the second node 5`] = `
+"from .first_node import FirstNodeDisplay
+from .second_node import SecondNodeDisplay
+
+__all__ = ["FirstNodeDisplay", "SecondNodeDisplay"]
+"
+`;
+
 exports[`WorkflowProjectGenerator > Nodes with forward references > should generate a proper Lazy Reference for the first node 1`] = `
 "from vellum.workflows.nodes.displayable import BaseNode
 from vellum.workflows.references import LazyReference

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -73,7 +73,7 @@ import {
   WorkflowSandboxInputs,
   WorkflowVersionExecConfig,
 } from "src/types/vellum";
-import { assertUnreachable, isNilOrEmpty } from "src/utils/typing";
+import { assertUnreachable, isDefined, isNilOrEmpty } from "src/utils/typing";
 
 export interface WorkflowProjectGeneratorOptions {
   /**
@@ -521,6 +521,23 @@ ${errors.slice(0, 3).map((err) => {
         });
       });
     }
+
+    // Include at the end nodes that are included in the workflow, but not referenced in the graph
+    // For example, Note Nodes.
+    const unprocessedNodes: WorkflowDataNode[] = rawData.nodes
+      .map<WorkflowDataNode | undefined>((node: WorkflowNode) => {
+        if (
+          processedNodeIds.has(node.id) ||
+          node.type === "ENTRYPOINT" ||
+          node.type === "TERMINAL"
+        ) {
+          return undefined;
+        }
+        return node;
+      })
+      .filter(isDefined);
+
+    orderedNodes.push(...unprocessedNodes);
 
     return orderedNodes;
   }

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -73,7 +73,7 @@ import {
   WorkflowSandboxInputs,
   WorkflowVersionExecConfig,
 } from "src/types/vellum";
-import { assertUnreachable, isDefined, isNilOrEmpty } from "src/utils/typing";
+import { assertUnreachable, isNilOrEmpty } from "src/utils/typing";
 
 export interface WorkflowProjectGeneratorOptions {
   /**
@@ -524,18 +524,15 @@ ${errors.slice(0, 3).map((err) => {
 
     // Include at the end nodes that are included in the workflow, but not referenced in the graph
     // For example, Note Nodes.
-    const unprocessedNodes: WorkflowDataNode[] = rawData.nodes
-      .map<WorkflowDataNode | undefined>((node: WorkflowNode) => {
-        if (
-          processedNodeIds.has(node.id) ||
-          node.type === "ENTRYPOINT" ||
-          node.type === "TERMINAL"
-        ) {
-          return undefined;
-        }
-        return node;
-      })
-      .filter(isDefined);
+    const unprocessedNodes: WorkflowDataNode[] = rawData.nodes.filter(
+      (node): node is WorkflowDataNode => {
+        return (
+          !processedNodeIds.has(node.id) &&
+          node.type !== "ENTRYPOINT" &&
+          node.type !== "TERMINAL"
+        );
+      }
+    );
 
     orderedNodes.push(...unprocessedNodes);
 


### PR DESCRIPTION
It's a valid case to have Nodes in a Workflow and for them to not be referenced in the graph, but for you to still want to codegen-them – for example, Note Nodes, or WIP nodes.

This PR:
1. Codegens nodes even if they're not in the graph
2. Adds test coverage
3. Cleans up some of our existing tests to share some expect helpers

Next Step: Add serialization support for nodes not in graph