### PR TITLE
[SC-6595] Add init command to initialize a new Vellum project with templates

### DIFF
--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -4,6 +4,7 @@ import click
 
 from vellum_cli.aliased_group import ClickAliasedGroup
 from vellum_cli.image_push import image_push_command
+from vellum_cli.init import init_command
 from vellum_cli.ping import ping_command
 from vellum_cli.pull import pull_command
 from vellum_cli.push import push_command
@@ -329,6 +330,13 @@ def images() -> None:
 def image_push(image: str, tag: Optional[List[str]] = None) -> None:
     """Push Docker image to Vellum"""
     image_push_command(image, tag)
+
+
+@workflows.command(name="init")
+def workflows_init() -> None:
+    """Initialize a new Vellum project"""
+
+    init_command()
 
 
 if __name__ == "__main__":

--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -334,7 +334,7 @@ def image_push(image: str, tag: Optional[List[str]] = None) -> None:
 
 @workflows.command(name="init")
 def workflows_init() -> None:
-    """Initialize a new Vellum project"""
+    """Initialize a new Vellum Workflow using a predefined template"""
 
     init_command()
 

--- a/ee/vellum_cli/init.py
+++ b/ee/vellum_cli/init.py
@@ -1,0 +1,141 @@
+import io
+import json
+import os
+from pathlib import Path
+import zipfile
+from typing import Optional
+
+import click
+from dotenv import load_dotenv
+from pydash import snake_case
+
+from vellum.workflows.vellum_client import create_vellum_client
+from vellum_cli.config import WorkflowConfig, load_vellum_cli_config
+from vellum_cli.logger import load_cli_logger
+from vellum_cli.pull import PullContentsMetadata, WorkflowConfigResolutionResult
+
+ERROR_LOG_FILE_NAME = "error.log"
+METADATA_FILE_NAME = "metadata.json"
+
+
+def init_command():
+    load_dotenv()
+    logger = load_cli_logger()
+    config = load_vellum_cli_config()
+
+    client = create_vellum_client()
+    templates_response = client.workflow_sandboxes.list_workflow_sandbox_examples(tag="TEMPLATES")
+
+    templates = templates_response.results
+    if not templates:
+        logger.error("No templates available")
+        return
+
+    click.echo(click.style("Available Templates", bold=True, fg="green"))
+    for idx, template in enumerate(templates, 1):
+        click.echo(f"{idx}. {template.label}")
+
+    choice = click.prompt(
+        f"Please select a template number (1-{len(templates)})", type=click.IntRange(1, len(templates))
+    )
+    selected_template = templates[choice - 1]
+
+    click.echo(click.style(f"\nYou selected: {selected_template.label}\n", bold=True, fg="cyan"))
+
+    # Create workflow config with module name from template label
+    workflow_config = WorkflowConfig(
+        workflow_sandbox_id=selected_template.id,
+        module=snake_case(selected_template.label),  # Set module name directly from template
+    )
+    config.workflows.append(workflow_config)
+
+    workflow_config_result = WorkflowConfigResolutionResult(
+        workflow_config=workflow_config,
+        pk=selected_template.id,
+    )
+
+    pk = workflow_config_result.pk
+    if not pk:
+        raise ValueError("No workflow sandbox ID found in project to pull from.")
+
+    logger.info(f"Pulling workflow into {workflow_config.module}...")
+
+    query_parameters = {
+        "include_sandbox": True,
+    }
+
+    response = client.workflows.pull(
+        pk,
+        request_options={"additional_query_parameters": query_parameters},
+    )
+
+    zip_bytes = b"".join(response)
+    zip_buffer = io.BytesIO(zip_bytes)
+
+    error_content = ""
+
+    with zipfile.ZipFile(zip_buffer) as zip_file:
+        if METADATA_FILE_NAME in zip_file.namelist():
+            metadata_json: Optional[dict] = None
+            with zip_file.open(METADATA_FILE_NAME) as source:
+                metadata_json = json.load(source)
+
+            pull_contents_metadata = PullContentsMetadata.model_validate(metadata_json)
+
+            if pull_contents_metadata.runner_config:
+                workflow_config.container_image_name = pull_contents_metadata.runner_config.container_image_name
+                workflow_config.container_image_tag = pull_contents_metadata.runner_config.container_image_tag
+                if workflow_config.container_image_name and not workflow_config.container_image_tag:
+                    workflow_config.container_image_tag = "latest"
+
+            if not workflow_config.module and pull_contents_metadata.label:
+                workflow_config.module = snake_case(pull_contents_metadata.label)
+
+        if not workflow_config.module:
+            raise ValueError(f"Failed to resolve a module name for Workflow {pk}")
+
+        target_dir = os.path.join(os.getcwd(), *workflow_config.module.split("."))
+
+        # Delete files in target_dir that aren't in the zip file
+        if os.path.exists(target_dir):
+            ignore_patterns = (
+                workflow_config.ignore
+                if isinstance(workflow_config.ignore, list)
+                else [workflow_config.ignore] if isinstance(workflow_config.ignore, str) else []
+            )
+            existing_files = []
+            for root, _, files in os.walk(target_dir):
+                for file in files:
+                    rel_path = os.path.relpath(os.path.join(root, file), target_dir)
+                    existing_files.append(rel_path)
+
+            for file in existing_files:
+                if any(Path(file).match(ignore_pattern) for ignore_pattern in ignore_patterns):
+                    continue
+
+                if file not in zip_file.namelist():
+                    file_path = os.path.join(target_dir, file)
+                    logger.info(f"Deleting {file_path}...")
+                    os.remove(file_path)
+
+        for file_name in zip_file.namelist():
+            with zip_file.open(file_name) as source:
+                content = source.read().decode("utf-8")
+                if file_name == ERROR_LOG_FILE_NAME:
+                    error_content = content
+                    continue
+                if file_name == METADATA_FILE_NAME:
+                    continue
+
+                target_file = os.path.join(target_dir, file_name)
+                os.makedirs(os.path.dirname(target_file), exist_ok=True)
+                with open(target_file, "w") as target:
+                    logger.info(f"Writing to {target_file}...")
+                    target.write(content)
+
+    config.save()
+
+    if error_content:
+        logger.error(error_content)
+    else:
+        logger.info(f"Successfully pulled Workflow into {target_dir}")

