### PR TITLE
Add adornments to legacy node serialization

### DIFF
--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
@@ -142,7 +142,8 @@
             "<adornment>"
           ],
           "name": "TryNode"
-        }
+        },
+        "adornments": []
       },
       {
         "id": "54803ff7-9afd-4eb1-bff3-242345d3443d",

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
@@ -143,7 +143,7 @@
           ],
           "name": "TryNode"
         },
-        "adornments": []
+        "adornments": [{"id": "3344083c-a32c-4a32-920b-0fb5093448fa", "label": "TryNode", "base": {"name": "TryNode", "module": ["vellum", "workflows", "nodes", "core", "try_node", "node"]}, "attributes": [{"id": "ab2fbab0-e2a0-419b-b1ef-ce11ecf11e90", "name": "on_error_code", "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": null}}}]}]
       },
       {
         "id": "54803ff7-9afd-4eb1-bff3-242345d3443d",

--- a/ee/vellum_ee/workflows/display/nodes/vellum/__init__.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/__init__.py
@@ -1,4 +1,5 @@
 from .api_node import BaseAPINodeDisplay
+from .base_adornment_node import BaseAdornmentNodeDisplay
 from .code_execution_node import BaseCodeExecutionNodeDisplay
 from .conditional_node import BaseConditionalNodeDisplay
 from .error_node import BaseErrorNodeDisplay
@@ -18,6 +19,7 @@ from .try_node import BaseTryNodeDisplay
 
 # All node display classes must be imported here to be registered in BaseNodeDisplay's node display registry
 __all__ = [
+    "BaseAdornmentNodeDisplay",
     "BaseAPINodeDisplay",
     "BaseCodeExecutionNodeDisplay",
     "BaseConditionalNodeDisplay",

--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 from typing import Any, Callable, Generic, Optional, TypeVar, cast
 
-from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.bases.base_adornment_node import BaseAdornmentNode
 from vellum.workflows.nodes.utils import get_wrapped_node
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
-from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
 _BaseAdornmentNodeType = TypeVar("_BaseAdornmentNodeType", bound=BaseAdornmentNode)
@@ -26,13 +24,9 @@ class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Ge
 
         wrapped_node = get_wrapped_node(node)
         if not wrapped_node:
-            subworkflow = raise_if_descriptor(node.subworkflow)
-            if not isinstance(subworkflow.graph, type) or not issubclass(subworkflow.graph, BaseNode):
-                raise NotImplementedError(
-                    "Unable to serialize Try Nodes that wrap subworkflows containing more than one Node."
-                )
-
-            wrapped_node = subworkflow.graph
+            raise NotImplementedError(
+                "Unable to serialize standalone adornment nodes. Please use adornment nodes as a decorator."
+            )
 
         wrapped_node_display_class = get_node_display_class(BaseNodeDisplay, wrapped_node)
         wrapped_node_display = wrapped_node_display_class()

--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
@@ -1,0 +1,21 @@
+from typing import Generic, TypeVar
+
+from vellum.workflows.nodes.bases.base_adornment_node import BaseAdornmentNode
+from vellum.workflows.types.core import JsonObject
+from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
+from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
+
+_BaseAdornmentNodeType = TypeVar("_BaseAdornmentNodeType", bound=BaseAdornmentNode)
+
+
+class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Generic[_BaseAdornmentNodeType]):
+    def serialize_inner_node(self, adornment: JsonObject) -> dict:
+        wrapped_node = self._node.__wrapped_node__
+        wrapped_node_display_class = get_node_display_class(BaseNodeVellumDisplay, wrapped_node)
+        wrapped_node_display = wrapped_node_display_class()
+        serialized_wrapped_node = wrapped_node_display.serialize()
+
+        adornments = serialized_wrapped_node.get("adornments") or []
+        serialized_wrapped_node["adornments"] = adornments + [adornment]
+
+        return serialized_wrapped_node

--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
@@ -1,19 +1,21 @@
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from vellum.workflows.nodes.bases.base_adornment_node import BaseAdornmentNode
 from vellum.workflows.types.core import JsonObject
+from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
+from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
 _BaseAdornmentNodeType = TypeVar("_BaseAdornmentNodeType", bound=BaseAdornmentNode)
 
 
 class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Generic[_BaseAdornmentNodeType]):
