### PR TITLE
[SC-6270] Default api node should only codegen url field

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1200,7 +1200,7 @@ export function apiNodeFactory({
             type: "CONSTANT_VALUE",
             data: {
               type: "STRING",
-              value: "fasdfadsf",
+              value: "https://example.vellum.ai",
             },
           },
         ],

--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -94,6 +94,15 @@ class APINode(BaseAPINode):
 "
 `;
 
+exports[`ApiNode > basic api node > should only generate url field 1`] = `
+"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "fasdfadsf"
+"
+`;
+
 exports[`ApiNode > basic auth secret node > secret ids should show names 1`] = `
 "from vellum.workflows.constants import APIRequestMethod, AuthorizationType
 from vellum.workflows.nodes.displayable import APINode as BaseAPINode

--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -94,6 +94,75 @@ class APINode(BaseAPINode):
 "
 `;
 
+exports[`ApiNode > basic api node > should generate API key header fields when API key is provided 1`] = `
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "https://api.example.com/data"
+    method = APIRequestMethod.GET
+    api_key_header_key = "X-API-KEY"
+    authorization_type = AuthorizationType.API_KEY
+    api_key_header_value = "my-api-key"
+"
+`;
+
+exports[`ApiNode > basic api node > should generate all fields when all conditions are provided 1`] = `
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "https://api.example.com/data"
+    method = APIRequestMethod.POST
+    json = {}
+    headers = {
+        "Content-Type": "application/json",
+    }
+    api_key_header_key = "X-API-KEY"
+    authorization_type = AuthorizationType.API_KEY
+    api_key_header_value = "my-api-key"
+"
+`;
+
+exports[`ApiNode > basic api node > should generate body field when body is provided 1`] = `
+"from vellum.workflows.constants import APIRequestMethod
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "https://api.example.com/data"
+    method = APIRequestMethod.GET
+    json = {}
+"
+`;
+
+exports[`ApiNode > basic api node > should generate headers field when headers are provided 1`] = `
+"from vellum.workflows.constants import APIRequestMethod
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "https://api.example.com/data"
+    method = APIRequestMethod.GET
+    headers = {
+        "Content-Type": "application/json",
+    }
+"
+`;
+
+exports[`ApiNode > basic api node > should generate method field when method is POST 1`] = `
+"from vellum.workflows.constants import APIRequestMethod
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "https://api.example.com/data"
+    method = APIRequestMethod.POST
+"
+`;
+
 exports[`ApiNode > basic api node > should only generate url field 1`] = `
 "from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -79,7 +79,7 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
     method = APIRequestMethod.POST
     headers = {
         "foo": "foo-value",
@@ -99,7 +99,7 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
     api_key_header_key = "X-API-KEY"
     authorization_type = AuthorizationType.API_KEY
     api_key_header_value = "my-api-key"
@@ -112,7 +112,7 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
     method = APIRequestMethod.POST
     json = {
         "foo": "bar",
@@ -131,7 +131,7 @@ exports[`ApiNode > basic api node > should generate headers field when headers a
 
 
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
     headers = {
         "Content-Type": "application/json",
     }
@@ -144,7 +144,7 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
     method = APIRequestMethod.POST
 "
 `;
@@ -154,7 +154,7 @@ exports[`ApiNode > basic api node > should not generate body field when body is 
 
 
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
 "
 `;
 
@@ -163,7 +163,7 @@ exports[`ApiNode > basic api node > should only generate url field 1`] = `
 
 
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
 "
 `;
 
@@ -174,7 +174,7 @@ from vellum.workflows.references import VellumSecretReference
 
 
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
     method = APIRequestMethod.POST
     headers = {
         "foo": "foo-value",
@@ -195,7 +195,7 @@ from vellum.workflows.references import VellumSecretReference
 
 
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
     method = APIRequestMethod.POST
     headers = {
         "X-Secret-Key": VellumSecretReference("test-secret"),
@@ -289,7 +289,7 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 @TryNode.wrap()
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
     method = APIRequestMethod.POST
     headers = {
         "foo": "foo-value",
@@ -309,7 +309,7 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
     method = APIRequestMethod.POST
     headers = {
         "foo": "foo-value",
@@ -327,7 +327,7 @@ from vellum.workflows.references import VellumSecretReference
 
 
 class APINode(BaseAPINode):
-    url = "fasdfadsf"
+    url = "https://example.vellum.ai"
     method = APIRequestMethod.POST
     headers = {
         "foo": "foo-value",

--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -81,7 +81,6 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 class APINode(BaseAPINode):
     url = "fasdfadsf"
     method = APIRequestMethod.POST
-    json = {}
     headers = {
         "foo": "foo-value",
         "bar": "bar-value",
@@ -95,13 +94,12 @@ class APINode(BaseAPINode):
 `;
 
 exports[`ApiNode > basic api node > should generate API key header fields when API key is provided 1`] = `
-"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+"from vellum.workflows.constants import AuthorizationType
 from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
     url = "fasdfadsf"
-    method = APIRequestMethod.GET
     api_key_header_key = "X-API-KEY"
     authorization_type = AuthorizationType.API_KEY
     api_key_header_value = "my-api-key"
@@ -116,7 +114,9 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 class APINode(BaseAPINode):
     url = "fasdfadsf"
     method = APIRequestMethod.POST
-    json = {}
+    json = {
+        "foo": "bar",
+    }
     headers = {
         "Content-Type": "application/json",
     }
@@ -126,26 +126,12 @@ class APINode(BaseAPINode):
 "
 `;
 
-exports[`ApiNode > basic api node > should generate body field when body is provided 1`] = `
-"from vellum.workflows.constants import APIRequestMethod
-from vellum.workflows.nodes.displayable import APINode as BaseAPINode
-
-
-class APINode(BaseAPINode):
-    url = "fasdfadsf"
-    method = APIRequestMethod.GET
-    json = {}
-"
-`;
-
 exports[`ApiNode > basic api node > should generate headers field when headers are provided 1`] = `
-"from vellum.workflows.constants import APIRequestMethod
-from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
     url = "fasdfadsf"
-    method = APIRequestMethod.GET
     headers = {
         "Content-Type": "application/json",
     }
@@ -160,6 +146,15 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 class APINode(BaseAPINode):
     url = "fasdfadsf"
     method = APIRequestMethod.POST
+"
+`;
+
+exports[`ApiNode > basic api node > should not generate body field when body is empty 1`] = `
+"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "fasdfadsf"
 "
 `;
 
@@ -181,7 +176,6 @@ from vellum.workflows.references import VellumSecretReference
 class APINode(BaseAPINode):
     url = "fasdfadsf"
     method = APIRequestMethod.POST
-    json = {}
     headers = {
         "foo": "foo-value",
         "bar": "bar-value",
@@ -203,7 +197,6 @@ from vellum.workflows.references import VellumSecretReference
 class APINode(BaseAPINode):
     url = "fasdfadsf"
     method = APIRequestMethod.POST
-    json = {}
     headers = {
         "X-Secret-Key": VellumSecretReference("test-secret"),
     }
@@ -298,7 +291,6 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 class APINode(BaseAPINode):
     url = "fasdfadsf"
     method = APIRequestMethod.POST
-    json = {}
     headers = {
         "foo": "foo-value",
         "bar": "bar-value",
@@ -319,7 +311,6 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 class APINode(BaseAPINode):
     url = "fasdfadsf"
     method = APIRequestMethod.POST
-    json = {}
     headers = {
         "foo": "foo-value",
         "bar": "bar-value",
@@ -338,7 +329,6 @@ from vellum.workflows.references import VellumSecretReference
 class APINode(BaseAPINode):
     url = "fasdfadsf"
     method = APIRequestMethod.POST
-    json = {}
     headers = {
         "foo": "foo-value",
         "bar": "bar-value",

--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -100,7 +100,7 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
-    url = "https://api.example.com/data"
+    url = "fasdfadsf"
     method = APIRequestMethod.GET
     api_key_header_key = "X-API-KEY"
     authorization_type = AuthorizationType.API_KEY
@@ -114,7 +114,7 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
-    url = "https://api.example.com/data"
+    url = "fasdfadsf"
     method = APIRequestMethod.POST
     json = {}
     headers = {
@@ -132,7 +132,7 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
-    url = "https://api.example.com/data"
+    url = "fasdfadsf"
     method = APIRequestMethod.GET
     json = {}
 "
@@ -144,7 +144,7 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
-    url = "https://api.example.com/data"
+    url = "fasdfadsf"
     method = APIRequestMethod.GET
     headers = {
         "Content-Type": "application/json",
@@ -158,7 +158,7 @@ from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 
 
 class APINode(BaseAPINode):
-    url = "https://api.example.com/data"
+    url = "fasdfadsf"
     method = APIRequestMethod.POST
 "
 `;

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -136,7 +136,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "STRING",
-                  value: "fasdfadsf",
+                  value: "https://example.vellum.ai",
                 },
               },
             ],
@@ -212,7 +212,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "STRING",
-                  value: "fasdfadsf",
+                  value: "https://example.vellum.ai",
                 },
               },
             ],
@@ -288,7 +288,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "STRING",
-                  value: "fasdfadsf",
+                  value: "https://example.vellum.ai",
                 },
               },
             ],
@@ -376,7 +376,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "STRING",
-                  value: "fasdfadsf",
+                  value: "https://example.vellum.ai",
                 },
               },
             ],
