### PR TITLE
Add function call obj handling for templating nodes

### DIFF
--- a/src/vellum/utils/templating/render.py
+++ b/src/vellum/utils/templating/render.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict, Optional
 
 from jinja2.sandbox import SandboxedEnvironment
+from pydantic import BaseModel
 
 from vellum.utils.templating.constants import FilterFunc
 from vellum.utils.templating.exceptions import JinjaTemplateError
@@ -11,6 +12,9 @@ from vellum.workflows.state.encoder import DefaultStateEncoder
 def finalize(obj: Any) -> str:
     if isinstance(obj, (dict, list)):
         return json.dumps(obj, cls=DefaultStateEncoder)
+
+    if isinstance(obj, BaseModel):
+        return json.dumps(obj.model_dump(), cls=DefaultStateEncoder)
 
     return str(obj)
 
@@ -23,7 +27,6 @@ def render_sandboxed_jinja_template(
     jinja_globals: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Render a Jinja template within a sandboxed environment."""
-
     try:
         environment = SandboxedEnvironment(
             keep_trailing_newline=True,

--- a/src/vellum/workflows/nodes/core/templating_node/node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/node.py
@@ -82,7 +82,6 @@ class TemplatingNode(BaseNode[StateType], Generic[StateType, _OutputType], metac
     def run(self) -> Outputs:
         rendered_template = self._render_template()
         result = self._cast_rendered_template(rendered_template)
-
         return self.Outputs(result=result)
 
     def _render_template(self) -> str:


### PR DESCRIPTION
This adds more support for function calling. This came from the change where if we reference array outputs instead of regular outputs on function calling, we don't need to access attributes the legacy way like `{{ json.loads(some_function_call[0].tool_id) }}`. We can now do templating like `{{ output[0] }}` when given array outputs