-    def serialize_inner_node(self, adornment: JsonObject) -> dict:
+    def serialize(self, display_context: WorkflowDisplayContext, adornment: JsonObject, **kwargs: Any) -> dict:
         wrapped_node = self._node.__wrapped_node__
-        wrapped_node_display_class = get_node_display_class(BaseNodeVellumDisplay, wrapped_node)
+        wrapped_node_display_class = get_node_display_class(BaseNodeDisplay, wrapped_node)
         wrapped_node_display = wrapped_node_display_class()
-        serialized_wrapped_node = wrapped_node_display.serialize()
+        serialized_wrapped_node = wrapped_node_display.serialize(display_context)
 
         adornments = serialized_wrapped_node.get("adornments") or []
         serialized_wrapped_node["adornments"] = adornments + [adornment]

--- a/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
@@ -3,8 +3,8 @@ from typing import Dict, Generic, List, Optional, TypeVar, cast
 
 from vellum.workflows.nodes import MapNode
 from vellum.workflows.types.core import JsonObject
-from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
+from vellum_ee.workflows.display.nodes.vellum.base_adornment_node import BaseAdornmentNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
@@ -12,7 +12,7 @@ from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class imp
 _MapNodeType = TypeVar("_MapNodeType", bound=MapNode)
 
 
-class BaseMapNodeDisplay(BaseNodeVellumDisplay[_MapNodeType], Generic[_MapNodeType]):
+class BaseMapNodeDisplay(BaseAdornmentNodeDisplay[_MapNodeType], Generic[_MapNodeType]):
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
     ) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
@@ -1,10 +1,42 @@
-from typing import Generic, TypeVar
+import inspect
+from typing import Any, Generic, TypeVar, cast
 
+from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.nodes.core.retry_node.node import RetryNode
+from vellum.workflows.types.core import JsonArray, JsonObject
+from vellum.workflows.utils.uuids import uuid4_from_hash
+from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.nodes.vellum.base_adornment_node import BaseAdornmentNodeDisplay
+from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
 _RetryNodeType = TypeVar("_RetryNodeType", bound=RetryNode)
 
 
 class BaseRetryNodeDisplay(BaseAdornmentNodeDisplay[_RetryNodeType], Generic[_RetryNodeType]):
-    pass
+    def serialize(self, display_context: WorkflowDisplayContext, **kwargs: Any) -> JsonObject:
+        node = self._node
+        node_id = self.node_id
+
+        attributes: JsonArray = []
+        for attribute in node:
+            if inspect.isclass(attribute.instance) and issubclass(attribute.instance, BaseWorkflow):
+                # We don't need to serialize attributes that are workflows
+                continue
+
+            id = str(uuid4_from_hash(f"{node_id}|{attribute.name}"))
+            attributes.append(
+                {
+                    "id": id,
+                    "name": attribute.name,
+                    "value": self.serialize_value(display_context, cast(BaseDescriptor, attribute.instance)),
+                }
+            )
+
+        adornment: JsonObject = {
+            "id": str(node_id),
+            "label": node.__qualname__,
+            "base": self.get_base().dict(),
+            "attributes": attributes,
+        }
+
+        return super().serialize(display_context, adornment)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
@@ -1,10 +1,10 @@
 from typing import Generic, TypeVar
 
 from vellum.workflows.nodes.core.retry_node.node import RetryNode
-from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
+from vellum_ee.workflows.display.nodes.vellum.base_adornment_node import BaseAdornmentNodeDisplay
 
 _RetryNodeType = TypeVar("_RetryNodeType", bound=RetryNode)
 
 
-class BaseRetryNodeDisplay(BaseNodeDisplay[_RetryNodeType], Generic[_RetryNodeType]):
+class BaseRetryNodeDisplay(BaseAdornmentNodeDisplay[_RetryNodeType], Generic[_RetryNodeType]):
     pass

