### PR TITLE
Surface subworkflow deployment not found error

### DIFF
--- a/src/vellum/workflows/nodes/displayable/subworkflow_deployment_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/subworkflow_deployment_node/node.py
@@ -127,10 +127,20 @@ class SubworkflowDeploymentNode(BaseNode[StateType], Generic[StateType]):
             "execution_context": {"parent_context": parent_context},
             **request_options.get("additional_body_parameters", {}),
         }
+
+        try:
+            deployment_id = str(self.deployment) if isinstance(self.deployment, UUID) else None
+            deployment_name = self.deployment if isinstance(self.deployment, str) else None
+        except AttributeError:
+            raise NodeException(
+                code=WorkflowErrorCode.NODE_EXECUTION,
+                message="Expected subworkflow deployment attribute to be either a UUID or STR, got None instead",
+            )
+
         subworkflow_stream = self._context.vellum_client.execute_workflow_stream(
             inputs=self._compile_subworkflow_inputs(),
-            workflow_deployment_id=str(self.deployment) if isinstance(self.deployment, UUID) else None,
-            workflow_deployment_name=self.deployment if isinstance(self.deployment, str) else None,
+            workflow_deployment_id=deployment_id,
+            workflow_deployment_name=deployment_name,
             release_tag=self.release_tag,
             external_id=self.external_id,
             event_types=["WORKFLOW"],


### PR DESCRIPTION
Main vellum PR:
https://github.com/vellum-ai/vellum/pull/8384

<img width="744" alt="Screenshot 2025-02-20 at 5 58 06 PM" src="https://github.com/user-attachments/assets/f6de5f6d-df0f-4696-b1f8-b86415e85541" />


Note: Displays the correct message but the UI is doing something weird with the warning. Can investigate later or introduce a new code to have it shown explicitly