### PR TITLE
Support returning arrays in  mode for code nodes

### DIFF
--- a/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
@@ -743,3 +743,27 @@ Node.js v21.7.3
 
     # AND the error should contain the execution error details
     assert exc_info.value.message == message
+
+
+def test_run_node__execute_code__list_extends():
+    # GIVEN a node that will throw a JSON.parse error
+    class ExampleCodeExecutionNode(CodeExecutionNode[BaseState, Json]):
+        code = """\
+def main(left, right):
+    all = []
+    all.extend(left)
+    all.extend(right)
+    return all
+"""
+        code_inputs = {
+            "left": [1, 2, 3],
+            "right": [4, 5, 6],
+        }
+        runtime = "PYTHON_3_11_6"
+
+    # WHEN we run the node
+    node = ExampleCodeExecutionNode()
+    outputs = node.run()
+
+    # AND the result should be the correct output
+    assert outputs == {"result": [1, 2, 3, 4, 5, 6], "log": ""}

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
@@ -1,7 +1,7 @@
 import io
 import os
 import re
-from typing import Any, Tuple, Union, get_args, get_origin
+from typing import Any, ForwardRef, Tuple, Union, get_args, get_origin
 
 from pydantic import BaseModel, ValidationError
 
@@ -79,6 +79,10 @@ def _get_type_name(obj: Any) -> str:
 
 
 def _cast_to_output_type(result: Any, output_type: Any) -> Any:
+    if isinstance(output_type, ForwardRef) or output_type is Any:
+        # Treat ForwardRefs as Any for now
+        return result
+
     is_valid_output_type = isinstance(output_type, type)
     if get_origin(output_type) is Union:
         allowed_types = get_args(output_type)
@@ -154,7 +158,6 @@ __arg__out = main({", ".join(run_args)})
     logs = log_buffer.getvalue()
     result = exec_globals["__arg__out"]
 
-    if output_type != Any:
-        result = _cast_to_output_type(result, output_type)
+    result = _cast_to_output_type(result, output_type)
 
     return logs, result


### PR DESCRIPTION
Found while QA-ing a customer's workflow - the ForwardRef in the `Json` type was causing problems.

I could've sworn I switched this to use pydantic. Will likely repursue that soon