### PR TITLE
allow execution-context from init 

### DIFF
--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, Iterator, Optional, Sequence, Set, Tuple, Type, Union
 
 from vellum.workflows.constants import undefined
-from vellum.workflows.context import execution_context, get_parent_context
+from vellum.workflows.context import ExecutionContext, execution_context, get_execution_context, get_parent_context
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.edges.edge import Edge
 from vellum.workflows.errors import WorkflowError, WorkflowErrorCode
@@ -76,6 +76,7 @@ class WorkflowRunner(Generic[StateType]):
         cancel_signal: Optional[ThreadingEvent] = None,
         node_output_mocks: Optional[MockNodeExecutionArg] = None,
         max_concurrency: Optional[int] = None,
+        current_execution_context: Optional[ExecutionContext] = None,
     ):
         if state and external_inputs:
             raise ValueError("Can only run a Workflow providing one of state or external inputs, not both")
@@ -137,7 +138,8 @@ class WorkflowRunner(Generic[StateType]):
 
         self._active_nodes_by_execution_id: Dict[UUID, BaseNode[StateType]] = {}
         self._cancel_signal = cancel_signal
-        self._parent_context = get_parent_context()
+        self._execution_context = current_execution_context or get_execution_context()
+        self._parent_context = self._execution_context.parent_context
 
         setattr(
             self._initial_state,

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -76,7 +76,7 @@ class WorkflowRunner(Generic[StateType]):
         cancel_signal: Optional[ThreadingEvent] = None,
         node_output_mocks: Optional[MockNodeExecutionArg] = None,
         max_concurrency: Optional[int] = None,
-        current_execution_context: Optional[ExecutionContext] = None,
+        init_execution_context: Optional[ExecutionContext] = None,
     ):
         if state and external_inputs:
             raise ValueError("Can only run a Workflow providing one of state or external inputs, not both")
@@ -138,7 +138,7 @@ class WorkflowRunner(Generic[StateType]):
 
         self._active_nodes_by_execution_id: Dict[UUID, BaseNode[StateType]] = {}
         self._cancel_signal = cancel_signal
-        self._execution_context = current_execution_context or get_execution_context()
+        self._execution_context = init_execution_context or get_execution_context()
         self._parent_context = self._execution_context.parent_context
 
         setattr(

--- a/src/vellum/workflows/state/context.py
+++ b/src/vellum/workflows/state/context.py
@@ -3,6 +3,7 @@ from queue import Queue
 from typing import TYPE_CHECKING, Dict, List, Optional, Type
 
 from vellum import Vellum
+from vellum.workflows.context import ExecutionContext
 from vellum.workflows.nodes.mocks import MockNodeExecution, MockNodeExecutionArg
 from vellum.workflows.outputs.base import BaseOutputs
 from vellum.workflows.references.constant import ConstantValueReference
@@ -17,10 +18,12 @@ class WorkflowContext:
         self,
         *,
         vellum_client: Optional[Vellum] = None,
+        execution_context: Optional[ExecutionContext] = None,
     ):
         self._vellum_client = vellum_client
         self._event_queue: Optional[Queue["WorkflowEvent"]] = None
         self._node_output_mocks_map: Dict[Type[BaseOutputs], List[MockNodeExecution]] = {}
+        self._execution_context = execution_context
 
     @cached_property
     def vellum_client(self) -> Vellum:
@@ -28,6 +31,13 @@ class WorkflowContext:
             return self._vellum_client
 
         return create_vellum_client()
+
+    @cached_property
+    def execution_context(self) -> ExecutionContext:
+        if self._execution_context:
+            return self._execution_context
+        else:
+            return ExecutionContext()
 
     @cached_property
     def node_output_mocks_map(self) -> Dict[Type[BaseOutputs], List[MockNodeExecution]]:

--- a/src/vellum/workflows/state/context.py
+++ b/src/vellum/workflows/state/context.py
@@ -23,7 +23,9 @@ class WorkflowContext:
         self._vellum_client = vellum_client
         self._event_queue: Optional[Queue["WorkflowEvent"]] = None
         self._node_output_mocks_map: Dict[Type[BaseOutputs], List[MockNodeExecution]] = {}
