### PR TITLE
Ignore serializing keys that are mapped to the undefined value

### DIFF
--- a/src/vellum/workflows/events/tests/test_event.py
+++ b/src/vellum/workflows/events/tests/test_event.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from deepdiff import DeepDiff
 
+from vellum.workflows.constants import undefined
 from vellum.workflows.errors.types import WorkflowError, WorkflowErrorCode
 from vellum.workflows.events.node import (
     NodeExecutionFulfilledBody,
@@ -330,6 +331,43 @@ mock_node_uuid = str(uuid4_from_hash(MockNode.__qualname__))
                 "parent": None,
             },
         ),
+        (
+            NodeExecutionFulfilledEvent(
+                id=UUID("123e4567-e89b-12d3-a456-426614174000"),
+                timestamp=datetime(2024, 1, 1, 12, 0, 0),
+                trace_id=UUID("123e4567-e89b-12d3-a456-426614174000"),
+                span_id=UUID("123e4567-e89b-12d3-a456-426614174000"),
+                body=NodeExecutionFulfilledBody(
+                    node_definition=MockNode,
+                    outputs=MockNode.Outputs(
+                        example=undefined,  # type: ignore[arg-type]
+                    ),
+                    invoked_ports={MockNode.Ports.default},
+                ),
+            ),
+            {
+                "id": "123e4567-e89b-12d3-a456-426614174000",
+                "api_version": "2024-10-25",
+                "timestamp": "2024-01-01T12:00:00",
+                "trace_id": "123e4567-e89b-12d3-a456-426614174000",
+                "span_id": "123e4567-e89b-12d3-a456-426614174000",
+                "name": "node.execution.fulfilled",
+                "body": {
+                    "node_definition": {
+                        "id": mock_node_uuid,
+                        "name": "MockNode",
+                        "module": module_root + ["events", "tests", "test_event"],
+                    },
+                    "outputs": {},
+                    "invoked_ports": [
+                        {
+                            "name": "default",
+                        }
+                    ],
+                },
+                "parent": None,
+            },
+        ),
     ],
     ids=[
         "workflow.execution.initiated",
@@ -339,6 +377,7 @@ mock_node_uuid = str(uuid4_from_hash(MockNode.__qualname__))
         "workflow.execution.rejected",
         "node.execution.streaming",
         "node.execution.fulfilled",
+        "fulfilled_node_with_undefined_outputs",
     ],
 )
 def test_event_serialization(event, expected_json):

--- a/src/vellum/workflows/state/encoder.py
+++ b/src/vellum/workflows/state/encoder.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, Type
 
 from pydantic import BaseModel
 
+from vellum.workflows.constants import undefined
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.outputs.base import BaseOutput, BaseOutputs
 from vellum.workflows.ports.port import Port
@@ -22,7 +23,7 @@ class DefaultStateEncoder(JSONEncoder):
             return dict(obj)
 
         if isinstance(obj, (BaseInputs, BaseOutputs)):
-            return {descriptor.name: value for descriptor, value in obj}
+            return {descriptor.name: value for descriptor, value in obj if value is not undefined}
 
         if isinstance(obj, (BaseOutput, Port)):
             return obj.serialize()


### PR DESCRIPTION
This was causing odd serialization failures on the Vellum side, bc `undefined` was serializing as `"undefined"`, which is not ideal. We now treat it exactly how javascript treats it