### PR TITLE
Catch invalid parent context on node execution rejected event

### DIFF
--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -328,11 +328,7 @@ class WorkflowRunner(Generic[StateType]):
                         node_definition=node.__class__,
                         error=e.error,
                     ),
-                    parent=WorkflowParentContext(
-                        span_id=span_id,
-                        workflow_definition=self.workflow.__class__,
-                        parent=self._parent_context,
-                    ),
+                    parent=parent_context,
                 )
             )
         except Exception as e:

--- a/tests/workflows/basic_node_rejection/tests/test_workflow.py
+++ b/tests/workflows/basic_node_rejection/tests/test_workflow.py
@@ -1,4 +1,6 @@
 from vellum.workflows.errors import WorkflowErrorCode
+from vellum.workflows.events.types import VellumCodeResourceDefinition
+from vellum.workflows.workflows.event_filters import all_workflow_event_filter
 
 from tests.workflows.basic_node_rejection.workflow import BasicRejectedWorkflow
 
@@ -16,3 +18,24 @@ def test_run_workflow__happy_path():
     # AND the output error message should be as expected
     assert terminal_event.error.code == WorkflowErrorCode.USER_DEFINED_ERROR
     assert terminal_event.error.message == "Node was rejected"
+
+
+def test_stream_workflow__parent_context():
+    # GIVEN a workflow that references a node that will fail
+    workflow = BasicRejectedWorkflow()
+
+    # WHEN the workflow is streamed
+    stream = workflow.stream(event_filter=all_workflow_event_filter)
+    events = list(stream)
+
+    # THEN the parent context be as expected
+    workflow_rejected_event = events[-1]
+    assert workflow_rejected_event.name == "workflow.execution.rejected"
+    assert workflow_rejected_event.parent is None
+
+    node_rejected_event = events[-2]
+    assert node_rejected_event.name == "node.execution.rejected"
+    assert node_rejected_event.parent is not None
+    assert node_rejected_event.parent.type == "WORKFLOW"
+    assert node_rejected_event.parent.workflow_definition == VellumCodeResourceDefinition.encode(BasicRejectedWorkflow)
+    assert node_rejected_event.parent.span_id == workflow_rejected_event.span_id


### PR DESCRIPTION
Was noticing that events coming in from the SDK had the wrong parent span id, resulting in UX like this:
![Screenshot 2025-03-01 at 3 03 43 PM](https://github.com/user-attachments/assets/88d0717c-6036-4200-8265-c7ebc44c4cea)

This now has the proper parent context for node rejected events