### PR TITLE
Supplement undefined class to show better error messages in userland code

### DIFF
--- a/src/vellum/workflows/constants.py
+++ b/src/vellum/workflows/constants.py
@@ -3,6 +3,15 @@ from typing import Any, cast
 
 
 class _UndefMeta(type):
+    def __new__(cls, name: str, bases: tuple[type, ...], attrs: dict[str, Any]) -> type:
+        cls.__name__ = "undefined"
+        cls.__qualname__ = "undefined"
+
+        undefined_class = super().__new__(cls, name, bases, attrs)
+        undefined_class.__name__ = "undefined"
+        undefined_class.__qualname__ = "undefined"
+        return undefined_class
+
     def __repr__(cls) -> str:
         return "undefined"
 

--- a/src/vellum/workflows/tests/test_undefined.py
+++ b/src/vellum/workflows/tests/test_undefined.py
@@ -1,0 +1,12 @@
+import pytest
+
+from vellum.workflows.constants import undefined
+
+
+def test_undefined__ensure_sensible_error_messages():
+    # WHEN we invoke an invalid operation on `undefined`
+    with pytest.raises(Exception) as e:
+        len(undefined)
+
+    # THEN we get a sensible error message
+    assert str(e.value) == "object of type 'undefined' has no len()"


### PR DESCRIPTION
Users can interface with our `undefined` type within base nodes and code nodes. We want error messages that involve them to clearly indicate an undefined type