### PR TITLE
Add support for handling duplicate port names in NodePorts

### DIFF
--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/node-ports.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/node-ports.test.ts.snap
@@ -7,6 +7,14 @@ exports[`NodePorts > basic > generates correct ports class 1`] = `
 "
 `;
 
+exports[`NodePorts > basic duplicate port names > handles duplicate port names correctly 1`] = `
+"class Ports(BaseNode.Ports):
+    same_port_name = Port.on_if("test-value-1")
+    same_port_name_1 = Port.on_elif("test-value-2")
+    unique_name = Port.on_else(None)
+"
+`;
+
 exports[`NodePorts > basic with nested expression in port > generates correct ports class 1`] = `
 "class Ports(BaseNode.Ports):
     if_port = Port.on_if(Inputs.count.is_null())

--- a/ee/codegen/src/__test__/nodes/generic-nodes/node-ports.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/node-ports.test.ts
@@ -141,7 +141,7 @@ describe("NodePorts", () => {
   });
   describe("basic duplicate port names", () => {
     beforeEach(async () => {
-      // Create ports with the same name
+      // GIVEN a node with duplicate port names
       const duplicateName = "same port name";
       const nodePortsData: NodePort[] = [
         nodePortFactory({
@@ -157,7 +157,7 @@ describe("NodePorts", () => {
         }),
         nodePortFactory({
           type: "ELIF",
-          name: duplicateName, // Same name as the first port
+          name: duplicateName,
           expression: {
             type: "CONSTANT_VALUE",
             value: {

--- a/ee/codegen/src/__test__/nodes/generic-nodes/node-ports.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/node-ports.test.ts
@@ -139,4 +139,59 @@ describe("NodePorts", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });
+  describe("basic duplicate port names", () => {
+    beforeEach(async () => {
+      // Create ports with the same name
+      const duplicateName = "same port name";
+      const nodePortsData: NodePort[] = [
+        nodePortFactory({
+          type: "IF",
+          name: duplicateName,
+          expression: {
+            type: "CONSTANT_VALUE",
+            value: {
+              type: "STRING",
+              value: "test-value-1",
+            },
+          },
+        }),
+        nodePortFactory({
+          type: "ELIF",
+          name: duplicateName, // Same name as the first port
+          expression: {
+            type: "CONSTANT_VALUE",
+            value: {
+              type: "STRING",
+              value: "test-value-2",
+            },
+          },
+        }),
+        nodePortFactory({
+          type: "ELSE",
+          name: "unique_name",
+        }),
+      ];
+
+      const nodeData = genericNodeFactory({
+        label: "GenericNodeWithDuplicatePorts",
+        nodePorts: nodePortsData,
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as GenericNodeContext;
+
+      nodePorts = new NodePorts({
+        nodePorts: nodePortsData,
+        nodeContext,
+        workflowContext,
+      });
+    });
+
+    it("handles duplicate port names correctly", async () => {
+      nodePorts.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });

--- a/ee/codegen/src/generators/node-port.ts
+++ b/ee/codegen/src/generators/node-port.ts
@@ -9,7 +9,6 @@ import {
   NodePort as NodePortType,
   WorkflowValueDescriptor as WorkflowValueDescriptorType,
 } from "src/types/vellum";
-import { toPythonSafeSnakeCase } from "src/utils/casing";
 import { assertUnreachable, isNilOrEmpty } from "src/utils/typing";
 
 export declare namespace NodePorts {
@@ -51,7 +50,7 @@ export class NodePorts extends AstNode {
       if (portExpression) {
         fields.push(
           python.field({
-            name: toPythonSafeSnakeCase(port.name),
+            name: this.nodeContext.generateSanitizedPortName(port.name),
             initializer: portExpression,
           })
         );


### PR DESCRIPTION
follow up for https://github.com/vellum-ai/vellum-python-sdks/pull/1099

Deduplicate port name when they are same