### PR TITLE
Add codegen for unused graph

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/unused-graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/unused-graph-attribute.test.ts.snap
@@ -3,29 +3,29 @@
 exports[`Workflow > unused_graphs > should be empty when all nodes are connected to entrypoint 1`] = `
 "from vellum.workflows import BaseWorkflow
 
-from .nodes.templating_node import TemplatingNode
-from .nodes.templating_node_2 import TemplatingNode2
+from .nodes.my_custom_node import ConnectedNode1
+from .nodes.my_custom_node_1 import ConnectedNode2
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = TemplatingNode >> TemplatingNode2
+    graph = ConnectedNode1 >> ConnectedNode2
 "
 `;
 
 exports[`Workflow > unused_graphs > should identify multiple disconnected graphs 1`] = `
 "from vellum.workflows import BaseWorkflow
 
-from .nodes.disconnected_node_1 import DisconnectedNode1
-from .nodes.disconnected_node_2 import DisconnectedNode2
-from .nodes.disconnected_node_3 import DisconnectedNode3
-from .nodes.disconnected_node_4 import DisconnectedNode4
-from .nodes.disconnected_node_5 import DisconnectedNode5
-from .nodes.disconnected_node_6 import DisconnectedNode6
-from .nodes.templating_node import TemplatingNode
+from .nodes.my_custom_node import ConnectedNode
+from .nodes.my_custom_node_1 import DisconnectedNode1
+from .nodes.my_custom_node_2 import DisconnectedNode2
+from .nodes.my_custom_node_3 import DisconnectedNode3
+from .nodes.my_custom_node_4 import DisconnectedNode4
+from .nodes.my_custom_node_5 import DisconnectedNode5
+from .nodes.my_custom_node_6 import DisconnectedNode6
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = TemplatingNode
+    graph = ConnectedNode
     unused_graphs = {
         DisconnectedNode1
         >> {
@@ -40,13 +40,13 @@ class TestWorkflow(BaseWorkflow):
 exports[`Workflow > unused_graphs > should identify simple disconnected graph 1`] = `
 "from vellum.workflows import BaseWorkflow
 
-from .nodes.templating_node import TemplatingNode
-from .nodes.templating_node_1 import TemplatingNode1
-from .nodes.templating_node_2 import TemplatingNode2
+from .nodes.my_custom_node import ConnectedNode
+from .nodes.my_custom_node_1 import DisconnectedNode1
+from .nodes.my_custom_node_2 import DisconnectedNode2
 
 
 class TestWorkflow(BaseWorkflow):
-    graph = TemplatingNode
-    unused_graphs = TemplatingNode1 >> TemplatingNode2
+    graph = ConnectedNode
+    unused_graphs = DisconnectedNode1 >> DisconnectedNode2
 "
 `;

--- a/ee/codegen/src/__test__/__snapshots__/unused-graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/unused-graph-attribute.test.ts.snap
@@ -1,0 +1,52 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Workflow > unused_graphs > should be empty when all nodes are connected to entrypoint 1`] = `
+"from vellum.workflows import BaseWorkflow
+
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_2 import TemplatingNode2
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = TemplatingNode >> TemplatingNode2
+"
+`;
+
+exports[`Workflow > unused_graphs > should identify multiple disconnected graphs 1`] = `
+"from vellum.workflows import BaseWorkflow
+
+from .nodes.disconnected_node_1 import DisconnectedNode1
+from .nodes.disconnected_node_2 import DisconnectedNode2
+from .nodes.disconnected_node_3 import DisconnectedNode3
+from .nodes.disconnected_node_4 import DisconnectedNode4
+from .nodes.disconnected_node_5 import DisconnectedNode5
+from .nodes.disconnected_node_6 import DisconnectedNode6
+from .nodes.templating_node import TemplatingNode
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = TemplatingNode
+    unused_graphs = {
+        DisconnectedNode1
+        >> {
+            DisconnectedNode2,
+            DisconnectedNode3,
+        },
+        DisconnectedNode4 >> DisconnectedNode5 >> DisconnectedNode6,
+    }
+"
+`;
+
+exports[`Workflow > unused_graphs > should identify simple disconnected graph 1`] = `
+"from vellum.workflows import BaseWorkflow
+
+from .nodes.templating_node import TemplatingNode
+from .nodes.templating_node_1 import TemplatingNode1
+from .nodes.templating_node_2 import TemplatingNode2
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = TemplatingNode
+    unused_graphs = TemplatingNode1 >> TemplatingNode2
+"
+`;

