### PR TITLE
Allow empty state for base node for testing purpose

### DIFF
--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -318,9 +318,12 @@ class BaseNode(Generic[StateType], metaclass=BaseNodeMeta):
             original_base = get_original_base(self.__class__)
 
             args = get_args(original_base)
-            state_type = args[0]
 
-            if isinstance(state_type, TypeVar):
+            if args and len(args) > 0:
+                state_type = args[0]
+                if isinstance(state_type, TypeVar):
+                    state_type = BaseState
+            else:
                 state_type = BaseState
 
             self.state = state_type()

--- a/src/vellum/workflows/nodes/displayable/api_node/tests/test_api_node.py
+++ b/src/vellum/workflows/nodes/displayable/api_node/tests/test_api_node.py
@@ -38,7 +38,7 @@ def test_run_workflow__secrets(vellum_client):
 
 
 def test_api_node_raises_error_when_api_call_fails(vellum_client):
-    # Mock the vellum_client to raise an ApiError
+    # GIVEN an API call that fails
     vellum_client.execute_api.side_effect = ApiError(status_code=400, body="API Error")
 
     class SimpleAPINode(APINode):
@@ -55,12 +55,12 @@ def test_api_node_raises_error_when_api_call_fails(vellum_client):
 
     node = SimpleAPINode()
 
-    # Assert that the NodeException is raised
+    # WHEN we run the node
     with pytest.raises(NodeException) as excinfo:
         node.run()
 
-    # Verify that the exception contains some error message
+    # THEN an exception should be raised
     assert "Failed to prepare HTTP request" in str(excinfo.value)
 
-    # Verify the vellum_client was called
+    # AND the API call should have been made
     assert vellum_client.execute_api.call_count == 1

--- a/src/vellum/workflows/nodes/displayable/api_node/tests/test_api_node.py
+++ b/src/vellum/workflows/nodes/displayable/api_node/tests/test_api_node.py
@@ -5,7 +5,6 @@ from vellum.client.core.api_error import ApiError
 from vellum.workflows.constants import APIRequestMethod, AuthorizationType
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes import APINode
-from vellum.workflows.state import BaseState
 from vellum.workflows.types.core import VellumSecret
 
 
@@ -29,7 +28,7 @@ def test_run_workflow__secrets(vellum_client):
         }
         bearer_token_value = VellumSecret(name="secret")
 
-    node = SimpleBaseAPINode(state=BaseState())
+    node = SimpleBaseAPINode()
     terminal = node.run()
 
     assert vellum_client.execute_api.call_count == 1
@@ -54,7 +53,7 @@ def test_api_node_raises_error_when_api_call_fails(vellum_client):
         }
         bearer_token_value = VellumSecret(name="api_key")
 
-    node = SimpleAPINode(state=BaseState())
+    node = SimpleAPINode()
 
     # Assert that the NodeException is raised
     with pytest.raises(NodeException) as excinfo:


### PR DESCRIPTION
context: when trying to remove non-used state https://github.com/vellum-ai/vellum-python-sdks/pull/1060#discussion_r1973436555, there's an error when args are empty since we access args[0] without checking it

As the comment mentions `# Instantiate a default state class if one is not provided, for ease of testing`, this should not affect anything besides test?

- Check if args have value first before assigning. Otherwise, it would cause index error if no state is provided