### PR TITLE
Add serialization for retry node wrap

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
@@ -1,11 +1,19 @@
 import inspect
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, Callable, Generic, Optional, Tuple, Type, TypeVar, cast
 
 from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.errors.types import WorkflowErrorCode
+from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.retry_node.node import RetryNode
+from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
+from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
+from vellum.workflows.types.utils import get_original_base
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum.workflows.workflows.base import BaseWorkflow
+from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
+from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.nodes.vellum.base_adornment_node import BaseAdornmentNodeDisplay
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
@@ -39,4 +47,87 @@ class BaseRetryNodeDisplay(BaseAdornmentNodeDisplay[_RetryNodeType], Generic[_Re
             "attributes": attributes,
         }
 
-        return super().serialize(display_context, adornment=adornment)
+        serialized_node = super().serialize(
+            display_context,
+            adornment=adornment,
+        )
+
+        if serialized_node["type"] == "GENERIC":
+            return serialized_node
+
+        serialized_node_definition = serialized_node.get("definition")
+        if isinstance(serialized_node_definition, dict):
+            serialized_node_definition_module = serialized_node_definition.get("module")
+            if isinstance(serialized_node_definition_module, list):
+                serialized_node_definition_module.extend(
+                    [
+                        serialized_node_definition["name"],
+                        ADORNMENT_MODULE_NAME,
+                    ]
+                )
+                serialized_node_definition["name"] = node.__name__
+
+        return serialized_node
+
+    def get_node_output_display(self, output: OutputReference) -> Tuple[Type[BaseNode], NodeOutputDisplay]:
+        inner_node = self._node.__wrapped_node__
+        if not inner_node:
+            return super().get_node_output_display(output)
+
+        node_display_class = get_node_display_class(BaseNodeDisplay, inner_node)
+        node_display = node_display_class()
+
+        inner_output = getattr(inner_node.Outputs, output.name)
+        return node_display.get_node_output_display(inner_output)
+
+    @classmethod
+    def wrap(
+        cls,
+        max_attempts: Optional[int] = None,
+        delay: Optional[float] = None,
+        retry_on_error_code: Optional[WorkflowErrorCode] = None,
+        retry_on_condition: Optional[BaseDescriptor] = None,
+    ) -> Callable[..., Type["BaseRetryNodeDisplay"]]:
+        _max_attempts = max_attempts
+        _delay = delay
+        _retry_on_error_code = retry_on_error_code
+        _retry_on_condition = retry_on_condition
+
+        NodeDisplayType = TypeVar("NodeDisplayType", bound=BaseNodeDisplay)
+
+        def decorator(inner_cls: Type[NodeDisplayType]) -> Type[NodeDisplayType]:
+            node_class = inner_cls.infer_node_class()
+            wrapped_node_class = cast(Type[BaseNode], node_class.__wrapped_node__)
+
+            # Create a specialized RetryNodeDisplay with the parameters
+            class RetryNodeDisplay(BaseRetryNodeDisplay[node_class]):  # type: ignore[valid-type]
+                max_attempts = _max_attempts
+                delay = _delay
+                retry_on_error_code = _retry_on_error_code
+                retry_on_condition = _retry_on_condition
+
+            setattr(inner_cls, "__adorned_by__", RetryNodeDisplay)
+
+            # We must edit the node display class to use __wrapped_node__ everywhere it
+            # references the adorned node class, which is three places:
+
+            # 1. The node display class' parameterized type
+            original_base_node_display = get_original_base(inner_cls)
+            original_base_node_display.__args__ = (wrapped_node_class,)
+            inner_cls._node_display_registry[wrapped_node_class] = inner_cls
+
+            # 2. The node display class' output displays
+            old_outputs = list(inner_cls.output_display.keys())
+            for old_output in old_outputs:
+                new_output = getattr(wrapped_node_class.Outputs, old_output.name)
+                inner_cls.output_display[new_output] = inner_cls.output_display.pop(old_output)
+
+            # 3. The node display class' port displays
+            old_ports = list(inner_cls.port_displays.keys())
+            for old_port in old_ports:
+                new_port = getattr(wrapped_node_class.Ports, old_port.name)
+                inner_cls.port_displays[new_port] = inner_cls.port_displays.pop(old_port)
+
+            return inner_cls
+
+        return decorator

--- a/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
@@ -99,7 +99,6 @@ class BaseRetryNodeDisplay(BaseAdornmentNodeDisplay[_RetryNodeType], Generic[_Re
             node_class = inner_cls.infer_node_class()
             wrapped_node_class = cast(Type[BaseNode], node_class.__wrapped_node__)
 
-            # Create a specialized RetryNodeDisplay with the parameters
             class RetryNodeDisplay(BaseRetryNodeDisplay[node_class]):  # type: ignore[valid-type]
                 max_attempts = _max_attempts
                 delay = _delay

--- a/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
@@ -83,7 +83,7 @@ class BaseRetryNodeDisplay(BaseAdornmentNodeDisplay[_RetryNodeType], Generic[_Re
     @classmethod
     def wrap(
         cls,
-        max_attempts: Optional[int] = None,
+        max_attempts: int,
         delay: Optional[float] = None,
         retry_on_error_code: Optional[WorkflowErrorCode] = None,
         retry_on_condition: Optional[BaseDescriptor] = None,

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_retry_node.py
@@ -1,0 +1,60 @@
+from typing import Any, Dict, cast
+
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.errors.types import WorkflowErrorCode
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.nodes.core.retry_node.node import RetryNode
+from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
+from vellum_ee.workflows.display.nodes.vellum.retry_node import BaseRetryNodeDisplay
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+
+
+def test_retry_node_parameters():
+    """Test that RetryNode parameters are correctly serialized."""
+
+    # GIVEN a RetryNode with specific parameters
+    @RetryNode.wrap(max_attempts=5, delay=2.5, retry_on_error_code=WorkflowErrorCode.INVALID_INPUTS)
+    class MyRetryNode(BaseNode):
+        pass
+
+    # AND a display class for the node
+    @BaseRetryNodeDisplay.wrap(max_attempts=5, delay=2.5, retry_on_error_code=WorkflowErrorCode.INVALID_INPUTS)
+    class MyRetryNodeDisplay(BaseNodeDisplay[MyRetryNode]):
+        pass
+
+    # AND a workflow using the node
+    class MyWorkflow(BaseWorkflow):
+        graph = MyRetryNode
+
+    # WHEN we serialize the workflow
+    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=MyWorkflow)
+    serialized_workflow = cast(Dict[str, Any], workflow_display.serialize())
+
+    # THEN the retry node parameters should be correctly serialized
+    # Find the node that isn't the entrypoint - that should be our retry node
+    serialized_node = next(
+        node for node in serialized_workflow["workflow_raw_data"]["nodes"] if node["type"] != "ENTRYPOINT"
+    )
+
+    # Verify it's our retry node
+    assert "MyRetryNode" in serialized_node["label"]
+
+    # Find the RetryNode adornment
+    retry_adornment = next(
+        adornment for adornment in serialized_node["adornments"] if adornment["label"] == "RetryNode"
+    )
+
+    # Check parameters in the adornment
+    max_attempts_attribute = next(attr for attr in retry_adornment["attributes"] if attr["name"] == "max_attempts")
+    assert max_attempts_attribute["value"]["value"]["value"] == 5.0
+
+    delay_attribute = next(attr for attr in retry_adornment["attributes"] if attr["name"] == "delay")
+    assert delay_attribute["value"]["value"]["value"] == 2.5
+
+    retry_on_error_code_attribute = next(
+        attr for attr in retry_adornment["attributes"] if attr["name"] == "retry_on_error_code"
+    )
+    # The error code is serialized as a string
+    assert retry_on_error_code_attribute["value"]["value"]["type"] == "STRING"
+    assert retry_on_error_code_attribute["value"]["value"]["value"] == "INVALID_INPUTS"

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_retry_node.py
@@ -4,8 +4,6 @@ from vellum.workflows import BaseWorkflow
 from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.retry_node.node import RetryNode
-from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
-from vellum_ee.workflows.display.nodes.vellum.retry_node import BaseRetryNodeDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -18,11 +16,6 @@ def test_retry_node_parameters():
     class MyRetryNode(BaseNode):
         pass
 
-    # AND a display class for the node
-    @BaseRetryNodeDisplay.wrap(max_attempts=5, delay=2.5, retry_on_error_code=WorkflowErrorCode.INVALID_INPUTS)
-    class MyRetryNodeDisplay(BaseNodeDisplay[MyRetryNode]):
-        pass
-
     # AND a workflow using the node
     class MyWorkflow(BaseWorkflow):
         graph = MyRetryNode
@@ -31,23 +24,18 @@ def test_retry_node_parameters():
     workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=MyWorkflow)
     serialized_workflow = cast(Dict[str, Any], workflow_display.serialize())
 
-    # THEN the retry node parameters should be correctly serialized
-    # Find the node that isn't the entrypoint - that should be our retry node
+    # THEN the correct inputs should be serialized on the node
     serialized_node = next(
         node for node in serialized_workflow["workflow_raw_data"]["nodes"] if node["type"] != "ENTRYPOINT"
     )
 
-    # Verify it's our retry node
-    assert "MyRetryNode" in serialized_node["label"]
-
-    # Find the RetryNode adornment
     retry_adornment = next(
         adornment for adornment in serialized_node["adornments"] if adornment["label"] == "RetryNode"
     )
 
     # Check parameters in the adornment
     max_attempts_attribute = next(attr for attr in retry_adornment["attributes"] if attr["name"] == "max_attempts")
-    assert max_attempts_attribute["value"]["value"]["value"] == 5.0
+    assert max_attempts_attribute["value"]["value"]["value"] == 5
 
     delay_attribute = next(attr for attr in retry_adornment["attributes"] if attr["name"] == "delay")
     assert delay_attribute["value"]["value"]["value"] == 2.5

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_retry_node.py
@@ -33,7 +33,6 @@ def test_retry_node_parameters():
         adornment for adornment in serialized_node["adornments"] if adornment["label"] == "RetryNode"
     )
 
-    # Check parameters in the adornment
     max_attempts_attribute = next(attr for attr in retry_adornment["attributes"] if attr["name"] == "max_attempts")
     assert max_attempts_attribute["value"]["value"]["value"] == 5
 
@@ -43,6 +42,6 @@ def test_retry_node_parameters():
     retry_on_error_code_attribute = next(
         attr for attr in retry_adornment["attributes"] if attr["name"] == "retry_on_error_code"
     )
-    # The error code is serialized as a string
+
     assert retry_on_error_code_attribute["value"]["value"]["type"] == "STRING"
     assert retry_on_error_code_attribute["value"]["value"]["value"] == "INVALID_INPUTS"

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -30,11 +30,7 @@ class InnerRetryGenericNode(BaseNode):
 
 
 @BaseRetryNodeDisplay.wrap(max_attempts=3)
-class InnerRetryGenericNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode]):  # type: ignore
-    pass
-
-
-class OuterRetryNodeDisplay(BaseRetryNodeDisplay[InnerRetryGenericNode]):  # type: ignore
+class InnerRetryGenericNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode]):
     pass
 
 