--- a/ee/codegen/src/__test__/__snapshots__/unused-graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/unused-graph-attribute.test.ts.snap
@@ -12,6 +12,23 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
+exports[`Workflow > unused_graphs > should handle circular graphs 1`] = `
+"from vellum.workflows import BaseWorkflow
+
+from .nodes.my_custom_node import ConnectedNode
+from .nodes.my_custom_node_1 import DisconnectedNode1
+from .nodes.my_custom_node_2 import DisconnectedNode2
+from .nodes.my_custom_node_3 import DisconnectedNode3
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = ConnectedNode
+    unused_graphs = {
+        DisconnectedNode1 >> DisconnectedNode2 >> DisconnectedNode3 >> DisconnectedNode1
+    }
+"
+`;
+
 exports[`Workflow > unused_graphs > should identify multiple disconnected graphs 1`] = `
 "from vellum.workflows import BaseWorkflow
 
@@ -37,6 +54,21 @@ class TestWorkflow(BaseWorkflow):
 "
 `;
 
+exports[`Workflow > unused_graphs > should identify multiple disconnected graphs with flipped edges 1`] = `
+"from vellum.workflows import BaseWorkflow
+
+from .nodes.my_custom_node import ConnectedNode
+from .nodes.my_custom_node_1 import DisconnectedNode2
+from .nodes.my_custom_node_2 import DisconnectedNode3
+from .nodes.my_custom_node_3 import DisconnectedNode1
+
+
+class TestWorkflow(BaseWorkflow):
+    graph = ConnectedNode
+    unused_graphs = {DisconnectedNode1 >> DisconnectedNode2 >> DisconnectedNode3}
+"
+`;
+
 exports[`Workflow > unused_graphs > should identify simple disconnected graph 1`] = `
 "from vellum.workflows import BaseWorkflow
 
@@ -47,6 +79,6 @@ from .nodes.my_custom_node_2 import DisconnectedNode2
 
 class TestWorkflow(BaseWorkflow):
     graph = ConnectedNode
-    unused_graphs = DisconnectedNode1 >> DisconnectedNode2
+    unused_graphs = {DisconnectedNode1 >> DisconnectedNode2}
 "
 `;

--- a/ee/codegen/src/__test__/unused-graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/unused-graph-attribute.test.ts
@@ -129,5 +129,54 @@ describe("Workflow", () => {
         [disconnectedNode5, disconnectedNode6],
       ]);
     });
+
+    it("should identify multiple disconnected graphs with flipped edges", async () => {
+      const connectedNode = genericNodeFactory({
+        label: "ConnectedNode",
+      });
+
+      const disconnectedNode1 = genericNodeFactory({
+        label: "DisconnectedNode1",
+      });
+
+      const disconnectedNode2 = genericNodeFactory({
+        label: "DisconnectedNode2",
+      });
+
+      const disconnectedNode3 = genericNodeFactory({
+        label: "DisconnectedNode3",
+      });
+
+      await runUnusedGraphsWorkflowTest([
+        [entrypointNode, connectedNode],
+        [disconnectedNode2, disconnectedNode3],
+        [disconnectedNode1, disconnectedNode2],
+      ]);
+    });
+
+    it("should handle circular graphs", async () => {
+      const connectedNode = genericNodeFactory({
+        label: "ConnectedNode",
+      });
+
+      const disconnectedNode1 = genericNodeFactory({
+        label: "DisconnectedNode1",
+      });
+
+      const disconnectedNode2 = genericNodeFactory({
+        label: "DisconnectedNode2",
+      });
+
+      const disconnectedNode3 = genericNodeFactory({
+        label: "DisconnectedNode3",
+      });
+
+      await runUnusedGraphsWorkflowTest([
+        [entrypointNode, connectedNode],
+        [disconnectedNode1, disconnectedNode2],
+        [disconnectedNode2, disconnectedNode3],
+        [disconnectedNode3, disconnectedNode1],
+      ]);
+    });
   });
 });

