### PR TITLE
Add mock node output parsing support

### DIFF
--- a/src/vellum/workflows/descriptors/base.py
+++ b/src/vellum/workflows/descriptors/base.py
@@ -71,6 +71,9 @@ class BaseDescriptor(Generic[_T]):
     def __hash__(self) -> int:
         return hash(self._name)
 
+    def __repr__(self) -> str:
+        return self._name
+
     @overload
     def __get__(self, instance: "BaseNode", owner: Type["BaseNode"]) -> _T: ...
 

--- a/src/vellum/workflows/nodes/mocks.py
+++ b/src/vellum/workflows/nodes/mocks.py
@@ -1,6 +1,6 @@
 from functools import reduce
 from uuid import UUID
-from typing import TYPE_CHECKING, Any, List, Literal, Sequence, Type, Union
+from typing import TYPE_CHECKING, Any, List, Literal, Optional, Sequence, Type, Union
 
 from pydantic import ConfigDict, ValidationError
 
@@ -107,9 +107,12 @@ class MockNodeExecution(UniversalBaseModel):
 
     @staticmethod
     def validate_all(
-        raw_mock_workflow_node_configs: List[Any],
+        raw_mock_workflow_node_configs: Optional[List[Any]],
         workflow: Type["BaseWorkflow"],
-    ) -> List["MockNodeExecution"]:
+    ) -> Optional[List["MockNodeExecution"]]:
+        if not raw_mock_workflow_node_configs:
+            return None
+
         ArrayVellumValue.model_rebuild()
         try:
             mock_workflow_node_configs = [

--- a/src/vellum/workflows/nodes/mocks.py
+++ b/src/vellum/workflows/nodes/mocks.py
@@ -1,10 +1,102 @@
-from typing import Sequence, Union
+from functools import reduce
+from uuid import UUID
+from typing import TYPE_CHECKING, Any, List, Literal, Sequence, Type, Union
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, ValidationError
 
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
+from vellum.client.types.array_vellum_value import ArrayVellumValue
+from vellum.client.types.vellum_value import VellumValue
 from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.errors.types import WorkflowErrorCode
+from vellum.workflows.exceptions import WorkflowInitializationException
 from vellum.workflows.outputs.base import BaseOutputs
+from vellum.workflows.references.constant import ConstantValueReference
+
+if TYPE_CHECKING:
+    from vellum.workflows import BaseWorkflow
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class _RawLogicalCondition(UniversalBaseModel):
+    type: Literal["LOGICAL_CONDITION"] = "LOGICAL_CONDITION"
+    lhs_variable_id: UUID
+    operator: Literal["==", ">", ">=", "<", "<=", "!="]
+    rhs_variable_id: UUID
+
+
+class _RawLogicalConditionGroup(UniversalBaseModel):
+    type: Literal["LOGICAL_CONDITION_GROUP"] = "LOGICAL_CONDITION_GROUP"
+    conditions: List["_RawLogicalExpression"]
+    combinator: Literal["AND", "OR"]
+    negated: bool
+
+
+_RawLogicalExpression = Union[_RawLogicalCondition, _RawLogicalConditionGroup]
+
+
+class _RawLogicalExpressionVariable(UniversalBaseModel):
+    id: UUID
+
+
+class _RawMockWorkflowNodeExecutionConstantValuePointer(_RawLogicalExpressionVariable):
+    type: Literal["CONSTANT_VALUE"] = "CONSTANT_VALUE"
+    variable_value: VellumValue
+
+
+class _RawMockWorkflowNodeExecutionNodeExecutionCounterPointer(_RawLogicalExpressionVariable):
+    type: Literal["EXECUTION_COUNTER"] = "EXECUTION_COUNTER"
+    node_id: UUID
+
+
+class _RawMockWorkflowNodeExecutionInputVariablePointer(_RawLogicalExpressionVariable):
+    type: Literal["INPUT_VARIABLE"] = "INPUT_VARIABLE"
+    input_variable_id: UUID
+
+
+class _RawMockWorkflowNodeExecutionNodeOutputPointer(_RawLogicalExpressionVariable):
+    type: Literal["NODE_OUTPUT"] = "NODE_OUTPUT"
+    node_id: UUID
+    input_id: UUID
+
+
+class _RawMockWorkflowNodeExecutionNodeInputPointer(_RawLogicalExpressionVariable):
+    type: Literal["NODE_INPUT"] = "NODE_INPUT"
+    node_id: UUID
+    input_id: UUID
+
+
+_RawMockWorkflowNodeExecutionValuePointer = Union[
+    _RawMockWorkflowNodeExecutionConstantValuePointer,
+    _RawMockWorkflowNodeExecutionNodeExecutionCounterPointer,
+    _RawMockWorkflowNodeExecutionInputVariablePointer,
+    _RawMockWorkflowNodeExecutionNodeOutputPointer,
+    _RawMockWorkflowNodeExecutionNodeInputPointer,
+]
+
+
+class _RawMockWorkflowNodeWhenCondition(UniversalBaseModel):
+    expression: _RawLogicalExpression
+    variables: List[_RawMockWorkflowNodeExecutionValuePointer]
+
+
+class _RawMockWorkflowNodeThenOutput(UniversalBaseModel):
+    output_id: UUID
+    value: _RawMockWorkflowNodeExecutionValuePointer
+
+
+class _RawMockWorkflowNodeExecution(UniversalBaseModel):
+    when_condition: _RawMockWorkflowNodeWhenCondition
+    then_outputs: List[_RawMockWorkflowNodeThenOutput]
+
+
+class _RawMockWorkflowNodeConfig(UniversalBaseModel):
+    type: Literal["WORKFLOW_NODE_OUTPUT"] = "WORKFLOW_NODE_OUTPUT"
+    node_id: UUID
+    mock_executions: List[_RawMockWorkflowNodeExecution]
 
 
 class MockNodeExecution(UniversalBaseModel):
@@ -12,6 +104,138 @@ class MockNodeExecution(UniversalBaseModel):
     then_outputs: BaseOutputs
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @staticmethod
+    def validate_all(
+        raw_mock_workflow_node_configs: List[Any],
+        workflow: Type["BaseWorkflow"],
+    ) -> List["MockNodeExecution"]:
+        ArrayVellumValue.model_rebuild()
+        try:
+            mock_workflow_node_configs = [
+                _RawMockWorkflowNodeConfig.model_validate(raw_mock_workflow_node_config)
+                for raw_mock_workflow_node_config in raw_mock_workflow_node_configs
+            ]
+        except ValidationError as e:
+            raise WorkflowInitializationException(
+                message="Failed to validate mock node executions",
+                code=WorkflowErrorCode.INVALID_INPUTS,
+            ) from e
+
+        nodes = {node.__id__: node for node in workflow.get_nodes()}
+        node_output_name_by_id = {
+            output.__id__: output.name for node in workflow.get_nodes() for output in node.Outputs
+        }
+
+        # We need to support the old way that the Vellum App's WorkflowRunner used to define Node Mocks in order to
+        # avoid needing to update the mock resolution strategy that it and the frontend uses. The path towards
+        # cleaning this up will go as follows:
+        # 1. Release Mock support in SDK-Enabled Workflows
+        # 2. Deprecate Mock support in non-SDK enabled Workflows, encouraging users to migrate to SDK-enabled Workflows
+        # 3. Remove the old mock resolution strategy
+        # 4. Update this SDK to handle the new mock resolution strategy with WorkflowValueDescriptors
+        # 5. Cutover the Vellum App to the new mock resolution strategy
+        # 6. Remove the old mock resolution strategy from this SDK
+        def _translate_raw_logical_expression(
+            raw_logical_expression: _RawLogicalExpression,
+            raw_variables: List[_RawMockWorkflowNodeExecutionValuePointer],
+        ) -> BaseDescriptor:
+            if raw_logical_expression.type == "LOGICAL_CONDITION":
+                return _translate_raw_logical_condition(raw_logical_expression, raw_variables)
+            else:
+                return _translate_raw_logical_condition_group(raw_logical_expression, raw_variables)
+
+        def _translate_raw_logical_condition_group(
+            raw_logical_condition_group: _RawLogicalConditionGroup,
+            raw_variables: List[_RawMockWorkflowNodeExecutionValuePointer],
+        ) -> BaseDescriptor:
+            if not raw_logical_condition_group.conditions:
+                return ConstantValueReference(True)
+
+            conditions = [
+                _translate_raw_logical_expression(condition, raw_variables)
+                for condition in raw_logical_condition_group.conditions
+            ]
+            return reduce(
+                lambda acc, condition: (
+                    acc and condition if raw_logical_condition_group.combinator == "AND" else acc or condition
+                ),
+                conditions,
+            )
+
+        def _translate_raw_logical_condition(
+            raw_logical_condition: _RawLogicalCondition,
+            raw_variables: List[_RawMockWorkflowNodeExecutionValuePointer],
+        ) -> BaseDescriptor:
+            variable_by_id = {v.id: v for v in raw_variables}
+            lhs = _translate_raw_logical_expression_variable(variable_by_id[raw_logical_condition.lhs_variable_id])
+            rhs = _translate_raw_logical_expression_variable(variable_by_id[raw_logical_condition.rhs_variable_id])
+            if raw_logical_condition.operator == ">":
+                return lhs.greater_than(rhs)
+            elif raw_logical_condition.operator == ">=":
+                return lhs.greater_than_or_equal_to(rhs)
+            elif raw_logical_condition.operator == "<":
+                return lhs.less_than(rhs)
+            elif raw_logical_condition.operator == "<=":
+                return lhs.less_than_or_equal_to(rhs)
+            elif raw_logical_condition.operator == "==":
+                return lhs.equals(rhs)
+            elif raw_logical_condition.operator == "!=":
+                return lhs.does_not_equal(rhs)
+            else:
+                raise WorkflowInitializationException(f"Unsupported logical operator: {raw_logical_condition.operator}")
+
+        def _translate_raw_logical_expression_variable(
+            raw_variable: _RawMockWorkflowNodeExecutionValuePointer,
+        ) -> BaseDescriptor:
+            if raw_variable.type == "CONSTANT_VALUE":
+                return ConstantValueReference(raw_variable.variable_value.value)
+            elif raw_variable.type == "EXECUTION_COUNTER":
+                node = nodes[raw_variable.node_id]
+                return node.Execution.count
+            else:
+                raise WorkflowInitializationException(f"Unsupported logical expression type: {raw_variable.type}")
+
+        mock_node_executions = []
+        for mock_workflow_node_config in mock_workflow_node_configs:
+            for mock_execution in mock_workflow_node_config.mock_executions:
+                try:
+                    when_condition = _translate_raw_logical_expression(
+                        mock_execution.when_condition.expression,
+                        mock_execution.when_condition.variables,
+                    )
+
+                    then_outputs = nodes[mock_workflow_node_config.node_id].Outputs()
+                    for then_output in mock_execution.then_outputs:
+                        node_output_name = node_output_name_by_id.get(then_output.output_id)
+                        if node_output_name is None:
+                            raise WorkflowInitializationException(
+                                f"Output {then_output.output_id} not found in node {mock_workflow_node_config.node_id}"
+                            )
+
+                        resolved_output_reference = _translate_raw_logical_expression_variable(then_output.value)
+                        if isinstance(resolved_output_reference, ConstantValueReference):
+                            setattr(
+                                then_outputs,
+                                node_output_name,
+                                resolved_output_reference._value,
+                            )
+                        else:
+                            raise WorkflowInitializationException(
+                                f"Unsupported resolved output reference type: {type(resolved_output_reference)}"
+                            )
+
+                    mock_node_executions.append(
+                        MockNodeExecution(
+                            when_condition=when_condition,
+                            then_outputs=then_outputs,
+                        )
+                    )
+                except Exception as e:
+                    logger.exception("Failed to validate mock node execution", exc_info=e)
+                    continue
+
+        return mock_node_executions
 
 
 MockNodeExecutionArg = Sequence[Union[BaseOutputs, MockNodeExecution]]

--- a/src/vellum/workflows/nodes/tests/test_mocks.py
+++ b/src/vellum/workflows/nodes/tests/test_mocks.py
@@ -1,0 +1,89 @@
+from vellum.client.types.string_vellum_value import StringVellumValue
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes import InlinePromptNode
+from vellum.workflows.nodes.mocks import MockNodeExecution
+
+
+def test_mocks__parse_from_app():
+    # GIVEN a PromptNode
+    class PromptNode(InlinePromptNode):
+        pass
+
+    # AND a workflow class with that PromptNode
+    class MyWorkflow(BaseWorkflow):
+        graph = PromptNode
+
+    # AND a mock workflow node execution from the app
+    raw_mock_workflow_node_execution = [
+        {
+            "type": "WORKFLOW_NODE_OUTPUT",
+            "node_id": str(PromptNode.__id__),
+            "mock_executions": [
+                {
+                    "when_condition": {
+                        "expression": {
+                            "type": "LOGICAL_CONDITION_GROUP",
+                            "combinator": "AND",
+                            "negated": False,
+                            "conditions": [
+                                {
+                                    "type": "LOGICAL_CONDITION",
+                                    "lhs_variable_id": "e60902d5-6892-4916-80c1-f0130af52322",
+                                    "operator": ">=",
+                                    "rhs_variable_id": "5c1bbb24-c288-49cb-a9b7-0c6f38a86037",
+                                }
+                            ],
+                        },
+                        "variables": [
+                            {
+                                "type": "EXECUTION_COUNTER",
+                                "node_id": str(PromptNode.__id__),
+                                "id": "e60902d5-6892-4916-80c1-f0130af52322",
+                            },
+                            {
+                                "type": "CONSTANT_VALUE",
+                                "variable_value": {"type": "NUMBER", "value": 0},
+                                "id": "5c1bbb24-c288-49cb-a9b7-0c6f38a86037",
+                            },
+                        ],
+                    },
+                    "then_outputs": [
+                        {
+                            "output_id": "9e6dc5d3-8ea0-4346-8a2a-7cce5495755b",
+                            "value": {
+                                "id": "27006b2a-fa81-430c-a0b2-c66a9351fc68",
+                                "type": "CONSTANT_VALUE",
+                                "variable_value": {"type": "STRING", "value": "Hello"},
+                            },
+                        },
+                        {
+                            "output_id": "60305ffd-60b0-42aa-b54e-4fdae0f8c28a",
+                            "value": {
+                                "id": "4559c778-6e27-4cfe-a460-734ba62a5082",
+                                "type": "CONSTANT_VALUE",
+                                "variable_value": {"type": "ARRAY", "value": [{"type": "STRING", "value": "Hello"}]},
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+    ]
+
+    # WHEN we parse the mock workflow node execution
+    mock_node_execution = MockNodeExecution.validate_all(
+        raw_mock_workflow_node_execution,
+        MyWorkflow,
+    )
+
+    # THEN we get a list of MockNodeExecution objects
+    assert len(mock_node_execution) == 1
+    assert mock_node_execution[0] == MockNodeExecution(
+        when_condition=PromptNode.Execution.count.greater_than_or_equal_to(0.0),
+        then_outputs=PromptNode.Outputs(
+            text="Hello",
+            results=[
+                StringVellumValue(value="Hello"),
+            ],
+        ),
+    )

--- a/src/vellum/workflows/nodes/tests/test_mocks.py
+++ b/src/vellum/workflows/nodes/tests/test_mocks.py
@@ -1,6 +1,7 @@
 from vellum.client.types.string_vellum_value import StringVellumValue
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.nodes import InlinePromptNode
+from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.mocks import MockNodeExecution
 
 
@@ -71,14 +72,15 @@ def test_mocks__parse_from_app():
     ]
 
     # WHEN we parse the mock workflow node execution
-    mock_node_execution = MockNodeExecution.validate_all(
+    node_output_mocks = MockNodeExecution.validate_all(
         raw_mock_workflow_node_execution,
         MyWorkflow,
     )
 
     # THEN we get a list of MockNodeExecution objects
-    assert len(mock_node_execution) == 1
-    assert mock_node_execution[0] == MockNodeExecution(
+    assert node_output_mocks
+    assert len(node_output_mocks) == 1
+    assert node_output_mocks[0] == MockNodeExecution(
         when_condition=PromptNode.Execution.count.greater_than_or_equal_to(0.0),
         then_outputs=PromptNode.Outputs(
             text="Hello",
@@ -87,3 +89,30 @@ def test_mocks__parse_from_app():
             ],
         ),
     )
+
+
+def test_mocks__parse_none_still_runs():
+    # GIVEN a Base Node
+    class StartNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            foo: str
+
+    # AND a workflow class with that Node
+    class MyWorkflow(BaseWorkflow):
+        graph = StartNode
+
+        class Outputs(BaseWorkflow.Outputs):
+            final_value = StartNode.Outputs.foo
+
+    # AND we parsed `None` on `MockNodeExecution`
+    node_output_mocks = MockNodeExecution.validate_all(
+        None,
+        MyWorkflow,
+    )
+
+    # WHEN we run the workflow
+    workflow = MyWorkflow()
+    final_event = workflow.run(node_output_mocks=node_output_mocks)
+
+    # THEN it was successful
+    assert final_event.name == "workflow.execution.fulfilled"

--- a/src/vellum/workflows/outputs/base.py
+++ b/src/vellum/workflows/outputs/base.py
@@ -201,7 +201,7 @@ class BaseOutputs(metaclass=_BaseOutputsMeta):
             self._outputs_post_init(**kwargs)
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, dict):
+        if not isinstance(other, (dict, BaseOutputs)):
             return super().__eq__(other)
 
         outputs = {ref.name: value for ref, value in self if value is not undefined}

--- a/src/vellum/workflows/references/output.py
+++ b/src/vellum/workflows/references/output.py
@@ -6,6 +6,7 @@ from pydantic_core import core_schema
 
 from vellum.workflows.constants import undefined
 from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.utils.uuids import uuid4_from_hash
 
 if TYPE_CHECKING:
     from vellum.workflows.outputs import BaseOutputs
@@ -26,6 +27,17 @@ class OutputReference(BaseDescriptor[_OutputType], Generic[_OutputType]):
     ) -> None:
         super().__init__(name=name, types=types, instance=instance)
         self._outputs_class = outputs_class
+
+        if hasattr(outputs_class, "_node_class"):
+            node_class = getattr(outputs_class, "_node_class")
+            if hasattr(node_class, "__id__"):
+                node_id = getattr(node_class, "__id__")
+            else:
+                node_id = uuid4_from_hash(f"{node_class.__qualname__}")
+
+            self.__id__ = uuid4_from_hash(f"{node_id}|{name}")
+        else:
+            self.__id__ = uuid4_from_hash(f"{outputs_class.__qualname__}|{name}")
 
     @property
     def outputs_class(self) -> Type["BaseOutputs"]:


### PR DESCRIPTION
For context, check out this PR in our Workflow Server for how we anticipate using this function: https://github.com/vellum-ai/vembda-service/pull/154

I view this PR as the quickest path to solving Node Output Mocks in the SDK that doesn't involve making big legacy workflow runner changes + data migrations. We parse the raw json that the FE/Django maintains today, and translate it into our SDK native shape. We also outline a migration path that allows us to delete mock support in old workflows and only support in SDK workflows, incentivizing more gradual adoption.

Still TODO:
- Support using output ids reassigned by output display classes
- Cut a release to merge the Vembda PR