### PR TITLE
[APO-181] Add default api method for api node

### DIFF
--- a/src/vellum/workflows/nodes/displayable/bases/api_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/api_node/node.py
@@ -29,7 +29,7 @@ class BaseAPINode(BaseNode, Generic[StateType]):
         merge_behavior = MergeBehavior.AWAIT_ANY
 
     url: str
-    method: APIRequestMethod
+    method: Optional[APIRequestMethod] = APIRequestMethod.GET
     data: Optional[str] = None
     json: Optional[Json] = None
     headers: Optional[Dict[str, Union[str, VellumSecret]]] = None
@@ -45,8 +45,8 @@ class BaseAPINode(BaseNode, Generic[StateType]):
 
     def _run(
         self,
-        method: APIRequestMethod,
         url: str,
+        method: Optional[APIRequestMethod] = APIRequestMethod.GET,
         data: Optional[Union[str, Any]] = None,
         json: Any = None,
         headers: Any = None,


### PR DESCRIPTION
linear: https://linear.app/vellum/issue/APO-181/investigate-api-node-server-error-with-sdk-enabled

Default to GET method if not provided