### PR TITLE
Replace isort with simple sort logic

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/inputs.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/inputs.test.ts.snap
@@ -1,8 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Inputs > write > should convert input variable names into valid python attributes 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from typing import Union
+"from typing import Union
+
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -12,8 +13,9 @@ class Inputs(BaseInputs):
 `;
 
 exports[`Inputs > write > should generate correct Optional types when required is false 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from typing import Optional, Union
+"from typing import Optional, Union
+
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -23,9 +25,10 @@ class Inputs(BaseInputs):
 `;
 
 exports[`Inputs > write > should generate correct code for complex input variables 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from typing import Union, List
+"from typing import List, Union
+
 from vellum import ChatMessage, SearchResult
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -48,8 +51,9 @@ class CustomInputs(BaseInputs):
 exports[`Inputs > write > should generate correct code when Inputs has no variables 1`] = `""`;
 
 exports[`Inputs > write > should generate correct code when Inputs has variables 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from typing import Union
+"from typing import Union
+
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -79,9 +83,10 @@ class Inputs(BaseInputs):
 `;
 
 exports[`Inputs > write > should generate correct code when default is a 'ARRAY' 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from typing import List
+"from typing import List
+
 from vellum import VellumValue
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -93,8 +98,8 @@ class Inputs(BaseInputs):
 `;
 
 exports[`Inputs > write > should generate correct code when default is a 'AUDIO' 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from vellum import VellumAudio
+"from vellum import VellumAudio
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -103,9 +108,10 @@ class Inputs(BaseInputs):
 `;
 
 exports[`Inputs > write > should generate correct code when default is a 'CHAT_HISTORY' 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from typing import List
+"from typing import List
+
 from vellum import ChatMessage
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -116,8 +122,8 @@ class Inputs(BaseInputs):
 `;
 
 exports[`Inputs > write > should generate correct code when default is a 'ERROR' 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from vellum import VellumError
+"from vellum import VellumError
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -128,8 +134,8 @@ class Inputs(BaseInputs):
 `;
 
 exports[`Inputs > write > should generate correct code when default is a 'FUNCTION_CALL' 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from vellum import FunctionCall
+"from vellum import FunctionCall
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -143,8 +149,8 @@ class Inputs(BaseInputs):
 `;
 
 exports[`Inputs > write > should generate correct code when default is a 'IMAGE' 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from vellum import VellumImage
+"from vellum import VellumImage
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -153,8 +159,9 @@ class Inputs(BaseInputs):
 `;
 
 exports[`Inputs > write > should generate correct code when default is a 'JSON' 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from typing import Any
+"from typing import Any
+
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -165,8 +172,9 @@ class Inputs(BaseInputs):
 `;
 
 exports[`Inputs > write > should generate correct code when default is a 'NUMBER' 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from typing import Union
+"from typing import Union
+
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
@@ -175,9 +183,10 @@ class Inputs(BaseInputs):
 `;
 
 exports[`Inputs > write > should generate correct code when default is a 'SEARCH_RESULTS' 1`] = `
-"from vellum.workflows.inputs import BaseInputs
-from typing import List
-from vellum import SearchResult, Document
+"from typing import List
+
+from vellum import Document, SearchResult
+from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):

--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`WorkflowProjectGenerator > Nodes present but not in graph > should still generate a file for the second node 1`] = `
 "from vellum.workflows import BaseWorkflow
+
 from .nodes.first_node import FirstNode
 
 
@@ -25,8 +26,9 @@ class SecondNode(BaseNode):
 
 exports[`WorkflowProjectGenerator > Nodes present but not in graph > should still generate a file for the second node 3`] = `
 "from vellum_ee.workflows.display.nodes import BaseNodeDisplay
-from ...nodes.second_node import SecondNode
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.second_node import SecondNode
 
 
 class SecondNodeDisplay(BaseNodeDisplay[SecondNode]):
@@ -96,10 +98,11 @@ class BadNode(TemplatingNode[BaseState, str]):
 `;
 
 exports[`WorkflowProjectGenerator > include sandbox > should include a sandbox.py file when passed sandboxInputs 1`] = `
-"from vellum.workflows.sandbox import WorkflowSandboxRunner
-from .workflow import Workflow
+"from vellum import ArrayChatMessageContent, ChatMessage, StringChatMessageContent
+from vellum.workflows.sandbox import WorkflowSandboxRunner
+
 from .inputs import Inputs
-from vellum import ChatMessage, StringChatMessageContent, ArrayChatMessageContent
+from .workflow import Workflow
 
 if __name__ != "__main__":
     raise Exception("This file is not meant to be imported")
@@ -143,6 +146,7 @@ runner.run()
 exports[`WorkflowProjectGenerator > nodes with output values > should prioritize terminal node data over output values 1`] = `
 "from vellum.workflows.nodes.displayable import FinalOutputNode
 from vellum.workflows.state import BaseState
+
 from .templating_node import TemplatingNode
 
 
@@ -154,6 +158,7 @@ class FinalOutput(FinalOutputNode[BaseState, str]):
 
 exports[`WorkflowProjectGenerator > runner config with no container image > should handle a runner config with no container image 1`] = `
 "from vellum.workflows import BaseWorkflow
+
 from .nodes.templating_node import TemplatingNode
 
 

--- a/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
@@ -2,8 +2,9 @@
 
 exports[`Workflow Sandbox > write > should generate correct and same code for snake and camel casing of input names 1`] = `
 "from vellum.workflows.sandbox import WorkflowSandboxRunner
-from .workflow import TestWorkflow
+
 from .inputs import Inputs
+from .workflow import TestWorkflow
 
 if __name__ != "__main__":
     raise Exception("This file is not meant to be imported")
@@ -23,8 +24,9 @@ runner.run()
 
 exports[`Workflow Sandbox > write > should generate correct code given inputs 1`] = `
 "from vellum.workflows.sandbox import WorkflowSandboxRunner
-from .workflow import TestWorkflow
+
 from .inputs import Inputs
+from .workflow import TestWorkflow
 
 if __name__ != "__main__":
     raise Exception("This file is not meant to be imported")
@@ -44,8 +46,9 @@ runner.run()
 
 exports[`Workflow Sandbox > write > should generate correct code given optional input with default of null string value 1`] = `
 "from vellum.workflows.sandbox import WorkflowSandboxRunner
-from .workflow import TestWorkflow
+
 from .inputs import Inputs
+from .workflow import TestWorkflow
 
 if __name__ != "__main__":
     raise Exception("This file is not meant to be imported")

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -20,8 +20,9 @@ class TestWorkflow(BaseWorkflow):
 
 exports[`Workflow > write > should generate correct code with Search Results as an output variable 1`] = `
 "from vellum.workflows import BaseWorkflow
-from .inputs import Inputs
 from vellum.workflows.state import BaseState
+
+from .inputs import Inputs
 from .nodes.final_output import FinalOutput
 
 
@@ -33,8 +34,9 @@ class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
 
 exports[`Workflow > write > should generate correct code with an output variable mapped to an input variable 1`] = `
 "from vellum.workflows import BaseWorkflow
-from .inputs import Inputs
 from vellum.workflows.state import BaseState
+
+from .inputs import Inputs
 
 
 class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
@@ -44,20 +46,22 @@ class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
 `;
 
 exports[`Workflow > write > should generate correct display code when there are input variables with escape characters 1`] = `
-"from vellum_ee.workflows.display.workflows.vellum_workflow_display import (
-    VellumWorkflowDisplay,
-)
-from ..workflow import TestWorkflow
+"from uuid import UUID
+
 from vellum_ee.workflows.display.vellum import (
-    WorkflowMetaVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
+    WorkflowMetaVellumDisplayOverrides,
 )
-from uuid import UUID
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import (
+    VellumWorkflowDisplay,
+)
+
 from ..inputs import Inputs
+from ..workflow import TestWorkflow
 
 
 class TestWorkflowDisplay(VellumWorkflowDisplay[TestWorkflow]):
@@ -85,8 +89,9 @@ class TestWorkflowDisplay(VellumWorkflowDisplay[TestWorkflow]):
 
 exports[`Workflow > write > should handle edges pointing to non-existent nodes 1`] = `
 "from vellum.workflows import BaseWorkflow
-from .inputs import Inputs
 from vellum.workflows.state import BaseState
+
+from .inputs import Inputs
 from .nodes.search_node import SearchNode
 
 
@@ -97,11 +102,12 @@ class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
 
 exports[`Workflow > write > should handle loops of conditionals and import Graph.from_set properly 1`] = `
 "from vellum.workflows import BaseWorkflow
+from vellum.workflows.graph import Graph
+
+from .nodes.final_output_node import FinalOutputNode
+from .nodes.loop_check_node import LoopCheckNode
 from .nodes.start_node import StartNode
 from .nodes.top_node import TopNode
-from vellum.workflows.graph import Graph
-from .nodes.loop_check_node import LoopCheckNode
-from .nodes.final_output_node import FinalOutputNode
 
 
 class TestWorkflow(BaseWorkflow):
@@ -119,6 +125,7 @@ class TestWorkflow(BaseWorkflow):
 
 exports[`Workflow > write > should handle the case of multiple nodes with the same label 1`] = `
 "from vellum.workflows import BaseWorkflow
+
 from .nodes.templating_node import TemplatingNode
 from .nodes.templating_node_1 import TemplatingNode1
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -1,14 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ApiNode > basic > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseAPINodeDisplay
-from ...nodes.api_node import APINode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseAPINodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.api_node import APINode
 
 
 class APINodeDisplay(BaseAPINodeDisplay[APINode]):
@@ -72,8 +74,9 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
 `;
 
 exports[`ApiNode > basic > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
-from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
 from ..inputs import Inputs
 
 
@@ -94,10 +97,11 @@ class APINode(BaseAPINode):
 `;
 
 exports[`ApiNode > basic auth secret node > secret ids should show names 1`] = `
-"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
-from vellum.workflows.constants import APIRequestMethod, AuthorizationType
-from ..inputs import Inputs
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 from vellum.workflows.references import VellumSecretReference
+
+from ..inputs import Inputs
 
 
 class APINode(BaseAPINode):
@@ -117,8 +121,8 @@ class APINode(BaseAPINode):
 `;
 
 exports[`ApiNode > basic auth secret node > should generate Workspace secrets for header values 1`] = `
-"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
-from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 from vellum.workflows.references import VellumSecretReference
 
 
@@ -137,14 +141,16 @@ class APINode(BaseAPINode):
 `;
 
 exports[`ApiNode > reject on error enabled > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseAPINodeDisplay, BaseTryNodeDisplay
-from ...nodes.api_node import APINode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseAPINodeDisplay, BaseTryNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.api_node import APINode
 
 
 @BaseTryNodeDisplay.wrap(error_output_id=UUID("af589f73-effe-4a80-b48f-fb912ac6ce67"))
@@ -209,9 +215,10 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
 `;
 
 exports[`ApiNode > reject on error enabled > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
 from vellum.workflows.nodes.core import TryNode
-from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
 from ..inputs import Inputs
 
 
@@ -233,8 +240,9 @@ class APINode(BaseAPINode):
 `;
 
 exports[`ApiNode > skip authorization type input id field if undefined > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
-from vellum.workflows.constants import APIRequestMethod
+"from vellum.workflows.constants import APIRequestMethod
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
 from ..inputs import Inputs
 
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -1,14 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`CodeExecutionNode > basic > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
-from ...nodes.code_execution_node import CodeExecutionNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.code_execution_node import CodeExecutionNode
 
 
 class CodeExecutionNodeDisplay(BaseCodeExecutionNodeDisplay[CodeExecutionNode]):
@@ -58,11 +60,12 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
 `;
 
 exports[`CodeExecutionNode > basic representation > should accept int and float 1`] = `
-"from vellum.workflows.nodes.displayable import (
+"from typing import Union
+
+from vellum.workflows.nodes.displayable import (
     CodeExecutionNode as BaseCodeExecutionNode,
 )
 from vellum.workflows.state import BaseState
-from typing import Union
 
 
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, Union[float, int]]):
@@ -77,8 +80,8 @@ exports[`CodeExecutionNode > basic secret node > secret ids should show names 1`
 "from vellum.workflows.nodes.displayable import (
     CodeExecutionNode as BaseCodeExecutionNode,
 )
-from vellum.workflows.state import BaseState
 from vellum.workflows.references import VellumSecretReference
+from vellum.workflows.state import BaseState
 
 
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):

--- a/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Conditional Node with numeric operator casts rhs to NUMBER > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port
+
 from ..inputs import Inputs
 
 
@@ -13,14 +14,16 @@ class ConditionalNode(BaseConditionalNode):
 `;
 
 exports[`ConditionalNode > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
-from ...nodes.conditional_node import ConditionalNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
-    RuleIdMap,
     ConditionId,
+    RuleIdMap,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.conditional_node import ConditionalNode
 
 
 class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
@@ -91,6 +94,7 @@ class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
 exports[`ConditionalNode > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port
+
 from ..inputs import Inputs
 
 
@@ -103,14 +107,16 @@ class ConditionalNode(BaseConditionalNode):
 `;
 
 exports[`ConditionalNode with invalid uuid for field and value node input ids > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
-from ...nodes.conditional_node import ConditionalNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
-    RuleIdMap,
     ConditionId,
+    RuleIdMap,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.conditional_node import ConditionalNode
 
 
 class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
@@ -159,6 +165,7 @@ class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
 exports[`ConditionalNode with invalid uuid for field and value node input ids > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port
+
 from ..inputs import Inputs
 
 
@@ -170,14 +177,16 @@ class ConditionalNode(BaseConditionalNode):
 `;
 
 exports[`ConditionalNode with null operator > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
-from ...nodes.conditional_node import ConditionalNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
-    RuleIdMap,
     ConditionId,
+    RuleIdMap,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.conditional_node import ConditionalNode
 
 
 class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
@@ -232,6 +241,7 @@ class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
 exports[`ConditionalNode with null operator > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port
+
 from ..inputs import Inputs
 from .templating_node import TemplatingNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
@@ -1,10 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ErrorNode > basic > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
-from ...nodes.error_node import ErrorNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.error_node import ErrorNode
 
 
 class ErrorNodeDisplay(BaseErrorNodeDisplay[ErrorNode]):
@@ -23,8 +25,8 @@ class ErrorNodeDisplay(BaseErrorNodeDisplay[ErrorNode]):
 `;
 
 exports[`ErrorNode > basic > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import ErrorNode as BaseErrorNode
-from vellum import VellumError
+"from vellum import VellumError
+from vellum.workflows.nodes.displayable import ErrorNode as BaseErrorNode
 
 
 class ErrorNode(BaseErrorNode):
@@ -33,10 +35,12 @@ class ErrorNode(BaseErrorNode):
 `;
 
 exports[`ErrorNode > should codegen successfully without error source inputs > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
-from ...nodes.error_node import ErrorNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.error_node import ErrorNode
 
 
 class ErrorNodeDisplay(BaseErrorNodeDisplay[ErrorNode]):

--- a/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
@@ -1,11 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FinalOutputNode > basic > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
-from ...nodes.final_output_node import FinalOutputNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.final_output_node import FinalOutputNode
 
 
 class FinalOutputNodeDisplay(BaseFinalOutputNodeDisplay[FinalOutputNode]):
@@ -43,11 +45,13 @@ class FinalOutputNode(BaseFinalOutputNode[BaseState, str]):
 `;
 
 exports[`FinalOutputNode > should codegen successfully without node input > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
-from ...nodes.final_output_node import FinalOutputNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.final_output_node import FinalOutputNode
 
 
 class FinalOutputNodeDisplay(BaseFinalOutputNodeDisplay[FinalOutputNode]):

--- a/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
@@ -1,14 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`GuardrailNode > basic > getNodeDisplayFile - multiple output variables 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseGuardrailNodeDisplay
-from ...nodes.guardrail_node import GuardrailNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseGuardrailNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.guardrail_node import GuardrailNode
 
 
 class GuardrailNodeDisplay(BaseGuardrailNodeDisplay[GuardrailNode]):
@@ -43,14 +45,16 @@ class GuardrailNodeDisplay(BaseGuardrailNodeDisplay[GuardrailNode]):
 `;
 
 exports[`GuardrailNode > basic > getNodeDisplayFile - single output variable 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseGuardrailNodeDisplay
-from ...nodes.guardrail_node import GuardrailNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseGuardrailNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.guardrail_node import GuardrailNode
 
 
 class GuardrailNodeDisplay(BaseGuardrailNodeDisplay[GuardrailNode]):
@@ -83,6 +87,7 @@ class GuardrailNodeDisplay(BaseGuardrailNodeDisplay[GuardrailNode]):
 
 exports[`GuardrailNode > basic > getNodeFile - multiple output variables 1`] = `
 "from vellum.workflows.nodes.displayable import GuardrailNode as BaseGuardrailNode
+
 from ..inputs import Inputs
 
 
@@ -98,6 +103,7 @@ class GuardrailNode(BaseGuardrailNode):
 
 exports[`GuardrailNode > basic > getNodeFile - single output variable 1`] = `
 "from vellum.workflows.nodes.displayable import GuardrailNode as BaseGuardrailNode
+
 from ..inputs import Inputs
 
 
@@ -112,17 +118,19 @@ class GuardrailNode(BaseGuardrailNode):
 `;
 
 exports[`GuardrailNode > reject on error enabled > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import (
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import (
     BaseGuardrailNodeDisplay,
     BaseTryNodeDisplay,
 )
-from ...nodes.guardrail_node import GuardrailNode
-from uuid import UUID
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.guardrail_node import GuardrailNode
 
 
 @BaseTryNodeDisplay.wrap(error_output_id=UUID("38361ff1-c826-49b8-aa8d-28179c3684cc"))
@@ -158,8 +166,9 @@ class GuardrailNodeDisplay(BaseGuardrailNodeDisplay[GuardrailNode]):
 `;
 
 exports[`GuardrailNode > reject on error enabled > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import GuardrailNode as BaseGuardrailNode
-from vellum.workflows.nodes.core import TryNode
+"from vellum.workflows.nodes.core import TryNode
+from vellum.workflows.nodes.displayable import GuardrailNode as BaseGuardrailNode
+
 from ..inputs import Inputs
 
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -1,14 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`InlinePromptNode > CHAT_MESSAGE block type > basic > getNodeDisplayFile for CHAT_MESSAGE block type 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
@@ -39,14 +41,15 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > CHAT_MESSAGE block type > basic > getNodeFile for CHAT_MESSAGE block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import (
-    PlainTextPromptBlock,
-    VariablePromptBlock,
-    RichTextPromptBlock,
+"from vellum import (
     ChatMessagePromptBlock,
+    PlainTextPromptBlock,
     PromptParameters,
+    RichTextPromptBlock,
+    VariablePromptBlock,
 )
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -91,14 +94,16 @@ Summarize the following text:
 `;
 
 exports[`InlinePromptNode > CHAT_MESSAGE block type > legacy prompt variant > getNodeDisplayFile for CHAT_MESSAGE block type 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
@@ -129,14 +134,15 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > CHAT_MESSAGE block type > legacy prompt variant > getNodeFile for CHAT_MESSAGE block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import (
-    PlainTextPromptBlock,
-    VariablePromptBlock,
-    RichTextPromptBlock,
+"from vellum import (
     ChatMessagePromptBlock,
+    PlainTextPromptBlock,
     PromptParameters,
+    RichTextPromptBlock,
+    VariablePromptBlock,
 )
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -181,17 +187,19 @@ Summarize the following text:
 `;
 
 exports[`InlinePromptNode > CHAT_MESSAGE block type > reject on error enabled > getNodeDisplayFile for CHAT_MESSAGE block type 1`] = `
-"from vellum_ee.workflows.display.nodes import (
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseTryNodeDisplay,
 )
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 @BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
@@ -223,15 +231,16 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > CHAT_MESSAGE block type > reject on error enabled > getNodeFile for CHAT_MESSAGE block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum.workflows.nodes.core import TryNode
-from vellum import (
-    PlainTextPromptBlock,
-    VariablePromptBlock,
-    RichTextPromptBlock,
+"from vellum import (
     ChatMessagePromptBlock,
+    PlainTextPromptBlock,
     PromptParameters,
+    RichTextPromptBlock,
+    VariablePromptBlock,
 )
+from vellum.workflows.nodes.core import TryNode
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -277,14 +286,16 @@ Summarize the following text:
 `;
 
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > basic > getNodeDisplayFile for FUNCTION_DEFINITION block type 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
@@ -315,9 +326,10 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > basic > getNodeFile for FUNCTION_DEFINITION block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
+"from vellum import FunctionDefinition, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
-from vellum import FunctionDefinition, PromptParameters
 
 
 class PromptNode(InlinePromptNode):
@@ -344,14 +356,16 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > legacy prompt variant > getNodeDisplayFile for FUNCTION_DEFINITION block type 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
@@ -382,9 +396,10 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > legacy prompt variant > getNodeFile for FUNCTION_DEFINITION block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
+"from vellum import FunctionDefinition, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
-from vellum import FunctionDefinition, PromptParameters
 
 
 class PromptNode(InlinePromptNode):
@@ -411,17 +426,19 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > reject on error enabled > getNodeDisplayFile for FUNCTION_DEFINITION block type 1`] = `
-"from vellum_ee.workflows.display.nodes import (
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseTryNodeDisplay,
 )
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 @BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
@@ -453,10 +470,11 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > reject on error enabled > getNodeFile for FUNCTION_DEFINITION block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
+"from vellum import FunctionDefinition, PromptParameters
 from vellum.workflows.nodes.core import TryNode
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
-from vellum import FunctionDefinition, PromptParameters
 
 
 @TryNode.wrap()
@@ -484,14 +502,16 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > JINJA block type > basic > getNodeDisplayFile for JINJA block type 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
@@ -522,8 +542,9 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > JINJA block type > basic > getNodeFile for JINJA block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import JinjaPromptBlock, PromptParameters
+"from vellum import JinjaPromptBlock, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -550,14 +571,16 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > JINJA block type > legacy prompt variant > getNodeDisplayFile for JINJA block type 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
@@ -588,8 +611,9 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > JINJA block type > legacy prompt variant > getNodeFile for JINJA block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import JinjaPromptBlock, PromptParameters
+"from vellum import JinjaPromptBlock, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -616,17 +640,19 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > JINJA block type > reject on error enabled > getNodeDisplayFile for JINJA block type 1`] = `
-"from vellum_ee.workflows.display.nodes import (
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseTryNodeDisplay,
 )
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 @BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
@@ -658,9 +684,10 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > JINJA block type > reject on error enabled > getNodeFile for JINJA block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
+"from vellum import JinjaPromptBlock, PromptParameters
 from vellum.workflows.nodes.core import TryNode
-from vellum import JinjaPromptBlock, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -688,14 +715,16 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > RICH_TEXT block type > basic > getNodeDisplayFile for RICH_TEXT block type 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
@@ -726,8 +755,9 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > RICH_TEXT block type > basic > getNodeFile for RICH_TEXT block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import PlainTextPromptBlock, RichTextPromptBlock, PromptParameters
+"from vellum import PlainTextPromptBlock, PromptParameters, RichTextPromptBlock
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -760,14 +790,16 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > RICH_TEXT block type > legacy prompt variant > getNodeDisplayFile for RICH_TEXT block type 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
@@ -798,8 +830,9 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > RICH_TEXT block type > legacy prompt variant > getNodeFile for RICH_TEXT block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import PlainTextPromptBlock, RichTextPromptBlock, PromptParameters
+"from vellum import PlainTextPromptBlock, PromptParameters, RichTextPromptBlock
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -832,17 +865,19 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > RICH_TEXT block type > reject on error enabled > getNodeDisplayFile for RICH_TEXT block type 1`] = `
-"from vellum_ee.workflows.display.nodes import (
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseTryNodeDisplay,
 )
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 @BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
@@ -874,9 +909,10 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > RICH_TEXT block type > reject on error enabled > getNodeFile for RICH_TEXT block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
+"from vellum import PlainTextPromptBlock, PromptParameters, RichTextPromptBlock
 from vellum.workflows.nodes.core import TryNode
-from vellum import PlainTextPromptBlock, RichTextPromptBlock, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -910,14 +946,16 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > VARIABLE block type > basic > getNodeDisplayFile for VARIABLE block type 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
@@ -948,8 +986,9 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > VARIABLE block type > basic > getNodeFile for VARIABLE block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import VariablePromptBlock, PromptParameters
+"from vellum import PromptParameters, VariablePromptBlock
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -976,14 +1015,16 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > VARIABLE block type > legacy prompt variant > getNodeDisplayFile for VARIABLE block type 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
@@ -1014,8 +1055,9 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > VARIABLE block type > legacy prompt variant > getNodeFile for VARIABLE block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import VariablePromptBlock, PromptParameters
+"from vellum import PromptParameters, VariablePromptBlock
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -1042,17 +1084,19 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > VARIABLE block type > reject on error enabled > getNodeDisplayFile for VARIABLE block type 1`] = `
-"from vellum_ee.workflows.display.nodes import (
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseTryNodeDisplay,
 )
-from ...nodes.prompt_node import PromptNode
-from uuid import UUID
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_node import PromptNode
 
 
 @BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
@@ -1084,9 +1128,10 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
 `;
 
 exports[`InlinePromptNode > VARIABLE block type > reject on error enabled > getNodeFile for VARIABLE block type 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
+"from vellum import PromptParameters, VariablePromptBlock
 from vellum.workflows.nodes.core import TryNode
-from vellum import VariablePromptBlock, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -1114,8 +1159,9 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > should generate cache config correctly 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import JinjaPromptBlock, EphemeralPromptCacheConfig, PromptParameters
+"from vellum import EphemeralPromptCacheConfig, JinjaPromptBlock, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 
@@ -1145,8 +1191,9 @@ class PromptNode(InlinePromptNode):
 `;
 
 exports[`InlinePromptNode > should generate prompt parameters correctly 1`] = `
-"from vellum.workflows.nodes.displayable import InlinePromptNode
-from vellum import JinjaPromptBlock, PromptParameters
+"from vellum import JinjaPromptBlock, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
 from ..inputs import Inputs
 
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -3,11 +3,13 @@
 exports[`InlineSubworkflowNode > basic > inline subworkflow node display file 1`] = `
 "# flake8: noqa: F401, F403
 
-from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
-from ....nodes.inline_subworkflow_node import InlineSubworkflowNode
 from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ....nodes.inline_subworkflow_node import InlineSubworkflowNode
 from .nodes import *
 from .workflow import *
 
@@ -32,6 +34,7 @@ class InlineSubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[InlineSubwor
 
 exports[`InlineSubworkflowNode > basic > inline subworkflow node file 1`] = `
 "from vellum.workflows.nodes.displayable import InlineSubworkflowNode as BaseInlineSubworkflowNode
+
 from .workflow import InlineSubworkflowNodeWorkflow
 
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/map-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/map-node.test.ts.snap
@@ -3,11 +3,13 @@
 exports[`MapNode > basic > map node display file 1`] = `
 "# flake8: noqa: F401, F403
 
-from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
-from ....nodes.map_node import MapNode
 from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ....nodes.map_node import MapNode
 from .nodes import *
 from .workflow import *
 
@@ -29,6 +31,7 @@ class MapNodeDisplay(BaseMapNodeDisplay[MapNode]):
 
 exports[`MapNode > basic > map node file 1`] = `
 "from vellum.workflows.nodes.displayable import MapNode as BaseMapNode
+
 from .workflow import MapNodeWorkflow
 
 
@@ -46,11 +49,13 @@ class MapNode(BaseMapNode):
 exports[`MapNode > with additional output > map node display file 1`] = `
 "# flake8: noqa: F401, F403
 
-from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
-from ....nodes.map_node import MapNode
 from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ....nodes.map_node import MapNode
 from .nodes import *
 from .workflow import *
 
@@ -75,6 +80,7 @@ class MapNodeDisplay(BaseMapNodeDisplay[MapNode]):
 
 exports[`MapNode > with additional output > map node file 1`] = `
 "from vellum.workflows.nodes.displayable import MapNode as BaseMapNode
+
 from .workflow import MapNodeWorkflow
 
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
@@ -1,11 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`MergeNode > basic > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseMergeNodeDisplay
-from ...nodes.merge_node import MergeNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseMergeNodeDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.merge_node import MergeNode
 
 
 class MergeNodeDisplay(BaseMergeNodeDisplay[MergeNode]):

--- a/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
@@ -1,14 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`InlinePromptNode referenced by Conditional Node > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
-from ...nodes.conditional_node import ConditionalNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
-    RuleIdMap,
     ConditionId,
+    RuleIdMap,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.conditional_node import ConditionalNode
 
 
 class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
@@ -61,6 +63,7 @@ class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
 exports[`InlinePromptNode referenced by Conditional Node > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port
+
 from .prompt_node import PromptNode
 
 
@@ -72,14 +75,16 @@ class ConditionalNode(BaseConditionalNode):
 `;
 
 exports[`InlinePromptNode referenced by Templating Node > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
-from ...nodes.templating_node import TemplatingNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.templating_node import TemplatingNode
 
 
 class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
@@ -110,6 +115,7 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
 exports[`InlinePromptNode referenced by Templating Node > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
 from vellum.workflows.state import BaseState
+
 from .prompt_node import PromptNode
 
 
@@ -122,14 +128,16 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
 `;
 
 exports[`Non-existent Subworkflow Deployment Node referenced by Templating Node > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
-from ...nodes.templating_node import TemplatingNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.templating_node import TemplatingNode
 
 
 class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
@@ -160,6 +168,7 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
 exports[`Non-existent Subworkflow Deployment Node referenced by Templating Node > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
 from vellum.workflows.state import BaseState
+
 from .prompt_node import PromptNode
 
 
@@ -172,14 +181,16 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
 `;
 
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDisplayFile with 'takes array output id' 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
-from ...nodes.conditional_node import ConditionalNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
-    RuleIdMap,
     ConditionId,
+    RuleIdMap,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.conditional_node import ConditionalNode
 
 
 class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
@@ -230,14 +241,16 @@ class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
 `;
 
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDisplayFile with 'takes error output id' 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
-from ...nodes.conditional_node import ConditionalNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
-    RuleIdMap,
     ConditionId,
+    RuleIdMap,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.conditional_node import ConditionalNode
 
 
 class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
@@ -288,14 +301,16 @@ class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
 `;
 
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDisplayFile with 'takes output id' 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
-from ...nodes.conditional_node import ConditionalNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
-    RuleIdMap,
     ConditionId,
+    RuleIdMap,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.conditional_node import ConditionalNode
 
 
 class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
@@ -348,6 +363,7 @@ class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeFile with 'takes array output id' 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port
+
 from .prompt_deployment_node import PromptDeploymentNode
 
 
@@ -361,6 +377,7 @@ class ConditionalNode(BaseConditionalNode):
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeFile with 'takes error output id' 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port
+
 from .prompt_deployment_node import PromptDeploymentNode
 
 
@@ -374,6 +391,7 @@ class ConditionalNode(BaseConditionalNode):
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeFile with 'takes output id' 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port
+
 from .prompt_deployment_node import PromptDeploymentNode
 
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
@@ -2,8 +2,9 @@
 
 exports[`NoteNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseNoteNodeDisplay
-from ...nodes.note_node import NoteNode
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.note_node import NoteNode
 
 
 class NoteNodeDisplay(BaseNoteNodeDisplay[NoteNode]):

--- a/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
@@ -1,14 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`PromptDeploymentNode > basic > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BasePromptDeploymentNodeDisplay
-from ...nodes.prompt_deployment_node import PromptDeploymentNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BasePromptDeploymentNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.prompt_deployment_node import PromptDeploymentNode
 
 
 class PromptDeploymentNodeDisplay(

--- a/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
@@ -1,14 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`TextSearchNode > basic > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
-from ...nodes.search_node import SearchNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.search_node import SearchNode
 
 
 class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
@@ -59,14 +61,15 @@ class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
 `;
 
 exports[`TextSearchNode > basic > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
-from ..inputs import Inputs
-from vellum import SearchWeightsRequest, SearchResultMergingRequest
+"from vellum import SearchResultMergingRequest, SearchWeightsRequest
+from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
 from vellum.workflows.nodes.displayable.bases.types import (
-    SearchFilters,
-    MetadataLogicalConditionGroup,
     MetadataLogicalCondition,
+    MetadataLogicalConditionGroup,
+    SearchFilters,
 )
+
+from ..inputs import Inputs
 
 
 class SearchNode(BaseSearchNode):
@@ -100,14 +103,15 @@ class SearchNode(BaseSearchNode):
 `;
 
 exports[`TextSearchNode > limit param should cast string to int > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
-from ..inputs import Inputs
-from vellum import SearchWeightsRequest, SearchResultMergingRequest
+"from vellum import SearchResultMergingRequest, SearchWeightsRequest
+from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
 from vellum.workflows.nodes.displayable.bases.types import (
-    SearchFilters,
-    MetadataLogicalConditionGroup,
     MetadataLogicalCondition,
+    MetadataLogicalConditionGroup,
+    SearchFilters,
 )
+
+from ..inputs import Inputs
 
 
 class SearchNode(BaseSearchNode):
@@ -141,14 +145,16 @@ class SearchNode(BaseSearchNode):
 `;
 
 exports[`TextSearchNode > metadata filters > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
-from ...nodes.search_node import SearchNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.search_node import SearchNode
 
 
 class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
@@ -211,14 +217,15 @@ class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
 `;
 
 exports[`TextSearchNode > metadata filters > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
-from ..inputs import Inputs
-from vellum import SearchWeightsRequest, SearchResultMergingRequest
+"from vellum import SearchResultMergingRequest, SearchWeightsRequest
+from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
 from vellum.workflows.nodes.displayable.bases.types import (
-    SearchFilters,
-    MetadataLogicalConditionGroup,
     MetadataLogicalCondition,
+    MetadataLogicalConditionGroup,
+    SearchFilters,
 )
+
+from ..inputs import Inputs
 
 
 class SearchNode(BaseSearchNode):
@@ -248,14 +255,16 @@ class SearchNode(BaseSearchNode):
 `;
 
 exports[`TextSearchNode > reject on error enabled > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay, BaseTryNodeDisplay
-from ...nodes.search_node import SearchNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay, BaseTryNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.search_node import SearchNode
 
 
 @BaseTryNodeDisplay.wrap(error_output_id=UUID("af589f73-effe-4a80-b48f-fb912ac6ce67"))
@@ -307,15 +316,16 @@ class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
 `;
 
 exports[`TextSearchNode > reject on error enabled > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
+"from vellum import SearchResultMergingRequest, SearchWeightsRequest
 from vellum.workflows.nodes.core import TryNode
-from ..inputs import Inputs
-from vellum import SearchWeightsRequest, SearchResultMergingRequest
+from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
 from vellum.workflows.nodes.displayable.bases.types import (
-    SearchFilters,
-    MetadataLogicalConditionGroup,
     MetadataLogicalCondition,
+    MetadataLogicalConditionGroup,
+    SearchFilters,
 )
+
+from ..inputs import Inputs
 
 
 @TryNode.wrap()
@@ -350,14 +360,16 @@ class SearchNode(BaseSearchNode):
 `;
 
 exports[`TextSearchNode > should codegen successfully without document index id input > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
-from ...nodes.search_node import SearchNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.search_node import SearchNode
 
 
 class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
@@ -407,12 +419,12 @@ class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
 `;
 
 exports[`TextSearchNode > should codegen successfully without document index id input > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
-from vellum import SearchWeightsRequest, SearchResultMergingRequest
+"from vellum import SearchResultMergingRequest, SearchWeightsRequest
+from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
 from vellum.workflows.nodes.displayable.bases.types import (
-    SearchFilters,
-    MetadataLogicalConditionGroup,
     MetadataLogicalCondition,
+    MetadataLogicalConditionGroup,
+    SearchFilters,
 )
 
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
@@ -1,14 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`SubworkflowDeploymentNode > basic > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
-from ...nodes.subworkflow_node import SubworkflowNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.subworkflow_node import SubworkflowNode
 
 
 class SubworkflowNodeDisplay(BaseSubworkflowDeploymentNodeDisplay[SubworkflowNode]):
@@ -38,8 +40,9 @@ class SubworkflowNodeDisplay(BaseSubworkflowDeploymentNodeDisplay[SubworkflowNod
 `;
 
 exports[`SubworkflowDeploymentNode > basic > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import SubworkflowDeploymentNode
-from typing import Union
+"from typing import Union
+
+from vellum.workflows.nodes.displayable import SubworkflowDeploymentNode
 
 
 class SubworkflowNode(SubworkflowDeploymentNode):
@@ -54,11 +57,13 @@ class SubworkflowNode(SubworkflowDeploymentNode):
 `;
 
 exports[`SubworkflowDeploymentNode > failure > should generate subworkflow deployment node display as much as possible for non strict workflow contexts 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
-from ...nodes.subworkflow_node import SubworkflowNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.subworkflow_node import SubworkflowNode
 
 
 class SubworkflowNodeDisplay(BaseSubworkflowDeploymentNodeDisplay[SubworkflowNode]):

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -1,14 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`TemplatingNode > basic > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
-from ...nodes.templating_node import TemplatingNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.templating_node import TemplatingNode
 
 
 class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
@@ -45,14 +47,16 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
 `;
 
 exports[`TemplatingNode > basic with json output type > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
-from ...nodes.templating_node import TemplatingNode
-from uuid import UUID
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.templating_node import TemplatingNode
 
 
 class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
@@ -90,17 +94,19 @@ class TemplatingNode(BaseTemplatingNode[BaseState, Json]):
 `;
 
 exports[`TemplatingNode > reject on error enabled > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import (
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import (
     BaseTemplatingNodeDisplay,
     BaseTryNodeDisplay,
 )
-from ...nodes.templating_node import TemplatingNode
-from uuid import UUID
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.templating_node import TemplatingNode
 
 
 @BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
@@ -127,9 +133,9 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
 `;
 
 exports[`TemplatingNode > reject on error enabled > getNodeFile 1`] = `
-"from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
+"from vellum.workflows.nodes.core import TryNode
+from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
 from vellum.workflows.state import BaseState
-from vellum.workflows.nodes.core import TryNode
 
 
 @TryNode.wrap()
@@ -142,6 +148,7 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
 exports[`TemplatingNode > reject on error enabled > should generate the node file for a dependency correctly 1`] = `
 "from vellum.workflows.nodes.displayable import TemplatingNode
 from vellum.workflows.state import BaseState
+
 from .templating_node import TemplatingNode as TemplatingNodeTemplatingNode
 
 

--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
@@ -2,8 +2,9 @@
 
 exports[`GenericNode > basic > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseNodeDisplay
-from ...nodes.my_custom_node import MyCustomNode
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.my_custom_node import MyCustomNode
 
 
 class MyCustomNodeDisplay(BaseNodeDisplay[MyCustomNode]):
@@ -16,6 +17,7 @@ class MyCustomNodeDisplay(BaseNodeDisplay[MyCustomNode]):
 
 exports[`GenericNode > basic > getNodeFile 1`] = `
 "from vellum.workflows.nodes import BaseNode
+
 from ..inputs import Inputs
 
 
@@ -33,8 +35,9 @@ class MyCustomNode(BaseNode):
 
 exports[`GenericNode > basic with adornments > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseNodeDisplay
-from ...nodes.my_custom_node import MyCustomNode
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.my_custom_node import MyCustomNode
 
 
 class MyCustomNodeDisplay(BaseNodeDisplay[MyCustomNode]):
@@ -49,6 +52,7 @@ exports[`GenericNode > basic with adornments > getNodeFile 1`] = `
 "from vellum.workflows.nodes import BaseNode
 from vellum.workflows.nodes.core import TryNode
 from vellum.workflows.nodes.core.map_node.node import MapNode
+
 from ..inputs import Inputs
 
 
@@ -68,6 +72,7 @@ class MyCustomNode(BaseNode):
 
 exports[`GenericNode > basic with generic node output as attribute > getNodeFile 1`] = `
 "from vellum.workflows.nodes import BaseNode
+
 from .my_custom_node import ReferencedNode
 
 
@@ -84,8 +89,9 @@ class MyCustomNode(BaseNode):
 
 exports[`GenericNode > basic with node output as attribute > getNodeDisplayFile 1`] = `
 "from vellum_ee.workflows.display.nodes import BaseNodeDisplay
-from ...nodes.my_custom_node import MyCustomNode
 from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.my_custom_node import MyCustomNode
 
 
 class MyCustomNodeDisplay(BaseNodeDisplay[MyCustomNode]):
@@ -98,6 +104,7 @@ class MyCustomNodeDisplay(BaseNodeDisplay[MyCustomNode]):
 
 exports[`GenericNode > basic with node output as attribute > getNodeFile 1`] = `
 "from vellum.workflows.nodes import BaseNode
+
 from .prompt_node import PromptNode
 
 

--- a/ee/codegen/src/generators/base-persisted-file.ts
+++ b/ee/codegen/src/generators/base-persisted-file.ts
@@ -1,11 +1,14 @@
 import { mkdir, writeFile } from "fs/promises";
 import path, { join } from "path";
 
-import { python } from "@fern-api/python-ast";
 import { Comment } from "@fern-api/python-ast/Comment";
+import { Reference } from "@fern-api/python-ast/Reference";
 import { StarImport } from "@fern-api/python-ast/StarImport";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
+import { ModulePath } from "@fern-api/python-ast/core/types";
+
+import { PythonFile } from "./protected-python-file";
 
 import { INIT_FILE_NAME } from "src/constants";
 import { WorkflowContext } from "src/context";
@@ -14,6 +17,128 @@ export declare namespace BasePersistedFile {
   interface Args {
     workflowContext: WorkflowContext;
     isInitFile?: boolean;
+  }
+}
+
+const VELLUM_MODULES = new Set(["vellum", "vellum_ee"]);
+
+class ImportSortedPythonFile extends PythonFile {
+  writeImports({
+    writer,
+    uniqueReferences,
+  }: {
+    writer: Writer;
+    uniqueReferences: Map<
+      string,
+      { modulePath: ModulePath; references: Reference[] }
+    >;
+  }) {
+    const sortedReferences = this.sortReferences(uniqueReferences);
+    let lastPriority: number | null = null;
+
+    for (const {
+      fullyQualifiedPath,
+      modulePath,
+      references,
+      priority,
+    } of sortedReferences) {
+      const refModulePath = modulePath;
+      // Check to see if the reference is defined in this same file and if so, skip its import
+      if (this.isDefinedInFile(refModulePath)) {
+        continue;
+      }
+
+      if (priority !== lastPriority) {
+        if (lastPriority !== null) {
+          writer.newLine();
+        }
+        lastPriority = priority;
+      }
+
+      if (refModulePath[0] === this.path[0]) {
+        // Relativize the import
+        // Calculate the common prefix length
+        let commonPrefixLength = 0;
+        while (
+          commonPrefixLength < this.path.length &&
+          commonPrefixLength < refModulePath.length &&
+          this.path[commonPrefixLength] === refModulePath[commonPrefixLength]
+        ) {
+          commonPrefixLength++;
+        }
+        // Calculate the number of levels to go up
+        let levelsUp = this.path.length - commonPrefixLength;
+        // If this is an __init__.py file, then we must go one more level up.
+        if (this.isInitFile) {
+          levelsUp++;
+        }
+        // Build the relative import path
+        let relativePath = levelsUp > 0 ? ".".repeat(levelsUp) : ".";
+        relativePath += refModulePath.slice(commonPrefixLength).join(".");
+        // Write the relative import statement
+        writer.write(
+          `from ${relativePath} import ${references
+            .map((reference) => this.getImportName({ writer, reference }))
+            .join(", ")}`
+        );
+      } else {
+        // Use fully qualified path
+        writer.write(
+          `from ${fullyQualifiedPath} import ${references
+            .map((reference) => this.getImportName({ writer, reference }))
+            .join(", ")}`
+        );
+      }
+      writer.newLine();
+    }
+    if (Object.keys(uniqueReferences).length > 0) {
+      writer.newLine();
+    }
+  }
+
+  // The above logic is copied and pasted from the Fern PythonFile AST Library
+  // The below is our only contribution to the class
+  private sortReferences(
+    uniqueReferences: Map<
+      string,
+      { modulePath: ModulePath; references: Reference[] }
+    >
+  ) {
+    return Array.from(uniqueReferences.entries())
+      .map(([fullyQualifiedPath, { modulePath, references }]) => ({
+        fullyQualifiedPath,
+        modulePath,
+        references: references.sort(),
+        priority: this.getModulePathPriority(modulePath),
+      }))
+      .sort((a, b) => {
+        if (a.priority !== b.priority) {
+          return b.priority - a.priority;
+        }
+        if (a.references[0]?.name === "*" && b.references[0]?.name !== "*") {
+          return 1;
+        }
+        if (b.references[0]?.name === "*" && a.references[0]?.name !== "*") {
+          return -1;
+        }
+        return a.modulePath.join(".").localeCompare(b.modulePath.join("."));
+      });
+  }
+
+  private getModulePathPriority(modulePath: ModulePath) {
+    if (!modulePath[0]) {
+      return 0;
+    }
+
+    if (modulePath[0] === this.path[0]) {
+      return 1;
+    }
+
+    if (VELLUM_MODULES.has(modulePath[0])) {
+      return 2;
+    }
+
+    return 3;
   }
 }
 
@@ -45,7 +170,7 @@ export abstract class BasePersistedFile extends AstNode {
       return;
     }
 
-    const file = python.file({
+    const file = new ImportSortedPythonFile({
       path: this.getModulePath(),
       isInitFile: this.isInitFile,
       statements: fileStatements,

--- a/ee/codegen/src/generators/protected-python-file.ts
+++ b/ee/codegen/src/generators/protected-python-file.ts
@@ -1,0 +1,309 @@
+// This file is a direct copy paste of
+// https://github.com/fern-api/fern/blob/main/generators/python-v2/ast/src/PythonFile.ts
+// But the only difference is that all private methods are now protected
+
+import { Class } from "@fern-api/python-ast/Class";
+import { Comment } from "@fern-api/python-ast/Comment";
+import { Field } from "@fern-api/python-ast/Field";
+import { Method } from "@fern-api/python-ast/Method";
+import { Reference } from "@fern-api/python-ast/Reference";
+import { StarImport } from "@fern-api/python-ast/StarImport";
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { ImportedName, ModulePath } from "@fern-api/python-ast/core/types";
+import { createPythonClassName } from "@fern-api/python-ast/core/utils";
+
+interface UniqueReferenceValue {
+  modulePath: ModulePath;
+  references: Reference[];
+  referenceNames: Set<string>;
+}
+
+export declare namespace PythonFile {
+  interface Args {
+    /* The path of the Python file relative to the module */
+    path: ModulePath;
+    /* The list of statements in the Python file. More can be added following initialization. */
+    statements?: AstNode[];
+    /* Whether or not this represents the root of a Python module */
+    isInitFile?: boolean;
+    /* Any comments that should be at the top of the file */
+    comments?: Comment[];
+    /* Any explicit imports that should be included */
+    imports?: StarImport[];
+  }
+}
+
+export class PythonFile extends AstNode {
+  public readonly path: ModulePath;
+  public readonly isInitFile: boolean;
+  private readonly statements: AstNode[] = [];
+  private readonly comments: Comment[];
+
+  constructor({
+    path,
+    statements,
+    isInitFile = false,
+    comments,
+    imports,
+  }: PythonFile.Args) {
+    super();
+    this.path = path;
+    this.isInitFile = isInitFile;
+
+    statements?.forEach((statement) => this.addStatement(statement));
+
+    this.comments = comments ?? [];
+
+    imports?.forEach((import_) => this.addReference(import_));
+  }
+
+  public addStatement(statement: AstNode): void {
+    this.statements.push(statement);
+    this.inheritReferences(statement);
+  }
+
+  public write(writer: Writer): void {
+    const uniqueReferences = this.deduplicateReferences();
+
+    this.updateWriterRefNameOverrides({ writer, uniqueReferences });
+
+    this.writeComments(writer);
+    this.writeImports({ writer, uniqueReferences });
+    this.statements.forEach((statement, idx) => {
+      statement.write(writer);
+      writer.newLine();
+      if (idx < this.statements.length - 1) {
+        writer.newLine();
+      }
+    });
+
+    writer.unsetRefNameOverrides();
+  }
+
+  /*******************************
+   * Helper Methods
+   *******************************/
+
+  protected updateWriterRefNameOverrides({
+    writer,
+    uniqueReferences,
+  }: {
+    writer: Writer;
+    uniqueReferences: Map<string, UniqueReferenceValue>;
+  }): void {
+    // Clone the map so that we can mutate its copy.
+    const referencesToHandle = new Map(uniqueReferences);
+
+    // Build up a map of refs to their name overrides, keeping track of names that have been used as we go.
+    const completeRefPathsToNameOverrides: Record<string, ImportedName> = {};
+    const usedNames = this.getInitialUsedNames();
+
+    // First, reserve the names of any references that are defined in the file itself and that don't need importing.
+    const filePath = this.path.join(".");
+    const fileReferences = uniqueReferences.get(filePath);
+    if (fileReferences) {
+      const { references } = fileReferences;
+
+      references.forEach((reference) => {
+        const fullyQualifiedModulePath =
+          reference.getFullyQualifiedModulePath();
+        const name = reference.name;
+
+        completeRefPathsToNameOverrides[fullyQualifiedModulePath] = {
+          name,
+          isAlias: false,
+        };
+        usedNames.add(reference.name);
+      });
+
+      referencesToHandle.delete(filePath);
+    }
+
+    // Continue on to resolving names for references that must be imported
+    const importedReferences: Reference[] = Array.from(
+      referencesToHandle.values()
+    ).flatMap(({ references }) => references);
+    importedReferences.forEach((reference) => {
+      // Skip star imports since we should never override their import alias
+      if (reference instanceof StarImport) {
+        return;
+      }
+
+      const name = reference.alias ?? reference.name;
+      const fullyQualifiedModulePath = reference.getFullyQualifiedModulePath();
+
+      let nameOverride = name;
+      let modulePathIdx = reference.modulePath.length - 1;
+      let isAlias = !!reference.alias;
+
+      while (usedNames.has(nameOverride)) {
+        isAlias = true;
+
+        const module = reference.modulePath[modulePathIdx];
+        if (modulePathIdx < 0 || !module) {
+          nameOverride = `_${nameOverride}`;
+        } else {
+          nameOverride = `${createPythonClassName(module)}${nameOverride}`;
+        }
+
+        modulePathIdx--;
+      }
+      usedNames.add(nameOverride);
+
+      completeRefPathsToNameOverrides[fullyQualifiedModulePath] = {
+        name: nameOverride,
+        isAlias,
+      };
+    });
+
+    writer.setRefNameOverrides(completeRefPathsToNameOverrides);
+  }
+
+  protected getInitialUsedNames(): Set<string> {
+    const usedNames = new Set<string>();
+
+    this.statements.forEach((statement) => {
+      if (statement instanceof Class) {
+        usedNames.add(statement.name);
+      } else if (statement instanceof Method) {
+        usedNames.add(statement.name);
+      } else if (statement instanceof Field) {
+        usedNames.add(statement.name);
+      }
+    });
+
+    return usedNames;
+  }
+
+  protected deduplicateReferences() {
+    // Deduplicate references by their fully qualified paths
+    const uniqueReferences = new Map<string, UniqueReferenceValue>();
+    for (const reference of this.references) {
+      const referenceName = reference.name;
+      const fullyQualifiedPath = reference.getFullyQualifiedPath();
+
+      // Skip references that don't have a path. It's inferred that they don't need to be imported.
+      if (fullyQualifiedPath === "") {
+        continue;
+      }
+
+      const existingRefs = uniqueReferences.get(fullyQualifiedPath);
+
+      if (existingRefs) {
+        if (!existingRefs.referenceNames.has(referenceName)) {
+          existingRefs.references.push(reference);
+          existingRefs.referenceNames.add(referenceName);
+        }
+      } else {
+        uniqueReferences.set(fullyQualifiedPath, {
+          modulePath: reference.modulePath,
+          references: [reference],
+          referenceNames: new Set([referenceName]),
+        });
+      }
+    }
+
+    return uniqueReferences;
+  }
+
+  protected writeComments(writer: Writer): void {
+    this.comments.forEach((comment) => {
+      comment.write(writer);
+    });
+
+    if (this.comments.length > 0) {
+      writer.newLine();
+    }
+  }
+
+  protected getImportName({
+    writer,
+    reference,
+  }: {
+    writer: Writer;
+    reference: Reference;
+  }): string {
+    const nameOverride = writer.getRefNameOverride(reference);
+
+    const name = reference.name;
+    const alias = nameOverride.isAlias ? nameOverride.name : undefined;
+
+    return `${name}${alias ? ` as ${alias}` : ""}`;
+  }
+
+  protected writeImports({
+    writer,
+    uniqueReferences,
+  }: {
+    writer: Writer;
+    uniqueReferences: Map<
+      string,
+      { modulePath: ModulePath; references: Reference[] }
+    >;
+  }): void {
+    for (const [
+      fullyQualifiedPath,
+      { modulePath, references },
+    ] of uniqueReferences) {
+      const refModulePath = modulePath;
+
+      // Check to see if the reference is defined in this same file and if so, skip its import
+      if (this.isDefinedInFile(refModulePath)) {
+        continue;
+      }
+
+      if (refModulePath[0] === this.path[0]) {
+        // Relativize the import
+        // Calculate the common prefix length
+        let commonPrefixLength = 0;
+        while (
+          commonPrefixLength < this.path.length &&
+          commonPrefixLength < refModulePath.length &&
+          this.path[commonPrefixLength] === refModulePath[commonPrefixLength]
+        ) {
+          commonPrefixLength++;
+        }
+
+        // Calculate the number of levels to go up
+        let levelsUp = this.path.length - commonPrefixLength;
+
+        // If this is an __init__.py file, then we must go one more level up.
+        if (this.isInitFile) {
+          levelsUp++;
+        }
+
+        // Build the relative import path
+        let relativePath = levelsUp > 0 ? ".".repeat(levelsUp) : ".";
+        relativePath += refModulePath.slice(commonPrefixLength).join(".");
+
+        // Write the relative import statement
+        writer.write(
+          `from ${relativePath} import ${references
+            .map((reference) => this.getImportName({ writer, reference }))
+            .join(", ")}`
+        );
+      } else {
+        // Use fully qualified path
+        writer.write(
+          `from ${fullyQualifiedPath} import ${references
+            .map((reference) => this.getImportName({ writer, reference }))
+            .join(", ")}`
+        );
+      }
+
+      writer.newLine();
+    }
+
+    if (Object.keys(uniqueReferences).length > 0) {
+      writer.newLine();
+    }
+  }
+
+  protected isDefinedInFile(modulePath: readonly string[]): boolean {
+    return (
+      modulePath.length === this.path.length &&
+      modulePath.every((part, idx) => part === this.path[idx])
+    );
+  }
+}

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -1,4 +1,3 @@
-import { exec } from "child_process";
 import fs from "fs";
 import { mkdir } from "fs/promises";
 import { join } from "path";
@@ -242,24 +241,6 @@ ${errors.slice(0, 3).map((err) => {
     // error.log - this gets generated separately from the other files because it
     // collects errors raised by the rest of the codegen process
     await this.generateErrorLogFile().persist();
-
-    if (!this.workflowContext.disableFormatting) {
-      const setupCfgPath = this.resolvePythonConfigFilePath();
-      const isortCmd = process.env.ISORT_CMD ?? "isort";
-
-      await new Promise((resolve, reject) => {
-        exec(
-          `${isortCmd} --sp ${setupCfgPath} --skip script.py ${this.workflowContext.absolutePathToOutputDirectory}`,
-          (error: Error | null) => {
-            if (error) {
-              reject(error);
-            } else {
-              resolve(undefined);
-            }
-          }
-        );
-      });
-    }
   }
 
   private generateRootInitFile(): InitFile {


### PR DESCRIPTION
Here's the exec(isort) bug that finally tipped me over the edge here:
- Part 1 https://www.loom.com/share/6576163093784bbb8c8a6eb4f25f4e45
- Part 2 https://www.loom.com/share/eae686ab09c44012b812932feb152594

Reasons why I'm not worried about risk:
- We don't need to account for user config in codgen service - that could happen on their machine as part of `vellum workflows pull` or in django
- Because of ^, we don't need perfect sorting within codegen service, just something deterministic. The deterministic algo I chose was one that minimized changes from the snapshot generated from `project.test.ts`

Other Benefits:
- Tests run 50% faster now
- No divergence from preview and run
- No flaky exec(isort) failures referenced in video
- All of our node unit tests snapshots will now have consistent sorting with our project tests and are no longer sensitive to order of references within implementation.
    - This is where the vast majority of the LoC lives. The actual sorting algo is ~40 lines