-        self._execution_context = execution_context or get_execution_context()
+        self._execution_context = get_execution_context()
+        if not self._execution_context.parent_context:
+            self._execution_context = execution_context
 
     @cached_property
     def vellum_client(self) -> Vellum:
@@ -34,10 +36,7 @@ class WorkflowContext:
 
     @cached_property
     def execution_context(self) -> ExecutionContext:
-        if self._execution_context:
-            return self._execution_context
-        else:
-            return ExecutionContext()
+        return self._execution_context
 
     @cached_property
     def node_output_mocks_map(self) -> Dict[Type[BaseOutputs], List[MockNodeExecution]]:

--- a/src/vellum/workflows/state/context.py
+++ b/src/vellum/workflows/state/context.py
@@ -3,7 +3,7 @@ from queue import Queue
 from typing import TYPE_CHECKING, Dict, List, Optional, Type
 
 from vellum import Vellum
-from vellum.workflows.context import ExecutionContext
+from vellum.workflows.context import ExecutionContext, get_execution_context
 from vellum.workflows.nodes.mocks import MockNodeExecution, MockNodeExecutionArg
 from vellum.workflows.outputs.base import BaseOutputs
 from vellum.workflows.references.constant import ConstantValueReference
@@ -23,7 +23,7 @@ class WorkflowContext:
         self._vellum_client = vellum_client
         self._event_queue: Optional[Queue["WorkflowEvent"]] = None
         self._node_output_mocks_map: Dict[Type[BaseOutputs], List[MockNodeExecution]] = {}
-        self._execution_context = execution_context
+        self._execution_context = execution_context or get_execution_context()
 
     @cached_property
     def vellum_client(self) -> Vellum:

--- a/src/vellum/workflows/state/context.py
+++ b/src/vellum/workflows/state/context.py
@@ -24,7 +24,7 @@ class WorkflowContext:
         self._event_queue: Optional[Queue["WorkflowEvent"]] = None
         self._node_output_mocks_map: Dict[Type[BaseOutputs], List[MockNodeExecution]] = {}
         self._execution_context = get_execution_context()
-        if not self._execution_context.parent_context:
+        if not self._execution_context.parent_context and execution_context:
             self._execution_context = execution_context
 
     @cached_property

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -172,6 +172,7 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
         self.resolvers = resolvers or (self.resolvers if hasattr(self, "resolvers") else [])
         self._context = context or WorkflowContext()
         self._store = Store()
+        self._execution_context = self._context.execution_context or get_execution_context()
 
         self.validate()
 
@@ -322,6 +323,7 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
             cancel_signal=cancel_signal,
             node_output_mocks=node_output_mocks,
             max_concurrency=max_concurrency,
+            current_execution_context=self._execution_context,
         ).stream()
         first_event: Optional[Union[WorkflowExecutionInitiatedEvent, WorkflowExecutionResumedEvent]] = None
         last_event = None
@@ -432,6 +434,7 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
             cancel_signal=cancel_signal,
             node_output_mocks=node_output_mocks,
             max_concurrency=max_concurrency,
+            current_execution_context=self._execution_context,
         ).stream():
             if should_yield(self.__class__, event):
                 yield event

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -323,7 +323,7 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
             cancel_signal=cancel_signal,
             node_output_mocks=node_output_mocks,
             max_concurrency=max_concurrency,
-            current_execution_context=self._execution_context,
+            init_execution_context=self._execution_context,
         ).stream()
         first_event: Optional[Union[WorkflowExecutionInitiatedEvent, WorkflowExecutionResumedEvent]] = None
         last_event = None
@@ -434,7 +434,7 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
             cancel_signal=cancel_signal,
             node_output_mocks=node_output_mocks,
             max_concurrency=max_concurrency,
-            current_execution_context=self._execution_context,
+            init_execution_context=self._execution_context,
         ).stream():
             if should_yield(self.__class__, event):
                 yield event

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -172,7 +172,7 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
         self.resolvers = resolvers or (self.resolvers if hasattr(self, "resolvers") else [])
         self._context = context or WorkflowContext()
         self._store = Store()
-        self._execution_context = self._context.execution_context or get_execution_context()
+        self._execution_context = self._context.execution_context
 
         self.validate()
 


### PR DESCRIPTION
turns out vembda did *not* play well with the wrapped context 
** moving back to using context to init workflow run with execution_context