### PR TITLE
Fix bug with nested try nodes

### DIFF
--- a/src/vellum/workflows/events/workflow.py
+++ b/src/vellum/workflows/events/workflow.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 from typing import TYPE_CHECKING, Any, Dict, Generator, Generic, Iterable, Literal, Optional, Type, Union
+from typing_extensions import TypeGuard
 
 from pydantic import field_serializer
 
@@ -182,3 +183,25 @@ WorkflowEvent = Union[
 ]
 
 WorkflowEventStream = Generator[WorkflowEvent, None, None]
+
+WorkflowExecutionEvent = Union[
+    WorkflowExecutionInitiatedEvent,
+    WorkflowExecutionStreamingEvent,
+    WorkflowExecutionRejectedEvent,
+    WorkflowExecutionPausedEvent,
+    WorkflowExecutionResumedEvent,
+    WorkflowExecutionFulfilledEvent,
+    WorkflowExecutionSnapshottedEvent,
+]
+
+
+def is_workflow_event(event: WorkflowEvent) -> TypeGuard[WorkflowExecutionEvent]:
+    return (
+        event.name == "workflow.execution.initiated"
+        or event.name == "workflow.execution.fulfilled"
+        or event.name == "workflow.execution.streaming"
+        or event.name == "workflow.execution.snapshotted"
+        or event.name == "workflow.execution.paused"
+        or event.name == "workflow.execution.resumed"
+        or event.name == "workflow.execution.rejected"
+    )

--- a/src/vellum/workflows/nodes/core/try_node/node.py
+++ b/src/vellum/workflows/nodes/core/try_node/node.py
@@ -2,6 +2,7 @@ from typing import Callable, Generic, Iterator, Optional, Set, Type
 
 from vellum.workflows.context import execution_context, get_parent_context
 from vellum.workflows.errors.types import WorkflowError, WorkflowErrorCode
+from vellum.workflows.events.workflow import is_workflow_event
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.bases.base_adornment_node import BaseAdornmentNode
@@ -45,6 +46,12 @@ class TryNode(BaseAdornmentNode[StateType], Generic[StateType]):
         for event in subworkflow_stream:
             self._context._emit_subworkflow_event(event)
             if exception:
+                continue
+
+            if not is_workflow_event(event):
+                continue
+
+            if event.workflow_definition != self.subworkflow:
                 continue
 
             if event.name == "workflow.execution.streaming":


### PR DESCRIPTION
Noticed in this PR: https://github.com/vellum-ai/vellum-python-sdks/pull/1118 that we are erroneously treating nested workflow events as the parent event.

This PR fixes it for Try Nodes. Next two PRs fixes for Retry and Inline Subworkflow Nodes