### PR TITLE
Explore resilience to node not found error's

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -676,6 +676,7 @@ export function templatingNodeFactory({
   targetHandleId,
   errorOutputId,
   outputType = VellumVariableType.String,
+  templateNodeInputId,
   inputs,
   template,
 }: {
@@ -685,6 +686,7 @@ export function templatingNodeFactory({
   targetHandleId?: string;
   errorOutputId?: string;
   outputType?: VellumVariableType;
+  templateNodeInputId?: string;
   inputs?: NodeInput[];
   template?: ConstantValuePointer;
 } = {}): TemplatingNode {
@@ -721,7 +723,8 @@ export function templatingNodeFactory({
       errorOutputId,
       sourceHandleId: sourceHandleId ?? "6ee2c814-d0a5-4ec9-83b6-45156e2f22c4",
       targetHandleId: targetHandleId ?? "3960c8e1-9baa-4b9c-991d-e399d16a45aa",
-      templateNodeInputId: "7b8af68b-cf60-4fca-9c57-868042b5b616",
+      templateNodeInputId:
+        templateNodeInputId ?? "7b8af68b-cf60-4fca-9c57-868042b5b616",
       outputType: outputType,
     },
     inputs: nodeInputs,

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -93,6 +93,19 @@ class TemplatingNode(BaseTemplatingNode[BaseState, Json]):
 "
 `;
 
+exports[`TemplatingNode > referencing an invalid node > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
+from vellum.workflows.state import BaseState
+
+
+class TemplatingNode(BaseTemplatingNode[BaseState, str]):
+    template = """Hello, World!"""
+    inputs = {
+        "text": {},
+    }
+"
+`;
+
 exports[`TemplatingNode > reject on error enabled > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 

--- a/ee/codegen/src/__test__/nodes/base-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/base-node.test.ts
@@ -68,7 +68,8 @@ describe("BaseNode", () => {
         });
       }).toThrow(
         new NodeAttributeGenerationError(
-          "Failed to generate attribute 'TemplatingNode.inputs.text': Failed to find node with id '12345678-1234-5678-1234-567812345678'"
+          "Failed to generate attribute 'TemplatingNode.inputs.text': Failed to find node with id '12345678-1234-5678-1234-567812345678'",
+          "WARNING"
         )
       );
     });
@@ -134,7 +135,8 @@ describe("BaseNode", () => {
         });
       }).toThrow(
         new NodeAttributeGenerationError(
-          "Failed to generate attribute 'TemplatingNode2.inputs.text': Failed to find output value TemplatingNode.Outputs given id '90abcdef-90ab-cdef-90ab-cdef90abcdef'"
+          "Failed to generate attribute 'TemplatingNode2.inputs.text': Failed to find TemplatingNode Output with id '90abcdef-90ab-cdef-90ab-cdef90abcdef'",
+          "WARNING"
         )
       );
     });

--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -358,7 +358,7 @@ describe("Non-existent Subworkflow Deployment Node referenced by Templating Node
     const error = errors[0];
     expect(error?.severity).toBe("WARNING");
     expect(error?.message).toContain(
-      "Could not find subworkflow deployment output with id some-non-existent-subworkflow-output-id"
+      "Could not find Subworkflow Deployment Output with id some-non-existent-subworkflow-output-id"
     );
   });
 });

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -258,7 +258,7 @@ describe("WorkflowProjectGenerator", () => {
         `\
 Encountered 1 error(s) while generating code:
 
-- Failed to generate attribute 'BadNode.inputs.other': Failed to find node with id 'node_that_doesnt_exist'
+- Failed to find node with id 'node_that_doesnt_exist'
 `
       );
     });

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -109,7 +109,7 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
       ) {
         this.workflowContext.addError(
           new NodeOutputNotFoundError(
-            `Could not find subworkflow deployment output with id ${outputId}`,
+            `Could not find Subworkflow Deployment Output with id ${outputId}`,
             "WARNING"
           )
         );
@@ -117,7 +117,8 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
       }
 
       throw new NodeOutputNotFoundError(
-        `Failed to find output value ${this.nodeClassName}.Outputs given id '${outputId}'`
+        `Failed to find ${this.nodeClassName} Output with id '${outputId}'`,
+        "WARNING"
       );
     }
 

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -167,7 +167,8 @@ export abstract class BaseNode<
       } catch (error) {
         if (error instanceof BaseCodegenError) {
           const nodeAttributeGenerationError = new NodeAttributeGenerationError(
-            `Failed to generate attribute '${this.nodeContext.nodeClassName}.inputs.${nodeInputData.key}': ${error.message}`
+            `Failed to generate attribute '${this.nodeContext.nodeClassName}.inputs.${nodeInputData.key}': ${error.message}`,
+            "WARNING"
           );
           this.workflowContext.addError(nodeAttributeGenerationError);
         } else {


### PR DESCRIPTION
This PR was originally invoked by a node not found error throwing from a customer workflow due to bad data. While exploring this PR, the line between an error and a warning is starting to blur in my head and I wanted to take a beat for it. Part of me wonders that instead of the changes in this PR, whether we should just run workflows with non-strict codgen: https://github.com/vellum-ai/vellum/blob/main/django/app/api/ad_hoc/views.py#L472