### PR TITLE
[WRK-4] Add support for adornments in inline subworkflow nodes

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1652,9 +1652,11 @@ export function mapNodeDataFactory({
 export function inlineSubworkflowNodeDataFactory({
   label,
   nodes,
+  adornments,
 }: {
   label?: string;
   nodes?: Array<WorkflowDataNode>;
+  adornments?: AdornmentNode[];
 } = {}): SubworkflowNode {
   const entrypoint = entrypointNodeDataFactory();
   const templatingNode = templatingNodeFactory();
@@ -1694,5 +1696,6 @@ export function inlineSubworkflowNodeDataFactory({
       targetHandleId: "3fe4b4a6-5ed2-4307-ac1c-02389337c4f2",
     },
     inputs: [],
+    ...(adornments && { adornments }),
   };
 }

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -1,5 +1,49 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`InlineSubworkflowNode > adornments > should generate adornments 1`] = `
+"from vellum.workflows.nodes.core.retry_node.node import RetryNode
+from vellum.workflows.nodes.displayable import InlineSubworkflowNode
+
+from .workflow import MyNodeWorkflow
+
+
+@RetryNode.wrap(max_attempts=3, delay=2)
+class MyNode(InlineSubworkflowNode):
+    subworkflow = MyNodeWorkflow
+"
+`;
+
+exports[`InlineSubworkflowNode > adornments > should generate adornments 2`] = `
+"# flake8: noqa: F401, F403
+
+from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay, BaseRetryNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ....nodes.my_node import MyNode
+from .nodes import *
+from .workflow import *
+
+
+@BaseRetryNodeDisplay.wrap(max_attempts=3, delay=2)
+class MyNodeDisplay(BaseInlineSubworkflowNodeDisplay[MyNode]):
+    label = "My node"
+    node_id = UUID("14fee4a0-ad25-402f-b942-104d3a5a0824")
+    target_handle_id = UUID("3fe4b4a6-5ed2-4307-ac1c-02389337c4f2")
+    workflow_input_ids_by_name = {}
+    node_input_ids_by_name = {}
+    output_display = {
+        MyNode.Outputs.final_output: NodeOutputDisplay(
+            id=UUID("edd5cfd5-6ad8-437d-8775-4b9aeb62a5fb"), name="final-output"
+        )
+    }
+    port_displays = {MyNode.Ports.default: PortDisplayOverrides(id=UUID("4878f525-d4a3-4e3d-9221-e146f282a96a"))}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None)
+"
+`;
+
 exports[`InlineSubworkflowNode > basic > inline subworkflow node display file 1`] = `
 "# flake8: noqa: F401, F403
 

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -752,27 +752,6 @@ export declare namespace SubworkflowNodeDataSerializer {
     | DeploymentSubworkflowNodeDataSerializer.Raw;
 }
 
-export const SubworkflowNodeSerializer: ObjectSchema<
-  SubworkflowNodeSerializer.Raw,
-  Omit<SubworkflowNode, "type">
-> = objectSchema({
-  id: stringSchema(),
-  data: SubworkflowNodeDataSerializer,
-  inputs: listSchema(NodeInputSerializer),
-  displayData: propertySchema(
-    "display_data",
-    NodeDisplayDataSerializer.optional()
-  ),
-  base: CodeResourceDefinitionSerializer.optional(),
-  definition: CodeResourceDefinitionSerializer.optional(),
-});
-
-export declare namespace SubworkflowNodeSerializer {
-  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
-    data: SubworkflowNodeDataSerializer.Raw;
-  }
-}
-
 export const InlinePromptNodeDataSerializer: ObjectSchema<
   InlinePromptNodeDataSerializer.Raw,
   Omit<InlinePromptNodeData, "variant">
@@ -1935,6 +1914,28 @@ export const PromptNodeSerializer: ObjectSchema<
 export declare namespace PromptNodeSerializer {
   interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     data: PromptNodeDataSerializer.Raw;
+  }
+}
+
+export const SubworkflowNodeSerializer: ObjectSchema<
+  SubworkflowNodeSerializer.Raw,
+  Omit<SubworkflowNode, "type">
+> = objectSchema({
+  id: stringSchema(),
+  data: SubworkflowNodeDataSerializer,
+  inputs: listSchema(NodeInputSerializer),
+  displayData: propertySchema(
+    "display_data",
+    NodeDisplayDataSerializer.optional()
+  ),
+  base: CodeResourceDefinitionSerializer.optional(),
+  definition: CodeResourceDefinitionSerializer.optional(),
+  adornments: listSchema(AdornmentNodeSerializer).optional(),
+});
+
+export declare namespace SubworkflowNodeSerializer {
+  interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
+    data: SubworkflowNodeDataSerializer.Raw;
   }
 }
 


### PR DESCRIPTION
Retry Nodes fail to generate when wrapping Inline Subworkflows

test workflow: 3224375e-e94c-459d-b97c-5b70c5fc5fce

<img width="787" alt="Screenshot 2025-03-09 at 6 30 27 PM" src="https://github.com/user-attachments/assets/275727ad-4929-4be8-abf4-cfd55a853932" />
<img width="787" alt="Screenshot 2025-03-09 at 6 30 35 PM" src="https://github.com/user-attachments/assets/fb82d7c2-7601-479b-881d-fe0a06be1d99" />
