### PR TITLE
Support `--target-dir` option for vellum init cli 

### DIFF
--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -361,10 +361,17 @@ def image_push(image: str, tag: Optional[List[str]] = None) -> None:
 
 @workflows.command(name="init")
 @click.argument("template_name", required=False)
-def workflows_init(template_name: Optional[str] = None) -> None:
+@click.option(
+    "--target-dir",
+    "target_directory",  # Internal parameter name is target_directory
+    type=str,
+    help="""Directory to pull the workflow into. If not specified, \
+the workflow will be pulled into the current working directory.""",
+)
+def workflows_init(template_name: Optional[str] = None, target_directory: Optional[str] = None) -> None:
     """Initialize a new Vellum Workflow using a predefined template"""
 
-    init_command(template_name=template_name)
+    init_command(template_name=template_name, target_directory=target_directory)
 
 
 if __name__ == "__main__":

--- a/ee/vellum_cli/config.py
+++ b/ee/vellum_cli/config.py
@@ -50,6 +50,7 @@ class WorkflowConfig(UniversalBaseModel):
     container_image_name: Optional[str] = None
     container_image_tag: Optional[str] = None
     workspace: str = DEFAULT_WORKSPACE_CONFIG.name
+    target_directory: Optional[str] = None
 
     def merge(self, other: "WorkflowConfig") -> "WorkflowConfig":
         self_deployment_by_id = {

--- a/ee/vellum_cli/init.py
+++ b/ee/vellum_cli/init.py
@@ -18,7 +18,7 @@ ERROR_LOG_FILE_NAME = "error.log"
 METADATA_FILE_NAME = "metadata.json"
 
 
-def init_command(template_name: Optional[str] = None):
+def init_command(template_name: Optional[str] = None, target_directory: Optional[str] = None):
     load_dotenv()
     logger = load_cli_logger()
     config = load_vellum_cli_config()
@@ -64,7 +64,10 @@ def init_command(template_name: Optional[str] = None):
     if not pk:
         raise ValueError("No workflow sandbox ID found in project to pull from.")
 
-    target_dir = os.path.join(os.getcwd(), workflow_config.module)
+    # Use target_directory if provided, otherwise use current working directory
+    base_dir = os.path.join(os.getcwd(), target_directory) if target_directory else os.getcwd()
+    target_dir = os.path.join(base_dir, *workflow_config.module.split("."))
+
     if os.path.exists(target_dir):
         click.echo(click.style(f"{target_dir} already exists.", fg="red"))
         return

--- a/ee/vellum_cli/init.py
+++ b/ee/vellum_cli/init.py
@@ -67,6 +67,7 @@ def init_command(template_name: Optional[str] = None, target_directory: Optional
     # Use target_directory if provided, otherwise use current working directory
     base_dir = os.path.join(os.getcwd(), target_directory) if target_directory else os.getcwd()
     target_dir = os.path.join(base_dir, *workflow_config.module.split("."))
+    workflow_config.target_directory = target_dir if target_directory else None
 
     if os.path.exists(target_dir):
         click.echo(click.style(f"{target_dir} already exists.", fg="red"))

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -179,6 +179,7 @@ def pull_command(
         # Use target_directory if provided, otherwise use current working directory
         base_dir = os.path.join(os.getcwd(), target_directory) if target_directory else os.getcwd()
         target_dir = os.path.join(base_dir, *workflow_config.module.split("."))
+        workflow_config.target_directory = target_dir if target_directory else None
 
         # Delete files in target_dir that aren't in the zip file
         if os.path.exists(target_dir):

--- a/ee/vellum_cli/tests/test_init.py
+++ b/ee/vellum_cli/tests/test_init.py
@@ -79,6 +79,7 @@ def test_init_command(vellum_client, mock_module):
                 "container_image_name": None,
                 "container_image_tag": None,
                 "workspace": "default",
+                "target_directory": None,
             }
         ]
 
@@ -252,6 +253,7 @@ def test_init_command_with_template_name(vellum_client, mock_module):
                 "container_image_name": None,
                 "container_image_tag": None,
                 "workspace": "default",
+                "target_directory": None,
             }
         ]
 