--- a/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
@@ -39,4 +39,4 @@ class BaseRetryNodeDisplay(BaseAdornmentNodeDisplay[_RetryNodeType], Generic[_Re
             "attributes": attributes,
         }
 
-        return super().serialize(display_context, adornment)
+        return super().serialize(display_context, adornment=adornment)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
@@ -9,16 +9,16 @@ from vellum.workflows.types.core import JsonObject
 from vellum.workflows.types.utils import get_original_base
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
-from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
+from vellum_ee.workflows.display.nodes.vellum.base_adornment_node import BaseAdornmentNodeDisplay
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
 _TryNodeType = TypeVar("_TryNodeType", bound=TryNode)
 
 
-class BaseTryNodeDisplay(BaseNodeVellumDisplay[_TryNodeType], Generic[_TryNodeType]):
+class BaseTryNodeDisplay(BaseAdornmentNodeDisplay[_TryNodeType], Generic[_TryNodeType]):
     error_output_id: ClassVar[Optional[UUID]] = None
 
     def serialize(self, display_context: WorkflowDisplayContext, **kwargs: Any) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
@@ -23,7 +23,7 @@ _TryNodeType = TypeVar("_TryNodeType", bound=TryNode)
 class BaseTryNodeDisplay(BaseAdornmentNodeDisplay[_TryNodeType], Generic[_TryNodeType]):
     error_output_id: ClassVar[Optional[UUID]] = None
 
-    def serialize(self, display_context: WorkflowDisplayContext, **kwargs: Any) -> JsonObject:
+    def serialize(self, display_context: "WorkflowDisplayContext", **kwargs: Any) -> JsonObject:
         node = self._node
         node_id = self.node_id
 

--- a/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, ClassVar, Generic, Optional, Tuple, Type, Type
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.try_node.node import TryNode
-from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME, get_wrapped_node
+from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
 from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.types.utils import get_original_base
@@ -14,7 +14,6 @@ from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.base_adornment_node import BaseAdornmentNodeDisplay
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
@@ -27,54 +26,43 @@ class BaseTryNodeDisplay(BaseAdornmentNodeDisplay[_TryNodeType], Generic[_TryNod
     def serialize(self, display_context: WorkflowDisplayContext, **kwargs: Any) -> JsonObject:
         node = self._node
         node_id = self.node_id
-        adornments = None
 
-        inner_node = get_wrapped_node(node)
-        if not inner_node:
-            subworkflow = raise_if_descriptor(node.subworkflow)
-            if not isinstance(subworkflow.graph, type) or not issubclass(subworkflow.graph, BaseNode):
-                raise NotImplementedError(
-                    "Unable to serialize Try Nodes that wrap subworkflows containing more than one Node."
-                )
+        # We let the inner node serialize first and then append to it
+        attributes: JsonArray = []
+        for attribute in node:
+            if inspect.isclass(attribute.instance) and issubclass(attribute.instance, BaseWorkflow):
+                # We don't need to serialize attributes that are workflows
+                continue
 
-            inner_node = subworkflow.graph
-        elif inner_node.__bases__[0] is BaseNode:
-            attributes: JsonArray = []
-            for attribute in node:
-                if inspect.isclass(attribute.instance) and issubclass(attribute.instance, BaseWorkflow):
-                    # We don't need to serialize attributes that are workflows
-                    continue
+            id = str(uuid4_from_hash(f"{node_id}|{attribute.name}"))
+            attributes.append(
+                {
+                    "id": id,
+                    "name": attribute.name,
+                    "value": self.serialize_value(display_context, cast(BaseDescriptor, attribute.instance)),
+                }
+            )
 
-                id = str(uuid4_from_hash(f"{node_id}|{attribute.name}"))
-                attributes.append(
-                    {
-                        "id": id,
-                        "name": attribute.name,
-                        "value": self.serialize_value(display_context, cast(BaseDescriptor, attribute.instance)),
-                    }
-                )
+        adornment: JsonObject = {
+            "id": str(node_id),
+            "label": node.__qualname__,
+            "base": self.get_base().dict(),
+            "attributes": attributes,
+        }
 
-            adornment: JsonObject = {
-                "id": str(node_id),
-                "label": node.__qualname__,
-                "base": self.get_base().dict(),
-                "attributes": attributes,
-            }
-
-            return super().serialize(display_context, adornment)
-        else:
-            # If the wrapped node is a Vellum node, we backfill adornments
-            adornments = []
-
-        # We need the node display class of the underlying node because
-        # it contains the logic for serializing the node and potential display overrides
-        node_display_class = get_node_display_class(BaseNodeDisplay, inner_node)
-        node_display = node_display_class()
-
-        serialized_node = node_display.serialize(
+        # We need the inner node's ID to generate the error output ID
+        # Long term we want to hoist error_output_id append from inner node displays to this display,
+        # But that's a lot of work and this allows us to punt a little longer
+        serialized_node = super().serialize(
             display_context,
-            error_output_id=self.error_output_id or uuid4_from_hash(f"{node_display.node_id}|error_output_id"),
+            adornment=adornment,
+            get_additional_kwargs=lambda node_id: {
+                "error_output_id": self.error_output_id or uuid4_from_hash(f"{node_id}|error_output_id")
+            },
         )
+
+        if serialized_node["type"] == "GENERIC":
+            return serialized_node
 
         serialized_node_definition = serialized_node.get("definition")
         if isinstance(serialized_node_definition, dict):
@@ -87,8 +75,6 @@ class BaseTryNodeDisplay(BaseAdornmentNodeDisplay[_TryNodeType], Generic[_TryNod
                     ]
                 )
                 serialized_node_definition["name"] = node.__name__
-
-        serialized_node["adornments"] = adornments
 
         return serialized_node
 

--- a/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
@@ -23,6 +23,7 @@ class BaseTryNodeDisplay(BaseNodeVellumDisplay[_TryNodeType], Generic[_TryNodeTy
 
     def serialize(self, display_context: WorkflowDisplayContext, **kwargs: Any) -> JsonObject:
         node = self._node
+        adornments = None
 
         inner_node = get_wrapped_node(node)
         if not inner_node:
@@ -39,6 +40,9 @@ class BaseTryNodeDisplay(BaseNodeVellumDisplay[_TryNodeType], Generic[_TryNodeTy
                 pass
 
             return TryBaseNodeDisplay().serialize(display_context)
+        else:
+            # If the wrapped node is a Vellum node, we backfill adornments
+            adornments = []
 
         # We need the node display class of the underlying node because
         # it contains the logic for serializing the node and potential display overrides
@@ -61,6 +65,8 @@ class BaseTryNodeDisplay(BaseNodeVellumDisplay[_TryNodeType], Generic[_TryNodeTy
                     ]
                 )
                 serialized_node_definition["name"] = node.__name__
+
+        serialized_node["adornments"] = adornments
 
         return serialized_node
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -33,7 +33,7 @@ class InnerRetryGenericNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode.__wrapp
     pass
 
 
-class OuterRetryNodeDisplay(BaseRetryNodeDisplay[InnerRetryGenericNode]):
+class OuterRetryNodeDisplay(BaseRetryNodeDisplay[InnerRetryGenericNode]):  # type: ignore
     pass
 
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -11,6 +11,7 @@ from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.base import WorkflowInputsDisplay
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
+from vellum_ee.workflows.display.nodes.vellum.retry_node import BaseRetryNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.try_node import BaseTryNodeDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
@@ -32,7 +33,7 @@ class InnerRetryGenericNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode.__wrapp
     pass
 
 
-class OuterRetryNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode]):
+class OuterRetryNodeDisplay(BaseRetryNodeDisplay[InnerRetryGenericNode]):
     pass
 
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -1,3 +1,4 @@
+import pytest
 from uuid import uuid4
 
 from deepdiff import DeepDiff
@@ -214,3 +215,25 @@ def test_serialize_node__try(serialize_node):
         },
         serialized_node,
     )
+
+
+@pytest.mark.skip(reason="Not implemented")
+def test_serialize_node__stacked():
+    @TryNode.wrap()
+    @RetryNode.wrap(max_attempts=5)
+    class InnerStackedGenericNode(BaseNode):
+        pass
+
+    # AND a workflow that uses the adornment node
+    class StackedWorkflow(BaseWorkflow):
+        graph = InnerStackedGenericNode
+
+    # WHEN we serialize the workflow
+    workflow_display = get_workflow_display(
+        base_display_class=VellumWorkflowDisplay,
+        workflow_class=StackedWorkflow,
+    )
+    exec_config = workflow_display.serialize()
+
+    # THEN the workflow display is created successfully
+    assert exec_config is not None

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
@@ -596,7 +596,20 @@ def test_serialize_workflow__try_wrapped():
             ],
             "name": "TryNode",
         },
-        "adornments": [],
+        "adornments": [
+            {
+                "id": "3344083c-a32c-4a32-920b-0fb5093448fa",
+                "label": "TryNode",
+                "base": {"name": "TryNode", "module": ["vellum", "workflows", "nodes", "core", "try_node", "node"]},
+                "attributes": [
+                    {
+                        "id": "ab2fbab0-e2a0-419b-b1ef-ce11ecf11e90",
+                        "name": "on_error_code",
+                        "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                    }
+                ],
+            }
+        ],
     }
 
     final_output_nodes = workflow_raw_data["nodes"][2:]

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
@@ -596,6 +596,7 @@ def test_serialize_workflow__try_wrapped():
             ],
             "name": "TryNode",
         },
