### PR TITLE
Fix Templating node event input display

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Dict,
     ForwardRef,
     Generic,
@@ -89,6 +90,7 @@ class BaseNodeDisplayMeta(type):
 class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
     output_display: Dict[OutputReference, NodeOutputDisplay] = {}
     port_displays: Dict[Port, PortDisplayOverrides] = {}
+    node_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
     # Used to store the mapping between node types and their display classes
     _node_display_registry: Dict[Type[NodeType], Type["BaseNodeDisplay"]] = {}

--- a/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from typing import ClassVar, Dict, Optional, Union
+from typing import ClassVar, Dict, Optional
 
 from vellum.workflows.nodes.utils import get_unadorned_node
 from vellum.workflows.ports import Port
@@ -16,9 +16,6 @@ class BaseNodeVellumDisplay(BaseNodeDisplay[NodeType]):
 
     # Used to explicitly set the target handle id for a node
     target_handle_id: ClassVar[Optional[UUID]] = None
-
-    # Used to explicitly set the node input ids by name for a node
-    node_input_ids_by_name: ClassVar[Dict[str, Union[UUID, str]]] = {}
 
     def _get_node_display_uuid(self, attribute: str) -> UUID:
         explicit_value = self._get_explicit_node_display_attr(attribute, UUID)

--- a/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
+++ b/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
@@ -1,9 +1,10 @@
 import types
-from uuid import UUID, uuid4
+from uuid import UUID
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.types.generics import NodeType
+from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 
 if TYPE_CHECKING:
@@ -37,7 +38,7 @@ def get_node_display_class(
             return node_input_ids_by_name
 
         if isinstance(inst, BaseDescriptor):
-            return {path: uuid4()}
+            return {path: uuid4_from_hash(f"{node_class.__id__}|{path}")}
 
         return {}
 

--- a/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
+++ b/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
@@ -1,6 +1,8 @@
 import types
-from typing import TYPE_CHECKING, Optional, Type
+from uuid import UUID, uuid4
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 
+from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.types.generics import NodeType
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 
@@ -26,16 +28,39 @@ def get_node_display_class(
 
     # `base_node_display_class` is always a Generic class, so it's safe to index into it
     NodeDisplayBaseClass = base_node_display_class[node_class]  # type: ignore[index]
+
+    def _get_node_input_ids_by_ref(path: str, inst: Any):
+        if isinstance(inst, dict):
+            node_input_ids_by_name: Dict[str, UUID] = {}
+            for key, value in inst.items():
+                node_input_ids_by_name.update(_get_node_input_ids_by_ref(f"{path}.{key}", value))
+            return node_input_ids_by_name
+
+        if isinstance(inst, BaseDescriptor):
+            return {path: uuid4()}
+
+        return {}
+
+    def exec_body(ns: Dict):
+        output_display = {
+            ref: NodeOutputDisplay(id=node_class.__output_ids__[ref.name], name=ref.name)
+            for ref in node_class.Outputs
+            if ref.name in node_class.__output_ids__
+        }
+        if output_display:
+            ns["output_display"] = output_display
+
+        node_input_ids_by_name: Dict[str, UUID] = {}
+        for ref in node_class:
+            node_input_ids_by_name.update(_get_node_input_ids_by_ref(ref.name, ref.instance))
+
+        if node_input_ids_by_name:
+            ns["node_input_ids_by_name"] = node_input_ids_by_name
+
     NodeDisplayClass = types.new_class(
         f"{node_class.__name__}Display",
         bases=(NodeDisplayBaseClass,),
+        exec_body=exec_body,
     )
-    output_display = {
-        ref: NodeOutputDisplay(id=node_class.__output_ids__[ref.name], name=ref.name)
-        for ref in node_class.Outputs
-        if ref.name in node_class.__output_ids__
-    }
-    if output_display:
-        setattr(NodeDisplayClass, "output_display", output_display)
 
     return NodeDisplayClass

--- a/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
@@ -23,14 +23,7 @@ class BaseTemplatingNodeDisplay(BaseNodeVellumDisplay[_TemplatingNodeType], Gene
         node = self._node
         node_id = self.node_id
 
-        template_input_id = self.template_input_id or next(
-            (
-                UUID(input_id) if isinstance(input_id, str) else input_id
-                for input_name, input_id in self.node_input_ids_by_name.items()
-                if input_name == TEMPLATE_INPUT_NAME
-            ),
-            None,
-        )
+        template_input_id = self.template_input_id or self.node_input_ids_by_name.get(TEMPLATE_INPUT_NAME)
 
         template_node_input = create_node_input(
             node_id=node_id,


### PR DESCRIPTION
This PR started as a way to fix node event input display, but I realized unfortunately that our display classes currently generate:
```python
node_input_ids_by_name = {
    "foo": UUID
}
```

but our templating node events will emit:
```python
node_input_ids_by_name = {
    "inputs.foo": UUID
}
```

The latter is more consistent with "attribute paths" - meaning it will be more extensible to dynamic attributes at any level. So in the meantime, this PR just supports generating input_display when there's no display classes defined, and we'll update vellum side handling to do both