### PR TITLE
[APO-108] Add post process to temporary handle docstring escape issue

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -237,3 +237,29 @@ class Workflow(BaseWorkflow):
     graph = TemplatingNode
 "
 `;
+
+exports[`WorkflowProjectGenerator > should escape special characters > should handle node comments with quotes at the beginning and end 1`] = `
+"from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
+from vellum.workflows.state import BaseState
+
+
+class TemplatingNode(BaseTemplatingNode[BaseState, str]):
+    """\\"Hello" "World\\""""
+
+    template = """test template"""
+    inputs = {}
+"
+`;
+
+exports[`WorkflowProjectGenerator > should escape special characters > should not escape single quotes in node comments 1`] = `
+"from vellum.workflows.nodes.displayable import TemplatingNode as BaseTemplatingNode
+from vellum.workflows.state import BaseState
+
+
+class TemplatingNode(BaseTemplatingNode[BaseState, str]):
+    """'Hello' 'World'"""
+
+    template = """test template"""
+    inputs = {}
+"
+`;

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -1599,4 +1599,189 @@ baz = foo + bar
       expectProjectFileToMatchSnapshot(project, ["nodes", "final_output.py"]);
     });
   });
+  describe("should escape special characters", () => {
+    it("should handle node comments with quotes at the beginning and end", async () => {
+      const displayData = {
+        workflow_raw_data: {
+          edges: [
+            {
+              id: "test-edge-1",
+              type: "DEFAULT",
+              source_node_id: "entry-node",
+              target_node_id: "templating-node",
+              source_handle_id: "entry_source",
+              target_handle_id: "template_target",
+            },
+          ],
+          nodes: [
+            {
+              id: "entry-node",
+              type: "ENTRYPOINT",
+              data: {
+                label: "Entrypoint",
+                source_handle_id: "entry_source",
+              },
+              inputs: [],
+              display_data: {
+                width: 124,
+                height: 48,
+                comment: null,
+                position: { x: 100, y: 100 },
+              },
+            },
+            {
+              id: "templating-node",
+              type: "TEMPLATING",
+              data: {
+                label: "Templating Node",
+                template_node_input_id: "template_input",
+                output_id: "output",
+                output_type: "STRING",
+                source_handle_id: "template_source",
+                target_handle_id: "template_target",
+              },
+              inputs: [
+                {
+                  id: "template_input",
+                  key: "template",
+                  value: {
+                    combinator: "OR",
+                    rules: [
+                      {
+                        type: "CONSTANT_VALUE",
+                        data: {
+                          type: "STRING",
+                          value: "test template",
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              display_data: {
+                width: 300,
+                height: 200,
+                comment: {
+                  value: '"Hello" "World"',
+                  expanded: false,
+                },
+                position: { x: 300, y: 100 },
+              },
+            },
+          ],
+        },
+        input_variables: [],
+        output_variables: [],
+      };
+
+      const project = new WorkflowProjectGenerator({
+        absolutePathToOutputDirectory: tempDir,
+        workflowVersionExecConfigData: displayData,
+        moduleName: "code",
+        vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
+      });
+
+      await project.generateCode();
+      expectProjectFileToExist(project, ["nodes", "templating_node.py"]);
+      expectProjectFileToMatchSnapshot(project, [
+        "nodes",
+        "templating_node.py",
+      ]);
+    });
+
+    it("should not escape single quotes in node comments", async () => {
+      const displayData = {
+        workflow_raw_data: {
+          edges: [
+            {
+              id: "test-edge-1",
+              type: "DEFAULT",
+              source_node_id: "entry-node",
+              target_node_id: "templating-node",
+              source_handle_id: "entry_source",
+              target_handle_id: "template_target",
+            },
+          ],
+          nodes: [
+            {
+              id: "entry-node",
+              type: "ENTRYPOINT",
+              data: {
+                label: "Entrypoint",
+                source_handle_id: "entry_source",
+              },
+              inputs: [],
+              display_data: {
+                width: 124,
+                height: 48,
+                comment: null,
+                position: { x: 100, y: 100 },
+              },
+            },
+            {
+              id: "templating-node",
+              type: "TEMPLATING",
+              data: {
+                label: "Templating Node",
+                template_node_input_id: "template_input",
+                output_id: "output",
+                output_type: "STRING",
+                source_handle_id: "template_source",
+                target_handle_id: "template_target",
+              },
+              inputs: [
+                {
+                  id: "template_input",
+                  key: "template",
+                  value: {
+                    combinator: "OR",
+                    rules: [
+                      {
+                        type: "CONSTANT_VALUE",
+                        data: {
+                          type: "STRING",
+                          value: "test template",
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              display_data: {
+                width: 300,
+                height: 200,
+                comment: {
+                  value: "'Hello' 'World'",
+                  expanded: false,
+                },
+                position: { x: 300, y: 100 },
+              },
+            },
+          ],
+        },
+        input_variables: [],
+        output_variables: [],
+      };
+
+      const project = new WorkflowProjectGenerator({
+        absolutePathToOutputDirectory: tempDir,
+        workflowVersionExecConfigData: displayData,
+        moduleName: "code",
+        vellumApiKey: "<TEST_API_KEY>",
+        options: {
+          disableFormatting: true,
+        },
+      });
+
+      await project.generateCode();
+      expectProjectFileToExist(project, ["nodes", "templating_node.py"]);
+      expectProjectFileToMatchSnapshot(project, [
+        "nodes",
+        "templating_node.py",
+      ]);
+    });
+  });
 });

--- a/ee/codegen/src/generators/base-persisted-file.ts
+++ b/ee/codegen/src/generators/base-persisted-file.ts
@@ -218,7 +218,7 @@ export abstract class BasePersistedFile extends AstNode {
 
   private postprocessDocstrings(content: string): string {
     // Find an escaped quote followed by space(s) right before closing triple quotes
-    const fixPattern = /(\\")(\s+)(""")/g;
+    const fixPattern = /(\\")(\s)(""")/g;
 
     // Remove the extra space between escaped quote and closing triple quotes
     return content.replace(fixPattern, "$1$3");

--- a/ee/codegen/src/generators/base-persisted-file.ts
+++ b/ee/codegen/src/generators/base-persisted-file.ts
@@ -207,11 +207,20 @@ export abstract class BasePersistedFile extends AstNode {
     let contents: string;
     try {
       contents = await writer.toStringFormatted({ line_width: 120 });
+      contents = this.postprocessDocstrings(contents);
     } catch (error) {
       console.error("Error formatting", fileName, "with error", error);
       contents = writer.toString();
     }
 
     await writeFile(filepath, contents);
+  }
+
+  private postprocessDocstrings(content: string): string {
+    // Find an escaped quote followed by space(s) right before closing triple quotes
+    const fixPattern = /(\\")(\s+)(""")/g;
+
+    // Remove the extra space between escaped quote and closing triple quotes
+    return content.replace(fixPattern, "$1$3");
   }
 }

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -481,7 +481,16 @@ export abstract class BaseNode<
     const nodeComment = this.getNodeComment();
 
     if (nodeComment && nodeComment.value) {
-      return nodeComment.value;
+      let comment = nodeComment.value;
+      // if comment start with ", add a \ in front of it
+      if (comment.startsWith('"')) {
+        comment = `\\${comment}`;
+      }
+      // if comment end with ", add a \ in front of it
+      if (comment.endsWith('"')) {
+        comment = `${comment.slice(0, -1)}\\"`;
+      }
+      return comment;
     }
     return undefined;
   }


### PR DESCRIPTION
linear: https://linear.app/vellum/issue/APO-108/node-comments-that-end-in-a-fail-to-generate-artifact-due-to-invalid

revisit when upstream fixed https://github.com/astral-sh/ruff/issues/16640

Handle extra space added by ruff formatted by post process


https://github.com/user-attachments/assets/51a95da0-fc88-4c7d-b1ef-56dab74cdcb4

