### PR TITLE
Consolidate all of the base display wraps

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node-retry.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node-retry.test.ts.snap
@@ -16,7 +16,7 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.prompt_node import PromptNode
 
 
-@BaseRetryNodeDisplay.wrap(max_attempts=3)
+@BaseRetryNodeDisplay.wrap()
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
@@ -93,7 +93,7 @@ from ...nodes.prompt_node import PromptNode
 
 
 @BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
-@BaseRetryNodeDisplay.wrap(max_attempts=3, delay=2)
+@BaseRetryNodeDisplay.wrap()
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
@@ -170,7 +170,7 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.prompt_node import PromptNode
 
 
-@BaseRetryNodeDisplay.wrap(max_attempts=3, delay=2)
+@BaseRetryNodeDisplay.wrap()
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -27,7 +27,7 @@ from .nodes import *
 from .workflow import *
 
 
-@BaseRetryNodeDisplay.wrap(max_attempts=3, delay=2)
+@BaseRetryNodeDisplay.wrap()
 class MyNodeDisplay(BaseInlineSubworkflowNodeDisplay[MyNode]):
     label = "My node"
     node_id = UUID("14fee4a0-ad25-402f-b942-104d3a5a0824")

--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
@@ -45,9 +45,9 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.my_custom_node import MyCustomNode
 
 
-@BaseTryNodeDisplay.wrap(on_error_code="USER_DEFINED_ERROR")
-@BaseMapNodeDisplay.wrap(items=[1, 2])
-@BaseRetryNodeDisplay.wrap(max_attempts=3)
+@BaseTryNodeDisplay.wrap()
+@BaseMapNodeDisplay.wrap()
+@BaseRetryNodeDisplay.wrap()
 class MyCustomNodeDisplay(BaseNodeDisplay[MyCustomNode]):
     node_input_ids_by_name = {}
     display_data = NodeDisplayData(

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -410,18 +410,8 @@ export abstract class BaseNode<
                   this.workflowContext.sdkModulePathNames
                     .NODE_DISPLAY_MODULE_PATH,
               }),
-              arguments_: adornment.attributes.map(
-                (attr) =>
-                  new MethodArgument({
-                    name: attr.name,
-                    value: new WorkflowValueDescriptor({
-                      workflowValueDescriptor: attr.value,
-                      nodeContext: this.nodeContext,
-                      workflowContext: this.workflowContext,
-                      iterableConfig: { endWithComma: false },
-                    }),
-                  })
-              ),
+              // When we define output transformations, that's what we'd use here. eg, `error_output_id`.
+              arguments_: [],
             }),
           })
         );

--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
@@ -1,9 +1,13 @@
+import re
+import types
 from uuid import UUID
-from typing import Any, Callable, Generic, Optional, TypeVar, cast
+from typing import Any, Callable, Generic, Optional, Type, TypeVar, cast
 
+from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.bases.base_adornment_node import BaseAdornmentNode
 from vellum.workflows.nodes.utils import get_wrapped_node
 from vellum.workflows.types.core import JsonArray, JsonObject
+from vellum.workflows.types.utils import get_original_base
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
@@ -37,3 +41,46 @@ class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Ge
         serialized_wrapped_node["adornments"] = adornments + [adornment] if adornment else adornments
 
         return serialized_wrapped_node
