### PR TITLE
Remove escape characters for quotes before processing chat message values

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/chat-message-content.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/chat-message-content.test.ts.snap
@@ -78,3 +78,5 @@ exports[`ChatMessageContent > IMAGE > should write an image content correctly 1`
 `;
 
 exports[`ChatMessageContent > STRING > should write a string content correctly 1`] = `"StringChatMessageContent(value="Hello, AI!")"`;
+
+exports[`ChatMessageContent > STRING > should write a string with nested quotes correctly 1`] = `"StringChatMessageContent(value="{\\"tool_calls\\":[{\\"id\\":\\"call_123\\",\\"type\\":\\"function\\",\\"function\\":{\\"name\\":\\"generate_query\\",\\"arguments\\":\\"{\\"query\\":\\"SELECT * FROM users WHERE id = 1\\"}\\"}}]}")"`;

--- a/ee/codegen/src/__test__/chat-message-content.test.ts
+++ b/ee/codegen/src/__test__/chat-message-content.test.ts
@@ -24,8 +24,7 @@ describe("ChatMessageContent", () => {
         chatMessageContent: {
           type: "STRING",
           value:
-            /* prettier-ignore */
-            "{\"tool_calls\":[{\"id\":\"call_123\",\"type\":\"function\",\"function\":{\"name\":\"generate_query\",\"arguments\":\"{\\\"query\\\":\\\"SELECT * FROM users WHERE id = 1\\\"}\"}}]}",
+            '{"tool_calls":[{"id":"call_123","type":"function","function":{"name":"generate_query","arguments":"{\\"query\\":\\"SELECT * FROM users WHERE id = 1\\"}"}}]}',
         },
       });
       chatMessageContent.write(writer);

--- a/ee/codegen/src/__test__/chat-message-content.test.ts
+++ b/ee/codegen/src/__test__/chat-message-content.test.ts
@@ -24,8 +24,7 @@ describe("ChatMessageContent", () => {
         chatMessageContent: {
           type: "STRING",
           value:
-            /* eslint-disable-next-line */
-          /* prettier-ignore */
+            /* prettier-ignore */
             "{\"tool_calls\":[{\"id\":\"call_123\",\"type\":\"function\",\"function\":{\"name\":\"generate_query\",\"arguments\":\"{\\\"query\\\":\\\"SELECT * FROM users WHERE id = 1\\\"}\"}}]}",
         },
       });

--- a/ee/codegen/src/__test__/chat-message-content.test.ts
+++ b/ee/codegen/src/__test__/chat-message-content.test.ts
@@ -18,6 +18,21 @@ describe("ChatMessageContent", () => {
       expect(await writer.toString()).toMatchSnapshot();
       expect(chatMessageContent.getReferences()).toHaveLength(1);
     });
+
+    it("should write a string with nested quotes correctly", async () => {
+      const chatMessageContent = new ChatMessageContent({
+        chatMessageContent: {
+          type: "STRING",
+          value:
+            /* eslint-disable-next-line */
+          /* prettier-ignore */
+            "{\"tool_calls\":[{\"id\":\"call_123\",\"type\":\"function\",\"function\":{\"name\":\"generate_query\",\"arguments\":\"{\\\"query\\\":\\\"SELECT * FROM users WHERE id = 1\\\"}\"}}]}",
+        },
+      });
+      chatMessageContent.write(writer);
+      expect(await writer.toString()).toMatchSnapshot();
+      expect(chatMessageContent.getReferences()).toHaveLength(1);
+    });
   });
 
   describe("FUNCTION_CALL", () => {

--- a/ee/codegen/src/generators/chat-message-content.ts
+++ b/ee/codegen/src/generators/chat-message-content.ts
@@ -18,6 +18,7 @@ import {
 
 import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
 import { Json } from "src/generators/json";
+import { removeEscapeCharacters } from "src/utils/casing";
 import { assertUnreachable } from "src/utils/typing";
 
 class StringChatMessageContent extends AstNode {
@@ -37,7 +38,7 @@ class StringChatMessageContent extends AstNode {
       arguments_: [
         python.methodArgument({
           name: "value",
-          value: python.TypeInstantiation.str(value),
+          value: python.TypeInstantiation.str(removeEscapeCharacters(value)),
         }),
       ],
     });

--- a/ee/codegen/src/generators/vellum-variable-value.ts
+++ b/ee/codegen/src/generators/vellum-variable-value.ts
@@ -18,6 +18,7 @@ import { ValueGenerationError } from "./errors";
 import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
 import { Json } from "src/generators/json";
 import { IterableConfig } from "src/types/vellum";
+import { removeEscapeCharacters } from "src/utils/casing";
 import { assertUnreachable, isNilOrEmpty } from "src/utils/typing";
 
 class StringVellumValue extends AstNode {
@@ -106,7 +107,9 @@ class ChatHistoryVellumValue extends AstNode {
         arguments_.push(
           python.methodArgument({
             name: "text",
-            value: python.TypeInstantiation.str(chatMessage.text),
+            value: python.TypeInstantiation.str(
+              removeEscapeCharacters(chatMessage.text)
+            ),
           })
         );
       }


### PR DESCRIPTION
Context: This came up from qa'ing a customer workflow. They had strings in the chat history that essentially represented sql strings and the nested quotes weren't being escaped correctly when passed into fern. This in turn generates a sandbox file that has syntax issues