### PR TITLE
Fix bug related to nested subworkflows inside a subworkflow node

### DIFF
--- a/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
+++ b/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generic, Iterator, Option
 from vellum.workflows.constants import undefined
 from vellum.workflows.context import execution_context, get_parent_context
 from vellum.workflows.errors.types import WorkflowErrorCode
+from vellum.workflows.events.workflow import is_workflow_event
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode, BaseNodeMeta
@@ -86,6 +87,12 @@ class InlineSubworkflowNode(
 
         for event in subworkflow_stream:
             self._context._emit_subworkflow_event(event)
+
+            if not is_workflow_event(event):
+                continue
+            if event.workflow_definition != self.subworkflow:
+                continue
+
             if event.name == "workflow.execution.streaming":
                 if event.output.is_fulfilled:
                     fulfilled_output_names.add(event.output.name)

--- a/src/vellum/workflows/nodes/core/inline_subworkflow_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/core/inline_subworkflow_node/tests/test_node.py
@@ -3,6 +3,7 @@ import pytest
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.inline_subworkflow_node.node import InlineSubworkflowNode
+from vellum.workflows.nodes.core.try_node.node import TryNode
 from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.state.base import BaseState
 from vellum.workflows.workflows.base import BaseWorkflow
@@ -55,3 +56,34 @@ def test_inline_subworkflow_node__support_inputs_as_attributes():
     assert events == [
         BaseOutput(name="out", value="bar"),
     ]
+
+
+def test_inline_subworkflow_node__nested_try():
+    """
+    Ensure that the nested try node doesn't affect the subworkflow node's outputs
+    """
+
+    # GIVEN a nested try node
+    @TryNode.wrap()
+    class InnerNode(BaseNode):
+        class Outputs:
+            foo = "hello"
+
+    # AND a subworkflow
+    class Subworkflow(BaseWorkflow):
+        graph = InnerNode
+
+        class Outputs(BaseWorkflow.Outputs):
+            bar = InnerNode.Outputs.foo
+
+    # AND an outer try node referencing that subworkflow
+    class OuterNode(InlineSubworkflowNode):
+        subworkflow = Subworkflow
+
+    # WHEN we run the try node
+    stream = OuterNode().run()
+    events = list(stream)
+
+    # THEN we only have the outer node's outputs
+    valid_events = [e for e in events if e.name == "bar"]
+    assert len(valid_events) == len(events)


### PR DESCRIPTION
Continuing the work from here: https://github.com/vellum-ai/vellum-python-sdks/pull/1119, but now for inline subworkflow nodes. Last PR in the series will be retry node