### PR TITLE
Support template name as argument in workflows init cli

### DIFF
--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -333,10 +333,11 @@ def image_push(image: str, tag: Optional[List[str]] = None) -> None:
 
 
 @workflows.command(name="init")
-def workflows_init() -> None:
+@click.argument("template_name", required=False)
+def workflows_init(template_name: Optional[str] = None) -> None:
     """Initialize a new Vellum Workflow using a predefined template"""
 
-    init_command()
+    init_command(template_name=template_name)
 
 
 if __name__ == "__main__":

--- a/ee/vellum_cli/tests/test_init.py
+++ b/ee/vellum_cli/tests/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import zipfile
 
 from click.testing import CliRunner
+from pydash import snake_case
 
 from vellum_cli import main as cli_main
 
@@ -234,6 +235,117 @@ def test_init_command_target_directory_exists(vellum_client, mock_module, base_c
     # AND no workflow files are created
     workflow_py = os.path.join(temp_dir, "example_workflow", "workflow.py")
     assert not os.path.exists(workflow_py)
+
+    # AND the lock file remains empty
+    vellum_lock_json = os.path.join(temp_dir, "vellum.lock.json")
+    if os.path.exists(vellum_lock_json):
+        with open(vellum_lock_json) as f:
+            lock_data = json.load(f)
+            assert lock_data["workflows"] == []
+
+
+@pytest.mark.parametrize(
+    "base_command",
+    [
+        ["workflows", "init"],
+    ],
+    ids=["workflows_init"],
+)
+def test_init_command_with_template_name(vellum_client, mock_module, base_command):
+    # GIVEN a module on the user's filesystem
+    temp_dir = mock_module.temp_dir
+    mock_module.set_pyproject_toml({"workflows": []})
+
+    # GIVEN the vellum client returns a list of template workflows
+    fake_templates = [
+        MockTemplate(id="template-1", label="Example Workflow"),
+        MockTemplate(id="template-2", label="Another Workflow"),
+    ]
+    vellum_client.workflow_sandboxes.list_workflow_sandbox_examples.return_value.results = fake_templates
+
+    # AND the workflow pull API call returns a zip file
+    vellum_client.workflows.pull.return_value = iter(
+        [_zip_file_map({"workflow.py": "print('hello')", "README.md": "# Another Workflow\nThis is a test template."})]
+    )
+
+    # WHEN the user runs the `init` command with a specific template name
+    template_name = snake_case("Another Workflow")
+    runner = CliRunner()
+    result = runner.invoke(cli_main, base_command + [template_name])
+
+    # THEN the command returns successfully
+    assert result.exit_code == 0
+
+    # AND `vellum_client.workflows.pull` is called with the correct template ID
+    vellum_client.workflows.pull.assert_called_once_with(
+        "template-2",  # ID of "Another Workflow"
+        request_options={"additional_query_parameters": {"include_sandbox": True}},
+    )
+
+    # AND the workflow files should be created in the correct module directory
+    workflow_py = os.path.join(temp_dir, "another_workflow", "workflow.py")
+
+    assert os.path.exists(workflow_py)
+
+    with open(workflow_py) as f:
+        assert f.read() == "print('hello')"
+
+    # AND the vellum.lock.json file should be created with the correct data
+    vellum_lock_json = os.path.join(temp_dir, "vellum.lock.json")
+    assert os.path.exists(vellum_lock_json)
+
+    with open(vellum_lock_json) as f:
+        lock_data = json.load(f)
+        assert lock_data["workflows"] == [
+            {
+                "module": "another_workflow",
+                "workflow_sandbox_id": "template-2",
+                "ignore": None,
+                "deployments": [],
+                "container_image_name": None,
+                "container_image_tag": None,
+                "workspace": "default",
+            }
+        ]
+
+
+@pytest.mark.parametrize(
+    "base_command",
+    [
+        ["workflows", "init"],
+    ],
+    ids=["workflows_init"],
+)
+def test_init_command_with_nonexistent_template_name(vellum_client, mock_module, base_command):
+    # GIVEN a module on the user's filesystem
+    temp_dir = mock_module.temp_dir
+    mock_module.set_pyproject_toml({"workflows": []})
+
+    # GIVEN the vellum client returns a list of template workflows
+    fake_templates = [
+        MockTemplate(id="template-1", label="Example Workflow"),
+        MockTemplate(id="template-2", label="Another Workflow"),
+    ]
+    vellum_client.workflow_sandboxes.list_workflow_sandbox_examples.return_value.results = fake_templates
+
+    # WHEN the user runs the `init` command with a non-existent template name
+    nonexistent_template = "nonexistent_template"
+    runner = CliRunner()
+    result = runner.invoke(cli_main, base_command + [nonexistent_template])
+
+    # THEN the command should indicate the template was not found
+    assert result.exit_code == 0
+    assert f"Template {nonexistent_template} not found" in result.output
+
+    # AND `vellum_client.workflows.pull` is not called
+    vellum_client.workflows.pull.assert_not_called()
+
+    # AND no workflow files are created
+    example_workflow_dir = os.path.join(temp_dir, "example_workflow")
+    nonexistent_workflow_dir = os.path.join(temp_dir, nonexistent_template)
+
+    assert not os.path.exists(example_workflow_dir)
+    assert not os.path.exists(nonexistent_workflow_dir)
 
     # AND the lock file remains empty
     vellum_lock_json = os.path.join(temp_dir, "vellum.lock.json")


### PR DESCRIPTION
Allow user to specify template name directly

currently only support following templates
- customer_support_q_a
- trust_center_q_a

test:
`vellum workflows init customer_support_q_a`