### PR TITLE
Support --target-dir option for vellum pull cli

### DIFF
--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -194,12 +194,20 @@ Should only be used for debugging purposes.""",
     help="""Generates a runnable sandbox.py file containing test data from the Resource's sandbox. \
 Helpful for running and debugging workflows locally.""",
 )
+@click.option(
+    "--target-dir",
+    "target_directory",  # Internal parameter name is target_directory
+    type=str,
+    help="""Directory to pull the workflow into. If not specified, \
+the workflow will be pulled into the current working directory.""",
+)
 def pull(
     ctx: click.Context,
     include_json: Optional[bool],
     exclude_code: Optional[bool],
     strict: Optional[bool],
     include_sandbox: Optional[bool],
+    target_directory: Optional[str],
 ) -> None:
     """Pull Resources from Vellum"""
 
@@ -209,6 +217,7 @@ def pull(
             exclude_code=exclude_code,
             strict=strict,
             include_sandbox=include_sandbox,
+            target_directory=target_directory,
         )
 
 
@@ -243,6 +252,13 @@ Should only be used for debugging purposes.""",
     help="""Generates a runnable sandbox.py file containing test data from the Resource's sandbox. \
 Helpful for running and debugging workflows locally.""",
 )
+@click.option(
+    "--target-dir",
+    "target_directory",  # Internal parameter name is target_directory
+    type=str,
+    help="""Directory to pull the workflow into. If not specified, \
+the workflow will be pulled into the current working directory.""",
+)
 def workflows_pull(
     module: Optional[str],
     include_json: Optional[bool],
@@ -251,6 +267,7 @@ def workflows_pull(
     exclude_code: Optional[bool],
     strict: Optional[bool],
     include_sandbox: Optional[bool],
+    target_directory: Optional[str],
 ) -> None:
     """
     Pull Workflows from Vellum. If a module is provided, only the Workflow for that module will be pulled.
@@ -265,6 +282,7 @@ def workflows_pull(
         exclude_code=exclude_code,
         strict=strict,
         include_sandbox=include_sandbox,
+        target_directory=target_directory,
     )
 
 
@@ -293,12 +311,20 @@ Should only be used for debugging purposes.""",
     help="""Generates a runnable sandbox.py file containing test data from the Resource's sandbox. \
 Helpful for running and debugging resources locally.""",
 )
+@click.option(
+    "--target-dir",
+    "target_directory",  # Internal parameter name is target_directory
+    type=str,
+    help="""Directory to pull the workflow into. If not specified, \
+the workflow will be pulled into the current working directory.""",
+)
 def pull_module(
     ctx: click.Context,
     include_json: Optional[bool],
     exclude_code: Optional[bool],
     strict: Optional[bool],
     include_sandbox: Optional[bool],
+    target_directory: Optional[str],
 ) -> None:
     """Pull a specific module from Vellum"""
 
@@ -309,6 +335,7 @@ def pull_module(
             exclude_code=exclude_code,
             strict=strict,
             include_sandbox=include_sandbox,
+            target_directory=target_directory,
         )
 
 

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -108,6 +108,7 @@ def pull_command(
     exclude_code: Optional[bool] = None,
     strict: Optional[bool] = None,
     include_sandbox: Optional[bool] = None,
+    target_directory: Optional[str] = None,
 ) -> None:
     load_dotenv()
     logger = load_cli_logger()
@@ -175,7 +176,9 @@ def pull_command(
         if not workflow_config.module:
             raise ValueError(f"Failed to resolve a module name for Workflow {pk}")
 
-        target_dir = os.path.join(os.getcwd(), *workflow_config.module.split("."))
+        # Use target_directory if provided, otherwise use current working directory
+        base_dir = target_directory if target_directory else os.getcwd()
+        target_dir = os.path.join(base_dir, *workflow_config.module.split("."))
 
         # Delete files in target_dir that aren't in the zip file
         if os.path.exists(target_dir):

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -130,7 +130,7 @@ def pull_command(
         raise ValueError("No workflow sandbox ID found in project to pull from.")
 
     if workflow_config.module:
-        logger.info(f"Pulling workflow into {workflow_config.module}...")
+        logger.info(f"Pulling workflow {workflow_config.module}...")
     else:
         logger.info(f"Pulling workflow from {pk}...")
 
@@ -177,7 +177,7 @@ def pull_command(
             raise ValueError(f"Failed to resolve a module name for Workflow {pk}")
 
         # Use target_directory if provided, otherwise use current working directory
-        base_dir = target_directory if target_directory else os.getcwd()
+        base_dir = os.path.join(os.getcwd(), target_directory) if target_directory else os.getcwd()
         target_dir = os.path.join(base_dir, *workflow_config.module.split("."))
 
         # Delete files in target_dir that aren't in the zip file
@@ -236,4 +236,4 @@ Its schema should be considered unstable and subject to change at any time."""
     if error_content:
         logger.error(error_content)
     else:
-        logger.info(f"Successfully pulled Workflow into {workflow_config.module}")
+        logger.info(f"Successfully pulled Workflow into {target_dir}")


### PR DESCRIPTION
Allow user to pull into custom target directory

test: pull `function calling example` into `somedir/function_calling_example`

`poetry run vellum workflows pull --workflow-sandbox-id=16d93158-e812-4a84-a034-6973fcd9105b --include-sandbox --target-dir=somedir`