### PR TITLE
Increase sleep time to avoid flaky cancel test

### DIFF
--- a/tests/workflows/basic_cancellable_workflow/workflow.py
+++ b/tests/workflows/basic_cancellable_workflow/workflow.py
@@ -9,7 +9,7 @@ class StartNode(BaseNode):
         value: str
 
     def run(self) -> Outputs:
-        time.sleep(0.1)
+        time.sleep(0.2)
         return self.Outputs(value="hello world")
 
 


### PR DESCRIPTION
Bump up sleep duration to prevent flaky tests for `test_workflow__cancel_run` and `test_workflow__cancel_stream`