### PR TITLE
Make getNodeContext more resilient by switching to a find

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -32,6 +32,18 @@ class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
 "
 `;
 
+exports[`Workflow > write > should generate correct code with an output variable mapped to a non-existent node 1`] = `
+"from vellum.workflows import BaseWorkflow
+from vellum.workflows.state import BaseState
+
+from .inputs import Inputs
+class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
+    class Outputs(BaseWorkflow.Outputs):
+        passthrough = None
+
+"
+`;
+
 exports[`Workflow > write > should generate correct code with an output variable mapped to an input variable 1`] = `
 "from vellum.workflows import BaseWorkflow
 from vellum.workflows.state import BaseState

--- a/ee/codegen/src/__test__/nodes/generic-nodes/workflow-value-descriptor.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/workflow-value-descriptor.test.ts
@@ -41,7 +41,7 @@ describe("WorkflowValueDescriptor", () => {
       })
     );
 
-    vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
+    vi.spyOn(workflowContext, "findNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
       getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -253,14 +253,12 @@ describe("WorkflowProjectGenerator", () => {
       expectProjectFileToExist(project, ["workflow.py"]);
       expectProjectFileToMatchSnapshot(project, ["nodes", "bad_node.py"]);
 
-      expectErrorLog(
-        project,
-        `\
-Encountered 1 error(s) while generating code:
-
-- Failed to find node with id 'node_that_doesnt_exist'
-`
+      const errors = project.workflowContext.getErrors();
+      expect(errors.length).toBe(1);
+      expect(errors[0]?.message).toBe(
+        "Failed to find node with id 'node_that_doesnt_exist'"
       );
+      expect(errors[0]?.severity).toBe("WARNING");
     });
 
     it("should fail to generate code if a node fails in strict mode", async () => {

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/node-output-workflow-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/node-output-workflow-reference.test.ts
@@ -14,7 +14,7 @@ describe("NodeOutputWorkflowReferencePointer", () => {
 
   beforeEach(() => {
     workflowContext = workflowContextFactory();
-    vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
+    vi.spyOn(workflowContext, "findNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
       getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/workflow-value-descriptor-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/workflow-value-descriptor-reference.test.ts
@@ -49,7 +49,7 @@ describe("WorkflowValueDescriptorReferencePointer", () => {
   });
 
   it("should generate correct AST for NODE_OUTPUT reference", async () => {
-    vi.spyOn(workflowContext, "getNodeContext").mockReturnValue({
+    vi.spyOn(workflowContext, "findNodeContext").mockReturnValue({
       nodeClassName: "TestNode",
       path: ["nodes", "test-node-path"],
       getNodeOutputNameById: vi.fn().mockReturnValue("my_output"),

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -368,16 +368,21 @@ export class WorkflowContext {
     this.addUsedNodeModuleName(nodeContext.nodeModuleName);
   }
 
-  public getNodeContext<T extends WorkflowDataNode>(
+  public findNodeContext(
     nodeId: string
-  ): BaseNodeContext<T> {
+  ): BaseNodeContext<WorkflowDataNode> | undefined {
     const nodeContext = this.globalNodeContextsByNodeId.get(nodeId);
 
     if (!nodeContext) {
-      throw new NodeNotFoundError(`Failed to find node with id '${nodeId}'`);
+      this.addError(
+        new NodeNotFoundError(
+          `Failed to find node with id '${nodeId}'`,
+          "WARNING"
+        )
+      );
     }
 
-    return nodeContext as BaseNodeContext<T>;
+    return nodeContext;
   }
 
   public addPortContext(portContext: PortContext): void {

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -225,7 +225,11 @@ export class GraphAttribute extends AstNode {
     componentEdges: Set<WorkflowEdge>
   ): GraphMutableAst {
     try {
-      const rootNode = this.workflowContext.getNodeContext(rootNodeId);
+      const rootNode = this.workflowContext.findNodeContext(rootNodeId);
+      if (!rootNode) {
+        return { type: "empty" };
+      }
+
       let graph: GraphMutableAst = {
         type: "node_reference",
         reference: rootNode,
@@ -277,7 +281,7 @@ export class GraphAttribute extends AstNode {
     edgeId: string
   ): BaseNodeContext<WorkflowDataNode> | null {
     try {
-      return this.workflowContext.getNodeContext(nodeId);
+      return this.workflowContext.findNodeContext(nodeId) ?? null;
     } catch (error) {
       if (error instanceof NodeNotFoundError) {
         this.workflowContext.addError(

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.ts
@@ -2,18 +2,21 @@ import { python } from "@fern-api/python-ast";
 
 import { BaseNodeInputValuePointerRule } from "./base";
 
-import { BaseNodeContext } from "src/context/node-context/base";
-import { ExecutionCounterPointer, WorkflowDataNode } from "src/types/vellum";
+import { ExecutionCounterPointer } from "src/types/vellum";
 
 export class ExecutionCounterPointerRule extends BaseNodeInputValuePointerRule<ExecutionCounterPointer> {
-  getReferencedNodeContext(): BaseNodeContext<WorkflowDataNode> {
+  getReferencedNodeContext() {
     const executionCounterData = this.nodeInputValuePointerRule.data;
 
-    return this.workflowContext.getNodeContext(executionCounterData.nodeId);
+    return this.workflowContext.findNodeContext(executionCounterData.nodeId);
   }
 
-  getAstNode(): python.Reference {
+  getAstNode(): python.Reference | undefined {
     const nodeContext = this.getReferencedNodeContext();
+
+    if (!nodeContext) {
+      return undefined;
+    }
 
     return python.reference({
       name: nodeContext.nodeClassName,

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-output-pointer.ts
@@ -3,14 +3,13 @@ import { python } from "@fern-api/python-ast";
 import { BaseNodeInputValuePointerRule } from "./base";
 
 import { OUTPUTS_CLASS_NAME } from "src/constants";
-import { BaseNodeContext } from "src/context/node-context/base";
-import { NodeOutputPointer, WorkflowDataNode } from "src/types/vellum";
+import { NodeOutputPointer } from "src/types/vellum";
 
 export class NodeOutputPointerRule extends BaseNodeInputValuePointerRule<NodeOutputPointer> {
-  getReferencedNodeContext(): BaseNodeContext<WorkflowDataNode> {
+  getReferencedNodeContext() {
     const nodeOutputPointerRuleData = this.nodeInputValuePointerRule.data;
 
-    return this.workflowContext.getNodeContext(
+    return this.workflowContext.findNodeContext(
       nodeOutputPointerRuleData.nodeId
     );
   }
@@ -19,6 +18,10 @@ export class NodeOutputPointerRule extends BaseNodeInputValuePointerRule<NodeOut
     const nodeOutputPointerRuleData = this.nodeInputValuePointerRule.data;
 
     const nodeContext = this.getReferencedNodeContext();
+
+    if (!nodeContext) {
+      return undefined;
+    }
 
     const nodeOutputName = nodeContext.getNodeOutputNameById(
       nodeOutputPointerRuleData.outputId

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/execution-counter-workflow-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/execution-counter-workflow-reference.ts
@@ -9,9 +9,13 @@ export class ExecutionCounterWorkflowReference extends BaseNodeInputWorkflowRefe
     const executionCounterNodeId =
       this.nodeInputWorkflowReferencePointer.nodeId;
 
-    const nodeContext = this.workflowContext.getNodeContext(
+    const nodeContext = this.workflowContext.findNodeContext(
       executionCounterNodeId
     );
+
+    if (!nodeContext) {
+      return undefined;
+    }
 
     return python.reference({
       name: nodeContext.nodeClassName,

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/node-output-workflow-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/node-output-workflow-reference.ts
@@ -9,9 +9,13 @@ export class NodeOutputWorkflowReference extends BaseNodeInputWorkflowReference<
   getAstNode(): AstNode | undefined {
     const nodeOutputPointer = this.nodeInputWorkflowReferencePointer;
 
-    const nodeContext = this.workflowContext.getNodeContext(
+    const nodeContext = this.workflowContext.findNodeContext(
       nodeOutputPointer.nodeId
     );
+
+    if (!nodeContext) {
+      return undefined;
+    }
 
     const nodeOutputName = nodeContext.getNodeOutputNameById(
       nodeOutputPointer.nodeOutputId

--- a/ee/codegen/src/generators/workflow-value-descriptor.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor.ts
@@ -12,6 +12,7 @@ import {
   OperatorMapping,
   WorkflowDataNode,
   WorkflowValueDescriptor as WorkflowValueDescriptorType,
+  WorkflowValueDescriptorReference as WorkflowValueDescriptorReferenceType,
 } from "src/types/vellum";
 import { assertUnreachable } from "src/utils/typing";
 
@@ -60,12 +61,18 @@ export class WorkflowValueDescriptor extends AstNode {
 
     // Base case
     if (this.isReference(workflowValueDescriptor)) {
-      return new WorkflowValueDescriptorReference({
+      const reference = new WorkflowValueDescriptorReference({
         nodeContext: this.nodeContext,
         workflowContext: this.workflowContext,
         workflowValueReferencePointer: workflowValueDescriptor,
         iterableConfig: this.iterableConfig,
       });
+
+      if (!reference.astNode) {
+        return python.TypeInstantiation.none();
+      }
+
+      return reference;
     }
 
     switch (workflowValueDescriptor.type) {
@@ -148,7 +155,9 @@ export class WorkflowValueDescriptor extends AstNode {
     );
   }
 
-  private isReference(workflowValueDescriptor: WorkflowValueDescriptorType) {
+  private isReference(
+    workflowValueDescriptor: WorkflowValueDescriptorType
+  ): workflowValueDescriptor is WorkflowValueDescriptorReferenceType {
     return (
       workflowValueDescriptor.type === "NODE_OUTPUT" ||
       workflowValueDescriptor.type === "WORKFLOW_INPUT" ||

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -538,7 +538,11 @@ ${errors.slice(0, 3).map((err) => {
       nodeIds.map(async (nodeId) => {
         let node: BaseNode<WorkflowDataNode, BaseNodeContext<WorkflowDataNode>>;
 
-        const nodeContext = this.workflowContext.getNodeContext(nodeId);
+        const nodeContext = this.workflowContext.findNodeContext(nodeId);
+        if (!nodeContext) {
+          return;
+        }
+
         const nodeData = nodeContext.nodeData;
 
         const nodeType = nodeData.type;

--- a/ee/codegen/src/utils/typing.ts
+++ b/ee/codegen/src/utils/typing.ts
@@ -1,3 +1,4 @@
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { isNil } from "lodash";
 
 import { ValueGenerationError } from "src/generators/errors";
@@ -29,4 +30,9 @@ export function isNilOrEmpty<T>(
   }
 
   return false;
+}
+
+export interface DictEntry {
+  key: AstNode;
+  value: AstNode;
 }


### PR DESCRIPTION
Puts an end to these sentry errors:
<img width="700" alt="Screenshot 2025-02-27 at 11 29 45 PM" src="https://github.com/user-attachments/assets/6368fb4d-3483-49b3-9d54-619ef9a1425d" />
