### PR TITLE
[SC-4850] Support json parse for descriptors

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -27,6 +27,7 @@ from vellum.workflows.expressions.is_not_undefined import IsNotUndefinedExpressi
 from vellum.workflows.expressions.is_null import IsNullExpression
 from vellum.workflows.expressions.is_undefined import IsUndefinedExpression
 from vellum.workflows.expressions.not_between import NotBetweenExpression
+from vellum.workflows.expressions.parse_json import ParseJsonExpression
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.utils import get_wrapped_node
 from vellum.workflows.ports import Port
@@ -386,7 +387,7 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
                 "node_id": str(node_class_display.node_id),
             }
 
-        if value.__class__.__name__ == "ParseJsonExpression":
+        if isinstance(value, ParseJsonExpression):
             raise ValueError("ParseJsonExpression is not supported in the UI")
 
         if not isinstance(value, BaseDescriptor):

--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -386,6 +386,9 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
                 "node_id": str(node_class_display.node_id),
             }
 
+        if value.__class__.__name__ == "ParseJsonExpression":
+            raise ValueError("ParseJsonExpression is not supported in the UI")
+
         if not isinstance(value, BaseDescriptor):
             vellum_value = primitive_to_vellum_value(value)
             return {

--- a/ee/vellum_ee/workflows/display/tests/test_vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/tests/test_vellum_workflow_display.py
@@ -1,3 +1,4 @@
+import pytest
 from uuid import UUID
 from typing import Dict
 
@@ -228,3 +229,33 @@ def test_vellum_workflow_display__serialize_with_unused_nodes_and_edges():
             break
 
     assert edge_found, "Edge between unused nodes NodeB and NodeC not found in serialized output"
+
+
+def test_parse_json_not_supported_in_ui():
+    """
+    Test that verifies ParseJsonExpression is not yet supported in the UI.
+    This test should fail once UI support is added, at which point it should be updated.
+    """
+    # GIVEN a workflow that uses the parse_json function
+    from vellum.workflows.references.constant import ConstantValueReference
+
+    class JsonNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            json_result = ConstantValueReference('{"key": "value"}').parse_json()
+
+    class Workflow(BaseWorkflow):
+        graph = JsonNode
+
+        class Outputs(BaseWorkflow.Outputs):
+            final = JsonNode.Outputs.json_result
+
+    # WHEN we attempt to serialize it
+    workflow_display = get_workflow_display(
+        base_display_class=VellumWorkflowDisplay,
+        workflow_class=Workflow,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        workflow_display.serialize()
+
+    assert "ParseJsonExpression is not supported in the UI" == str(exc_info.value)

--- a/src/vellum/workflows/descriptors/base.py
+++ b/src/vellum/workflows/descriptors/base.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from vellum.workflows.expressions.not_between import NotBetweenExpression
     from vellum.workflows.expressions.not_in import NotInExpression
     from vellum.workflows.expressions.or_ import OrExpression
+    from vellum.workflows.expressions.parse_json import ParseJsonExpression
     from vellum.workflows.nodes.bases import BaseNode
     from vellum.workflows.state.base import BaseState
 
@@ -349,3 +350,8 @@ class BaseDescriptor(Generic[_T]):
         from vellum.workflows.expressions.is_not_blank import IsNotBlankExpression
 
         return IsNotBlankExpression(expression=self)
+
+    def parse_json(self) -> "ParseJsonExpression[_T]":
+        from vellum.workflows.expressions.parse_json import ParseJsonExpression
+
+        return ParseJsonExpression(expression=self)

--- a/src/vellum/workflows/descriptors/tests/test_utils.py
+++ b/src/vellum/workflows/descriptors/tests/test_utils.py
@@ -97,6 +97,9 @@ class DummyNode(BaseNode[FixtureState]):
             False,
         ),
         (ConstantValueReference('{"foo": "bar"}').parse_json(), {"foo": "bar"}),
+        (ConstantValueReference('{"foo": "bar"}').parse_json()["foo"], "bar"),
+        (ConstantValueReference("[1, 2, 3]").parse_json(), [1, 2, 3]),
+        (ConstantValueReference("[1, 2, 3]").parse_json()[0], 1),
     ],
     ids=[
         "or",
@@ -145,6 +148,9 @@ class DummyNode(BaseNode[FixtureState]):
         "error_contains",
         "error_does_not_contain",
         "parse_json_constant",
+        "parse_json_accessor",
+        "parse_json_list",
+        "parse_json_list_index",
     ],
 )
 def test_resolve_value__happy_path(descriptor, expected_value):