@@ -45,7 +41,6 @@ def test_serialize_node__retry(serialize_node):
         global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)},
         global_node_displays={
             InnerRetryGenericNode.__wrapped_node__: InnerRetryGenericNodeDisplay,
-            InnerRetryGenericNode: OuterRetryNodeDisplay,
         },
     )
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -115,6 +115,26 @@ def test_serialize_node__retry(serialize_node):
     )
 
 
+def test_serialize_node__retry__no_display():  # GIVEN an adornment node
+    @RetryNode.wrap(max_attempts=5)
+    class StartNode(BaseNode):
+        pass
+
+    # AND a workflow that uses the adornment node
+    class MyWorkflow(BaseWorkflow):
+        graph = StartNode
+
+    # WHEN we serialize the workflow
+    workflow_display = get_workflow_display(
+        base_display_class=VellumWorkflowDisplay,
+        workflow_class=MyWorkflow,
+    )
+    exec_config = workflow_display.serialize()
+
+    # THEN the workflow display is created successfully
+    assert exec_config is not None
+
+
 @TryNode.wrap()
 class InnerTryGenericNode(BaseNode):
     input = Inputs.input

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -29,7 +29,8 @@ class InnerRetryGenericNode(BaseNode):
         output: str
 
 
-class InnerRetryGenericNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode.__wrapped_node__]):  # type: ignore
+@BaseRetryNodeDisplay.wrap(max_attempts=3)
+class InnerRetryGenericNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode]):  # type: ignore
     pass
 
 
@@ -117,26 +118,6 @@ def test_serialize_node__retry(serialize_node):
         },
         serialized_node,
     )
-
-
-def test_serialize_node__retry__no_display():  # GIVEN an adornment node
-    @RetryNode.wrap(max_attempts=5)
-    class StartNode(BaseNode):
-        pass
-
-    # AND a workflow that uses the adornment node
-    class MyWorkflow(BaseWorkflow):
-        graph = StartNode
-
-    # WHEN we serialize the workflow
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=MyWorkflow,
-    )
-    exec_config = workflow_display.serialize()
-
-    # THEN the workflow display is created successfully
-    assert exec_config is not None
 
 
 @TryNode.wrap()


### PR DESCRIPTION
Context: when we run retry node with adornment in FE, it will return `'BaseRetryNodeDisplay' has no attribute 'wrap'`

- add support for retry node wrap
- mostly follow try node but remove `error_output_id`