### PR TITLE
Removed unused node output utils

### DIFF
--- a/ee/codegen/src/utils/nodes.ts
+++ b/ee/codegen/src/utils/nodes.ts
@@ -1,7 +1,6 @@
 import { VellumError } from "vellum-ai/errors";
 
-import { WorkflowGenerationError } from "src/generators/errors";
-import { WorkflowNode, WorkflowOutputValue } from "src/types/vellum";
+import { WorkflowNode } from "src/types/vellum";
 
 export function getNodeLabel(nodeData: WorkflowNode): string {
   switch (nodeData.type) {
@@ -14,36 +13,6 @@ export function getNodeLabel(nodeData: WorkflowNode): string {
 
 export function isUnaryOperator(operator: string): boolean {
   return operator === "null" || operator === "notNull";
-}
-
-export function getNodeIdFromNodeOutputWorkflowReference(
-  workflowOutput: WorkflowOutputValue
-): string {
-  if (
-    "type" in workflowOutput.value &&
-    workflowOutput.value.type === "NODE_OUTPUT"
-  ) {
-    return workflowOutput.value.nodeId;
-  } else {
-    throw new WorkflowGenerationError(
-      `Expected WorkflowOutputValue to be of type NODE_OUTPUT but got ${workflowOutput.value.type} instead`
-    );
-  }
-}
-
-export function getNodeOutputIdFromNodeOutputWorkflowReference(
-  workflowOutput: WorkflowOutputValue
-): string {
-  if (
-    "type" in workflowOutput.value &&
-    workflowOutput.value.type === "NODE_OUTPUT"
-  ) {
-    return workflowOutput.value.nodeOutputId;
-  } else {
-    throw new WorkflowGenerationError(
-      `Expected WorkflowOutputValue to be of type NODE_OUTPUT but got ${workflowOutput.value.type} instead`
-    );
-  }
 }
 
 export function isVellumErrorWithDetail(


### PR DESCRIPTION
I'm in the middle of triaging all of our codegen errors and noticed these two in code paths that never get invoked