### PR TITLE
Return output ids in event display contexts without needing a display class defined

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
+++ b/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
@@ -2,6 +2,7 @@ import types
 from typing import TYPE_CHECKING, Optional, Type
 
 from vellum.workflows.types.generics import NodeType
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.types import NodeDisplayType
@@ -29,4 +30,12 @@ def get_node_display_class(
         f"{node_class.__name__}Display",
         bases=(NodeDisplayBaseClass,),
     )
+    output_display = {
+        ref: NodeOutputDisplay(id=node_class.__output_ids__[ref.name], name=ref.name)
+        for ref in node_class.Outputs
+        if ref.name in node_class.__output_ids__
+    }
+    if output_display:
+        setattr(NodeDisplayClass, "output_display", output_display)
+
     return NodeDisplayClass

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -411,7 +411,7 @@ class BaseWorkflowDisplay(
             input_display = {}
             if isinstance(current_node_display, BaseNodeVellumDisplay):
                 input_display = current_node_display.node_input_ids_by_name
-            node_display_meta = {
+            output_display = {
                 output.name: current_node_display.output_display[output].id
                 for output in current_node_display.output_display
             }
@@ -434,7 +434,7 @@ class BaseWorkflowDisplay(
 
             node_event_displays[node_id] = NodeEventDisplayContext(
                 input_display=input_display,
-                output_display=node_display_meta,
+                output_display=output_display,
                 port_display=port_display_meta,
                 subworkflow_display=subworkflow_display_context,
             )

--- a/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
@@ -95,6 +95,26 @@ def test_serialize_workflow__node_display_class_not_registered():
     assert data is not None
 
 
+def test_get_event_display_context__node_display_filled_without_base_display():
+    # GIVEN a simple workflow
+    class StartNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            foo: str
+
+    class MyWorkflow(BaseWorkflow):
+        graph = StartNode
+
+    # WHEN we gather the event display context
+    display_context = VellumWorkflowDisplay(MyWorkflow).get_event_display_context()
+
+    # THEN the node display should be included
+    assert str(StartNode.__id__) in display_context.node_displays
+    node_event_display = display_context.node_displays[str(StartNode.__id__)]
+
+    # AND so should their output ids
+    assert StartNode.__output_ids__ == node_event_display.output_display
+
+
 def test_get_event_display_context__node_display_to_include_subworkflow_display():
     # GIVEN a simple workflow
     class InnerNode(BaseNode):


### PR DESCRIPTION
This allows Generic Nodes to show outputs after being pushed to vellum