### PR TITLE
Validate external input types in WorkflowRunner

### DIFF
--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -97,6 +97,11 @@ class WorkflowRunner(Generic[StateType]):
         elif external_inputs:
             self._initial_state = self.workflow.get_most_recent_state()
             for descriptor, value in external_inputs.items():
+                if not any(isinstance(value, type_) for type_ in descriptor.types):
+                    raise NodeException(
+                        f"Invalid external input type for {descriptor.name}",
+                        code=WorkflowErrorCode.INVALID_INPUTS,
+                    )
                 self._initial_state.meta.external_inputs[descriptor] = value
 
             self._entrypoints = [

--- a/tests/workflows/basic_external_input/tests/test_workflow.py
+++ b/tests/workflows/basic_external_input/tests/test_workflow.py
@@ -1,3 +1,10 @@
+import pytest
+from typing import Union
+
+from vellum.workflows.exceptions import NodeException
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.workflows.base import BaseWorkflow
+
 from tests.workflows.basic_external_input.workflow import BasicInputNodeWorkflow, InputNode
 
 
@@ -29,3 +36,89 @@ def test_workflow__happy_path_multi_stop():
     # THEN we should get workflow in FULFILLED state
     assert final_terminal_event.name == "workflow.execution.fulfilled"
     assert final_terminal_event.outputs.final_value == "sunny"
+
+
+def test_workflow__happy_path_multi_stop_invalid_external_input():
+    """
+    Runs the non-streamed execution of a Workflow with a single Nodes defining ExternalInputs.
+    """
+
+    # GIVEN a workflow that uses an Input Node
+    workflow = BasicInputNodeWorkflow()
+
+    # WHEN we run the workflow
+    terminal_event = workflow.run()
+
+    # THEN we should get workflow in PAUSED state
+    assert terminal_event.name == "workflow.execution.paused"
+    external_inputs = list(terminal_event.external_inputs)
+
+    assert InputNode.ExternalInputs.message == external_inputs[0]
+    assert len(external_inputs) == 1
+
+    # WHEN we resume the workflow
+    with pytest.raises(NodeException) as exc_info:
+        final_terminal_event = workflow.run(  # noqa: F841
+            external_inputs={
+                InputNode.ExternalInputs.message: 12,
+            },
+        )
+
+    assert "Invalid external input type for message" == str(exc_info.value)
+
+
+def test_workflow__happy_path_multi_stop_union_type():
+    """
+    Runs the non-streamed execution of a Workflow with a single Nodes defining ExternalInputs.
+    """
+
+    class InputNode(BaseNode):
+        class ExternalInputs(BaseNode.ExternalInputs):
+            message: Union[str, int]
+
+    class TestWorkflow(BaseWorkflow):
+        graph = InputNode
+
+        class Outputs(BaseWorkflow.Outputs):
+            final_value = InputNode.ExternalInputs.message
+
+    # GIVEN a workflow that uses an Input Node
+    workflow = TestWorkflow()
+
+    # WHEN we run the workflow
+    terminal_event = workflow.run()
+
+    # THEN we should get workflow in PAUSED state
+    assert terminal_event.name == "workflow.execution.paused"
+    external_inputs = list(terminal_event.external_inputs)
+
+    assert InputNode.ExternalInputs.message == external_inputs[0]
+    assert len(external_inputs) == 1
+
+    # WHEN we resume the workflow
+    final_terminal_event = workflow.run(
+        external_inputs={
+            InputNode.ExternalInputs.message: "hello",
+        },
+    )
+
+    # THEN we should get a rejected workflow event with the correct error
+    assert final_terminal_event.name == "workflow.execution.fulfilled"
+
+    final_terminal_event = workflow.run(
+        external_inputs={
+            InputNode.ExternalInputs.message: 12,
+        },
+    )
+
+    # THEN we should get a rejected workflow event with the correct error
+    assert final_terminal_event.name == "workflow.execution.fulfilled"
+
+    with pytest.raises(NodeException) as exc_info:
+        final_terminal_event = workflow.run(  # noqa: F841
+            external_inputs={
+                InputNode.ExternalInputs.message: [1, 2, 3],
+            },
+        )
+
+    assert "Invalid external input type for message" == str(exc_info.value)

--- a/tests/workflows/basic_external_input/tests/test_workflow.py
+++ b/tests/workflows/basic_external_input/tests/test_workflow.py
@@ -40,7 +40,7 @@ def test_workflow__happy_path_multi_stop():
 
 def test_workflow__happy_path_multi_stop_invalid_external_input():
     """
-    Runs the non-streamed execution of a Workflow with a single Nodes defining ExternalInputs.
+    Runs the non-streamed execution of a Workflow with a single Nodes defining invalid ExternalInputs.
     """
 
     # GIVEN a workflow that uses an Input Node
@@ -70,7 +70,8 @@ def test_workflow__happy_path_multi_stop_invalid_external_input():
 
 def test_workflow__happy_path_multi_stop_union_type():
     """
-    Runs the non-streamed execution of a Workflow with a single Nodes defining ExternalInputs.
+    Runs the non-streamed execution of a Workflow with a single Nodes defining ExternalInputs with Union type.
+    Should fail if the input is not in the defined Union type.
     """
 
     class InputNode(BaseNode):

--- a/tests/workflows/basic_external_input/tests/test_workflow.py
+++ b/tests/workflows/basic_external_input/tests/test_workflow.py
@@ -56,7 +56,7 @@ def test_workflow__happy_path_multi_stop_invalid_external_input():
     assert InputNode.ExternalInputs.message == external_inputs[0]
     assert len(external_inputs) == 1
 
-    # WHEN we resume the workflow
+    # WHEN we resume the workflow with invalid external input
     with pytest.raises(NodeException) as exc_info:
         final_terminal_event = workflow.run(  # noqa: F841
             external_inputs={
@@ -64,6 +64,7 @@ def test_workflow__happy_path_multi_stop_invalid_external_input():
             },
         )
 
+    # THEN we should get a rejected workflow event with the correct error
     assert "Invalid external input type for message" == str(exc_info.value)
 
 
@@ -95,25 +96,27 @@ def test_workflow__happy_path_multi_stop_union_type():
     assert InputNode.ExternalInputs.message == external_inputs[0]
     assert len(external_inputs) == 1
 
-    # WHEN we resume the workflow
+    # WHEN we resume the workflow with valid external input
     final_terminal_event = workflow.run(
         external_inputs={
             InputNode.ExternalInputs.message: "hello",
         },
     )
 
-    # THEN we should get a rejected workflow event with the correct error
+    # THEN we should get a fulfilled workflow event
     assert final_terminal_event.name == "workflow.execution.fulfilled"
 
+    # WHEN we resume the workflow with valid external input
     final_terminal_event = workflow.run(
         external_inputs={
             InputNode.ExternalInputs.message: 12,
         },
     )
 
-    # THEN we should get a rejected workflow event with the correct error
+    # THEN we should get a fulfilled workflow event
     assert final_terminal_event.name == "workflow.execution.fulfilled"
 
+    # WHEN we resume the workflow with invalid external input
     with pytest.raises(NodeException) as exc_info:
         final_terminal_event = workflow.run(  # noqa: F841
             external_inputs={
@@ -121,4 +124,5 @@ def test_workflow__happy_path_multi_stop_union_type():
             },
         )
 
+    # THEN we should get a rejected workflow event with the correct error
     assert "Invalid external input type for message" == str(exc_info.value)


### PR DESCRIPTION
inspired by #1034 

Validate external input type in workflow runner, which I think is the earliest point that gets the value passed in with types?