### PR TITLE
[SC-6893] [SC-6882] Fix conditional node lhs key resilience

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
@@ -12,6 +12,18 @@ class ConditionalNode(BaseConditionalNode):
 "
 `;
 
+exports[`Conditional Node warning cases > should log warning when lhs key is missing 1`] = `
+"from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
+from vellum.workflows.ports import Port
+
+
+class ConditionalNode(BaseConditionalNode):
+    class Ports(BaseConditionalNode.Ports):
+        branch_1 = Port.on_if(None)
+        branch_2 = Port.on_else()
+"
+`;
+
 exports[`Conditional Node with numeric operator casts rhs to NUMBER > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port

--- a/ee/codegen/src/generators/conditional-node-port.ts
+++ b/ee/codegen/src/generators/conditional-node-port.ts
@@ -5,11 +5,7 @@ import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
 import { isNil } from "lodash";
 
-import {
-  NodeAttributeGenerationError,
-  NodePortGenerationError,
-  ValueGenerationError,
-} from "./errors";
+import { NodePortGenerationError, ValueGenerationError } from "./errors";
 
 import * as codegen from "src/codegen";
 import { PortContext } from "src/context/port-context";
@@ -144,9 +140,13 @@ export class ConditionalNodePort extends AstNode {
 
     const lhsKey = this.inputFieldKeysByRuleId.get(ruleId);
     if (isNil(lhsKey)) {
-      throw new NodeAttributeGenerationError(
-        `Could not find input field key given ruleId: ${ruleId} on rule index: ${ruleIdx} on condition index: ${this.conditionalNodeDataIndex} for node: ${this.nodeLabel}`
+      this.portContext.workflowContext.addError(
+        new NodePortGenerationError(
+          `Node ${this.nodeLabel} is missing required left-hand side input field for rule: ${ruleIdx} in condition: ${this.conditionalNodeDataIndex}`,
+          "WARNING"
+        )
       );
+      return python.TypeInstantiation.none();
     }
     const lhs = this.nodeInputsByKey.get(lhsKey);
     if (isNil(lhs)) {


### PR DESCRIPTION
sc: https://app.shortcut.com/vellum/story/6893/conditional-node-branch-1-not-found-generation-error

this one should also be fixed https://app.shortcut.com/vellum/story/6882/conditional-node-preventing-workflow-from-initializing

Changes:
- if lhsKey is nil, it should add a warning to workflowContext instead of throwing it directly (similar to lhs check)

Before this PR, `vellum workflows pull --workflow-sandbox-id=1bea50d1-825a-40dd-9dcc-ec52370f3664 --include-sandbox` fail with 

```sh
Encountered 1 error(s) while generating code:

- Node Data Google Sheet verifier is missing required left-hand side input field with key: 9703f005-5ae7-48a6-8991-ab47f5ad76e3.field for rule: 0 in condition: 0
```

and the pulled down `workflow.py` will be
```py
class DataGoogleSheetVerifier(ConditionalNode):
    pass
```

After:
```py
class DataGoogleSheetVerifier(ConditionalNode):
    class Ports(ConditionalNode.Ports):
        branch_1 = Port.on_if(None)
        branch_2 = Port.on_else()

```