--- a/ee/vellum_cli/tests/test_init.py
+++ b/ee/vellum_cli/tests/test_init.py
@@ -1,0 +1,178 @@
+import pytest
+import io
+import json
+import os
+from unittest.mock import patch
+import zipfile
+
+from click.testing import CliRunner
+
+from vellum_cli import main as cli_main
+
+
+def _zip_file_map(file_map: dict[str, str]) -> bytes:
+    # Create an in-memory bytes buffer to store the zip
+    zip_buffer = io.BytesIO()
+
+    # Create zip file and add files from file_map
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        for filename, content in file_map.items():
+            zip_file.writestr(filename, content)
+
+    # Get the bytes from the buffer
+    zip_bytes = zip_buffer.getvalue()
+    zip_buffer.close()
+
+    return zip_bytes
+
+
+class MockTemplate:
+    def __init__(self, id, label):
+        self.id = id
+        self.label = label
+
+
+@pytest.mark.parametrize(
+    "base_command",
+    [
+        ["workflows", "init"],
+    ],
+    ids=["workflows_init"],
+)
+def test_init_command(vellum_client, mock_module, base_command):
+    # GIVEN a module on the user's filesystem
+    temp_dir = mock_module.temp_dir
+    mock_module.set_pyproject_toml({"workflows": []})
+    # GIVEN the vellum client returns a list of template workflows
+    fake_templates = [
+        MockTemplate(id="template-1", label="Example Workflow"),
+        MockTemplate(id="template-2", label="Another Workflow"),
+    ]
+    vellum_client.workflow_sandboxes.list_workflow_sandbox_examples.return_value.results = fake_templates
+
+    # AND the workflow pull API call returns a zip file
+    vellum_client.workflows.pull.return_value = iter(
+        [
+            _zip_file_map(
+                {
+                    "workflow.py": "print('hello')",
+                }
+            )
+        ]
+    )
+    # WHEN the user runs the `init` command and selects the first template
+    runner = CliRunner()
+    result = runner.invoke(cli_main, base_command, input="1\n")
+
+    # THEN the command returns successfully
+    assert result.exit_code == 0
+
+    # AND `vellum_client.workflows.pull` is called with the selected template ID
+    vellum_client.workflows.pull.assert_called_once_with(
+        "template-1",
+        request_options={"additional_query_parameters": {"include_sandbox": True}},
+    )
+
+    # AND the `workflow.py` file should be created in the correct module directory
+    workflow_py = os.path.join(temp_dir, "example_workflow", "workflow.py")
+    assert os.path.exists(workflow_py)
+    with open(workflow_py) as f:
+        assert f.read() == "print('hello')"
+
+    # AND the vellum.lock.json file should be created
+    vellum_lock_json = os.path.join(temp_dir, "vellum.lock.json")
+    assert os.path.exists(vellum_lock_json)
+    with open(vellum_lock_json) as f:
+        lock_data = json.load(f)
+        assert lock_data["workflows"] == [
+            {
+                "module": "example_workflow",
+                "workflow_sandbox_id": "template-1",
+                "ignore": None,
+                "deployments": [],
+                "container_image_name": None,
+                "container_image_tag": None,
+                "workspace": "default",
+            }
+        ]
+
+
+@pytest.mark.parametrize(
+    "base_command",
+    [
+        ["workflows", "init"],
+    ],
+    ids=["workflows_init"],
+)
+def test_init_command__invalid_template_id(vellum_client, mock_module, base_command):
+    # GIVEN a module on the user's filesystem
+    temp_dir = mock_module.temp_dir
+    mock_module.set_pyproject_toml({"workflows": []})
+    # GIVEN the vellum client returns a list of template workflows
+    fake_templates = [
+        MockTemplate(id="template-1", label="Example Workflow"),
+        MockTemplate(id="template-2", label="Another Workflow"),
+    ]
+    vellum_client.workflow_sandboxes.list_workflow_sandbox_examples.return_value.results = fake_templates
+
+    # WHEN the user runs the `init` command, enters invalid input and then cancels
+    runner = CliRunner()
+    # Mock click.prompt to raise a KeyboardInterrupt (simulating Ctrl+C)
+    with patch("click.prompt", side_effect=KeyboardInterrupt):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, base_command)
+
+    # THEN the command is aborted
+    assert result.exit_code != 0
+    assert "Aborted!" in result.output  # Click shows this message on Ctrl+C
+
+    # AND `vellum_client.workflows.pull` is not called
+    vellum_client.workflows.pull.assert_not_called()
+
+    # AND no workflow files are created
+    workflow_py = os.path.join(temp_dir, "example_workflow", "workflow.py")
+    assert not os.path.exists(workflow_py)
+
+    # AND the lock file remains empty
+    vellum_lock_json = os.path.join(temp_dir, "vellum.lock.json")
+    if os.path.exists(vellum_lock_json):
+        with open(vellum_lock_json) as f:
+            lock_data = json.load(f)
+            assert lock_data["workflows"] == []
+
+
+@pytest.mark.parametrize(
+    "base_command",
+    [
+        ["workflows", "init"],
+    ],
+    ids=["workflows_init"],
+)
+def test_init_command__no_templates(vellum_client, mock_module, base_command):
+    # GIVEN a module on the user's filesystem
+    temp_dir = mock_module.temp_dir
+    mock_module.set_pyproject_toml({"workflows": []})
+    # GIVEN the vellum client returns no template workflows
+    vellum_client.workflow_sandboxes.list_workflow_sandbox_examples.return_value.results = []
+
+    # WHEN the user runs the `init` command
+    runner = CliRunner()
+    result = runner.invoke(cli_main, base_command)
+
+    # THEN the command gracefully exits
+    assert result.exit_code == 0
+    assert "No templates available" in result.output
+
+    # AND `vellum_client.workflows.pull` is not called
+    vellum_client.workflows.pull.assert_not_called()
+
+    # AND no workflow files are created
+    workflow_py = os.path.join(temp_dir, "example_workflow", "workflow.py")
+    assert not os.path.exists(workflow_py)
+
+    # AND the lock file remains empty
+    vellum_lock_json = os.path.join(temp_dir, "vellum.lock.json")
+    if os.path.exists(vellum_lock_json):
+        with open(vellum_lock_json) as f:
+            lock_data = json.load(f)
+            assert lock_data["workflows"] == []