--- a/src/vellum/workflows/descriptors/tests/test_utils.py
+++ b/src/vellum/workflows/descriptors/tests/test_utils.py
@@ -96,6 +96,7 @@ class DummyNode(BaseNode[FixtureState]):
             ).does_not_contain("test"),
             False,
         ),
+        (ConstantValueReference('{"foo": "bar"}').parse_json(), {"foo": "bar"}),
     ],
     ids=[
         "or",
@@ -143,6 +144,7 @@ class DummyNode(BaseNode[FixtureState]):
         "list_index",
         "error_contains",
         "error_does_not_contain",
+        "parse_json_constant",
     ],
 )
 def test_resolve_value__happy_path(descriptor, expected_value):

--- a/src/vellum/workflows/descriptors/tests/test_utils.py
+++ b/src/vellum/workflows/descriptors/tests/test_utils.py
@@ -100,6 +100,9 @@ class DummyNode(BaseNode[FixtureState]):
         (ConstantValueReference('{"foo": "bar"}').parse_json()["foo"], "bar"),
         (ConstantValueReference("[1, 2, 3]").parse_json(), [1, 2, 3]),
         (ConstantValueReference("[1, 2, 3]").parse_json()[0], 1),
+        (ConstantValueReference(b'{"foo": "bar"}').parse_json(), {"foo": "bar"}),
+        (ConstantValueReference(bytearray(b'{"foo": "bar"}')).parse_json(), {"foo": "bar"}),
+        (ConstantValueReference(b'{"key": "\xf0\x9f\x8c\x9f"}').parse_json(), {"key": "🌟"}),
     ],
     ids=[
         "or",
@@ -151,6 +154,9 @@ class DummyNode(BaseNode[FixtureState]):
         "parse_json_accessor",
         "parse_json_list",
         "parse_json_list_index",
+        "parse_json_bytes",
+        "parse_json_bytearray",
+        "parse_json_bytes_with_utf8_chars",
     ],
 )
 def test_resolve_value__happy_path(descriptor, expected_value):

--- a/src/vellum/workflows/expressions/parse_json.py
+++ b/src/vellum/workflows/expressions/parse_json.py
@@ -21,7 +21,7 @@ class ParseJsonExpression(BaseDescriptor[Any], Generic[_T]):
     def resolve(self, state: "BaseState") -> Any:
         value = resolve_value(self._expression, state)
 
-        if not isinstance(value, str):
+        if not isinstance(value, (str, bytes, bytearray)):
             raise InvalidExpressionException(f"Expected a string, but got {value} of type {type(value)}")
 
         try:

--- a/src/vellum/workflows/expressions/parse_json.py
+++ b/src/vellum/workflows/expressions/parse_json.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Generic, TypeVar, Union
+from typing import Any, Generic, TypeVar, Union
 
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.descriptors.exceptions import InvalidExpressionException
@@ -9,27 +9,22 @@ from vellum.workflows.state.base import BaseState
 _T = TypeVar("_T")
 
 
-class ParseJsonExpression(BaseDescriptor[Dict[str, Any]], Generic[_T]):
+class ParseJsonExpression(BaseDescriptor[Any], Generic[_T]):
     def __init__(
         self,
         *,
         expression: Union[BaseDescriptor[_T], _T],
     ) -> None:
-        super().__init__(name=f"parse_json({expression})", types=(dict,))
+        super().__init__(name=f"parse_json({expression})", types=(Any,))  # type: ignore[arg-type]
         self._expression = expression
 
-    def resolve(self, state: "BaseState") -> Dict[str, Any]:
+    def resolve(self, state: "BaseState") -> Any:
         value = resolve_value(self._expression, state)
 
         if not isinstance(value, str):
             raise InvalidExpressionException(f"Expected a string, but got {value} of type {type(value)}")
 
         try:
-            parsed = json.loads(value)
-            if not isinstance(parsed, dict):
-                raise InvalidExpressionException(
-                    f"Expected JSON to parse to a dictionary, but got {type(parsed).__name__}"
-                )
-            return parsed
+            return json.loads(value)
         except json.JSONDecodeError:
             raise InvalidExpressionException(f"Failed to parse JSON: {value}")

--- a/src/vellum/workflows/expressions/parse_json.py
+++ b/src/vellum/workflows/expressions/parse_json.py
@@ -26,5 +26,5 @@ class ParseJsonExpression(BaseDescriptor[Any], Generic[_T]):
 
         try:
             return json.loads(value)
-        except json.JSONDecodeError:
-            raise InvalidExpressionException(f"Failed to parse JSON: {value}")
+        except json.JSONDecodeError as e:
+            raise InvalidExpressionException(f"Failed to parse JSON: {e}") from e

--- a/src/vellum/workflows/expressions/parse_json.py
+++ b/src/vellum/workflows/expressions/parse_json.py
@@ -1,0 +1,35 @@
+import json
+from typing import Any, Dict, Generic, TypeVar, Union
+
+from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.descriptors.exceptions import InvalidExpressionException
+from vellum.workflows.descriptors.utils import resolve_value
+from vellum.workflows.state.base import BaseState
+
+_T = TypeVar("_T")
+
+
+class ParseJsonExpression(BaseDescriptor[Dict[str, Any]], Generic[_T]):
+    def __init__(
+        self,
+        *,
+        expression: Union[BaseDescriptor[_T], _T],
+    ) -> None:
+        super().__init__(name=f"parse_json({expression})", types=(dict,))
+        self._expression = expression
+
+    def resolve(self, state: "BaseState") -> Dict[str, Any]:
+        value = resolve_value(self._expression, state)
+
+        if not isinstance(value, str):
+            raise InvalidExpressionException(f"Expected a string, but got {value} of type {type(value)}")
+
+        try:
+            parsed = json.loads(value)
+            if not isinstance(parsed, dict):
+                raise InvalidExpressionException(
+                    f"Expected JSON to parse to a dictionary, but got {type(parsed).__name__}"
+                )
+            return parsed
+        except json.JSONDecodeError:
+            raise InvalidExpressionException(f"Failed to parse JSON: {value}")

--- a/src/vellum/workflows/expressions/tests/test_parse_json.py
+++ b/src/vellum/workflows/expressions/tests/test_parse_json.py
@@ -18,13 +18,9 @@ def test_parse_json_array():
     # Test parsing a JSON array
     state = BaseState()
     expression = ConstantValueReference("[1, 2, 3]").parse_json()
+    result = expression.resolve(state)
 
-    # This should raise an exception because we've defined types=(dict,)
-    with pytest.raises(InvalidExpressionException) as exc_info:
-        expression.resolve(state)
-
-    # Verify the error message mentions the expected type
-    assert "Expected JSON to parse to a dictionary, but got list" == str(exc_info.value)
+    assert result == [1, 2, 3]
 
 
 def test_parse_json_invalid_json():

--- a/src/vellum/workflows/expressions/tests/test_parse_json.py
+++ b/src/vellum/workflows/expressions/tests/test_parse_json.py
@@ -5,7 +5,7 @@ from vellum.workflows.references.constant import ConstantValueReference
 from vellum.workflows.state.base import BaseState
 
 
-def test_parse_json_success():
+def test_parse_json():
     # GIVEN a valid JSON string
     state = BaseState()
     expression = ConstantValueReference('{"key": "value"}').parse_json()
@@ -18,12 +18,54 @@ def test_parse_json_success():
 
 
 def test_parse_json_array():
-    # Test parsing a JSON array
+    # GIVEN a valid JSON array
     state = BaseState()
     expression = ConstantValueReference("[1, 2, 3]").parse_json()
+
+    # WHEN we attempt to resolve the expression
     result = expression.resolve(state)
 
+    # THEN the JSON should be parsed successfully
     assert result == [1, 2, 3]
