### PR TITLE
Triage all codegen warning/errors

### DIFF
--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -228,12 +228,19 @@ export class WorkflowContext {
       (n): n is EntrypointNode => n.type === "ENTRYPOINT"
     );
     if (entrypointNodes.length > 1) {
-      throw new WorkflowGenerationError("Multiple entrypoint nodes found");
+      this.addError(
+        new WorkflowGenerationError(
+          "Multiple entrypoint nodes found",
+          "WARNING"
+        )
+      );
     }
 
     const entrypointNode = entrypointNodes[0];
     if (!entrypointNode) {
-      throw new WorkflowGenerationError("Entrypoint node not found");
+      this.addError(
+        new WorkflowGenerationError("Entrypoint node not found", "WARNING")
+      );
     }
     this.entrypointNode = entrypointNode;
 
@@ -272,8 +279,11 @@ export class WorkflowContext {
     const inputVariableId = inputVariableContext.getInputVariableId();
 
     if (this.globalInputVariableContextsById.get(inputVariableId)) {
-      throw new WorkflowInputGenerationError(
-        `Input variable context already exists for input variable ID: ${inputVariableId}`
+      this.addError(
+        new WorkflowInputGenerationError(
+          `Input variable context already exists for input variable ID: ${inputVariableId}`,
+          "WARNING"
+        )
       );
     }
 
@@ -303,8 +313,11 @@ export class WorkflowContext {
     const outputVariableId = outputVariableContext.getOutputVariableId();
 
     if (this.globalOutputVariableContextsById.get(outputVariableId)) {
-      throw new WorkflowOutputGenerationError(
-        `Output variable context already exists for output variable ID: ${outputVariableId}`
+      this.addError(
+        new WorkflowOutputGenerationError(
+          `Output variable context already exists for output variable ID: ${outputVariableId}`,
+          "WARNING"
+        )
       );
     }
 
@@ -328,8 +341,9 @@ export class WorkflowContext {
       this.findOutputVariableContextById(outputVariableId);
 
     if (!outputVariableContext) {
-      throw new WorkflowInputGenerationError(
-        `Output variable context not found for ID: ${outputVariableId}`
+      throw new WorkflowOutputGenerationError(
+        `Output variable context not found for ID: ${outputVariableId}`,
+        "WARNING"
       );
     }
 
@@ -370,8 +384,11 @@ export class WorkflowContext {
     const nodeId = nodeContext.nodeData.id;
 
     if (this.globalNodeContextsByNodeId.get(nodeId)) {
-      throw new NodeDefinitionGenerationError(
-        `Node context already exists for node ID: ${nodeId}`
+      this.addError(
+        new NodeDefinitionGenerationError(
+          `Node context already exists for node ID: ${nodeId}`,
+          "WARNING"
+        )
       );
     }
 
@@ -401,8 +418,11 @@ export class WorkflowContext {
     const portId = portContext.portId;
 
     if (this.portContextById.get(portId)) {
-      throw new NodePortGenerationError(
-        `Port context already exists for port id: ${portId}`
+      this.addError(
+        new NodePortGenerationError(
+          `Port context already exists for port id: ${portId}`,
+          "WARNING"
+        )
       );
     }
     this.portContextById.set(portId, portContext);

--- a/ee/codegen/src/generators/conditional-node-port.ts
+++ b/ee/codegen/src/generators/conditional-node-port.ts
@@ -169,8 +169,11 @@ export class ConditionalNodePort extends AstNode {
       ? this.convertOperatorToMethod(conditionData.operator, lhs)
       : undefined;
     if (isNil(operator)) {
-      throw new NodePortGenerationError(
-        `Node ${this.nodeLabel} is missing required operator for rule: ${ruleIdx} in condition: ${this.conditionalNodeDataIndex}`
+      this.portContext.workflowContext.addError(
+        new NodePortGenerationError(
+          `Node ${this.nodeLabel} is missing required operator for rule: ${ruleIdx} in condition: ${this.conditionalNodeDataIndex}`,
+          "WARNING"
+        )
       );
     }
 
@@ -321,7 +324,8 @@ export class ConditionalNodePort extends AstNode {
     const castedValue = Number(nodeValue.data.value);
     if (isNaN(castedValue)) {
       const error = new ValueGenerationError(
-        `Failed to cast constant value ${nodeValue.data.value} to NUMBER for attribute ${this.nodeLabel}.${nodeInput.nodeInputData.key}`
+        `Failed to cast constant value ${nodeValue.data.value} to NUMBER for attribute ${this.nodeLabel}.${nodeInput.nodeInputData.key}`,
+        "WARNING"
       );
       this.portContext.workflowContext.addError(error);
       return;

--- a/ee/codegen/src/generators/expression.ts
+++ b/ee/codegen/src/generators/expression.ts
@@ -76,7 +76,8 @@ export class Expression extends AstNode {
     let rawLhs = base;
     if (!rhs) {
       throw new NodeAttributeGenerationError(
-        "rhs must be defined if base is defined"
+        "rhs must be defined if base is defined",
+        "WARNING"
       );
     }
     if (

--- a/ee/codegen/src/generators/json.ts
+++ b/ee/codegen/src/generators/json.ts
@@ -14,7 +14,7 @@ export class Json extends AstNode {
     try {
       JSON.stringify(value);
     } catch {
-      throw new ValueGenerationError("Value is not JSON serializable");
+      throw new ValueGenerationError("Value is not JSON serializable", "WARNING");
     }
 
     this.astNode = this.generateAstNode(value);
@@ -70,7 +70,8 @@ export class Json extends AstNode {
     }
 
     throw new ValueGenerationError(
-      `Unsupported JSON value type: ${typeof value}`
+      `Unsupported JSON value type: ${typeof value}`,
+      "WARNING"
     );
   }
 

--- a/ee/codegen/src/generators/nodes/bases/nested-workflow-base.ts
+++ b/ee/codegen/src/generators/nodes/bases/nested-workflow-base.ts
@@ -45,8 +45,11 @@ export abstract class BaseNestedWorkflowNode<
     const nestedWorkflowContext = this.nestedWorkflowContextsByName.get(name);
 
     if (!nestedWorkflowContext) {
-      throw new NodeAttributeGenerationError(
-        `Nested workflow context not found for attribute name: ${name}`
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          `Nested workflow context not found for attribute name: ${name}`,
+          "WARNING"
+        )
       );
     }
 

--- a/ee/codegen/src/generators/nodes/code-execution-node.ts
+++ b/ee/codegen/src/generators/nodes/code-execution-node.ts
@@ -212,8 +212,11 @@ export class CodeExecutionNode extends BaseSingleFileNode<
       codeInputRule.type !== "CONSTANT_VALUE" ||
       codeInputRule.data.type !== "STRING"
     ) {
-      throw new NodeAttributeGenerationError(
-        "Expected to find code input with constant string value"
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          "Expected to find code input with constant string value",
+          "WARNING"
+        )
       );
     }
 
@@ -232,7 +235,8 @@ export class CodeExecutionNode extends BaseSingleFileNode<
     ) {
       this.workflowContext.addError(
         new NodeAttributeGenerationError(
-          "Expected to find runtime input with constant string value"
+          "Expected to find runtime input with constant string value",
+          "WARNING"
         )
       );
       runtime = "";

--- a/ee/codegen/src/generators/nodes/guardrail-node.ts
+++ b/ee/codegen/src/generators/nodes/guardrail-node.ts
@@ -21,8 +21,11 @@ export class GuardrailNode extends BaseSingleFileNode<
     const statements: AstNode[] = [];
 
     if (!this.nodeData.data.metricDefinitionId) {
-      throw new NodeAttributeGenerationError(
-        "metric_definition_id is required"
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          "metric_definition_id is required",
+          "WARNING"
+        )
       );
     }
 
@@ -51,7 +54,12 @@ export class GuardrailNode extends BaseSingleFileNode<
     );
 
     if (!this.nodeData.data.releaseTag) {
-      throw new NodeAttributeGenerationError("release_tag is required");
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          "release_tag is required",
+          "WARNING"
+        )
+      );
     }
 
     statements.push(
@@ -105,8 +113,11 @@ export class GuardrailNode extends BaseSingleFileNode<
           const name = this.nodeContext.getNodeOutputNameById(output.id);
 
           if (!name) {
-            throw new NodeAttributeGenerationError(
-              `Could not find output name for ${this.nodeContext.nodeClassName}.Outputs.${output.key} given output id ${output.id}`
+            this.workflowContext.addError(
+              new NodeAttributeGenerationError(
+                `Could not find output name for ${this.nodeContext.nodeClassName}.Outputs.${output.key} given output id ${output.id}`,
+                "WARNING"
+              )
             );
           }
           return {

--- a/ee/codegen/src/generators/nodes/inline-prompt-node.ts
+++ b/ee/codegen/src/generators/nodes/inline-prompt-node.ts
@@ -30,8 +30,11 @@ export class InlinePromptNode extends BaseSingleFileNode<
     const statements: AstNode[] = [];
 
     if (this.nodeData.data.variant !== "INLINE") {
-      throw new NodeAttributeGenerationError(
-        `InlinePromptNode only supports INLINE variant. Received ${this.nodeData.data.variant}`
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          `InlinePromptNode only supports INLINE variant. Received ${this.nodeData.data.variant}`,
+          "WARNING"
+        )
       );
     }
 

--- a/ee/codegen/src/generators/nodes/search-node.ts
+++ b/ee/codegen/src/generators/nodes/search-node.ts
@@ -64,8 +64,11 @@ export class SearchNode extends BaseSingleFileNode<
         if (limitValue.data.value != null) {
           const parsedInt = parseInt(limitValue.data.value);
           if (isNaN(parsedInt)) {
-            throw new ValueGenerationError(
-              `Failed to parse search node limit value "${limitValue.data.value}" as an integer`
+            this.workflowContext.addError(
+              new ValueGenerationError(
+                `Failed to parse search node limit value "${limitValue.data.value}" as an integer`,
+                "WARNING"
+              )
             );
           }
           bodyStatements.push(
@@ -79,8 +82,11 @@ export class SearchNode extends BaseSingleFileNode<
         limitValue?.type === "CONSTANT_VALUE" &&
         limitValue.data.type !== "NUMBER"
       ) {
-        throw new NodeAttributeGenerationError(
-          `Limit param input should be a CONSTANT_VALUE and of type NUMBER, got ${limitValue.data.type} instead`
+        this.workflowContext.addError(
+          new NodeAttributeGenerationError(
+            `Limit param input should be a CONSTANT_VALUE and of type NUMBER, got ${limitValue.data.type} instead`,
+            "WARNING"
+          )
         );
       } else {
         bodyStatements.push(
@@ -130,7 +136,9 @@ export class SearchNode extends BaseSingleFileNode<
     const weightsRule =
       this.findNodeInputByName("weights")?.nodeInputData?.value.rules[0];
     if (!weightsRule || weightsRule.type !== "CONSTANT_VALUE") {
-      throw new NodeAttributeGenerationError("weights input is required");
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError("weights input is required", "WARNING")
+      );
     }
 
     // TODO: Determine what we want to cast JSON values to
@@ -141,14 +149,20 @@ export class SearchNode extends BaseSingleFileNode<
       unknown
     >;
     if (typeof semantic_similarity !== "number") {
-      throw new NodeAttributeGenerationError(
-        "semantic_similarity weight must be a number"
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          "semantic_similarity weight must be a number",
+          "WARNING"
+        )
       );
     }
 
     if (typeof keywords !== "number") {
-      throw new NodeAttributeGenerationError(
-        "keywords weight must be a number"
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          "keywords weight must be a number",
+          "WARNING"
+        )
       );
     }
 
@@ -176,15 +190,21 @@ export class SearchNode extends BaseSingleFileNode<
     const resultMergingRule = this.findNodeInputByName("result_merging_enabled")
       ?.nodeInputData?.value.rules[0];
     if (!resultMergingRule || resultMergingRule.type !== "CONSTANT_VALUE") {
-      throw new NodeAttributeGenerationError(
-        "result_merging_enabled input is required"
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          "result_merging_enabled input is required",
+          "WARNING"
+        )
       );
     }
 
     const resultMergingEnabled = resultMergingRule.data.value;
     if (typeof resultMergingEnabled !== "string") {
-      throw new NodeAttributeGenerationError(
-        "result_merging_enabled must be a boolean"
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          "result_merging_enabled must be a boolean",
+          "WARNING"
+        )
       );
     }
 
@@ -257,10 +277,13 @@ export class SearchNode extends BaseSingleFileNode<
       VellumValueLogicalExpressionSerializer.parse(metadataFilters);
 
     if (!parsedData.ok) {
-      throw new NodeAttributeGenerationError(
-        `Failed to parse metadata filter JSON: ${JSON.stringify(
-          parsedData.errors
-        )}`
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          `Failed to parse metadata filter JSON: ${JSON.stringify(
+            parsedData.errors
+          )}`,
+          "WARNING"
+        )
       );
     }
 
@@ -524,8 +547,11 @@ export class SearchNodeMetadataFilters extends AstNode {
     const lhsId = data.lhsVariableId;
     const lhs = this.nodeInputsById.get(lhsId);
     if (!lhs) {
-      throw new NodeAttributeGenerationError(
-        `Could not find search node input for id ${lhsId}`
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          `Could not find search node input for id ${lhsId}`,
+          "WARNING"
+        )
       );
     }
 
@@ -543,8 +569,11 @@ export class SearchNodeMetadataFilters extends AstNode {
     const rhsId = data.rhsVariableId;
     const rhs = this.nodeInputsById.get(rhsId);
     if (!isUnaryOperator(data.operator) && !rhs) {
-      throw new NodeAttributeGenerationError(
-        `Could not find search node input for id ${rhsId}`
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          `Could not find search node input for id ${rhsId}`,
+          "WARNING"
+        )
       );
     }
 

--- a/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
@@ -27,7 +27,8 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
     if (!this.nodeContext.workflowDeploymentRelease) {
       this.workflowContext.addError(
         new NodeAttributeGenerationError(
-          `Failed to generate attribute: ${this.nodeData.data.label}.deployment`
+          `Failed to generate attribute: ${this.nodeData.data.label}.deployment`,
+          "WARNING"
         )
       );
     } else {
@@ -77,7 +78,8 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
     if (!this.nodeContext.workflowDeploymentRelease) {
       this.workflowContext.addError(
         new NodeAttributeGenerationError(
-          `Failed to generate ${this.nodeData.data.label}.Outputs class`
+          `Failed to generate ${this.nodeData.data.label}.Outputs class`,
+          "WARNING"
         )
       );
       return null;
@@ -167,8 +169,11 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
         outputVariables.map((output) => {
           const outputName = this.nodeContext.getNodeOutputNameById(output.id);
           if (!outputName) {
-            throw new NodeAttributeGenerationError(
-              `Could not find output name for ${this.nodeContext.nodeClassName}.Outputs.${output.key} given output id ${output.id}`
+            this.workflowContext.addError(
+              new NodeAttributeGenerationError(
+                `Could not find output name for ${this.nodeContext.nodeClassName}.Outputs.${output.key} given output id ${output.id}`,
+                "WARNING"
+              )
             );
           }
           return {

--- a/ee/codegen/src/generators/nodes/templating-node.ts
+++ b/ee/codegen/src/generators/nodes/templating-node.ts
@@ -104,29 +104,42 @@ export class TemplatingNode extends BaseSingleFileNode<
       (input) => input.id === this.nodeData.data.templateNodeInputId
     );
     if (!templatingInput) {
-      throw new NodeAttributeGenerationError(`Templating input not found`);
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(`Templating input not found`)
+      );
     }
 
     const templateRule = templatingInput.value.rules[0];
     if (!templateRule) {
-      throw new NodeAttributeGenerationError("Templating input rule not found");
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError("Templating input rule not found")
+      );
     }
 
     if (templateRule.type !== "CONSTANT_VALUE") {
-      throw new NodeAttributeGenerationError(
-        "Templating input rule is not a constant value"
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          "Templating input rule is not a constant value",
+          "WARNING"
+        )
       );
     }
 
     if (templateRule.data.type !== "STRING") {
-      throw new NodeAttributeGenerationError(
-        "Templating input rule is not a string"
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          "Templating input rule is not a string",
+          "WARNING"
+        )
       );
     }
 
     if (!templateRule.data.value) {
-      throw new NodeAttributeGenerationError(
-        "Templating input rule value must be defined and nonempty"
+      this.workflowContext.addError(
+        new NodeAttributeGenerationError(
+          "Templating input rule value must be defined and nonempty",
+          "WARNING"
+        )
       );
     }
 

--- a/ee/codegen/src/generators/vellum-variable-value.ts
+++ b/ee/codegen/src/generators/vellum-variable-value.ts
@@ -252,7 +252,8 @@ class ArrayVellumValue extends AstNode {
   ): AstNode {
     if (!Array.isArray(value)) {
       throw new ValueGenerationError(
-        "Expected array value for ArrayVellumValue"
+        "Expected array value for ArrayVellumValue",
+        "WARNING"
       );
     }
 

--- a/ee/codegen/src/generators/workflow-sandbox-file.ts
+++ b/ee/codegen/src/generators/workflow-sandbox-file.ts
@@ -4,6 +4,7 @@ import { isNil } from "lodash";
 
 import { vellumValue } from "src/codegen";
 import { BasePersistedFile } from "src/generators/base-persisted-file";
+import { WorkflowInputGenerationWarning } from "src/generators/errors";
 import { WorkflowSandboxInputs } from "src/types/vellum";
 import { removeEscapeCharacters } from "src/utils/casing";
 import { getGeneratedInputsModulePath } from "src/utils/paths";
@@ -92,6 +93,11 @@ if __name__ != "__main__":
             this.workflowContext.findInputVariableContextByRawName(rawName);
 
           if (isNil(inputVariableContext)) {
+            this.workflowContext.addError(
+              new WorkflowInputGenerationWarning(
+                `Input variable context not found for raw name: ${rawName}`
+              )
+            );
             return null;
           }
 

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-input-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-input-reference.ts
@@ -17,7 +17,8 @@ export class WorkflowInputReference extends BaseNodeInputWorkflowReference<Workf
     if (!inputVariableContext) {
       this.workflowContext.addError(
         new NodeInputNotFoundError(
-          `Could not find input variable context with id ${workflowInputReference.inputVariableId}`
+          `Could not find input variable context with id ${workflowInputReference.inputVariableId}`,
+          "WARNING"
         )
       );
       return python.TypeInstantiation.none();

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-value-descriptor-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-value-descriptor-reference.ts
@@ -80,7 +80,8 @@ export class WorkflowValueDescriptorReference extends AstNode {
       case "WORKFLOW_STATE":
         this.workflowContext.addError(
           new ValueGenerationError(
-            "WORKFLOW_STATE reference pointers is not implemented"
+            "WORKFLOW_STATE reference pointers is not implemented",
+            "WARNING"
           )
         );
         return undefined;

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -108,12 +108,20 @@ export class Workflow {
 
     this.workflowContext.workflowOutputContexts.forEach(
       (workflowOutputContext) => {
-        outputsClass.add(
-          new WorkflowOutput({
-            workflowContext: this.workflowContext,
-            workflowOutputContext,
-          })
-        );
+        try {
+          outputsClass.add(
+            new WorkflowOutput({
+              workflowContext: this.workflowContext,
+              workflowOutputContext,
+            })
+          );
+        } catch (error) {
+          if (error instanceof BaseCodegenError) {
+            this.workflowContext.addError(error);
+          } else {
+            throw error;
+          }
+        }
       }
     );
 
@@ -374,7 +382,7 @@ export class Workflow {
               this.workflowContext.getPortContextById(sourcePortId);
           } catch (e) {
             if (e instanceof NodePortNotFoundError) {
-              console.warn(e.message);
+              this.workflowContext.addError(e);
             } else {
               throw e;
             }
@@ -388,7 +396,7 @@ export class Workflow {
             targetNode = this.workflowContext.findNodeContext(targetNodeId);
           } catch (e) {
             if (e instanceof NodeNotFoundError) {
-              console.warn(e.message);
+              this.workflowContext.addError(e);
             } else {
               throw e;
             }

--- a/ee/codegen/src/utils/typing.ts
+++ b/ee/codegen/src/utils/typing.ts
@@ -8,7 +8,7 @@ export function isDefined<TValue>(value: TValue | undefined): value is TValue {
 }
 
 export function assertUnreachable(_: never): never {
-  throw new ValueGenerationError("Didn't expect to get here");
+  throw new ValueGenerationError("Didn't expect to get here", "WARNING");
 }
 
 export function isNilOrEmpty<T>(


### PR DESCRIPTION
Part 2 of the following 4 step process:

- Run workflows in non-vembda mode (started [here](https://github.com/vellum-ai/vellum-python-sdks/compare/vargas/triage-base-codegen-errors?expand=1))
- Audit existing BaseCodegenErrors and turn most that would not affect runtime into warnings instead
- Change strict to still error on both error/warnings
- non-strict codegen always errors on errors