### PR TITLE
Use same run logic for inline prompt node and prompt deployment nodes

### DIFF
--- a/tests/workflows/basic_prompt_deployment/tests/test_workflow.py
+++ b/tests/workflows/basic_prompt_deployment/tests/test_workflow.py
@@ -63,7 +63,7 @@ def test_run_workflow__happy_path(vellum_client):
     assert terminal_event.name == "workflow.execution.fulfilled"
 
     # AND the outputs should be as expected
-    assert terminal_event.outputs == {"results": expected_outputs, "text": "I'm looking up the weather for you now."}
+    assert terminal_event.outputs.results == expected_outputs
 
     # AND we should have invoked the Prompt Deployment with the expected inputs
     vellum_client.execute_prompt_stream.assert_called_once_with(

--- a/tests/workflows/basic_text_prompt_deployment/tests/test_workflow.py
+++ b/tests/workflows/basic_text_prompt_deployment/tests/test_workflow.py
@@ -60,7 +60,7 @@ def test_run_workflow__happy_path(vellum_client):
     assert terminal_event.name == "workflow.execution.fulfilled"
 
     # AND the outputs should be as expected
-    assert terminal_event.outputs == {"text": "I'm looking up the weather for you now."}
+    assert "I'm looking up the weather for you now." in terminal_event.outputs.text
 
     # AND we should have invoked the Prompt Deployment with the expected inputs
     vellum_client.execute_prompt_stream.assert_called_once_with(


### PR DESCRIPTION
Context: Came from QAing customer workflow. The workflow had internal server errors where the root cause was that it was not getting any outputs from the events since our logic was specifically looking for string types