### PR TITLE
[SC-6686] Handle escape characters in input variable name

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -9,6 +9,17 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
+exports[`Workflow > write > should generate correct code when there are input variables with escape characters 1`] = `
+"from vellum.workflows import BaseWorkflow
+from .inputs import Inputs
+from vellum.workflows.state import BaseState
+
+
+class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
+    pass
+"
+`;
+
 exports[`Workflow > write > should generate correct code when there are no input variables 1`] = `
 "from vellum.workflows import BaseWorkflow
 
@@ -40,6 +51,46 @@ from vellum.workflows.state import BaseState
 class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
     class Outputs(BaseWorkflow.Outputs):
         passthrough = Inputs.query
+"
+`;
+
+exports[`Workflow > write > should generate correct display code when there are input variables with escape characters 1`] = `
+"from vellum_ee.workflows.display.workflows.vellum_workflow_display import (
+    VellumWorkflowDisplay,
+)
+from ..workflow import TestWorkflow
+from vellum_ee.workflows.display.vellum import (
+    WorkflowMetaVellumDisplayOverrides,
+    NodeDisplayData,
+    NodeDisplayPosition,
+    WorkflowDisplayData,
+    WorkflowDisplayDataViewport,
+    WorkflowInputsVellumDisplayOverrides,
+)
+from uuid import UUID
+from ..inputs import Inputs
+
+
+class TestWorkflowDisplay(VellumWorkflowDisplay[TestWorkflow]):
+    workflow_display = WorkflowMetaVellumDisplayOverrides(
+        entrypoint_node_id=UUID("entrypoint"),
+        entrypoint_node_source_handle_id=UUID("<source_handle_id>"),
+        entrypoint_node_display=NodeDisplayData(
+            position=NodeDisplayPosition(x=0, y=0), width=None, height=None
+        ),
+        display_data=WorkflowDisplayData(
+            viewport=WorkflowDisplayDataViewport(x=0, y=0, zoom=0)
+        ),
+    )
+    inputs_display = {
+        Inputs.bad_input: WorkflowInputsVellumDisplayOverrides(
+            id=UUID("5f64210f-ec43-48ce-ae40-40a9ba4c4c11"),
+            name='Bad "Input"',
+            required=False,
+        )
+    }
+    entrypoint_displays = {}
+    output_displays = {}
 "
 `;
 

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -370,5 +370,36 @@ describe("Workflow", () => {
       workflow.getWorkflowFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+
+    it("should generate correct display code when there are input variables with escape characters", async () => {
+      const entrypointNode = entrypointNodeDataFactory();
+      workflowContext = workflowContextFactory();
+      workflowContext.addEntrypointNode(entrypointNode);
+
+      const nodeData = terminalNodeDataFactory();
+      await createNodeContext({
+        workflowContext,
+        nodeData,
+      });
+      workflowContext.addInputVariableContext(
+        inputVariableContextFactory({
+          inputVariableData: {
+            id: "5f64210f-ec43-48ce-ae40-40a9ba4c4c11",
+            key: 'Bad \\"Input\\"',
+            type: "STRING",
+          },
+          workflowContext,
+        })
+      );
+      const inputs = codegen.inputs({ workflowContext });
+      const workflow = codegen.workflow({
+        moduleName,
+        workflowContext,
+        inputs,
+      });
+
+      workflow.getWorkflowDisplayFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/context/input-variable-context.ts
+++ b/ee/codegen/src/context/input-variable-context.ts
@@ -2,7 +2,10 @@ import { isEmpty, isNil } from "lodash";
 import { VellumVariable } from "vellum-ai/api/types";
 
 import { WorkflowContext } from "src/context/workflow-context";
-import {removeEscapeCharacters, toPythonSafeSnakeCase} from "src/utils/casing";
+import {
+  removeEscapeCharacters,
+  toPythonSafeSnakeCase,
+} from "src/utils/casing";
 import { getGeneratedInputsModulePath } from "src/utils/paths";
 
 export declare namespace InputVariableContext {

--- a/ee/codegen/src/context/input-variable-context.ts
+++ b/ee/codegen/src/context/input-variable-context.ts
@@ -2,7 +2,7 @@ import { isEmpty, isNil } from "lodash";
 import { VellumVariable } from "vellum-ai/api/types";
 
 import { WorkflowContext } from "src/context/workflow-context";
-import { toPythonSafeSnakeCase } from "src/utils/casing";
+import {removeEscapeCharacters, toPythonSafeSnakeCase} from "src/utils/casing";
 import { getGeneratedInputsModulePath } from "src/utils/paths";
 
 export declare namespace InputVariableContext {
@@ -39,7 +39,8 @@ export class InputVariableContext {
   }
 
   public getRawName(): string {
-    return this.inputVariableData.key;
+    // This is for an edge case where there are escape characters in the variable
+    return removeEscapeCharacters(this.inputVariableData.key);
   }
 
   private generateSanitizedInputVariableName(): string {

--- a/ee/codegen/src/generators/workflow-sandbox-file.ts
+++ b/ee/codegen/src/generators/workflow-sandbox-file.ts
@@ -5,8 +5,8 @@ import { isNil } from "lodash";
 import { vellumValue } from "src/codegen";
 import { BasePersistedFile } from "src/generators/base-persisted-file";
 import { WorkflowSandboxInputs } from "src/types/vellum";
+import { removeEscapeCharacters } from "src/utils/casing";
 import { getGeneratedInputsModulePath } from "src/utils/paths";
-import {removeEscapeCharacters} from "src/utils/casing";
 
 export declare namespace WorkflowSandboxFile {
   interface Args extends BasePersistedFile.Args {

--- a/ee/codegen/src/generators/workflow-sandbox-file.ts
+++ b/ee/codegen/src/generators/workflow-sandbox-file.ts
@@ -6,6 +6,7 @@ import { vellumValue } from "src/codegen";
 import { BasePersistedFile } from "src/generators/base-persisted-file";
 import { WorkflowSandboxInputs } from "src/types/vellum";
 import { getGeneratedInputsModulePath } from "src/utils/paths";
+import {removeEscapeCharacters} from "src/utils/casing";
 
 export declare namespace WorkflowSandboxFile {
   interface Args extends BasePersistedFile.Args {
@@ -83,8 +84,9 @@ if __name__ != "__main__":
       arguments_: inputs
         .filter((input) => !isNil(input.value))
         .map((input) => {
+          const rawName = removeEscapeCharacters(input.name);
           const inputVariableContext =
-            this.workflowContext.getInputVariableContextByRawName(input.name);
+            this.workflowContext.getInputVariableContextByRawName(rawName);
 
           return python.methodArgument({
             name: inputVariableContext.name,

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -273,7 +273,7 @@ export class Workflow {
                   value: python.TypeInstantiation.str(
                     // Intentionally use the raw name from the input variable data
                     // rather than the sanitized name from the input variable context
-                    inputVariableContext.getInputVariableData().key
+                    inputVariableContext.getRawName()
                   ),
                 })
               );

--- a/ee/codegen/src/utils/casing.ts
+++ b/ee/codegen/src/utils/casing.ts
@@ -87,3 +87,7 @@ export function toPythonSafeSnakeCase(
       : `${safetyPrefix}${safetyPrefix.endsWith("_") ? "" : "_"}`;
   return startsWithUnsafe ? cleanedSafetyPrefix + snakeCase : snakeCase;
 }
+
+export function removeEscapeCharacters(str: string): string {
+  return str.replace(/\\"/g, '"');
+}


### PR DESCRIPTION
Context: A customer has escape characters in the input variable names. This PR aims to codegen correct python code for that and allow that workflow to run