### PR TITLE
Allow node id annotation of the inner wrapped node in adornment setups

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -59,17 +59,20 @@ _NodeDisplayAttrType = TypeVar("_NodeDisplayAttrType")
 class BaseNodeDisplayMeta(type):
     def __new__(mcs, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
         cls = super().__new__(mcs, name, bases, dct)
+        return cls.__annotate_node__()
+
+    def __annotate_node__(cls):
         base_node_display_class = cast(Type["BaseNodeDisplay"], cls)
         node_class = base_node_display_class.infer_node_class()
         if not issubclass(node_class, BaseNode):
             return cls
 
-        display_node_id = dct.get("node_id")
+        display_node_id = getattr(cls, "node_id", None)
         if isinstance(display_node_id, UUID):
             # Display classes are able to override the id of the node class it's parameterized by
             node_class.__id__ = display_node_id
 
-        output_display = dct.get("output_display")
+        output_display = getattr(cls, "output_display", None)
         if isinstance(output_display, dict):
             # And the node class' output ids
             for reference, node_output_display in output_display.items():

--- a/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
+++ b/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
@@ -1,5 +1,5 @@
 import types
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Optional, Type, get_origin
 
 from vellum.workflows.types.generics import NodeType
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
@@ -23,6 +23,9 @@ def get_node_display_class(
     base_node_display_class = get_node_display_class(
         base_class, node_class.__bases__[0], node_class if root_node_class is None else root_node_class
     )
+
+    if not get_origin(base_node_display_class):
+        return base_node_display_class
 
     # `base_node_display_class` is always a Generic class, so it's safe to index into it
     NodeDisplayBaseClass = base_node_display_class[node_class]  # type: ignore[index]

--- a/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
+++ b/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
@@ -1,5 +1,5 @@
 import types
-from typing import TYPE_CHECKING, Optional, Type, get_origin
+from typing import TYPE_CHECKING, Optional, Type
 
 from vellum.workflows.types.generics import NodeType
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
@@ -23,9 +23,6 @@ def get_node_display_class(
     base_node_display_class = get_node_display_class(
         base_class, node_class.__bases__[0], node_class if root_node_class is None else root_node_class
     )
-
-    if not get_origin(base_node_display_class):
-        return base_node_display_class
 
     # `base_node_display_class` is always a Generic class, so it's safe to index into it
     NodeDisplayBaseClass = base_node_display_class[node_class]  # type: ignore[index]

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -212,8 +212,6 @@ class BaseWorkflowDisplay(
 
         port_displays: Dict[Port, PortDisplay] = {}
 
-        # TODO: We should still serialize nodes that are in the workflow's directory but aren't used in the graph.
-        # https://app.shortcut.com/vellum/story/5394
         for node in self._workflow.get_nodes():
             extracted_node_displays = self._extract_node_displays(node)
 
@@ -403,11 +401,11 @@ class BaseWorkflowDisplay(
             for input in display_context.workflow_input_displays
         }
         node_displays = {
-            str(node.__id__): display_context.node_displays[node] for node in display_context.node_displays
+            node.__id__: (node, display_context.node_displays[node]) for node in display_context.node_displays
         }
         node_event_displays = {}
         for node_id in node_displays:
-            current_node_display = node_displays[node_id]
+            node, current_node_display = node_displays[node_id]
             input_display = {}
             if isinstance(current_node_display, BaseNodeVellumDisplay):
                 input_display = current_node_display.node_input_ids_by_name
@@ -418,7 +416,6 @@ class BaseWorkflowDisplay(
             port_display_meta = {
                 port.name: current_node_display.port_displays[port].id for port in current_node_display.port_displays
             }
-            node = current_node_display._node
             subworkflow_display_context: Optional[WorkflowEventDisplayContext] = None
             if hasattr(node, "subworkflow"):
                 # All nodes that have a subworkflow attribute are currently expected to call them `subworkflow`
@@ -432,7 +429,7 @@ class BaseWorkflowDisplay(
                     )
                     subworkflow_display_context = subworkflow_display.get_event_display_context()
 
-            node_event_displays[node_id] = NodeEventDisplayContext(
+            node_event_displays[str(node_id)] = NodeEventDisplayContext(
                 input_display=input_display,
                 output_display=output_display,
                 port_display=port_display_meta,


### PR DESCRIPTION
~Gonna block this guy on this one first: https://github.com/vellum-ai/vellum-python-sdks/pull/1130~

Before this PR, we were returning:
```js
display context = {
    nodes: {
        inner_node_id: {
            nodes: {
                outer_node_id
            }
        }
    }
}
```

This unblocked our monitoring in the short term, but now prevents us from showing separate traces invoked by an adornment. By putting it in the correct order, we can now treat adornments as any other subworkflow paradigm.

We'll need to update vellum-side logic before this goes live with version 0.14.15