### PR DESCRIPTION
sc: https://app.shortcut.com/vellum/story/6595/create-a-vellum-workflows-init-cli-command

Update: merged (https://github.com/vellum-ai/vellum/pull/8408)
~~to test now~~:
<strike>
- in vellum repo find list_examples under `vellum/django/app/api/workflow_sandboxes/views.py`
- add `authentication_classes` and `permission_classes` in action
</strike>

```python
@action(
    detail=False,
    methods=["get"],
    url_path="examples",
    url_name="list-examples",
    pagination_class=LimitOffsetPagination,
    authentication_classes=[APIKeyAuthentication, CustomJWTAuthentication],
    permission_classes=[HasAPIKey | (IsAuthenticated & HasWorkspacePermission)],
)
```


After above changes:
- `VELLUM_API_URL=http://localhost:8000 poetry run vellum workflows init`
- should see sandbox templates
- choose a number in the range
- it should pull down the template


https://github.com/user-attachments/assets/32c85f7b-5657-4443-a7e9-2b5a2a9d4cfc

### TODO:
- update vellum repo `authentication_classes` and `permission_classes`
- add [blank workspace](https://app.vellum.ai/workflow-sandboxes/e5fe5f20-fe0b-4b2a-b893-d192ba5c349b) to vellum repo
- group same logic between pull and init into `utils.py`
- follow PR in vellum repo will add blank project
- discuss which sandbox needs to be added as templates
