### PR TITLE
Custom class comments

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -237,3 +237,32 @@ class Workflow(BaseWorkflow):
     graph = TemplatingNode
 "
 `;
+
+exports[`WorkflowProjectGenerator > should escape special characters > should correctly handle multi-line comments 1`] = `
+"from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
+from vellum.workflows.state import BaseState
+
+
+class TemplatingNode(BaseTemplatingNode[BaseState, str]):
+    """
+    "Hello"
+    "World"
+    """
+
+    template = """test template"""
+    inputs = {}
+"
+`;
+
+exports[`WorkflowProjectGenerator > should escape special characters > should correctly handle node comments with quotes 1`] = `
+"from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
+from vellum.workflows.state import BaseState
+
+
+class TemplatingNode(BaseTemplatingNode[BaseState, str]):
+    """\\"Hello" "World\\" """
+
+    template = """test template"""
+    inputs = {}
+"
+`;

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -1599,4 +1599,185 @@ baz = foo + bar
       expectProjectFileToMatchSnapshot(project, ["nodes", "final_output.py"]);
     });
   });
+  describe("should escape special characters", () => {
+    it("should correctly handle node comments with quotes", async () => {
+      const displayData = {
+        workflow_raw_data: {
+          edges: [
+            {
+              id: "test-edge-1",
+              type: "DEFAULT",
+              source_node_id: "entry-node",
+              target_node_id: "templating-node",
+              source_handle_id: "entry_source",
+              target_handle_id: "template_target",
+            },
+          ],
+          nodes: [
+            {
+              id: "entry-node",
+              type: "ENTRYPOINT",
+              data: {
+                label: "Entrypoint",
+                source_handle_id: "entry_source",
+              },
+              inputs: [],
+              display_data: {
+                width: 124,
+                height: 48,
+                comment: null,
+                position: { x: 100, y: 100 },
+              },
+            },
+            {
+              id: "templating-node",
+              type: "TEMPLATING",
+              data: {
+                label: "Templating Node",
+                template_node_input_id: "template_input",
+                output_id: "output",
+                output_type: "STRING",
+                source_handle_id: "template_source",
+                target_handle_id: "template_target",
+              },
+              inputs: [
+                {
+                  id: "template_input",
+                  key: "template",
+                  value: {
+                    combinator: "OR",
+                    rules: [
+                      {
+                        type: "CONSTANT_VALUE",
+                        data: {
+                          type: "STRING",
+                          value: "test template",
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              display_data: {
+                width: 300,
+                height: 200,
+                comment: {
+                  value: '"Hello" "World"',
+                  expanded: false,
+                },
+                position: { x: 300, y: 100 },
+              },
+            },
+          ],
+        },
+        input_variables: [],
+        output_variables: [],
+      };
+
+      const project = new WorkflowProjectGenerator({
+        absolutePathToOutputDirectory: tempDir,
+        workflowVersionExecConfigData: displayData,
+        moduleName: "code",
+        vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
+      });
+
+      await project.generateCode();
+      // check the templating node file
+      expectProjectFileToExist(project, ["nodes", "templating_node.py"]);
+      expectProjectFileToMatchSnapshot(project, [
+        "nodes",
+        "templating_node.py",
+      ]);
+    });
+    it("should correctly handle multi-line comments", async () => {
+      const displayData = {
+        workflow_raw_data: {
+          edges: [
+            {
+              id: "test-edge-1",
+              type: "DEFAULT",
+              source_node_id: "entry-node",
+              target_node_id: "templating-node",
+              source_handle_id: "entry_source",
+              target_handle_id: "template_target",
+            },
+          ],
+          nodes: [
+            {
+              id: "entry-node",
+              type: "ENTRYPOINT",
+              data: {
+                label: "Entrypoint",
+                source_handle_id: "entry_source",
+              },
+              inputs: [],
+              display_data: {
+                width: 124,
+                height: 48,
+                comment: null,
+                position: { x: 100, y: 100 },
+              },
+            },
+            {
+              id: "templating-node",
+              type: "TEMPLATING",
+              data: {
+                label: "Templating Node",
+                template_node_input_id: "template_input",
+                output_id: "output",
+                output_type: "STRING",
+                source_handle_id: "template_source",
+                target_handle_id: "template_target",
+              },
+              inputs: [
+                {
+                  id: "template_input",
+                  key: "template",
+                  value: {
+                    combinator: "OR",
+                    rules: [
+                      {
+                        type: "CONSTANT_VALUE",
+                        data: {
+                          type: "STRING",
+                          value: "test template",
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              display_data: {
+                width: 300,
+                height: 200,
+                comment: {
+                  value: '"Hello"\n"World"',
+                  expanded: false,
+                },
+                position: { x: 300, y: 100 },
+              },
+            },
+          ],
+        },
+        input_variables: [],
+        output_variables: [],
+      };
+      const project = new WorkflowProjectGenerator({
+        absolutePathToOutputDirectory: tempDir,
+        workflowVersionExecConfigData: displayData,
+        moduleName: "code",
+        vellumApiKey: "<TEST_API_KEY>",
+      });
+
+      await project.generateCode();
+      expectProjectFileToExist(project, ["nodes", "templating_node.py"]);
+      expectProjectFileToMatchSnapshot(project, [
+        "nodes",
+        "templating_node.py",
+      ]);
+    });
+  });
 });

--- a/ee/codegen/src/generators/extensions/__tests__/custom-comment.test.ts
+++ b/ee/codegen/src/generators/extensions/__tests__/custom-comment.test.ts
@@ -1,0 +1,27 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { describe, expect, it } from "vitest";
+
+import { CustomComment } from "src/generators/extensions/custom-comment";
+
+describe("CustomComment", () => {
+  it("should escape end quotes in triple-quoted strings", () => {
+    const writer = new Writer();
+    const comment = new CustomComment({ docs: 'Hello World"' });
+    comment.write(writer);
+    expect(writer.toString()).toBe('"""Hello World\\""""');
+  });
+
+  it("should escape start quotes in triple-quoted strings", () => {
+    const writer = new Writer();
+    const comment = new CustomComment({ docs: '"Hello World' });
+    comment.write(writer);
+    expect(writer.toString()).toBe('"""\\"Hello World"""');
+  });
+
+  it("should escape all double quotes in the string", () => {
+    const writer = new Writer();
+    const comment = new CustomComment({ docs: '"Hello "World"' });
+    comment.write(writer);
+    expect(writer.toString()).toBe('"""\\"Hello "World\\""""');
+  });
+});

--- a/ee/codegen/src/generators/extensions/__tests__/python-utils.test.ts
+++ b/ee/codegen/src/generators/extensions/__tests__/python-utils.test.ts
@@ -1,0 +1,45 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { describe, expect, it } from "vitest";
+
+import { python } from "src/generators/extensions/python-utils";
+
+describe("python.class_", () => {
+  it("should properly escape quotes in docs at the beginning", () => {
+    const classWithStartQuote = python.class_({
+      name: "TestClass",
+      docs: '"Hello World',
+    });
+
+    const writer = new Writer();
+    classWithStartQuote.write(writer);
+    const result = writer.toString();
+
+    expect(result).toContain('\\"Hello World');
+  });
+
+  it("should properly escape quotes in docs at the end", () => {
+    const classWithEndQuote = python.class_({
+      name: "TestClass",
+      docs: 'Hello World"',
+    });
+
+    const writer = new Writer();
+    classWithEndQuote.write(writer);
+    const result = writer.toString();
+
+    expect(result).toContain('Hello World\\"');
+  });
+
+  it("should not escape quotes in docs in the middle", () => {
+    const classWithMiddleQuote = python.class_({
+      name: "TestClass",
+      docs: 'Hello "World',
+    });
+
+    const writer = new Writer();
+    classWithMiddleQuote.write(writer);
+    const result = writer.toString();
+
+    expect(result).toContain('Hello "World');
+  });
+});

--- a/ee/codegen/src/generators/extensions/custom-class.ts
+++ b/ee/codegen/src/generators/extensions/custom-class.ts
@@ -1,0 +1,93 @@
+import { Decorator } from "@fern-api/python-ast/Decorator";
+import { Reference } from "@fern-api/python-ast/Reference";
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+import { Writer } from "@fern-api/python-ast/core/Writer";
+
+import { CustomComment } from "./custom-comment";
+
+export declare namespace CustomClass {
+  interface Args {
+    name: string;
+    docs?: string;
+    extends_?: Reference[];
+    decorators?: Decorator[];
+  }
+}
+
+export class CustomClass extends AstNode {
+  private readonly name: string;
+  private readonly docs?: string;
+  private readonly extends_?: Reference[];
+  private readonly decorators?: Decorator[];
+  private readonly children: AstNode[] = [];
+
+  constructor({ name, docs, extends_, decorators }: CustomClass.Args) {
+    super();
+    this.name = name;
+    this.docs = docs;
+    this.extends_ = extends_;
+    this.decorators = decorators;
+
+    if (extends_) {
+      extends_.forEach((extend) => this.inheritReferences(extend));
+    }
+    if (decorators) {
+      decorators.forEach((decorator) => this.inheritReferences(decorator));
+    }
+  }
+
+  public add(child: AstNode): void {
+    this.children.push(child);
+    this.inheritReferences(child);
+  }
+
+  public write(writer: Writer): void {
+    if (this.decorators) {
+      this.decorators.forEach((decorator) => {
+        decorator.write(writer);
+        writer.newLine();
+      });
+    }
+
+    writer.write("class ");
+    writer.write(this.name);
+
+    if (this.extends_ && this.extends_.length > 0) {
+      writer.write("(");
+
+      const extends_ = this.extends_;
+      extends_.forEach((extend, index) => {
+        extend.write(writer);
+        if (index < extends_.length - 1) {
+          writer.write(", ");
+        }
+      });
+
+      writer.write(")");
+    }
+
+    writer.write(":");
+    writer.newLine();
+    writer.indent();
+
+    if (this.docs) {
+      const comment = new CustomComment({ docs: this.docs });
+      comment.write(writer);
+      writer.newLine();
+    }
+
+    if (this.children.length > 0) {
+      this.children.forEach((child, index) => {
+        child.write(writer);
+        if (index < this.children.length - 1) {
+          writer.newLine();
+        }
+      });
+    } else {
+      writer.write("pass");
+      writer.newLine();
+    }
+
+    writer.dedent();
+  }
+}

--- a/ee/codegen/src/generators/extensions/custom-comment.ts
+++ b/ee/codegen/src/generators/extensions/custom-comment.ts
@@ -1,0 +1,55 @@
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+import { Writer } from "@fern-api/python-ast/core/Writer";
+
+export declare namespace CustomComment {
+  interface Args {
+    docs: string;
+  }
+}
+
+export class CustomComment extends AstNode {
+  private readonly docs: string;
+
+  constructor({ docs }: CustomComment.Args) {
+    super();
+    this.docs = docs;
+  }
+
+  public write(writer: Writer): void {
+    if (this.docs.includes("\n")) {
+      // For multi-line comments
+      writer.write('"""');
+      writer.newLine();
+
+      const lines = this.docs.split("\n");
+
+      lines.forEach((line, index) => {
+        writer.write(line);
+        if (index < lines.length - 1) {
+          writer.newLine();
+        }
+      });
+
+      writer.newLine();
+      writer.write('"""');
+    } else {
+      // For single-line comments
+      let escapedDocs = this.docs;
+
+      // Handle quotes at the beginning
+      if (this.docs.startsWith('"')) {
+        escapedDocs = "\\" + escapedDocs;
+      }
+
+      // Handle quotes at the end
+      if (this.docs.endsWith('"')) {
+        escapedDocs = escapedDocs.slice(0, -1) + '\\"';
+      }
+
+      // Write the triple-quoted string without any extra spaces
+      writer.write('"""');
+      writer.write(escapedDocs);
+      writer.write('"""');
+    }
+  }
+}

--- a/ee/codegen/src/generators/extensions/index.ts
+++ b/ee/codegen/src/generators/extensions/index.ts
@@ -12,3 +12,6 @@
  */
 
 export * from "./protected-python-file";
+export * from "./custom-comment";
+export * from "./custom-class";
+export * from "./python-utils";

--- a/ee/codegen/src/generators/extensions/python-utils.ts
+++ b/ee/codegen/src/generators/extensions/python-utils.ts
@@ -1,0 +1,21 @@
+import { Class } from "@fern-api/python-ast/Class";
+
+import { CustomClass } from "./custom-class";
+import { CustomComment } from "./custom-comment";
+
+export namespace python {
+  export function customComment(args: CustomComment.Args): CustomComment {
+    return new CustomComment(args);
+  }
+
+  export function class_(args: Class.Args): Class {
+    const customClass = new CustomClass({
+      name: args.name,
+      docs: args.docs,
+      extends_: args.extends_,
+      decorators: args.decorators,
+    });
+
+    return customClass as unknown as Class;
+  }
+}

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -10,6 +10,7 @@ import {
   BaseCodegenError,
   NodeAttributeGenerationError,
 } from "src/generators/errors";
+import { python as customPython } from "src/generators/extensions/python-utils";
 import { NodeDisplayData } from "src/generators/node-display-data";
 import { NodeInput } from "src/generators/node-inputs/node-input";
 import { UuidOrString } from "src/generators/uuid-or-string";
@@ -337,7 +338,7 @@ export abstract class BaseNode<
       });
     }
 
-    const nodeClass = python.class_({
+    const nodeClass = customPython.class_({
       name: nodeContext.nodeClassName,
       extends_: [nodeBaseClass],
       docs: this.generateNodeComment(),


### PR DESCRIPTION
Init attempt for custom class, since docs accept a string type, I think we couldn't simply customize its writer instead overriding the whole class_, but this may introduce more issues 

there are two errors now:
- comments will now have a new line which may be caused by ` writer.newLine();` under `if (this.docs) { `. However, if we remove that one, the children will just concat after """
- there is a white space for single line comment `"""\\"Hello" "World\\" """`

