### PR TITLE
Support nested subworkflow display for NodeEventDisplayContext's

### DIFF
--- a/ee/vellum_ee/workflows/tests/test_display_meta.py
+++ b/ee/vellum_ee/workflows/tests/test_display_meta.py
@@ -40,11 +40,13 @@ def test_base_class_dynamic_import(files):
                 },
                 "output_display": {"result": UUID("423bc529-1a1a-4f72-af4d-cbdb5f0a5929")},
                 "port_display": {"default": UUID("afda9a19-0618-42e1-9b63-5d0db2a88f62")},
+                "subworkflow_display": None,
             },
             "f3ef4b2b-fec9-4026-9cc6-e5eac295307f": {
                 "input_display": {"node_input": UUID("fe6cba85-2423-4b5e-8f85-06311a8be5fb")},
                 "output_display": {"value": UUID("5469b810-6ea6-4362-9e79-e360d44a1405")},
                 "port_display": {},
+                "subworkflow_display": None,
             },
         },
         "workflow_inputs": {"input_value": UUID("2268a996-bd17-4832-b3ff-f5662d54b306")},

--- a/src/vellum/workflows/events/workflow.py
+++ b/src/vellum/workflows/events/workflow.py
@@ -39,14 +39,15 @@ class _BaseWorkflowEvent(BaseEvent):
         return self.body.workflow_definition
 
 
-class NodeDisplay(UniversalBaseModel):
+class NodeEventDisplayContext(UniversalBaseModel):
     input_display: Dict[str, UUID]
     output_display: Dict[str, UUID]
     port_display: Dict[str, UUID]
+    subworkflow_display: Optional["WorkflowEventDisplayContext"] = None
 
 
 class WorkflowEventDisplayContext(UniversalBaseModel):
-    node_displays: Dict[str, NodeDisplay]
+    node_displays: Dict[str, NodeEventDisplayContext]
     workflow_inputs: Dict[str, UUID]
     workflow_outputs: Dict[str, UUID]
 


### PR DESCRIPTION
The vellum app has already been updated to start consuming this context, PR here: https://github.com/vellum-ai/vellum/pull/8600

We need this to properly identify the inputs/outputs/ports of all nested workflows going forward