### PR TITLE
Solve Internal Server Error initiated by Map Node index access

### DIFF
--- a/src/vellum/workflows/nodes/core/map_node/node.py
+++ b/src/vellum/workflows/nodes/core/map_node/node.py
@@ -107,11 +107,17 @@ class MapNode(BaseAdornmentNode[StateType], Generic[StateType, MapNodeItemType])
                 subworkflow_event = map_node_event[1]
                 self._context._emit_subworkflow_event(subworkflow_event)
 
-                if subworkflow_event.name == "workflow.execution.initiated":
+                if (
+                    subworkflow_event.name == "workflow.execution.initiated"
+                    and subworkflow_event.workflow_definition == self.subworkflow
+                ):
                     for output_name in mapped_items.keys():
                         yield BaseOutput(name=output_name, delta=(None, index, "INITIATED"))
 
-                elif subworkflow_event.name == "workflow.execution.fulfilled":
+                elif (
+                    subworkflow_event.name == "workflow.execution.fulfilled"
+                    and subworkflow_event.workflow_definition == self.subworkflow
+                ):
                     for output_reference, output_value in subworkflow_event.outputs:
                         if not isinstance(output_reference, OutputReference):
                             logger.error(

--- a/src/vellum/workflows/nodes/core/map_node/node.py
+++ b/src/vellum/workflows/nodes/core/map_node/node.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import logging
 from queue import Empty, Queue
 from threading import Thread
 from typing import (
@@ -32,6 +33,8 @@ from vellum.workflows.workflows.event_filters import all_workflow_event_filter
 
 if TYPE_CHECKING:
     from vellum.workflows.events.workflow import WorkflowEvent
+
+logger = logging.getLogger(__name__)
 
 MapNodeItemType = TypeVar("MapNodeItemType")
 
@@ -109,14 +112,25 @@ class MapNode(BaseAdornmentNode[StateType], Generic[StateType, MapNodeItemType])
                         yield BaseOutput(name=output_name, delta=(None, index, "INITIATED"))
 
                 elif subworkflow_event.name == "workflow.execution.fulfilled":
-                    workflow_output_vars = vars(subworkflow_event.outputs)
+                    for output_reference, output_value in subworkflow_event.outputs:
+                        if not isinstance(output_reference, OutputReference):
+                            logger.error(
+                                "Invalid key to map node's subworkflow event outputs",
+                                extra={"output_reference_type": type(output_reference)},
+                            )
+                            continue
 
-                    for output_name in workflow_output_vars:
-                        output_mapped_items = mapped_items[output_name]
-                        output_mapped_items[index] = workflow_output_vars[output_name]
+                        output_mapped_items = mapped_items[output_reference.name]
+                        if index < 0 or index >= len(output_mapped_items):
+                            logger.error(
+                                "Invalid map node index", extra={"index": index, "output_name": output_reference.name}
+                            )
+                            continue
+
+                        output_mapped_items[index] = output_value
                         yield BaseOutput(
-                            name=output_name,
-                            delta=(output_mapped_items[index], index, "FULFILLED"),
+                            name=output_reference.name,
+                            delta=(output_value, index, "FULFILLED"),
                         )
 
                     fulfilled_iterations[index] = True


### PR DESCRIPTION
Here is the sentry error I was debugging: https://vellum.sentry.io/issues/6360534819/?alert_rule_id=15639643&alert_type=issue&notification_uuid=5d198d7e-0177-433f-8a37-405afcfc54e8&project=4508362683514880

The bug was that map node was confusing workflow events from internal subworkflows as its own. We likely have this issue with all subworkflowable nodes, so will follow up this PR with tests/fixes for those nodes as well