@@ -497,7 +497,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "STRING",
-                  value: "fasdfadsf",
+                  value: "https://example.vellum.ai",
                 },
               },
             ],
@@ -633,7 +633,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "STRING",
-                  value: "fasdfadsf",
+                  value: "https://example.vellum.ai",
                 },
               },
             ],

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -184,6 +184,602 @@ describe("ApiNode", () => {
       // THEN the generated code should only contain the url field
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
+    it("should generate method field when method is POST", async () => {
+      // GIVEN a node with url and POST method
+      const inputs: NodeInput[] = [
+        {
+          id: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          key: "method",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE" as const,
+                data: {
+                  type: "STRING" as const,
+                  value: "POST",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          key: "url",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "https://api.example.com/data",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          key: "body",
+          value: {
+            rules: [],
+            combinator: "OR",
+          },
+        },
+      ];
+      const nodeData: ApiNodeType = {
+        id: "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
+        type: "API",
+        data: {
+          label: "API Node",
+          methodInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          urlInputId: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          bodyInputId: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          textOutputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
+          jsonOutputId: "af576eaa-d39d-4c19-8992-1f01a65a709a",
+          statusCodeOutputId: "69250713-617d-42a4-9326-456c70d0ef20",
+          targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
+          sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
+        },
+        inputs: inputs,
+      };
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      // WHEN generating the code
+      node.getNodeFile().write(writer);
+
+      // THEN the generated code should contain both url and method fields
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+    it("should generate body field when body is provided", async () => {
+      // GIVEN a node with url, GET method, and body
+      const inputs: NodeInput[] = [
+        {
+          id: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          key: "method",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE" as const,
+                data: {
+                  type: "STRING" as const,
+                  value: "GET",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          key: "url",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "https://api.example.com/data",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          key: "body",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "JSON",
+                  value: {},
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+      ];
+      const nodeData: ApiNodeType = {
+        id: "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
+        type: "API",
+        data: {
+          label: "API Node",
+          methodInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          urlInputId: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          bodyInputId: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          textOutputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
+          jsonOutputId: "af576eaa-d39d-4c19-8992-1f01a65a709a",
+          statusCodeOutputId: "69250713-617d-42a4-9326-456c70d0ef20",
+          targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
+          sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
+        },
+        inputs: inputs,
+      };
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      // WHEN generating the code
+      node.getNodeFile().write(writer);
+
+      // THEN the generated code should contain url and json fields
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should generate headers field when headers are provided", async () => {
+      // GIVEN a node with url, GET method, and headers
+      const headerKeyInputId = "header-key-input-id";
+      const headerValueInputId = "header-value-input-id";
+
+      const inputs: NodeInput[] = [
+        {
+          id: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          key: "method",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE" as const,
+                data: {
+                  type: "STRING" as const,
+                  value: "GET",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          key: "url",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "https://api.example.com/data",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          key: "body",
+          value: {
+            rules: [],
+            combinator: "OR",
+          },
+        },
+        {
+          id: headerKeyInputId,
+          key: "header-key",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "Content-Type",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: headerValueInputId,
+          key: "header-value",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "application/json",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+      ];
+
+      const nodeData: ApiNodeType = {
+        id: "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
+        type: "API",
+        data: {
+          label: "API Node",
+          methodInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          urlInputId: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          bodyInputId: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          textOutputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
+          jsonOutputId: "af576eaa-d39d-4c19-8992-1f01a65a709a",
+          statusCodeOutputId: "69250713-617d-42a4-9326-456c70d0ef20",
+          targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
+          sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
+          additionalHeaders: [
+            {
+              headerKeyInputId: headerKeyInputId,
+              headerValueInputId: headerValueInputId,
+            },
+          ],
+        },
+        inputs: inputs,
+      };
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      // WHEN generating the code
+      node.getNodeFile().write(writer);
+
+      // THEN the generated code should contain url and headers fields
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should generate API key header fields when API key is provided", async () => {
+      // GIVEN a node with url, GET method, and API key header
+      const apiKeyHeaderKeyInputId = "api-key-header-key-input-id";
+      const apiKeyHeaderValueInputId = "api-key-header-value-input-id";
+      const authTypeInputId = "auth-type-input-id";
+
+      const inputs: NodeInput[] = [
+        {
+          id: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          key: "method",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE" as const,
+                data: {
+                  type: "STRING" as const,
+                  value: "GET",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          key: "url",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "https://api.example.com/data",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          key: "body",
+          value: {
+            rules: [],
+            combinator: "OR",
+          },
+        },
+        {
+          id: apiKeyHeaderKeyInputId,
+          key: "api-key-header-key",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "X-API-KEY",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: apiKeyHeaderValueInputId,
+          key: "api-key-header-value",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "my-api-key",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: authTypeInputId,
+          key: "authorization-type",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "API_KEY",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+      ];
+
+      const nodeData: ApiNodeType = {
+        id: "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
+        type: "API",
+        data: {
+          label: "API Node",
+          methodInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          urlInputId: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          bodyInputId: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          textOutputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
+          jsonOutputId: "af576eaa-d39d-4c19-8992-1f01a65a709a",
+          statusCodeOutputId: "69250713-617d-42a4-9326-456c70d0ef20",
+          targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
+          sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
+          apiKeyHeaderKeyInputId: apiKeyHeaderKeyInputId,
+          apiKeyHeaderValueInputId: apiKeyHeaderValueInputId,
+          authorizationTypeInputId: authTypeInputId,
+        },
+        inputs: inputs,
+      };
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      // WHEN generating the code
+      node.getNodeFile().write(writer);
+
+      // THEN the generated code should contain url and API key header fields
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should generate all fields when all conditions are provided", async () => {
+      // GIVEN a node with all possible fields
+      const headerKeyInputId = "header-key-input-id";
+      const headerValueInputId = "header-value-input-id";
+      const apiKeyHeaderKeyInputId = "api-key-header-key-input-id";
+      const apiKeyHeaderValueInputId = "api-key-header-value-input-id";
+      const authTypeInputId = "auth-type-input-id";
+
+      const inputs: NodeInput[] = [
+        {
+          id: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          key: "method",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE" as const,
+                data: {
+                  type: "STRING" as const,
+                  value: "POST",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          key: "url",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "https://api.example.com/data",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          key: "body",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "JSON",
+                  value: {},
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: headerKeyInputId,
+          key: "header-key",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "Content-Type",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: headerValueInputId,
+          key: "header-value",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "application/json",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: apiKeyHeaderKeyInputId,
+          key: "api-key-header-key",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "X-API-KEY",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: apiKeyHeaderValueInputId,
+          key: "api-key-header-value",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "my-api-key",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: authTypeInputId,
+          key: "authorization-type",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "API_KEY",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+      ];
+
+      const nodeData: ApiNodeType = {
+        id: "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
+        type: "API",
+        data: {
+          label: "API Node",
+          methodInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          urlInputId: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          bodyInputId: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          textOutputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
+          jsonOutputId: "af576eaa-d39d-4c19-8992-1f01a65a709a",
+          statusCodeOutputId: "69250713-617d-42a4-9326-456c70d0ef20",
+          targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
+          sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
+          additionalHeaders: [
+            {
+              headerKeyInputId: headerKeyInputId,
+              headerValueInputId: headerValueInputId,
+            },
+          ],
+          apiKeyHeaderKeyInputId: apiKeyHeaderKeyInputId,
+          apiKeyHeaderValueInputId: apiKeyHeaderValueInputId,
+          authorizationTypeInputId: authTypeInputId,
+        },
+        inputs: inputs,
+      };
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      // WHEN generating the code
+      node.getNodeFile().write(writer);
+
+      // THEN the generated code should contain all fields
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
   });
 
   describe("basic auth secret node", () => {

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -212,7 +212,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "STRING",
-                  value: "https://api.example.com/data",
+                  value: "fasdfadsf",
                 },
               },
             ],
@@ -288,7 +288,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "STRING",
-                  value: "https://api.example.com/data",
+                  value: "fasdfadsf",
                 },
               },
             ],
@@ -376,7 +376,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "STRING",
-                  value: "https://api.example.com/data",
+                  value: "fasdfadsf",
                 },
               },
             ],
@@ -497,7 +497,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "STRING",
-                  value: "https://api.example.com/data",
+                  value: "fasdfadsf",
                 },
               },
             ],
@@ -633,7 +633,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "STRING",
-                  value: "https://api.example.com/data",
+                  value: "fasdfadsf",
                 },
               },
             ],

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -260,7 +260,7 @@ describe("ApiNode", () => {
       // THEN the generated code should contain both url and method fields
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
-    it("should generate body field when body is provided", async () => {
+    it("should not generate body field when body is empty", async () => {
       // GIVEN a node with url, GET method, and body
       const inputs: NodeInput[] = [
         {
@@ -649,7 +649,7 @@ describe("ApiNode", () => {
                 type: "CONSTANT_VALUE",
                 data: {
                   type: "JSON",
-                  value: {},
+                  value: { foo: "bar" },
                 },
               },
             ],

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -16,6 +16,7 @@ import { createNodeContext, WorkflowContext } from "src/context";
 import { ApiNodeContext } from "src/context/node-context/api-node";
 import { EntityNotFoundError } from "src/generators/errors";
 import { ApiNode } from "src/generators/nodes/api-node";
+import { ApiNode as ApiNodeType, NodeInput } from "src/types/vellum";
 
 describe("ApiNode", () => {
   let workflowContext: WorkflowContext;
@@ -105,6 +106,85 @@ describe("ApiNode", () => {
       nodeContext,
     });
   };
+
+  describe("basic api node", () => {
+    it("should only generate url field", async () => {
+      // GIVEN a node with only url and GET method
+      const inputs: NodeInput[] = [
+        {
+          id: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          key: "method",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE" as const,
+                data: {
+                  type: "STRING" as const,
+                  value: "GET",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          key: "url",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "fasdfadsf",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          key: "body",
+          value: {
+            rules: [],
+            combinator: "OR",
+          },
+        },
+      ];
+      const nodeData: ApiNodeType = {
+        id: "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
+        type: "API",
+        data: {
+          label: "API Node",
+          methodInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          urlInputId: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          bodyInputId: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          textOutputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
+          jsonOutputId: "af576eaa-d39d-4c19-8992-1f01a65a709a",
+          statusCodeOutputId: "69250713-617d-42a4-9326-456c70d0ef20",
+          targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
+          sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
+        },
+        inputs: inputs,
+      };
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      // WHEN generating the code
+      node.getNodeFile().write(writer);
+
+      // THEN the generated code should only contain the url field
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 
   describe("basic auth secret node", () => {
     it.each([{ id: "1234", name: "test-secret" }])(

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -47,7 +47,7 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
     }
 
     const additionalHeaders = this.nodeData.data.additionalHeaders;
-    if (additionalHeaders) {
+    if (additionalHeaders && additionalHeaders.length > 0) {
       statements.push(
         python.field({
           name: "headers",


### PR DESCRIPTION
sc: https://app.shortcut.com/vellum/story/6270/skip-codegenning-of-default-api-node-fields

Default api node (GET & empty body & empty headers) should only generate url field
- add test for each conditions
  - should only generate url field
  - should generate method field when method is POST
  - should generate headers field when headers are provided
  - ~~should generate body field when body is provided~~ -> should not generate body field when body is empty
  - should generate all fields when all conditions are provided

since current API node factory didn't accept some fields, follow up PR could address this