+        "adornments": [],
     }
 
     final_output_nodes = workflow_raw_data["nodes"][2:]

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_try_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_try_node_serialization.py
@@ -1,9 +1,11 @@
+import pytest
+
 from deepdiff import DeepDiff
 
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
-from tests.workflows.basic_try_node.workflow import SimpleTryExample
+from tests.workflows.basic_try_node.workflow import SimpleTryExample, StandaloneTryExample
 
 
 def test_serialize_workflow():
@@ -69,3 +71,19 @@ def test_serialize_workflow():
 
     try_node = workflow_raw_data["nodes"][1]
     assert try_node["id"] == "1381c078-efa2-4255-89a1-7b4cb742c7fc"
+
+
+def test_serialize_workflow__standalone():
+    # GIVEN a Workflow with a standalone TryNode
+    # WHEN we serialize it
+    with pytest.raises(NotImplementedError) as exc:
+        workflow_display = get_workflow_display(
+            base_display_class=VellumWorkflowDisplay, workflow_class=StandaloneTryExample
+        )
+        workflow_display.serialize()
+
+    # THEN we should get an error
+    assert (
+        exc.value.args[0]
+        == "Unable to serialize standalone adornment nodes. Please use adornment nodes as a decorator."
+    )

--- a/tests/workflows/basic_try_node/workflow.py
+++ b/tests/workflows/basic_try_node/workflow.py
@@ -5,6 +5,7 @@ from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.core.try_node.node import TryNode
 
 
+@TryNode.wrap()
 class StartNode(BaseNode):
     class Outputs(BaseNode.Outputs):
         value: int
