### PR TITLE
[SC-6974] Resile missing URL field in ApiNode to default empty string

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -149,6 +149,15 @@ class APINode(BaseAPINode):
 "
 `;
 
+exports[`ApiNode > basic api node > should handle missing url field gracefully 1`] = `
+"from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = ""
+"
+`;
+
 exports[`ApiNode > basic api node > should not generate body field when body is empty 1`] = `
 "from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -108,6 +108,66 @@ describe("ApiNode", () => {
   };
 
   describe("basic api node", () => {
+    it("should handle missing url field gracefully", async () => {
+      // GIVEN a node without a url field
+      const inputs: NodeInput[] = [
+        {
+          id: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          key: "method",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE" as const,
+                data: {
+                  type: "STRING" as const,
+                  value: "GET",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        // url input is missing
+        {
+          id: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          key: "body",
+          value: {
+            rules: [],
+            combinator: "OR",
+          },
+        },
+      ];
+
+      const nodeData: ApiNodeType = {
+        id: "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
+        type: "API",
+        data: {
+          label: "API Node",
+          methodInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
+          urlInputId: "480a4c12-22d6-4223-a38a-85db5eda118c",
+          bodyInputId: "74865eb7-cdaf-4d40-a499-0a6505e72680",
+          textOutputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
+          jsonOutputId: "af576eaa-d39d-4c19-8992-1f01a65a709a",
+          statusCodeOutputId: "69250713-617d-42a4-9326-456c70d0ef20",
+          targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
+          sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
+        },
+        inputs: inputs,
+      };
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
     it("should only generate url field", async () => {
       // GIVEN a node with only url and GET method
       const inputs: NodeInput[] = [

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -14,16 +14,10 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
     const statements: AstNode[] = [];
 
     const urlInput = this.nodeInputsByKey.get("url");
-    if (!urlInput) {
-      throw new NodeAttributeGenerationError(
-        'Node input "url" is required but not found.'
-      );
-    }
-
     statements.push(
       python.field({
         name: "url",
-        initializer: urlInput,
+        initializer: urlInput || python.TypeInstantiation.str(""),
       })
     );
 


### PR DESCRIPTION
sc: https://app.shortcut.com/vellum/story/6974/make-codegen-resilient-to-missing-url-field-on-api-node

Set url as empty string `""` if not given in API node