### PR TITLE
Remove the add entrypoint node method

### DIFF
--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -16,7 +16,7 @@ import {
   templatingNodeFactory,
 } from "./helpers/node-data-factories";
 
-import { WorkflowContext, createNodeContext } from "src/context";
+import { createNodeContext } from "src/context";
 import { GraphAttribute } from "src/generators/graph-attribute";
 import { WorkflowDataNode } from "src/types/vellum";
 
@@ -25,7 +25,6 @@ describe("Workflow", () => {
   const runGraphTest = async (edges: EdgeFactoryNodePair[]) => {
     const workflowContext = workflowContextFactory();
     const writer = new Writer();
-    workflowContext.addEntrypointNode(entrypointNode);
 
     const nodes = Array.from(
       new Set(
@@ -54,13 +53,6 @@ describe("Workflow", () => {
     new GraphAttribute({ workflowContext }).write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
   };
-
-  let workflowContext: WorkflowContext;
-
-  beforeEach(() => {
-    workflowContext = workflowContextFactory();
-    workflowContext.addEntrypointNode(entrypointNode);
-  });
 
   describe("graph", () => {
     it("should be correct for a basic single node case", async () => {

--- a/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
+++ b/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
@@ -1,3 +1,5 @@
+import { entrypointNodeDataFactory } from "./node-data-factories";
+
 import { WorkflowContext } from "src/context";
 
 export function workflowContextFactory({
@@ -16,7 +18,7 @@ export function workflowContextFactory({
     workflowClassName: workflowClassName || "TestWorkflow",
     vellumApiKey: "<TEST_API_KEY>",
     workflowRawData: workflowRawData || {
-      nodes: [],
+      nodes: [entrypointNodeDataFactory()],
       edges: [],
     },
     strict,

--- a/ee/codegen/src/__test__/unused-graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/unused-graph-attribute.test.ts
@@ -22,7 +22,6 @@ describe("Workflow", () => {
     ) => {
       const workflowContext = workflowContextFactory();
       const writer = new Writer();
-      workflowContext.addEntrypointNode(entrypointNode);
 
       const nodes = Array.from(
         new Set(

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -38,7 +38,6 @@ describe("Workflow", () => {
     );
 
     workflowContext = workflowContextFactory();
-    workflowContext.addEntrypointNode(entrypointNode);
 
     const nodeData = terminalNodeDataFactory();
     await createNodeContext({
@@ -230,7 +229,6 @@ describe("Workflow", () => {
       });
 
       const workflowContext = workflowContextFactory({ strict: false });
-      workflowContext.addEntrypointNode(entrypointNode);
 
       const templatingNodeData1 = templatingNodeFactory({
         id: "7e09927b-6d6f-4829-92c9-54e66bdcaf80",
@@ -372,9 +370,7 @@ describe("Workflow", () => {
     });
 
     it("should generate correct display code when there are input variables with escape characters", async () => {
-      const entrypointNode = entrypointNodeDataFactory();
       workflowContext = workflowContextFactory();
-      workflowContext.addEntrypointNode(entrypointNode);
 
       const nodeData = terminalNodeDataFactory();
       await createNodeContext({

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -213,18 +213,23 @@ export class WorkflowContext {
     });
   }
 
-  public addEntrypointNode(entrypointNode: EntrypointNode): void {
+  public getEntrypointNode(): EntrypointNode {
     if (this.entrypointNode) {
-      throw new WorkflowGenerationError("Entrypoint node already exists");
+      return this.entrypointNode;
     }
 
-    this.entrypointNode = entrypointNode;
-  }
+    const entrypointNodes = this.workflowRawData.nodes.filter(
+      (n): n is EntrypointNode => n.type === "ENTRYPOINT"
+    );
+    if (entrypointNodes.length > 1) {
+      throw new WorkflowGenerationError("Multiple entrypoint nodes found");
+    }
 
-  public getEntrypointNode(): EntrypointNode {
-    if (!this.entrypointNode) {
+    const entrypointNode = entrypointNodes[0];
+    if (!entrypointNode) {
       throw new WorkflowGenerationError("Entrypoint node not found");
     }
+    this.entrypointNode = entrypointNode;
 
     return this.entrypointNode;
   }

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -20,7 +20,6 @@ import { ErrorLogFile, InitFile, Inputs, Workflow } from "./generators";
 import {
   NodeDefinitionGenerationError,
   ProjectSerializationError,
-  WorkflowGenerationError,
 } from "./generators/errors";
 import { BaseNode } from "./generators/nodes/bases";
 import { GuardrailNode } from "./generators/nodes/guardrail-node";
@@ -61,7 +60,6 @@ import { SubworkflowDeploymentNode } from "src/generators/nodes/subworkflow-depl
 import { WorkflowSandboxFile } from "src/generators/workflow-sandbox-file";
 import { WorkflowVersionExecConfigSerializer } from "src/serializers/vellum";
 import {
-  EntrypointNode,
   FinalOutputNode as FinalOutputNodeType,
   WorkflowDataNode,
   WorkflowEdge,
@@ -396,20 +394,6 @@ ${errors.slice(0, 3).map((err) => {
         }
       );
     }
-
-    const entrypointNodes =
-      this.workflowVersionExecConfig.workflowRawData.nodes.filter(
-        (n): n is EntrypointNode => n.type === "ENTRYPOINT"
-      );
-    if (entrypointNodes.length > 1) {
-      throw new WorkflowGenerationError("Multiple entrypoint nodes found");
-    }
-
-    const entrypointNode = entrypointNodes[0];
-    if (!entrypointNode) {
-      throw new WorkflowGenerationError("Entrypoint node not found");
-    }
-    this.workflowContext.addEntrypointNode(entrypointNode);
 
     const nodesToGenerate = await Promise.all(
       this.getOrderedNodes().map(async (nodeData) => {


### PR DESCRIPTION
Now that `WorkflowContext` has the `WorkflowRawData`, we can derive the Entrypoint Node instead of require consumers to pass it in. This in turn simplifies our tests and usage of Workflow Context in general.

Eventually working up to this PR: https://github.com/vellum-ai/vellum-python-sdks/pull/1067