### PR TITLE
Remove unused input variable context utils

### DIFF
--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -278,21 +278,6 @@ export class WorkflowContext {
     return this.globalOutputVariableContextsById.get(outputVariableId);
   }
 
-  public getInputVariableContextById(
-    inputVariableId: string
-  ): InputVariableContext {
-    const inputVariableContext =
-      this.findInputVariableContextById(inputVariableId);
-
-    if (!inputVariableContext) {
-      throw new WorkflowInputGenerationError(
-        `Input variable context not found for ID: ${inputVariableId}`
-      );
-    }
-
-    return inputVariableContext;
-  }
-
   public addOutputVariableContext(
     outputVariableContext: OutputVariableContext
   ): void {
@@ -338,21 +323,6 @@ export class WorkflowContext {
     return Array.from(this.inputVariableContextsById.values()).find(
       (inputContext) => inputContext.getRawName() === rawName
     );
-  }
-
-  public getInputVariableContextByRawName(
-    rawName: string
-  ): InputVariableContext {
-    const inputVariableContext =
-      this.findInputVariableContextByRawName(rawName);
-
-    if (!inputVariableContext) {
-      throw new WorkflowInputGenerationError(
-        `Input variable context not found for raw name: ${rawName}`
-      );
-    }
-
-    return inputVariableContext;
   }
 
   public isOutputVariableNameUsed(outputVariableName: string): boolean {

--- a/ee/codegen/src/generators/workflow-sandbox-file.ts
+++ b/ee/codegen/src/generators/workflow-sandbox-file.ts
@@ -82,11 +82,18 @@ if __name__ != "__main__":
         modulePath: getGeneratedInputsModulePath(this.workflowContext),
       }),
       arguments_: inputs
-        .filter((input) => !isNil(input.value))
         .map((input) => {
+          if (isNil(input.value)) {
+            return null;
+          }
+
           const rawName = removeEscapeCharacters(input.name);
           const inputVariableContext =
-            this.workflowContext.getInputVariableContextByRawName(rawName);
+            this.workflowContext.findInputVariableContextByRawName(rawName);
+
+          if (isNil(inputVariableContext)) {
+            return null;
+          }
 
           return python.methodArgument({
             name: inputVariableContext.name,
@@ -94,7 +101,10 @@ if __name__ != "__main__":
               vellumValue: input,
             }),
           });
-        }),
+        })
+        .filter(
+          (argument): argument is python.MethodArgument => !isNil(argument)
+        ),
     });
   }
 }


### PR DESCRIPTION
Am in the middle of triaging all codegen errors here: https://github.com/vellum-ai/vellum-python-sdks/pull/1003

came across some more unused input variable contexts