+
+
+def test_parse_json_bytes():
+    # GIVEN a valid JSON as bytes
+    state = BaseState()
+    json_bytes = b'{"key": "value"}'
+    expression = ConstantValueReference(json_bytes).parse_json()
+
+    # WHEN we attempt to resolve the expression
+    result = expression.resolve(state)
+
+    # THEN the JSON should be parsed successfully
+    assert result == {"key": "value"}
+
+
+def test_parse_json_bytearray():
+    # GIVEN a valid JSON as bytearray
+    state = BaseState()
+    json_bytearray = bytearray(b'{"key": "value"}')
+    expression = ConstantValueReference(json_bytearray).parse_json()
+
+    # WHEN we attempt to resolve the expression
+    result = expression.resolve(state)
+
+    # THEN the JSON should be parsed successfully
+    assert result == {"key": "value"}
+
+
+def test_parse_json_bytes_with_utf8_chars():
+    # GIVEN a valid JSON as bytes with UTF-8 characters
+    state = BaseState()
+    json_bytes = b'{"key": "\xf0\x9f\x8c\x9f"}'  # UTF-8 encoded star emoji
+    expression = ConstantValueReference(json_bytes).parse_json()
+
+    # WHEN we attempt to resolve the expression
+    result = expression.resolve(state)
+
+    # THEN the JSON should be parsed successfully
+    assert result == {"key": "🌟"}
 
 
 def test_parse_json_invalid_json():
@@ -39,7 +81,7 @@ def test_parse_json_invalid_json():
     assert "Failed to parse JSON" in str(exc_info.value)
 
 
-def test_parse_json_non_string():
+def test_parse_json_invalid_type():
     # GIVEN a non-string value
     state = BaseState()
     expression = ConstantValueReference(123).parse_json()

--- a/src/vellum/workflows/expressions/tests/test_parse_json.py
+++ b/src/vellum/workflows/expressions/tests/test_parse_json.py
@@ -6,11 +6,14 @@ from vellum.workflows.state.base import BaseState
 
 
 def test_parse_json_success():
-    # Test successful JSON parsing
+    # GIVEN a valid JSON string
     state = BaseState()
     expression = ConstantValueReference('{"key": "value"}').parse_json()
+
+    # WHEN we attempt to resolve the expression
     result = expression.resolve(state)
 
+    # THEN the JSON should be parsed successfully
     assert result == {"key": "value"}
 
 
@@ -24,24 +27,26 @@ def test_parse_json_array():
 
 
 def test_parse_json_invalid_json():
-    # Test with invalid JSON
+    # GIVEN an invalid JSON string
     state = BaseState()
     expression = ConstantValueReference('{"key": value}').parse_json()
 
+    # WHEN we attempt to resolve the expression
     with pytest.raises(InvalidExpressionException) as exc_info:
         expression.resolve(state)
 
-    # Verify the error message indicates JSON parsing failure
-    assert 'Failed to parse JSON: {"key": value}' == str(exc_info.value)
+    # THEN an exception should be raised
+    assert "Failed to parse JSON" in str(exc_info.value)
 
 
 def test_parse_json_non_string():
-    # Test with a non-string value
+    # GIVEN a non-string value
     state = BaseState()
     expression = ConstantValueReference(123).parse_json()
 
+    # WHEN we attempt to resolve the expression
     with pytest.raises(InvalidExpressionException) as exc_info:
         expression.resolve(state)
 
-    # Verify the error message indicates type error
+    # THEN an exception should be raised
     assert "Expected a string, but got 123 of type <class 'int'>" == str(exc_info.value)