@@ -345,6 +347,7 @@ def test_init__with_target_dir(vellum_client, mock_module):
                 "container_image_name": None,
                 "container_image_tag": None,
                 "workspace": "default",
+                "target_directory": module_path,
             }
         ]
 
@@ -401,6 +404,7 @@ def test_init__with_nested_target_dir(vellum_client, mock_module):
                 "container_image_name": None,
                 "container_image_tag": None,
                 "workspace": "default",
+                "target_directory": module_path,
             }
         ]
 
@@ -464,5 +468,6 @@ def test_init__with_template_name_and_target_dir(vellum_client, mock_module):
                 "container_image_name": None,
                 "container_image_tag": None,
                 "workspace": "default",
+                "target_directory": module_path,
             }
         ]

--- a/ee/vellum_cli/tests/test_init.py
+++ b/ee/vellum_cli/tests/test_init.py
@@ -264,9 +264,7 @@ def test_init_command_with_template_name(vellum_client, mock_module, base_comman
     vellum_client.workflow_sandboxes.list_workflow_sandbox_examples.return_value.results = fake_templates
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter(
-        [_zip_file_map({"workflow.py": "print('hello')", "README.md": "# Another Workflow\nThis is a test template."})]
-    )
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
 
     # WHEN the user runs the `init` command with a specific template name
     template_name = snake_case("Another Workflow")

--- a/ee/vellum_cli/tests/test_init.py
+++ b/ee/vellum_cli/tests/test_init.py
@@ -52,15 +52,8 @@ def test_init_command(vellum_client, mock_module, base_command):
     vellum_client.workflow_sandboxes.list_workflow_sandbox_examples.return_value.results = fake_templates
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter(
-        [
-            _zip_file_map(
-                {
-                    "workflow.py": "print('hello')",
-                }
-            )
-        ]
-    )
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
+
     # WHEN the user runs the `init` command and selects the first template
     runner = CliRunner()
     result = runner.invoke(cli_main, base_command, input="1\n")
@@ -208,15 +201,7 @@ def test_init_command_target_directory_exists(vellum_client, mock_module, base_c
     vellum_client.workflow_sandboxes.list_workflow_sandbox_examples.return_value.results = fake_templates
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter(
-        [
-            _zip_file_map(
-                {
-                    "workflow.py": "print('hello')",
-                }
-            )
-        ]
-    )
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
 
     # WHEN the user runs the `init` command and selects the template
     runner = CliRunner()
@@ -372,15 +357,7 @@ def test_init__with_target_dir(vellum_client, mock_module, base_command):
     vellum_client.workflow_sandboxes.list_workflow_sandbox_examples.return_value.results = fake_templates
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter(
-        [
-            _zip_file_map(
-                {
-                    "workflow.py": "print('hello')",
-                }
-            )
-        ]
-    )
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
 
     # AND a target directory
     target_dir = os.path.join(temp_dir, "dir")
@@ -441,15 +418,7 @@ def test_init__with_nested_target_dir(vellum_client, mock_module, base_command):
     vellum_client.workflow_sandboxes.list_workflow_sandbox_examples.return_value.results = fake_templates
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter(
-        [
-            _zip_file_map(
-                {
-                    "workflow.py": "print('hello')",
-                }
-            )
-        ]
-    )
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
 
     # AND a nested target directory that doesn't exist yet
     nested_target_dir = os.path.join(temp_dir, "dir-1", "dir-2")
@@ -513,15 +482,7 @@ def test_init__with_template_name_and_target_dir(vellum_client, mock_module, bas
     vellum_client.workflow_sandboxes.list_workflow_sandbox_examples.return_value.results = fake_templates
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter(
-        [
-            _zip_file_map(
-                {
-                    "workflow.py": "print('hello')",
-                }
-            )
-        ]
-    )
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
 
     # AND a target directory
     target_dir = os.path.join(temp_dir, "dir")

--- a/ee/vellum_cli/tests/test_init.py
+++ b/ee/vellum_cli/tests/test_init.py
@@ -1,4 +1,3 @@
-import pytest
 import io
 import json
 import os
@@ -33,14 +32,7 @@ class MockTemplate:
         self.label = label
 
 
-@pytest.mark.parametrize(
-    "base_command",
-    [
-        ["workflows", "init"],
-    ],
-    ids=["workflows_init"],
-)
-def test_init_command(vellum_client, mock_module, base_command):
+def test_init_command(vellum_client, mock_module):
     # GIVEN a module on the user's filesystem
     temp_dir = mock_module.temp_dir
     mock_module.set_pyproject_toml({"workflows": []})
@@ -56,7 +48,7 @@ def test_init_command(vellum_client, mock_module, base_command):
 
     # WHEN the user runs the `init` command and selects the first template
     runner = CliRunner()
-    result = runner.invoke(cli_main, base_command, input="1\n")
+    result = runner.invoke(cli_main, ["workflows", "init"], input="1\n")
 
     # THEN the command returns successfully
     assert result.exit_code == 0
@@ -91,14 +83,7 @@ def test_init_command(vellum_client, mock_module, base_command):
         ]
 
 
-@pytest.mark.parametrize(
-    "base_command",
-    [
-        ["workflows", "init"],
-    ],
-    ids=["workflows_init"],
-)
-def test_init_command__invalid_template_id(vellum_client, mock_module, base_command):
+def test_init_command__invalid_template_id(vellum_client, mock_module):
     # GIVEN a module on the user's filesystem
     temp_dir = mock_module.temp_dir
     mock_module.set_pyproject_toml({"workflows": []})
@@ -114,7 +99,7 @@ def test_init_command__invalid_template_id(vellum_client, mock_module, base_comm
     # Mock click.prompt to raise a KeyboardInterrupt (simulating Ctrl+C)
     with patch("click.prompt", side_effect=KeyboardInterrupt):
         runner = CliRunner()
-        result = runner.invoke(cli_main, base_command)
+        result = runner.invoke(cli_main, ["workflows", "init"])
 
     # THEN the command is aborted
     assert result.exit_code != 0
@@ -135,14 +120,7 @@ def test_init_command__invalid_template_id(vellum_client, mock_module, base_comm
             assert lock_data["workflows"] == []
 
 
-@pytest.mark.parametrize(
-    "base_command",
-    [
-        ["workflows", "init"],
-    ],
-    ids=["workflows_init"],
-)
-def test_init_command__no_templates(vellum_client, mock_module, base_command):
+def test_init_command__no_templates(vellum_client, mock_module):
     # GIVEN a module on the user's filesystem
     temp_dir = mock_module.temp_dir
     mock_module.set_pyproject_toml({"workflows": []})
@@ -151,7 +129,7 @@ def test_init_command__no_templates(vellum_client, mock_module, base_command):
 
     # WHEN the user runs the `init` command
     runner = CliRunner()
-    result = runner.invoke(cli_main, base_command)
+    result = runner.invoke(cli_main, ["workflows", "init"])
 
     # THEN the command gracefully exits
     assert result.exit_code == 0
@@ -172,14 +150,7 @@ def test_init_command__no_templates(vellum_client, mock_module, base_command):
             assert lock_data["workflows"] == []
 
 
-@pytest.mark.parametrize(
-    "base_command",
-    [
-        ["workflows", "init"],
-    ],
-    ids=["workflows_init"],
-)
-def test_init_command_target_directory_exists(vellum_client, mock_module, base_command):
+def test_init_command_target_directory_exists(vellum_client, mock_module):
     """
     GIVEN a target directory already exists
     WHEN the user tries to run the `init` command
@@ -205,7 +176,7 @@ def test_init_command_target_directory_exists(vellum_client, mock_module, base_c
 
     # WHEN the user runs the `init` command and selects the template
     runner = CliRunner()
-    result = runner.invoke(cli_main, base_command, input="1\n")
+    result = runner.invoke(cli_main, ["workflows", "init"], input="1\n")
 
     # THEN the command should detect the existing directory and abort
     assert result.exit_code == 0
@@ -229,14 +200,7 @@ def test_init_command_target_directory_exists(vellum_client, mock_module, base_c
             assert lock_data["workflows"] == []
 
 
-@pytest.mark.parametrize(
-    "base_command",
-    [
-        ["workflows", "init"],
-    ],
-    ids=["workflows_init"],
-)
-def test_init_command_with_template_name(vellum_client, mock_module, base_command):
+def test_init_command_with_template_name(vellum_client, mock_module):
     # GIVEN a module on the user's filesystem
     temp_dir = mock_module.temp_dir
     mock_module.set_pyproject_toml({"workflows": []})
@@ -254,7 +218,7 @@ def test_init_command_with_template_name(vellum_client, mock_module, base_comman
     # WHEN the user runs the `init` command with a specific template name
     template_name = snake_case("Another Workflow")
     runner = CliRunner()
-    result = runner.invoke(cli_main, base_command + [template_name])
+    result = runner.invoke(cli_main, ["workflows", "init", template_name])
 
     # THEN the command returns successfully
     assert result.exit_code == 0
@@ -292,14 +256,7 @@ def test_init_command_with_template_name(vellum_client, mock_module, base_comman
         ]
 
 
-@pytest.mark.parametrize(
-    "base_command",
-    [
-        ["workflows", "init"],
-    ],
-    ids=["workflows_init"],
-)
-def test_init_command_with_nonexistent_template_name(vellum_client, mock_module, base_command):
+def test_init_command_with_nonexistent_template_name(vellum_client, mock_module):
     # GIVEN a module on the user's filesystem
     temp_dir = mock_module.temp_dir
     mock_module.set_pyproject_toml({"workflows": []})
@@ -314,7 +271,7 @@ def test_init_command_with_nonexistent_template_name(vellum_client, mock_module,
     # WHEN the user runs the `init` command with a non-existent template name
     nonexistent_template = "nonexistent_template"
     runner = CliRunner()
-    result = runner.invoke(cli_main, base_command + [nonexistent_template])
+    result = runner.invoke(cli_main, ["workflows", "init", nonexistent_template])
 
     # THEN the command should indicate the template was not found
     assert result.exit_code == 0
@@ -338,14 +295,7 @@ def test_init_command_with_nonexistent_template_name(vellum_client, mock_module,
             assert lock_data["workflows"] == []
 
 
-@pytest.mark.parametrize(
-    "base_command",
-    [
-        ["workflows", "init"],
-    ],
-    ids=["workflows_init"],
-)
-def test_init__with_target_dir(vellum_client, mock_module, base_command):
+def test_init__with_target_dir(vellum_client, mock_module):
     # GIVEN a module on the user's filesystem
     temp_dir = mock_module.temp_dir
     mock_module.set_pyproject_toml({"workflows": []})
@@ -365,7 +315,7 @@ def test_init__with_target_dir(vellum_client, mock_module, base_command):
 
     # WHEN the user runs the init command with target-dir
     runner = CliRunner()
-    result = runner.invoke(cli_main, base_command + ["--target-dir", target_dir], input="1\n")
+    result = runner.invoke(cli_main, ["workflows", "init", "--target-dir", target_dir], input="1\n")
 
     # THEN the command returns successfully
     assert result.exit_code == 0
@@ -399,14 +349,7 @@ def test_init__with_target_dir(vellum_client, mock_module, base_command):
         ]
 
 
-@pytest.mark.parametrize(
-    "base_command",
-    [
-        ["workflows", "init"],
-    ],
-    ids=["workflows_init"],
-)
-def test_init__with_nested_target_dir(vellum_client, mock_module, base_command):
+def test_init__with_nested_target_dir(vellum_client, mock_module):
     # GIVEN a module on the user's filesystem
     temp_dir = mock_module.temp_dir
     mock_module.set_pyproject_toml({"workflows": []})
@@ -425,7 +368,7 @@ def test_init__with_nested_target_dir(vellum_client, mock_module, base_command):
 
     # WHEN the user runs the init command with nested target-dir
     runner = CliRunner()
-    result = runner.invoke(cli_main, base_command + ["--target-dir", nested_target_dir], input="1\n")
+    result = runner.invoke(cli_main, ["workflows", "init", "--target-dir", nested_target_dir], input="1\n")
 
     # THEN the command returns successfully
     assert result.exit_code == 0
@@ -462,14 +405,7 @@ def test_init__with_nested_target_dir(vellum_client, mock_module, base_command):
         ]
 
 
-@pytest.mark.parametrize(
-    "base_command",
-    [
-        ["workflows", "init"],
-    ],
-    ids=["workflows_init"],
-)
-def test_init__with_template_name_and_target_dir(vellum_client, mock_module, base_command):
+def test_init__with_template_name_and_target_dir(vellum_client, mock_module):
     # GIVEN a module on the user's filesystem
     temp_dir = mock_module.temp_dir
     mock_module.set_pyproject_toml({"workflows": []})
@@ -491,7 +427,7 @@ def test_init__with_template_name_and_target_dir(vellum_client, mock_module, bas
     # WHEN the user runs the init command with a specific template name and target-dir
     template_name = snake_case("Another Workflow")
     runner = CliRunner()
-    result = runner.invoke(cli_main, base_command + [template_name, "--target-dir", target_dir])
+    result = runner.invoke(cli_main, ["workflows", "init", template_name, "--target-dir", target_dir])
 
     # THEN the command returns successfully
     assert result.exit_code == 0

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -73,6 +73,7 @@ def test_pull(vellum_client, mock_module, base_command):
                     "ignore": None,
                     "deployments": [],
                     "workspace": "default",
+                    "target_directory": None,
                 }
             ],
             "workspaces": [],
@@ -167,6 +168,7 @@ def test_pull__with_target_dir(vellum_client, mock_module, base_command):
                     "ignore": None,
                     "deployments": [],
                     "workspace": "default",
+                    "target_directory": module_path,
                 }
             ],
             "workspaces": [],
@@ -233,6 +235,7 @@ def test_pull__with_nested_target_dir(vellum_client, mock_module, base_command):
                     "ignore": None,
                     "deployments": [],
                     "workspace": "default",
+                    "target_directory": module_path,
                 }
             ],
             "workspaces": [],
@@ -289,6 +292,7 @@ def test_pull__sandbox_id_with_no_config(vellum_client):
                     "container_image_tag": None,
                     "container_image_name": None,
                     "workspace": "default",
+                    "target_directory": None,
                 }
             ],
         }
@@ -372,6 +376,7 @@ def test_pull__workflow_deployment_with_no_config(vellum_client):
                     "container_image_tag": None,
                     "container_image_name": None,
                     "workspace": "default",
+                    "target_directory": None,
                 }
             ],
             "workspaces": [],
@@ -619,6 +624,7 @@ def test_pull__sandbox_id_with_other_workflow_deployment_in_lock(vellum_client, 
                 "container_image_name": None,
                 "container_image_tag": None,
                 "workspace": "default",
+                "target_directory": None,
             },
             {
                 "module": "super_cool_workflow",
@@ -628,6 +634,7 @@ def test_pull__sandbox_id_with_other_workflow_deployment_in_lock(vellum_client, 
                 "container_image_name": "test",
                 "container_image_tag": "1.0",
                 "workspace": "default",
+                "target_directory": None,
             },
         ]
 
@@ -771,6 +778,7 @@ def test_pull__module_not_in_config(vellum_client, mock_module):
                 "container_image_name": None,
                 "container_image_tag": None,
                 "workspace": "default",
+                "target_directory": None,
             }
         ]
 

--- a/ee/vellum_cli/tests/test_push.py
+++ b/ee/vellum_cli/tests/test_push.py
@@ -508,6 +508,7 @@ MY_OTHER_VELLUM_API_KEY=aaabbbcccddd
             "container_image_tag": None,
             "deployments": [],
             "ignore": None,
+            "target_directory": None,
         }
 
 


### PR DESCRIPTION
Allow user to specify --target-dir when init

test:
- `vellum workflows init --target-dir="dir1"`
- `vellum workflows init trust_center_q_a --target-dir="dir2"`