--- a/ee/codegen/src/__test__/unused-graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/unused-graph-attribute.test.ts
@@ -1,5 +1,4 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
-import { v4 as uuidv4 } from "uuid";
 
 import { workflowContextFactory } from "./helpers";
 import {
@@ -7,8 +6,8 @@ import {
   edgesFactory,
 } from "./helpers/edge-data-factories";
 import {
-  templatingNodeFactory,
   entrypointNodeDataFactory,
+  genericNodeFactory,
 } from "./helpers/node-data-factories";
 
 import * as codegen from "src/codegen";
@@ -61,12 +60,11 @@ describe("Workflow", () => {
     };
 
     it("should be empty when all nodes are connected to entrypoint", async () => {
-      const connectedNode1 = templatingNodeFactory();
-      const connectedNode2 = templatingNodeFactory({
-        id: uuidv4(),
-        label: "Templating Node 2",
-        sourceHandleId: uuidv4(),
-        targetHandleId: uuidv4(),
+      const connectedNode1 = genericNodeFactory({
+        label: "ConnectedNode1",
+      });
+      const connectedNode2 = genericNodeFactory({
+        label: "ConnectedNode2",
       });
 
       await runUnusedGraphsWorkflowTest([
@@ -76,18 +74,16 @@ describe("Workflow", () => {
     });
 
     it("should identify simple disconnected graph", async () => {
-      const connectedNode = templatingNodeFactory();
-
-      const disconnectedNode1 = templatingNodeFactory({
-        id: uuidv4(),
-        sourceHandleId: uuidv4(),
-        targetHandleId: uuidv4(),
+      const connectedNode = genericNodeFactory({
+        label: "ConnectedNode",
       });
 
-      const disconnectedNode2 = templatingNodeFactory({
-        id: uuidv4(),
-        sourceHandleId: uuidv4(),
-        targetHandleId: uuidv4(),
+      const disconnectedNode1 = genericNodeFactory({
+        label: "DisconnectedNode1",
+      });
+
+      const disconnectedNode2 = genericNodeFactory({
+        label: "DisconnectedNode2",
       });
 
       await runUnusedGraphsWorkflowTest([
@@ -97,48 +93,32 @@ describe("Workflow", () => {
     });
 
     it("should identify multiple disconnected graphs", async () => {
-      const connectedNode = templatingNodeFactory();
-
-      const disconnectedNode1 = templatingNodeFactory({
-        id: uuidv4(),
-        label: "Disconnected Node 1",
-        sourceHandleId: uuidv4(),
-        targetHandleId: uuidv4(),
+      const connectedNode = genericNodeFactory({
+        label: "ConnectedNode",
       });
 
-      const disconnectedNode2 = templatingNodeFactory({
-        id: uuidv4(),
-        label: "Disconnected Node 2",
-        sourceHandleId: uuidv4(),
-        targetHandleId: uuidv4(),
+      const disconnectedNode1 = genericNodeFactory({
+        label: "DisconnectedNode1",
       });
 
-      const disconnectedNode3 = templatingNodeFactory({
-        id: uuidv4(),
-        label: "Disconnected Node 3",
-        sourceHandleId: uuidv4(),
-        targetHandleId: uuidv4(),
+      const disconnectedNode2 = genericNodeFactory({
+        label: "DisconnectedNode2",
       });
 
-      const disconnectedNode4 = templatingNodeFactory({
-        id: uuidv4(),
-        label: "Disconnected Node 4",
-        sourceHandleId: uuidv4(),
-        targetHandleId: uuidv4(),
+      const disconnectedNode3 = genericNodeFactory({
+        label: "DisconnectedNode3",
       });
 
-      const disconnectedNode5 = templatingNodeFactory({
-        id: uuidv4(),
-        label: "Disconnected Node 5",
-        sourceHandleId: uuidv4(),
-        targetHandleId: uuidv4(),
+      const disconnectedNode4 = genericNodeFactory({
+        label: "DisconnectedNode4",
       });
 
-      const disconnectedNode6 = templatingNodeFactory({
-        id: uuidv4(),
-        label: "Disconnected Node 6",
-        sourceHandleId: uuidv4(),
-        targetHandleId: uuidv4(),
+      const disconnectedNode5 = genericNodeFactory({
+        label: "DisconnectedNode5",
+      });
+
+      const disconnectedNode6 = genericNodeFactory({
+        label: "DisconnectedNode6",
       });
 
       await runUnusedGraphsWorkflowTest([

--- a/ee/codegen/src/__test__/unused-graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/unused-graph-attribute.test.ts
@@ -1,0 +1,153 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { v4 as uuidv4 } from "uuid";
+
+import { workflowContextFactory } from "./helpers";
+import {
+  EdgeFactoryNodePair,
+  edgesFactory,
+} from "./helpers/edge-data-factories";
+import {
+  templatingNodeFactory,
+  entrypointNodeDataFactory,
+} from "./helpers/node-data-factories";
+
+import * as codegen from "src/codegen";
+import { createNodeContext } from "src/context";
+import { WorkflowDataNode } from "src/types/vellum";
+
+describe("Workflow", () => {
+  const entrypointNode = entrypointNodeDataFactory();
+  describe("unused_graphs", () => {
+    const runUnusedGraphsWorkflowTest = async (
+      edges: EdgeFactoryNodePair[]
+    ) => {
+      const workflowContext = workflowContextFactory();
+      const writer = new Writer();
+      workflowContext.addEntrypointNode(entrypointNode);
+
+      const nodes = Array.from(
+        new Set(
+          edges
+            .flatMap(([source, target]) => [
+              Array.isArray(source) ? source[0] : source,
+              Array.isArray(target) ? target[0] : target,
+            ])
+            .filter(
+              (node): node is WorkflowDataNode => node.type !== "ENTRYPOINT"
+            )
+        )
+      );
+
+      await Promise.all(
+        nodes.map((node) => {
+          createNodeContext({
+            workflowContext,
+            nodeData: node,
+          });
+        })
+      );
+
+      workflowContext.addWorkflowEdges(edgesFactory(edges));
+
+      const inputs = codegen.inputs({ workflowContext });
+      const workflow = codegen.workflow({
+        moduleName: "test",
+        workflowContext,
+        inputs,
+      });
+
+      workflow.getWorkflowFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    };
+
+    it("should be empty when all nodes are connected to entrypoint", async () => {
+      const connectedNode1 = templatingNodeFactory();
+      const connectedNode2 = templatingNodeFactory({
+        id: uuidv4(),
+        label: "Templating Node 2",
+        sourceHandleId: uuidv4(),
+        targetHandleId: uuidv4(),
+      });
+
+      await runUnusedGraphsWorkflowTest([
+        [entrypointNode, connectedNode1],
+        [connectedNode1, connectedNode2],
+      ]);
+    });
+
+    it("should identify simple disconnected graph", async () => {
+      const connectedNode = templatingNodeFactory();
+
+      const disconnectedNode1 = templatingNodeFactory({
+        id: uuidv4(),
+        sourceHandleId: uuidv4(),
+        targetHandleId: uuidv4(),
+      });
+
+      const disconnectedNode2 = templatingNodeFactory({
+        id: uuidv4(),
+        sourceHandleId: uuidv4(),
+        targetHandleId: uuidv4(),
+      });
+
+      await runUnusedGraphsWorkflowTest([
+        [entrypointNode, connectedNode],
+        [disconnectedNode1, disconnectedNode2],
+      ]);
+    });
+
+    it("should identify multiple disconnected graphs", async () => {
+      const connectedNode = templatingNodeFactory();
+
+      const disconnectedNode1 = templatingNodeFactory({
+        id: uuidv4(),
+        label: "Disconnected Node 1",
+        sourceHandleId: uuidv4(),
+        targetHandleId: uuidv4(),
+      });
+
+      const disconnectedNode2 = templatingNodeFactory({
+        id: uuidv4(),
+        label: "Disconnected Node 2",
+        sourceHandleId: uuidv4(),
+        targetHandleId: uuidv4(),
+      });
+
+      const disconnectedNode3 = templatingNodeFactory({
+        id: uuidv4(),
+        label: "Disconnected Node 3",
+        sourceHandleId: uuidv4(),
+        targetHandleId: uuidv4(),
+      });
+
+      const disconnectedNode4 = templatingNodeFactory({
+        id: uuidv4(),
+        label: "Disconnected Node 4",
+        sourceHandleId: uuidv4(),
+        targetHandleId: uuidv4(),
+      });
+
+      const disconnectedNode5 = templatingNodeFactory({
+        id: uuidv4(),
+        label: "Disconnected Node 5",
+        sourceHandleId: uuidv4(),
+        targetHandleId: uuidv4(),
+      });
+
+      const disconnectedNode6 = templatingNodeFactory({
+        id: uuidv4(),
+        label: "Disconnected Node 6",
+        sourceHandleId: uuidv4(),
+        targetHandleId: uuidv4(),
+      });
+
+      await runUnusedGraphsWorkflowTest([
+        [entrypointNode, connectedNode],
+        [disconnectedNode1, disconnectedNode2],
+        [disconnectedNode1, disconnectedNode3],
+        [disconnectedNode4, disconnectedNode5],
+        [disconnectedNode5, disconnectedNode6],
+      ]);
+    });
+  });
+});

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -222,6 +222,7 @@ export class GraphAttribute extends AstNode {
     if (graphMutableAst.type === "empty") return componentGraph;
     if (componentGraph.type === "empty") return graphMutableAst;
 
+    // If both are sets, merge their values
     if (graphMutableAst.type === "set" && componentGraph.type === "set") {
       return {
         type: "set",
@@ -229,20 +230,22 @@ export class GraphAttribute extends AstNode {
       };
     }
 
+    // If only one is a set, add the other element into it
     if (graphMutableAst.type === "set") {
       return {
         type: "set",
-        values: [...graphMutableAst.values, componentGraph], // No push() to avoid modifying existing set
+        values: [...graphMutableAst.values, componentGraph],
       };
     }
 
     if (componentGraph.type === "set") {
       return {
         type: "set",
-        values: [graphMutableAst, ...componentGraph.values], // No push() to avoid modifying existing set
+        values: [graphMutableAst, ...componentGraph.values],
       };
     }
 
+    // Otherwise, create a new set containing both
     return { type: "set", values: [graphMutableAst, componentGraph] };
   }
 

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -1104,7 +1104,7 @@ export class GraphAttribute extends AstNode {
   /**
    * Translates our mutable graph AST into a Fern-native Python AST node.
    */
-  public getGraphAttributeAstNode(
+  private getGraphAttributeAstNode(
     mutableAst: GraphMutableAst,
     useWrap: boolean = false
   ): AstNode {

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -44,7 +44,6 @@ type GraphMutableAst =
 export declare namespace GraphAttribute {
   interface Args {
     workflowContext: WorkflowContext;
-    isUnused?: boolean;
     unusedEdges?: Set<WorkflowEdge>;
   }
 }


### PR DESCRIPTION
for unused graph
- add two attr to GraphAttribute
  - ~~`isUnused`: default to false for normal graph~~
  - `unusedEdges`: since we check if there are unused edges right after we enter `addUnusedGraphs` and return directly without adding the `unused_graph` field, we don't want to recompute unused edges that will be used 
  - separate logic in generateGraphMutableAst with`unusedEdges` field

for unused graph (updated)
- maintain unused edges
- keep parsing next edges -> get all nodes that belongs to that edge
- find root node (if cycle return any)
- construct graph based on root node

~~Here, we didn't wrap the return value into set since its already a set~~
```py
const unusedGraphsField = python.field({
  name: "unused_graphs",
  initializer: new GraphAttribute({
    workflowContext: this.workflowContext,
    isUnused: true, // This flag tells GraphAttribute to handle unused nodes
    unusedEdges,
  }),
});
```