### PR TITLE
Allow users to use the client SDK with pydantic v1

### DIFF
--- a/src/vellum/plugins/utils.py
+++ b/src/vellum/plugins/utils.py
@@ -1,11 +1,19 @@
-from pydantic.plugin import _loader as _pydantic_plugin_loader
+import pydantic
 
-from vellum.plugins.pydantic import pydantic_plugin
-
+IS_PYDANTIC_V1 = pydantic.VERSION.startswith("1.")
 _loaded = False
 
 
 def load_runtime_plugins() -> None:
+    if IS_PYDANTIC_V1:
+        # Pydantic plugins are only available in v2, so we defer the imports
+        # below until we confirm we are running a supported version of pydantic
+        return
+
+    from pydantic.plugin import _loader as _pydantic_plugin_loader
+
+    from vellum.plugins.pydantic import pydantic_plugin
+
     global _loaded
     if _loaded:
         return


### PR DESCRIPTION
Unfortunately this is tough to test pre-release. [tox](https://vellum-ai.slack.com/archives/C06P13ABK0W/p1741716824246289) may be a compelling option for us in that regard long term.

For now, this is a quick fix to unblock pydantic v1 customers