@@ -16,20 +17,39 @@ class StartNode(BaseNode):
         return self.Outputs(value=arg)
 
 
-class Subworkflow(BaseWorkflow):
+class SimpleTryExample(BaseWorkflow):
     graph = StartNode
 
-    class Outputs(StartNode.Outputs):
+    class Outputs(BaseWorkflow.Outputs):
+        final_value = StartNode.Outputs.value
+        error = StartNode.Outputs.error
+
+
+class StandaloneStartNode(BaseNode):
+    class Outputs(BaseNode.Outputs):
+        value: int
+
+    def run(self) -> Outputs:
+        arg = random.randint(0, 10)
+        if arg < 5:
+            raise Exception("This is a flaky node")
+        return self.Outputs(value=arg)
+
+
+class StandaloneSubworkflow(BaseWorkflow):
+    graph = StandaloneStartNode
+
+    class Outputs(StandaloneStartNode.Outputs):
         pass
 
 
-class TryableNode(TryNode):
-    subworkflow = Subworkflow
+class StandaloneTryableNode(TryNode):
+    subworkflow = StandaloneSubworkflow
 
 
-class SimpleTryExample(BaseWorkflow):
-    graph = TryableNode
+class StandaloneTryExample(BaseWorkflow):
+    graph = StandaloneTryableNode
 
     class Outputs(BaseWorkflow.Outputs):
-        final_value = TryableNode.Outputs.value
-        error = TryableNode.Outputs.error
+        final_value = StandaloneTryableNode.Outputs.value
+        error = StandaloneTryableNode.Outputs.error


### PR DESCRIPTION
This PR creates a base adornment node display that is used by `RetryNode` and `TryNode` to backfill adornments on non-generic nodes.

While `MapNode` is inheriting from the same display, it does not actively use it right now. IIRC we're not supporting map node as an adornment yet.

Some thoughts:
- It seems that we can't tell the difference between a `TryNode` adornment and an explicitly defined `TryNode`. At least not in the `TryNodeDisplay`. They both have wrapped nodes.