### PR TITLE
Strict mode throws warnings

### DIFF
--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/input-variable-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/input-variable-pointer.test.ts
@@ -49,7 +49,7 @@ describe("InputVariablePointer", () => {
   });
 
   it("should handle when it's referencing an input variable that no longer exists", async () => {
-    const workflowContext = workflowContextFactory();
+    const workflowContext = workflowContextFactory({ strict: false });
     const nodeContext = await nodeContextFactory({ workflowContext });
 
     const inputVariablePointer = new InputVariablePointerRule({

--- a/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
@@ -100,7 +100,7 @@ describe("PromptDeploymentNode", () => {
         })
       );
       writer = new Writer();
-      workflowContext = workflowContextFactory();
+      workflowContext = workflowContextFactory({ strict: false });
       const nodeData = promptDeploymentNodeDataFactory();
 
       const nodeContext = (await createNodeContext({

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -416,12 +416,12 @@ export class WorkflowContext {
   }
 
   public addError(error: BaseCodegenError): void {
-    if (this.strict && error.severity === "ERROR") {
+    if (this.strict) {
       throw error;
-    }
-    if (error.severity === "WARNING") {
+    } else {
       error.log();
     }
+
     const errorExists = this.errors.some(
       (existingError) => existingError.message === error.message
     );


### PR DESCRIPTION
Part 3 of the following 4 step process:

- Run workflows in non-vembda mode (started [here](https://github.com/vellum-ai/vellum-python-sdks/compare/vargas/triage-base-codegen-errors?expand=1))
- Audit existing BaseCodegenErrors and turn most that would not affect runtime into warnings instead (ongoing [here](https://github.com/vellum-ai/vellum-python-sdks/pull/1003))
- Change strict to still error on both error/warnings (this PR)
- non-strict codegen always errors on errors (after we finish the audit in step 2)

This is safe to do since we are no longer sending strict: true from vellum for our sandbox and deployment code paths