--- a/src/vellum/workflows/expressions/tests/test_parse_json.py
+++ b/src/vellum/workflows/expressions/tests/test_parse_json.py
@@ -1,0 +1,51 @@
+import pytest
+
+from vellum.workflows.descriptors.exceptions import InvalidExpressionException
+from vellum.workflows.references.constant import ConstantValueReference
+from vellum.workflows.state.base import BaseState
+
+
+def test_parse_json_success():
+    # Test successful JSON parsing
+    state = BaseState()
+    expression = ConstantValueReference('{"key": "value"}').parse_json()
+    result = expression.resolve(state)
+
+    assert result == {"key": "value"}
+
+
+def test_parse_json_array():
+    # Test parsing a JSON array
+    state = BaseState()
+    expression = ConstantValueReference("[1, 2, 3]").parse_json()
+
+    # This should raise an exception because we've defined types=(dict,)
+    with pytest.raises(InvalidExpressionException) as exc_info:
+        expression.resolve(state)
+
+    # Verify the error message mentions the expected type
+    assert "Expected JSON to parse to a dictionary, but got list" == str(exc_info.value)
+
+
+def test_parse_json_invalid_json():
+    # Test with invalid JSON
+    state = BaseState()
+    expression = ConstantValueReference('{"key": value}').parse_json()
+
+    with pytest.raises(InvalidExpressionException) as exc_info:
+        expression.resolve(state)
+
+    # Verify the error message indicates JSON parsing failure
+    assert 'Failed to parse JSON: {"key": value}' == str(exc_info.value)
+
+
+def test_parse_json_non_string():
+    # Test with a non-string value
+    state = BaseState()
+    expression = ConstantValueReference(123).parse_json()
+
+    with pytest.raises(InvalidExpressionException) as exc_info:
+        expression.resolve(state)
+
+    # Verify the error message indicates type error
+    assert "Expected a string, but got 123 of type <class 'int'>" == str(exc_info.value)

--- a/src/vellum/workflows/expressions/tests/test_parse_json.py
+++ b/src/vellum/workflows/expressions/tests/test_parse_json.py
@@ -5,69 +5,6 @@ from vellum.workflows.references.constant import ConstantValueReference
 from vellum.workflows.state.base import BaseState
 
 
-def test_parse_json():
-    # GIVEN a valid JSON string
-    state = BaseState()
-    expression = ConstantValueReference('{"key": "value"}').parse_json()
-
-    # WHEN we attempt to resolve the expression
-    result = expression.resolve(state)
-
-    # THEN the JSON should be parsed successfully
-    assert result == {"key": "value"}
-
-
-def test_parse_json_array():
-    # GIVEN a valid JSON array
-    state = BaseState()
-    expression = ConstantValueReference("[1, 2, 3]").parse_json()
-
-    # WHEN we attempt to resolve the expression
-    result = expression.resolve(state)
-
-    # THEN the JSON should be parsed successfully
-    assert result == [1, 2, 3]
-
-
-def test_parse_json_bytes():
-    # GIVEN a valid JSON as bytes
-    state = BaseState()
-    json_bytes = b'{"key": "value"}'
-    expression = ConstantValueReference(json_bytes).parse_json()
-
-    # WHEN we attempt to resolve the expression
-    result = expression.resolve(state)
-
-    # THEN the JSON should be parsed successfully
-    assert result == {"key": "value"}
-
-
-def test_parse_json_bytearray():
-    # GIVEN a valid JSON as bytearray
-    state = BaseState()
-    json_bytearray = bytearray(b'{"key": "value"}')
-    expression = ConstantValueReference(json_bytearray).parse_json()
-
-    # WHEN we attempt to resolve the expression
-    result = expression.resolve(state)
-
-    # THEN the JSON should be parsed successfully
-    assert result == {"key": "value"}
-
-
-def test_parse_json_bytes_with_utf8_chars():
-    # GIVEN a valid JSON as bytes with UTF-8 characters
-    state = BaseState()
-    json_bytes = b'{"key": "\xf0\x9f\x8c\x9f"}'  # UTF-8 encoded star emoji
-    expression = ConstantValueReference(json_bytes).parse_json()
-
-    # WHEN we attempt to resolve the expression
-    result = expression.resolve(state)
-
-    # THEN the JSON should be parsed successfully
-    assert result == {"key": "🌟"}
-
-
 def test_parse_json_invalid_json():
     # GIVEN an invalid JSON string
     state = BaseState()


### PR DESCRIPTION
sc: https://app.shortcut.com/vellum/story/4850/add-a-json-parse-operation-to-descriptors

Allow user to call `parse_json`() on descriptor
- comply with json.load types
- add serialization test to make sure it assert UI not supported yet