### PR TITLE
Update ast node to write nothing when chat history is an empty list

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
@@ -18,6 +18,8 @@ exports[`VellumValue > CHAT_HISTORY > should write a CHAT_HISTORY value with a s
 
 exports[`VellumValue > CHAT_HISTORY > should write a CHAT_HISTORY value with just text 1`] = `"[ChatMessage(role="USER", text="Hello, AI!"),]"`;
 
+exports[`VellumValue > CHAT_HISTORY > should write nothing when CHAT_HISTORY value is empty list 1`] = `"None"`;
+
 exports[`VellumValue > CHAT_HISTORY > should write nothing when CHAT_HISTORY value is null 1`] = `"None"`;
 
 exports[`VellumValue > ERROR > should write a ERROR value correctly 1`] = `

--- a/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
@@ -18,7 +18,7 @@ exports[`VellumValue > CHAT_HISTORY > should write a CHAT_HISTORY value with a s
 
 exports[`VellumValue > CHAT_HISTORY > should write a CHAT_HISTORY value with just text 1`] = `"[ChatMessage(role="USER", text="Hello, AI!"),]"`;
 
-exports[`VellumValue > CHAT_HISTORY > should write nothing when CHAT_HISTORY value is empty list 1`] = `"None"`;
+exports[`VellumValue > CHAT_HISTORY > should write empty list when CHAT_HISTORY value is empty list 1`] = `"[]"`;
 
 exports[`VellumValue > CHAT_HISTORY > should write nothing when CHAT_HISTORY value is null 1`] = `"None"`;
 

--- a/ee/codegen/src/__test__/vellum-variable-value.test.ts
+++ b/ee/codegen/src/__test__/vellum-variable-value.test.ts
@@ -83,7 +83,7 @@ describe("VellumValue", () => {
       expect(chatHistoryValue.getReferences()).toHaveLength(0);
     });
 
-    it("should write nothing when CHAT_HISTORY value is empty list", async () => {
+    it("should write empty list when CHAT_HISTORY value is empty list", async () => {
       const chatHistoryValue = codegen.vellumValue({
         vellumValue: {
           type: "CHAT_HISTORY",

--- a/ee/codegen/src/__test__/vellum-variable-value.test.ts
+++ b/ee/codegen/src/__test__/vellum-variable-value.test.ts
@@ -82,6 +82,18 @@ describe("VellumValue", () => {
       expect(await writer.toString()).toMatchSnapshot();
       expect(chatHistoryValue.getReferences()).toHaveLength(0);
     });
+
+    it("should write nothing when CHAT_HISTORY value is empty list", async () => {
+      const chatHistoryValue = codegen.vellumValue({
+        vellumValue: {
+          type: "CHAT_HISTORY",
+          value: [],
+        },
+      });
+      chatHistoryValue.write(writer);
+      expect(await writer.toString()).toMatchSnapshot();
+      expect(chatHistoryValue.getReferences()).toHaveLength(0);
+    });
   });
 
   describe("JSON", () => {

--- a/ee/codegen/src/generators/vellum-variable-value.ts
+++ b/ee/codegen/src/generators/vellum-variable-value.ts
@@ -19,7 +19,7 @@ import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
 import { Json } from "src/generators/json";
 import { IterableConfig } from "src/types/vellum";
 import { removeEscapeCharacters } from "src/utils/casing";
-import { assertUnreachable, isNilOrEmpty } from "src/utils/typing";
+import { assertUnreachable } from "src/utils/typing";
 
 class StringVellumValue extends AstNode {
   private astNode: AstNode;
@@ -75,7 +75,7 @@ class JsonVellumValue extends AstNode {
 }
 
 class ChatHistoryVellumValue extends AstNode {
-  public astNode: AstNode | undefined;
+  private astNode: AstNode | undefined;
 
   public constructor({
     value,
@@ -92,7 +92,7 @@ class ChatHistoryVellumValue extends AstNode {
     value: ChatMessageRequest[],
     isRequestType: boolean
   ): AstNode | undefined {
-    if (isNilOrEmpty(value)) {
+    if (isNil(value)) {
       return undefined;
     }
     const chatMessages = value.map((chatMessage) => {
@@ -473,14 +473,12 @@ export class VellumValue extends AstNode {
       case "JSON":
         this.astNode = new JsonVellumValue(vellumValue.value);
         break;
-      case "CHAT_HISTORY": {
-        const chatHistoryValue = new ChatHistoryVellumValue({
+      case "CHAT_HISTORY":
+        this.astNode = new ChatHistoryVellumValue({
           value: vellumValue.value,
           isRequestType,
         });
-        this.astNode = chatHistoryValue.astNode ? chatHistoryValue : null;
         break;
-      }
       case "ERROR":
         this.astNode = new ErrorVellumValue(vellumValue.value);
         break;
@@ -503,7 +501,7 @@ export class VellumValue extends AstNode {
         assertUnreachable(vellumValue);
     }
 
-    this.inheritReferences(this.astNode ?? undefined);
+    this.inheritReferences(this.astNode);
   }
 
   public write(writer: Writer): void {

--- a/ee/codegen/src/generators/vellum-variable-value.ts
+++ b/ee/codegen/src/generators/vellum-variable-value.ts
@@ -75,7 +75,7 @@ class JsonVellumValue extends AstNode {
 }
 
 class ChatHistoryVellumValue extends AstNode {
-  private astNode: AstNode | undefined;
+  public astNode: AstNode | undefined;
 
   public constructor({
     value,
@@ -473,12 +473,14 @@ export class VellumValue extends AstNode {
       case "JSON":
         this.astNode = new JsonVellumValue(vellumValue.value);
         break;
-      case "CHAT_HISTORY":
-        this.astNode = new ChatHistoryVellumValue({
+      case "CHAT_HISTORY": {
+        const chatHistoryValue = new ChatHistoryVellumValue({
           value: vellumValue.value,
           isRequestType,
         });
+        this.astNode = chatHistoryValue.astNode ? chatHistoryValue : null;
         break;
+      }
       case "ERROR":
         this.astNode = new ErrorVellumValue(vellumValue.value);
         break;
@@ -501,7 +503,7 @@ export class VellumValue extends AstNode {
         assertUnreachable(vellumValue);
     }
 
-    this.inheritReferences(this.astNode);
+    this.inheritReferences(this.astNode ?? undefined);
   }
 
   public write(writer: Writer): void {
@@ -509,7 +511,6 @@ export class VellumValue extends AstNode {
       python.TypeInstantiation.none().write(writer);
       return;
     }
-
     this.astNode.write(writer);
   }
 }


### PR DESCRIPTION
Context: Came up from QAing a customer workflow. I was trying to debug a related issue by running the sandbox locally and noticed the sandbox file was having syntax issues from codegen. It was writing things like `Inputs(chat_history=,foo=bar`.