### PR TITLE
Remove the add Workflow Edges method on workflow context

### DIFF
--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -429,10 +429,6 @@ export class WorkflowContext {
     return mlModel.name;
   }
 
-  public addWorkflowEdges(edges: WorkflowEdge[]): void {
-    this.workflowRawData.edges.push(...edges);
-  }
-
   public addError(error: BaseCodegenError): void {
     if (this.strict) {
       throw error;


### PR DESCRIPTION
Last refactor needed before I tackle: https://github.com/vellum-ai/vellum-python-sdks/pull/1067

This method on workflow context was only ever used in tests. It's a dangerous method for consumers to interact with as it distorts the original user supplied data. So this PR removes it