+
+    @classmethod
+    def wrap(cls, **kwargs: Any) -> Callable[..., Type[BaseNodeDisplay]]:
+        NodeDisplayType = TypeVar("NodeDisplayType", bound=BaseNodeDisplay)
+
+        def decorator(inner_cls: Type[NodeDisplayType]) -> Type[NodeDisplayType]:
+            node_class = inner_cls.infer_node_class()
+            wrapped_node_class = cast(Type[BaseNode], node_class.__wrapped_node__)
+
+            # `mypy` is wrong here, `cls` is indexable bc it's Generic
+            BaseAdornmentDisplay = cls[node_class]  # type: ignore[index]
+            AdornmentDisplay = types.new_class(
+                re.sub(r"^Base", "", cls.__name__),
+                bases=(BaseAdornmentDisplay,),
+            )
+            for key, kwarg in kwargs.items():
+                setattr(AdornmentDisplay, key, kwarg)
+
+            setattr(inner_cls, "__adorned_by__", AdornmentDisplay)
+
+            # We must edit the node display class to use __wrapped_node__ everywhere it
+            # references the adorned node class, which is three places:
+
+            # 1. The node display class' parameterized type
+            original_base_node_display = get_original_base(inner_cls)
+            original_base_node_display.__args__ = (wrapped_node_class,)
+            inner_cls._node_display_registry[wrapped_node_class] = inner_cls
+
+            # 2. The node display class' output displays
+            old_outputs = list(inner_cls.output_display.keys())
+            for old_output in old_outputs:
+                new_output = getattr(wrapped_node_class.Outputs, old_output.name)
+                inner_cls.output_display[new_output] = inner_cls.output_display.pop(old_output)
+
+            # 3. The node display class' port displays
+            old_ports = list(inner_cls.port_displays.keys())
+            for old_port in old_ports:
+                new_port = getattr(wrapped_node_class.Ports, old_port.name)
+                inner_cls.port_displays[new_port] = inner_cls.port_displays.pop(old_port)
+
+            return inner_cls
+
+        return decorator

--- a/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
@@ -1,14 +1,12 @@
 import inspect
-from typing import Any, Callable, Generic, Optional, Tuple, Type, TypeVar, cast
+from typing import Any, Generic, Tuple, Type, TypeVar, cast
 
 from vellum.workflows.descriptors.base import BaseDescriptor
-from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.retry_node.node import RetryNode
 from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
 from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
-from vellum.workflows.types.utils import get_original_base
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
@@ -79,54 +77,3 @@ class BaseRetryNodeDisplay(BaseAdornmentNodeDisplay[_RetryNodeType], Generic[_Re
 
         inner_output = getattr(inner_node.Outputs, output.name)
         return node_display.get_node_output_display(inner_output)
-
-    @classmethod
-    def wrap(
-        cls,
-        max_attempts: int,
-        delay: Optional[float] = None,
-        retry_on_error_code: Optional[WorkflowErrorCode] = None,
-        retry_on_condition: Optional[BaseDescriptor] = None,
-    ) -> Callable[..., Type["BaseRetryNodeDisplay"]]:
-        _max_attempts = max_attempts
-        _delay = delay
-        _retry_on_error_code = retry_on_error_code
-        _retry_on_condition = retry_on_condition
-
-        NodeDisplayType = TypeVar("NodeDisplayType", bound=BaseNodeDisplay)
-
-        def decorator(inner_cls: Type[NodeDisplayType]) -> Type[NodeDisplayType]:
-            node_class = inner_cls.infer_node_class()
-            wrapped_node_class = cast(Type[BaseNode], node_class.__wrapped_node__)
-
-            class RetryNodeDisplay(BaseRetryNodeDisplay[node_class]):  # type: ignore[valid-type]
-                max_attempts = _max_attempts
-                delay = _delay
-                retry_on_error_code = _retry_on_error_code
-                retry_on_condition = _retry_on_condition
-
-            setattr(inner_cls, "__adorned_by__", RetryNodeDisplay)
-
-            # We must edit the node display class to use __wrapped_node__ everywhere it
-            # references the adorned node class, which is three places:
-
-            # 1. The node display class' parameterized type
-            original_base_node_display = get_original_base(inner_cls)
-            original_base_node_display.__args__ = (wrapped_node_class,)
-            inner_cls._node_display_registry[wrapped_node_class] = inner_cls
-
-            # 2. The node display class' output displays
-            old_outputs = list(inner_cls.output_display.keys())
-            for old_output in old_outputs:
-                new_output = getattr(wrapped_node_class.Outputs, old_output.name)
-                inner_cls.output_display[new_output] = inner_cls.output_display.pop(old_output)
-
-            # 3. The node display class' port displays
-            old_ports = list(inner_cls.port_displays.keys())
-            for old_port in old_ports:
-                new_port = getattr(wrapped_node_class.Ports, old_port.name)
-                inner_cls.port_displays[new_port] = inner_cls.port_displays.pop(old_port)
-
-            return inner_cls
-
-        return decorator


### PR DESCRIPTION
In this PR, we consolidate all of the `Base[Adornment]Display.wrap` classes to a single method. This will allow us a centralized place for future adornment changes that we need for event monitoring across all adornments.

We also clean up some codegen for Adornments. Attribute values are only needed for the node classes themselves, not the adornment classes