### PR TITLE
Move WorkflowEventDisplayContext into open source directory for use within workflow.execution.initiated

### DIFF
--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass, field
-from uuid import UUID
 from typing import TYPE_CHECKING, Dict, Generic, Tuple, Type, TypeVar
 
-from vellum.client.core import UniversalBaseModel
 from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.events.workflow import WorkflowEventDisplayContext  # noqa: F401
 from vellum.workflows.nodes import BaseNode
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference, StateValueReference, WorkflowInputReference
@@ -23,18 +22,6 @@ if TYPE_CHECKING:
 
 NodeDisplayType = TypeVar("NodeDisplayType", bound="BaseNodeDisplay")
 WorkflowDisplayType = TypeVar("WorkflowDisplayType", bound="BaseWorkflowDisplay")
-
-
-class NodeDisplay(UniversalBaseModel):
-    input_display: Dict[str, UUID]
-    output_display: Dict[str, UUID]
-    port_display: Dict[str, UUID]
-
-
-class WorkflowEventDisplayContext(UniversalBaseModel):
-    node_displays: Dict[str, NodeDisplay]
-    workflow_inputs: Dict[str, UUID]
-    workflow_outputs: Dict[str, UUID]
 
 
 @dataclass

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Generic, Iterator, List, Optional, Tuple, Type, Un
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.edges import Edge
+from vellum.workflows.events.workflow import NodeDisplay, WorkflowEventDisplayContext
 from vellum.workflows.expressions.coalesce_expression import CoalesceExpression
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.utils import get_wrapped_node
@@ -33,12 +34,7 @@ from vellum_ee.workflows.display.base import (
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.types import (
-    NodeDisplay,
-    NodeDisplayType,
-    WorkflowDisplayContext,
-    WorkflowEventDisplayContext,
-)
+from vellum_ee.workflows.display.types import NodeDisplayType, WorkflowDisplayContext
 
 logger = logging.getLogger(__name__)
 

--- a/ee/vellum_ee/workflows/tests/test_server.py
+++ b/ee/vellum_ee/workflows/tests/test_server.py
@@ -2,6 +2,7 @@ from vellum.client.core.pydantic_utilities import UniversalBaseModel
 
 
 def test_load_workflow_event_display_context():
+    # DEPRECATED: Use `vellum.workflows.events.workflow.WorkflowEventDisplayContext` instead. Will be removed in 0.15.0
     from vellum_ee.workflows.display.types import WorkflowEventDisplayContext
 
     # We are actually just ensuring there are no circular dependencies when

--- a/src/vellum/workflows/events/tests/test_event.py
+++ b/src/vellum/workflows/events/tests/test_event.py
@@ -87,6 +87,7 @@ mock_node_uuid = str(uuid4_from_hash(MockNode.__qualname__))
                     "inputs": {
                         "foo": "bar",
                     },
+                    "display_context": None,
                 },
                 "parent": None,
             },

--- a/src/vellum/workflows/events/workflow.py
+++ b/src/vellum/workflows/events/workflow.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, Generator, Generic, Iterable, Literal, Type, Union
+from uuid import UUID
+from typing import TYPE_CHECKING, Any, Dict, Generator, Generic, Iterable, Literal, Optional, Type, Union
 
 from pydantic import field_serializer
 
@@ -38,8 +39,26 @@ class _BaseWorkflowEvent(BaseEvent):
         return self.body.workflow_definition
 
 
+class NodeDisplay(UniversalBaseModel):
+    input_display: Dict[str, UUID]
+    output_display: Dict[str, UUID]
+    port_display: Dict[str, UUID]
+
+
+class WorkflowEventDisplayContext(UniversalBaseModel):
+    node_displays: Dict[str, NodeDisplay]
+    workflow_inputs: Dict[str, UUID]
+    workflow_outputs: Dict[str, UUID]
+
+
 class WorkflowExecutionInitiatedBody(_BaseWorkflowExecutionBody, Generic[InputsType]):
     inputs: InputsType
+    # It is still the responsibility of the workflow server to populate this context. The SDK's
+    # Workflow Runner will always leave this field None.
+    #
+    # It's conceivable in a future where all `id`s are agnostic to display and reside in a third location,
+    # that the Workflow Runner can begin populating this field then.
+    display_context: Optional[WorkflowEventDisplayContext] = None
 
     @field_serializer("inputs")
     def serialize_inputs(self, inputs: InputsType, _info: Any) -> Dict[str, Any]:


### PR DESCRIPTION
This moves us one step closer to moving the initiated event for the workflow server to the entry of the method