### PR TITLE
Add unused to support non-graph nodes or graph in workflow

### DIFF
--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -113,9 +113,7 @@ class _BaseWorkflowMeta(type):
             elif issubclass(graph_item, BaseNode):
                 nodes.add(graph_item)
             else:
-                raise ValueError(
-                    f"Invalid graph item: {graph_item}. Must be Graph, BaseNode subclass, or set of these types."
-                )
+                raise ValueError(f"Unexpected graph type: {graph_item.__class__}")
             return nodes
 
         graph_nodes = collect_nodes(dct.get("graph", set()))

--- a/src/vellum/workflows/workflows/tests/test_base_workflow.py
+++ b/src/vellum/workflows/workflows/tests/test_base_workflow.py
@@ -95,14 +95,14 @@ def test_workflow__nodes_not_in_graph():
     # WHEN we create a workflow with multiple unused nodes
     class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
         graph = NodeA
-        unused_graph = {NodeB, NodeC}
+        unused_graphs = {NodeB, NodeC}
 
-    # TEST that all nodes from unused_graph are collected
-    unused_graph = set(TestWorkflow.get_unused_nodes())
-    assert unused_graph == {NodeB, NodeC}
+    # TEST that all nodes from unused_graphs are collected
+    unused_graphs = set(TestWorkflow.get_unused_nodes())
+    assert unused_graphs == {NodeB, NodeC}
 
 
-def test_workflow__unused_graph():
+def test_workflow__unused_graphs():
     class NodeA(BaseNode):
         pass
 
@@ -124,11 +124,11 @@ def test_workflow__unused_graph():
     # WHEN we create a workflow with unused nodes in a graph
     class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
         graph = NodeA
-        unused_graph = {NodeB >> {NodeC >> NodeD}, NodeE, NodeF}
+        unused_graphs = {NodeB >> {NodeC >> NodeD}, NodeE, NodeF}
 
-    # TEST that all nodes from unused_graph are collected
-    unused_graph = set(TestWorkflow.get_unused_nodes())
-    assert unused_graph == {NodeB, NodeC, NodeD, NodeE, NodeF}
+    # TEST that all nodes from unused_graphs are collected
+    unused_graphs = set(TestWorkflow.get_unused_nodes())
+    assert unused_graphs == {NodeB, NodeC, NodeD, NodeE, NodeF}
 
 
 def test_workflow__no_unused_nodes():
@@ -162,7 +162,7 @@ def test_workflow__node_in_both_graph_and_unused():
 
         class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
             graph = NodeA >> NodeB
-            unused_graph = {NodeA >> NodeC}
+            unused_graphs = {NodeA >> NodeC}
 
     # THEN it should raise an error
-    assert "Node(s) NodeA cannot appear in both graph and unused_graph" in str(exc_info.value)
+    assert "Node(s) NodeA cannot appear in both graph and unused_graphs" in str(exc_info.value)

--- a/src/vellum/workflows/workflows/tests/test_base_workflow.py
+++ b/src/vellum/workflows/workflows/tests/test_base_workflow.py
@@ -78,3 +78,62 @@ def test_subworkflow__inherit_base_outputs():
     # TEST that the outputs are correct
     assert terminal_event.name == "workflow.execution.fulfilled", terminal_event
     assert terminal_event.outputs == {"output": "bar"}
+
+
+def test_workflow_nodes_not_in_graph():
+    class NodeA(BaseNode):
+        pass
+
+    class NodeB(BaseNode):
+        pass
+
+    class NodeC(BaseNode):
+        pass
+
+    # WHEN we create a workflow with multiple unused nodes
+    class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+        graph = NodeA
+        unused = [NodeB, NodeC]
+
+    # TEST that all nodes from unused are collected
+    unused = set(TestWorkflow.get_nodes_not_in_graph())
+    assert unused == {NodeB, NodeC}
+
+
+def test_workflow_unused_graph():
+    class NodeA(BaseNode):
+        pass
+
+    class NodeB(BaseNode):
+        pass
+
+    class NodeC(BaseNode):
+        pass
+
+    class NodeD(BaseNode):
+        pass
+
+    # WHEN we create a workflow with unused nodes in a graph
+    class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+        graph = NodeA
+        unused = [NodeB >> NodeC, NodeD]
+
+    # TEST that all nodes from unused are collected
+    unused = set(TestWorkflow.get_nodes_not_in_graph())
+    assert unused == {NodeB, NodeC, NodeD}
+
+
+def test_workflow_no_unused_nodes():
+    class NodeA(BaseNode):
+        pass
+
+    class NodeB(BaseNode):
+        pass
+
+    # WHEN we create a workflow with no unused nodes
+    class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+        graph = NodeA >> NodeB
+
+    # TEST that nodes_not_in_graph is empty
+    nodes = set(TestWorkflow.get_nodes_not_in_graph())
+    assert nodes == set()


### PR DESCRIPTION
Current workflow does not support unused nodes. However, if a user defines nodes that are not part of the graph, they will be lost during serialization.

- add unused attr to workflow
- tests