### PR TITLE
[SC-6683] Convert hyphenated output names from fulfilled events to underscore

### DIFF
--- a/src/vellum/workflows/outputs/base.py
+++ b/src/vellum/workflows/outputs/base.py
@@ -32,7 +32,7 @@ class BaseOutput(Generic[_Delta, _Accumulated]):
         if value is not undefined and delta is not undefined:
             raise ValueError("Cannot set both value and delta")
 
-        self._name = name
+        self._name = name.replace("-", "_")  # Convert hyphens to underscores for valid python variable names
         self._value = value
         self._delta = delta
 


### PR DESCRIPTION
Context: For this ticket, the workflow that flagged this issue had a final output name with a hyphen in it. Main vellum was using this key in the exec config (i.e `some-final_output`) but when we try to match that here, it doesn't find the attr and uses undefined. Codegen uses all underscores by sanitizing the key