### PR TITLE
[SC-6977] Resile port name context

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -277,6 +277,14 @@ exports[`Workflow > graph > should handle a simple edge of generic nodes 1`] = `
 "
 `;
 
+exports[`Workflow > graph > should properly format UUID-like port names in graph references 1`] = `
+"{
+    GenericNode.Ports._7d813792_04c2_4d26_a126_16de4c4cebaf >> FirstNode,
+    GenericNode.Ports._6f909cc6_887c_46d8_966b_46547900fc9c >> SecondNode,
+}
+"
+`;
+
 exports[`Workflow > graph > should support an edge between two sets 1`] = `
 "{
     TopLeftNode

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -889,7 +889,7 @@ describe("Workflow", () => {
       ]);
     });
     it("should properly format UUID-like port names in graph references", async () => {
-      // Create a generic node with UUID-like port names
+      // Given a UUID-like port names
       const uuidPortName1 = "7d813792-04c2-4d26-a126-16de4c4cebaf";
       const uuidPortName2 = "6f909cc6-887c-46d8-966b-46547900fc9c";
 
@@ -913,7 +913,6 @@ describe("Workflow", () => {
         ],
       });
 
-      // Create target nodes
       const firstNode = genericNodeFactory({
         label: "FirstNode",
       });
@@ -922,7 +921,6 @@ describe("Workflow", () => {
         label: "SecondNode",
       });
 
-      // Run the graph test with UUID-like port names
       await runGraphTest([
         [entrypointNode, genericNodeData],
         [[genericNodeData, uuidPortName1], firstNode],

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -888,5 +888,46 @@ describe("Workflow", () => {
         [BottomNode, SecondBottomNode],
       ]);
     });
+    it("should properly format UUID-like port names in graph references", async () => {
+      // Create a generic node with UUID-like port names
+      const uuidPortName1 = "7d813792-04c2-4d26-a126-16de4c4cebaf";
+      const uuidPortName2 = "6f909cc6-887c-46d8-966b-46547900fc9c";
+
+      const genericNodeData = genericNodeFactory({
+        label: "GenericNode",
+        nodePorts: [
+          {
+            id: uuidv4(),
+            name: uuidPortName1,
+            type: "IF",
+            expression: {
+              type: "CONSTANT_VALUE",
+              value: { type: "STRING", value: "test" },
+            },
+          },
+          {
+            id: uuidv4(),
+            name: uuidPortName2,
+            type: "ELSE",
+          },
+        ],
+      });
+
+      // Create target nodes
+      const firstNode = genericNodeFactory({
+        label: "FirstNode",
+      });
+
+      const secondNode = genericNodeFactory({
+        label: "SecondNode",
+      });
+
+      // Run the graph test with UUID-like port names
+      await runGraphTest([
+        [entrypointNode, genericNodeData],
+        [[genericNodeData, uuidPortName1], firstNode],
+        [[genericNodeData, uuidPortName2], secondNode],
+      ]);
+    });
   });
 });

--- a/ee/codegen/src/context/port-context.ts
+++ b/ee/codegen/src/context/port-context.ts
@@ -2,6 +2,7 @@ import { DEFAULT_PORT_NAME } from "src/constants";
 import { WorkflowContext } from "src/context/index";
 import { BaseNodeContext } from "src/context/node-context/base";
 import { WorkflowDataNode } from "src/types/vellum";
+import { toPythonSafeSnakeCase } from "src/utils/casing";
 
 export declare namespace PortContext {
   export type Args = {
@@ -32,7 +33,7 @@ export class PortContext {
     this.nodeContext = nodeContext;
 
     this.portId = portId;
-    this.portName = portName;
+    this.portName = toPythonSafeSnakeCase(portName);
     this.isDefault = isDefault;
   }
 }


### PR DESCRIPTION
sc: https://app.shortcut.com/vellum/story/6977/generic-ports-are-codegen-ing-port-ids-instead-of-port-names
slack: https://vellum-ai.slack.com/archives/C06P13ABK0W/p1741215085018699

Add `toPythonSafeSnakeCase` to transform port name