### PR TITLE
Refactor workflow serialization tests to use local classes for node definitions

### DIFF
--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -21,20 +21,18 @@ class Inputs(BaseInputs):
     input: str
 
 
-@RetryNode.wrap(max_attempts=3)
-class InnerRetryGenericNode(BaseNode):
-    input = Inputs.input
-
-    class Outputs(BaseOutputs):
-        output: str
-
-
-@BaseRetryNodeDisplay.wrap(max_attempts=3)
-class InnerRetryGenericNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode]):
-    pass
-
-
 def test_serialize_node__retry(serialize_node):
+    @RetryNode.wrap(max_attempts=3)
+    class InnerRetryGenericNode(BaseNode):
+        input = Inputs.input
+
+        class Outputs(BaseOutputs):
+            output: str
+
+    @BaseRetryNodeDisplay.wrap(max_attempts=3)
+    class InnerRetryGenericNodeDisplay(BaseNodeDisplay[InnerRetryGenericNode]):
+        pass
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=InnerRetryGenericNode,
@@ -49,8 +47,8 @@ def test_serialize_node__retry(serialize_node):
     )
     assert not DeepDiff(
         {
-            "id": "f2a95e79-7d4b-47ad-b986-4f648297ec65",
-            "label": "InnerRetryGenericNode",
+            "id": "188b50aa-e518-4b7b-a5e0-e2585fb1d7b5",
+            "label": "test_serialize_node__retry.<locals>.InnerRetryGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -66,8 +64,8 @@ def test_serialize_node__retry(serialize_node):
                     "test_adornments_serialization",
                 ],
             },
-            "trigger": {"id": "af9ba01c-4cde-4632-9aa1-7673b42e7bd8", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "c2ecc6c0-f353-4495-9b93-a61a47248556", "name": "default", "type": "DEFAULT"}],
+            "trigger": {"id": "d38a83bf-23d1-4f9d-a875-a08dc27cf397", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "078650c9-f775-4cd0-a08c-23af9983a361", "name": "default", "type": "DEFAULT"}],
             "adornments": [
                 {
                     "id": "5be7d260-74f7-4734-b31b-a46a94539586",
@@ -102,13 +100,13 @@ def test_serialize_node__retry(serialize_node):
             ],
             "attributes": [
                 {
-                    "id": "c363daa7-9482-4c0e-aee8-faa080602ee3",
+                    "id": "278df25e-58b5-43c3-b346-cf6444d893a5",
                     "name": "input",
                     "value": {"type": "WORKFLOW_INPUT", "input_variable_id": str(input_id)},
                 }
             ],
             "outputs": [
-                {"id": "8aaf6cd8-3fa5-4f17-a60f-ec7da5ec6498", "name": "output", "type": "STRING", "value": None}
+                {"id": "dc89dc0d-c0bd-47fd-88aa-ec7b262aa2f1", "name": "output", "type": "STRING", "value": None}
             ],
         },
         serialized_node,
@@ -136,20 +134,18 @@ def test_serialize_node__retry__no_display():
     assert exec_config is not None
 
 
-@TryNode.wrap()
-class InnerTryGenericNode(BaseNode):
-    input = Inputs.input
-
-    class Outputs(BaseOutputs):
-        output: str
-
-
-@BaseTryNodeDisplay.wrap()
-class InnerTryGenericNodeDisplay(BaseNodeDisplay[InnerTryGenericNode]):
-    pass
-
-
 def test_serialize_node__try(serialize_node):
+    @TryNode.wrap()
+    class InnerTryGenericNode(BaseNode):
+        input = Inputs.input
+
+        class Outputs(BaseOutputs):
+            output: str
+
+    @BaseTryNodeDisplay.wrap()
+    class InnerTryGenericNodeDisplay(BaseNodeDisplay[InnerTryGenericNode]):
+        pass
+
     input_id = uuid4()
     serialized_node = serialize_node(
         base_class=BaseNodeVellumDisplay,
@@ -163,7 +159,7 @@ def test_serialize_node__try(serialize_node):
     assert not DeepDiff(
         {
             "id": str(InnerTryGenericNode.__wrapped_node__.__id__),
-            "label": "InnerTryGenericNode",
+            "label": "test_serialize_node__try.<locals>.InnerTryGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -179,8 +175,8 @@ def test_serialize_node__try(serialize_node):
                     "test_adornments_serialization",
                 ],
             },
-            "trigger": {"id": "741f7f75-e921-47a9-8c05-9e66640d0866", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "1b8f8ab5-a656-4015-926c-80655bbd9cb8", "name": "default", "type": "DEFAULT"}],
+            "trigger": {"id": "16bc1522-c408-47ad-9a22-0ef136384abf", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "8d25f244-4b12-4f8b-b202-8948698679a0", "name": "default", "type": "DEFAULT"}],
             "adornments": [
                 {
                     "id": "3344083c-a32c-4a32-920b-0fb5093448fa",
@@ -200,13 +196,13 @@ def test_serialize_node__try(serialize_node):
             ],
             "attributes": [
                 {
-                    "id": "4d8b4c2c-4f92-4c7a-abf0-b9c88a15a790",
+                    "id": "51aa0077-4060-496b-8e2e-e79d56ee6a32",
                     "name": "input",
                     "value": {"type": "WORKFLOW_INPUT", "input_variable_id": str(input_id)},
                 }
             ],
             "outputs": [
-                {"id": "63ba929b-bf79-44ee-bd1f-d259dbe8d48e", "name": "output", "type": "STRING", "value": None}
+                {"id": "ce9f8b86-6d26-4c03-8bfa-a31aa2cd97f1", "name": "output", "type": "STRING", "value": None}
             ],
         },
         serialized_node,

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
@@ -19,17 +19,16 @@ class Inputs(BaseInputs):
     input: str
 
 
-class ConstantValueGenericNode(BaseNode):
-    attr: str = "hello"
-
-
 def test_serialize_node__constant_value(serialize_node):
+    class ConstantValueGenericNode(BaseNode):
+        attr: str = "hello"
+
     serialized_node = serialize_node(ConstantValueGenericNode)
 
     assert not DeepDiff(
         {
-            "id": "be892bc8-e4de-47ef-ab89-dc9d869af1fe",
-            "label": "ConstantValueGenericNode",
+            "id": "67e07859-7f67-4287-9854-06ab4199e576",
+            "label": "test_serialize_node__constant_value.<locals>.ConstantValueGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -45,12 +44,12 @@ def test_serialize_node__constant_value(serialize_node):
                     "test_attributes_serialization",
                 ],
             },
-            "trigger": {"id": "279e8228-9b82-43a3-8c31-affc036e3a0b", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "7cd373aa-34d1-402d-bcb4-1c8f329b63e9", "type": "DEFAULT", "name": "default"}],
+            "trigger": {"id": "5d41f6fc-fc1a-4a19-9a06-6a0ea9d38557", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "96ac6512-0128-4cf7-ba51-2725b4807c8f", "type": "DEFAULT", "name": "default"}],
             "adornments": None,
             "attributes": [
                 {
-                    "id": "4cbbfd98-9ab6-41a8-bf4e-ae65f0eafe47",
+                    "id": "84e4f91c-af1a-4f9d-a578-e3f234dea23b",
                     "name": "attr",
                     "value": {
                         "type": "CONSTANT_VALUE",
@@ -68,17 +67,16 @@ def test_serialize_node__constant_value(serialize_node):
     )
 
 
-class ConstantValueReferenceGenericNode(BaseNode):
-    attr: str = ConstantValueReference("hello")
-
-
 def test_serialize_node__constant_value_reference(serialize_node):
+    class ConstantValueReferenceGenericNode(BaseNode):
+        attr: str = ConstantValueReference("hello")
+
     serialized_node = serialize_node(ConstantValueReferenceGenericNode)
 
     assert not DeepDiff(
         {
-            "id": "9271e2b1-f47e-47a4-95ae-51299dedb62f",
-            "label": "ConstantValueReferenceGenericNode",
+            "id": "73643f17-e49e-47d2-bd01-bb9c3eab6ae9",
+            "label": "test_serialize_node__constant_value_reference.<locals>.ConstantValueReferenceGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -94,12 +92,12 @@ def test_serialize_node__constant_value_reference(serialize_node):
                     "test_attributes_serialization",
                 ],
             },
-            "trigger": {"id": "8cc0b4c4-4ae4-4248-8fd5-bfb2e658eb51", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "fe696d84-47c2-4325-8020-34a1c586a759", "name": "default", "type": "DEFAULT"}],
+            "trigger": {"id": "174f3a8e-99c2-4045-8327-ad2dc658889e", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "61adfacf-c3a9-4aea-a3da-bcdbc03273c6", "name": "default", "type": "DEFAULT"}],
             "adornments": None,
             "attributes": [
                 {
-                    "id": "460aeb68-7369-43d2-9d3d-37caa425611f",
+                    "id": "f8e5efc6-8117-4a1c-bcea-5ba23555409a",
                     "name": "attr",
                     "value": {"type": "CONSTANT_VALUE", "value": {"type": "STRING", "value": "hello"}},
                 }
@@ -111,17 +109,16 @@ def test_serialize_node__constant_value_reference(serialize_node):
     )
 
 
-class LazyReferenceGenericNode(BaseNode):
-    attr: str = LazyReference(lambda: ConstantValueReference("hello"))
-
-
 def test_serialize_node__lazy_reference(serialize_node):
+    class LazyReferenceGenericNode(BaseNode):
+        attr: str = LazyReference(lambda: ConstantValueReference("hello"))
+
     serialized_node = serialize_node(LazyReferenceGenericNode)
 
     assert not DeepDiff(
         {
-            "id": "29563b11-bd4d-47b0-b017-372f78aeaef5",
-            "label": "LazyReferenceGenericNode",
+            "id": "3d6bfe3b-263a-40a6-8a05-98288e9559a4",
+            "label": "test_serialize_node__lazy_reference.<locals>.LazyReferenceGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -137,12 +134,12 @@ def test_serialize_node__lazy_reference(serialize_node):
                     "test_attributes_serialization",
                 ],
             },
-            "trigger": {"id": "56e9791a-078a-4bb7-90bc-a26c3991c70f", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "acb761a0-fcc2-4d21-bc8c-d0d560912c04", "name": "default", "type": "DEFAULT"}],
+            "trigger": {"id": "a3598540-7464-4965-8a2f-f022a011007d", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "2dba7224-a376-4780-8414-2b50601f9283", "name": "default", "type": "DEFAULT"}],
             "adornments": None,
             "attributes": [
                 {
-                    "id": "4370b381-9165-4fb4-881e-480507abe069",
+                    "id": "7ae37eb4-18c8-49e1-b5ac-6369ce7ed5dd",
                     "name": "attr",
                     "value": {"type": "CONSTANT_VALUE", "value": {"type": "STRING", "value": "hello"}},
                 }
@@ -191,20 +188,20 @@ def test_serialize_node__lazy_reference_with_string():
     ]
 
 
-class WorkflowInputGenericNode(BaseNode):
-    attr: str = Inputs.input
-
-
 def test_serialize_node__workflow_input(serialize_node):
+    class WorkflowInputGenericNode(BaseNode):
+        attr: str = Inputs.input
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=WorkflowInputGenericNode,
         global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)},
     )
+
     assert not DeepDiff(
         {
-            "id": "ddfa947f-0830-476b-b07e-ac573968f9a7",
-            "label": "WorkflowInputGenericNode",
+            "id": "30116483-6f38-40e0-baf2-32de0e14e9a3",
+            "label": "test_serialize_node__workflow_input.<locals>.WorkflowInputGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -220,12 +217,12 @@ def test_serialize_node__workflow_input(serialize_node):
                     "test_attributes_serialization",
                 ],
             },
-            "trigger": {"id": "b1a5d749-bac0-4f11-8427-191febb2198e", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "d15c7175-139c-4885-8ef8-3e4081db121b", "type": "DEFAULT", "name": "default"}],
+            "trigger": {"id": "dcb92d51-1fbd-4d41-ab89-c8f490d2bb38", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "20d91130-ca86-4420-b2e7-a962c0f1a509", "type": "DEFAULT", "name": "default"}],
             "adornments": None,
             "attributes": [
                 {
-                    "id": "56d44313-cfdd-4d75-9b19-0beb94e59c4e",
+                    "id": "6b2f781b-1a70-4abc-965a-a4edb8563f0e",
                     "name": "attr",
                     "value": {
                         "type": "WORKFLOW_INPUT",
@@ -240,20 +237,17 @@ def test_serialize_node__workflow_input(serialize_node):
     )
 
 
-class NodeWithOutput(BaseNode):
-    class Outputs(BaseNode.Outputs):
-        output = Inputs.input
-
-
-class NodeWithOutputDisplay(BaseNodeDisplay[NodeWithOutput]):
-    pass
-
-
-class GenericNodeReferencingOutput(BaseNode):
-    attr = NodeWithOutput.Outputs.output
-
-
 def test_serialize_node__node_output(serialize_node):
+    class NodeWithOutput(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output = Inputs.input
+
+    class NodeWithOutputDisplay(BaseNodeDisplay[NodeWithOutput]):
+        pass
+
+    class GenericNodeReferencingOutput(BaseNode):
+        attr = NodeWithOutput.Outputs.output
+
     workflow_input_id = uuid4()
     node_output_id = uuid4()
     serialized_node = serialize_node(
@@ -267,8 +261,8 @@ def test_serialize_node__node_output(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "c1e2ce60-ac3a-4b17-915e-abe861734e03",
-            "label": "GenericNodeReferencingOutput",
+            "id": "7210742f-8c3e-4379-9800-8b4b7f5dd7ed",
+            "label": "test_serialize_node__node_output.<locals>.GenericNodeReferencingOutput",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -284,16 +278,16 @@ def test_serialize_node__node_output(serialize_node):
                     "test_attributes_serialization",
                 ],
             },
-            "trigger": {"id": "449072ba-f7b6-4314-ac96-682123f225e5", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "1879f33e-6efa-46a0-9281-e02bbbc1d413", "type": "DEFAULT", "name": "default"}],
+            "trigger": {"id": "aa7f0dce-0413-4802-b1dd-f96a2d2eb8e5", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "a345665a-decd-4f6b-af38-387bd41c2643", "type": "DEFAULT", "name": "default"}],
             "adornments": None,
             "attributes": [
                 {
-                    "id": "73e6a103-1339-41ec-a245-42d43b0637c1",
+                    "id": "1318ab14-deb1-4254-9636-4bd783bdd9eb",
                     "name": "attr",
                     "value": {
                         "type": "NODE_OUTPUT",
-                        "node_id": "cd954d76-0b0a-4d9b-9bdf-347179c38cb6",
+                        "node_id": "48cf26cc-7b6d-49a7-a1a3-298f6d66772b",
                         "node_output_id": str(node_output_id),
                     },
                 }
@@ -305,20 +299,20 @@ def test_serialize_node__node_output(serialize_node):
     )
 
 
-class VellumSecretGenericNode(BaseNode):
-    attr = VellumSecretReference(name="hello")
-
-
 def test_serialize_node__vellum_secret(serialize_node):
+    class VellumSecretGenericNode(BaseNode):
+        attr = VellumSecretReference(name="hello")
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=VellumSecretGenericNode,
         global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)},
     )
+
     assert not DeepDiff(
         {
-            "id": "89aa6faa-b533-4179-8912-70a048bf0712",
-            "label": "VellumSecretGenericNode",
+            "id": "0e75bd8f-882e-4ab7-8348-061319b574f7",
+            "label": "test_serialize_node__vellum_secret.<locals>.VellumSecretGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -334,12 +328,12 @@ def test_serialize_node__vellum_secret(serialize_node):
                     "test_attributes_serialization",
                 ],
             },
-            "trigger": {"id": "3ea0305d-d8ea-45fe-8cf1-f6c1c85e6979", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "881abc1c-ada3-4405-8faf-e167fa2f851b", "type": "DEFAULT", "name": "default"}],
+            "trigger": {"id": "c5006d90-90cc-4e97-9092-f75785fa61ec", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "6d1c2139-64bd-4433-84d7-3fe08850134b", "type": "DEFAULT", "name": "default"}],
             "adornments": None,
             "attributes": [
                 {
-                    "id": "8edd27da-eec1-4539-8bec-629b5ef7a9f9",
+                    "id": "c2eb79e2-4cd3-4176-8da9-0d76327cbf0f",
                     "name": "attr",
                     "value": {"type": "VELLUM_SECRET", "vellum_secret_name": "hello"},
                 }
@@ -351,19 +345,16 @@ def test_serialize_node__vellum_secret(serialize_node):
     )
 
 
-class NodeWithExecutions(BaseNode):
-    pass
-
-
-class NodeWithExecutionsDisplay(BaseNodeDisplay[NodeWithExecutions]):
-    pass
-
-
-class GenericNodeReferencingExecutions(BaseNode):
-    attr: int = NodeWithExecutions.Execution.count
-
-
 def test_serialize_node__node_execution(serialize_node):
+    class NodeWithExecutions(BaseNode):
+        pass
+
+    class NodeWithExecutionsDisplay(BaseNodeDisplay[NodeWithExecutions]):
+        pass
+
+    class GenericNodeReferencingExecutions(BaseNode):
+        attr: int = NodeWithExecutions.Execution.count
+
     workflow_input_id = uuid4()
     serialized_node = serialize_node(
         node_class=GenericNodeReferencingExecutions,
@@ -373,8 +364,8 @@ def test_serialize_node__node_execution(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "6e4d2fb7-891e-492e-97a1-adf44693f518",
-            "label": "GenericNodeReferencingExecutions",
+            "id": "f42dda6b-e856-49bd-b203-46c9dd66c08b",
+            "label": "test_serialize_node__node_execution.<locals>.GenericNodeReferencingExecutions",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -390,16 +381,16 @@ def test_serialize_node__node_execution(serialize_node):
                     "test_attributes_serialization",
                 ],
             },
-            "trigger": {"id": "68a91426-4c30-4194-a4c0-cff224d3c0f3", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "0e1f78d5-8be1-4533-b2b4-a52777a8d43d", "type": "DEFAULT", "name": "default"}],
+            "trigger": {"id": "2fc95236-b5bc-4574-bade-2c9f0933b18c", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "59844b72-ac5e-43c5-b3a7-9c57ba73ec8c", "type": "DEFAULT", "name": "default"}],
             "adornments": None,
             "attributes": [
                 {
-                    "id": "090e18d7-d5b9-4d5f-9aec-0f562e4b33a8",
+                    "id": "8be1be85-ac70-4e61-b52a-cd416f5320b9",
                     "name": "attr",
                     "value": {
                         "type": "EXECUTION_COUNTER",
-                        "node_id": "c09bd5a6-dc04-4036-90d4-580acd43c71f",
+                        "node_id": "d68cc3c3-d5dc-4a51-bbfc-1fd4b41abad0",
                     },
                 }
             ],
@@ -410,33 +401,27 @@ def test_serialize_node__node_execution(serialize_node):
     )
 
 
-class CoalesceNodeA(BaseNode):
-    class Outputs(BaseNode.Outputs):
-        output: str
-
-
-class CoalesceNodeADisplay(BaseNodeDisplay[CoalesceNodeA]):
-    pass
-
-
-class CoalesceNodeB(BaseNode):
-    class Outputs(BaseNode.Outputs):
-        output: str
-
-
-class CoalesceNodeBDisplay(BaseNodeDisplay[CoalesceNodeB]):
-    pass
-
-
-class CoalesceNodeFinal(BaseNode):
-    attr = CoalesceNodeA.Outputs.output.coalesce(CoalesceNodeB.Outputs.output)
-
-
-class CoalesceNodeFinalDisplay(BaseNodeDisplay[CoalesceNodeFinal]):
-    pass
-
-
 def test_serialize_node__coalesce(serialize_node):
+    class CoalesceNodeA(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output: str
+
+    class CoalesceNodeADisplay(BaseNodeDisplay[CoalesceNodeA]):
+        pass
+
+    class CoalesceNodeB(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output: str
+
+    class CoalesceNodeBDisplay(BaseNodeDisplay[CoalesceNodeB]):
+        pass
+
+    class CoalesceNodeFinal(BaseNode):
+        attr = CoalesceNodeA.Outputs.output.coalesce(CoalesceNodeB.Outputs.output)
+
+    class CoalesceNodeFinalDisplay(BaseNodeDisplay[CoalesceNodeFinal]):
+        pass
+
     coalesce_node_a_output_id = uuid4()
     coalesce_node_b_output_id = uuid4()
     serialized_node = serialize_node(
@@ -460,8 +445,8 @@ def test_serialize_node__coalesce(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "84d0ce62-afd1-4186-b0e3-5dd8e5ca8b65",
-            "label": "CoalesceNodeFinal",
+            "id": "bb99f326-7d2a-4b5e-95f3-6039114798da",
+            "label": "test_serialize_node__coalesce.<locals>.CoalesceNodeFinal",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -477,24 +462,24 @@ def test_serialize_node__coalesce(serialize_node):
                     "test_attributes_serialization",
                 ],
             },
-            "trigger": {"id": "5165f887-153b-4ecd-9219-1beb3cf4f906", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "08ab456d-f541-4400-8305-e97f30cbe745", "name": "default", "type": "DEFAULT"}],
+            "trigger": {"id": "0302231d-73f2-4587-8a62-8ed3640f0f91", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "9d97a0c9-6a79-433a-bcdf-e07aa10c0f3c", "name": "default", "type": "DEFAULT"}],
             "adornments": None,
             "attributes": [
                 {
-                    "id": "5a22dd48-9ef3-456b-85b8-7662cf7823eb",
+                    "id": "2e25b25b-4aac-425f-91f4-f0fa55453b8c",
                     "name": "attr",
                     "value": {
                         "type": "BINARY_EXPRESSION",
                         "lhs": {
                             "type": "NODE_OUTPUT",
-                            "node_id": "20c340f2-409c-4d31-b44b-eeffd76938d5",
+                            "node_id": "f6d1aa4d-c3fd-421d-9dc8-4209bddf7fd3",
                             "node_output_id": str(coalesce_node_a_output_id),
                         },
                         "operator": "coalesce",
                         "rhs": {
                             "type": "NODE_OUTPUT",
-                            "node_id": "9fac3c54-4e75-46ca-a1f2-a80fc6d8ad3f",
+                            "node_id": "d1f673fb-80e1-4f9e-9d7d-afe64599ce39",
                             "node_output_id": str(coalesce_node_b_output_id),
                         },
                     },

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_outputs_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_outputs_serialization.py
@@ -13,18 +13,17 @@ class Inputs(BaseInputs):
     input: str
 
 
-class AnnotatedOutputGenericNode(BaseNode):
-    class Outputs(BaseNode.Outputs):
-        output: int
-
-
 def test_serialize_node__annotated_output(serialize_node):
+    class AnnotatedOutputGenericNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output: int
+
     serialized_node = serialize_node(AnnotatedOutputGenericNode)
 
     assert not DeepDiff(
         {
-            "id": "c0b71cfa-0d9e-4329-bde0-967c44be5c3c",
-            "label": "AnnotatedOutputGenericNode",
+            "id": "e33ddf79-f48c-4057-ba17-d41a3a60ac98",
+            "label": "test_serialize_node__annotated_output.<locals>.AnnotatedOutputGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -40,13 +39,13 @@ def test_serialize_node__annotated_output(serialize_node):
                     "test_outputs_serialization",
                 ],
             },
-            "trigger": {"id": "256ef76c-39a6-4a8f-8bda-922f5972a1d4", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "9f391128-5d83-4c46-a62e-2b8bd075f569", "type": "DEFAULT", "name": "default"}],
+            "trigger": {"id": "753f7ef1-8724-4af2-939a-794f74ffc21b", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "d83b7a5d-bbac-47ee-9277-1fbed71e83e8", "type": "DEFAULT", "name": "default"}],
             "adornments": None,
             "attributes": [],
             "outputs": [
                 {
-                    "id": "8c3c9aff-e1d5-49f4-af75-3ec2fcbb4af2",
+                    "id": "0fd1356f-ca4e-4e85-b923-8a0164bfc451",
                     "name": "output",
                     "type": "NUMBER",
                     "value": None,
@@ -58,12 +57,11 @@ def test_serialize_node__annotated_output(serialize_node):
     )
 
 
-class WorkflowInputGenericNode(BaseNode):
-    class Outputs(BaseNode.Outputs):
-        output = Inputs.input
-
-
 def test_serialize_node__workflow_input(serialize_node):
+    class WorkflowInputGenericNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output = Inputs.input
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=WorkflowInputGenericNode,
@@ -72,8 +70,8 @@ def test_serialize_node__workflow_input(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "ddfa947f-0830-476b-b07e-ac573968f9a7",
-            "label": "WorkflowInputGenericNode",
+            "id": "30116483-6f38-40e0-baf2-32de0e14e9a3",
+            "label": "test_serialize_node__workflow_input.<locals>.WorkflowInputGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -89,13 +87,13 @@ def test_serialize_node__workflow_input(serialize_node):
                     "test_outputs_serialization",
                 ],
             },
-            "trigger": {"id": "b1a5d749-bac0-4f11-8427-191febb2198e", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "d15c7175-139c-4885-8ef8-3e4081db121b", "type": "DEFAULT", "name": "default"}],
+            "trigger": {"id": "dcb92d51-1fbd-4d41-ab89-c8f490d2bb38", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "20d91130-ca86-4420-b2e7-a962c0f1a509", "type": "DEFAULT", "name": "default"}],
             "adornments": None,
             "attributes": [],
             "outputs": [
                 {
-                    "id": "2c4a85c0-b017-4cea-a261-e8e8498570c9",
+                    "id": "b62c0cbe-48d5-465d-8d9e-4ff82847f8c7",
                     "name": "output",
                     "type": "STRING",
                     "value": {
@@ -110,21 +108,18 @@ def test_serialize_node__workflow_input(serialize_node):
     )
 
 
-class NodeWithOutput(BaseNode):
-    class Outputs(BaseNode.Outputs):
-        output = Inputs.input
-
-
-class NodeWithOutputDisplay(BaseNodeDisplay[NodeWithOutput]):
-    pass
-
-
-class GenericNodeReferencingOutput(BaseNode):
-    class Outputs(BaseNode.Outputs):
-        output = NodeWithOutput.Outputs.output
-
-
 def test_serialize_node__node_output_reference(serialize_node):
+    class NodeWithOutput(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output = Inputs.input
+
+    class NodeWithOutputDisplay(BaseNodeDisplay[NodeWithOutput]):
+        pass
+
+    class GenericNodeReferencingOutput(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output = NodeWithOutput.Outputs.output
+
     workflow_input_id = uuid4()
     node_output_id = uuid4()
     serialized_node = serialize_node(
@@ -138,8 +133,8 @@ def test_serialize_node__node_output_reference(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "c1e2ce60-ac3a-4b17-915e-abe861734e03",
-            "label": "GenericNodeReferencingOutput",
+            "id": "ac067acc-6a6f-44b1-ae84-428e965ce691",
+            "label": "test_serialize_node__node_output_reference.<locals>.GenericNodeReferencingOutput",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -155,18 +150,18 @@ def test_serialize_node__node_output_reference(serialize_node):
                     "test_outputs_serialization",
                 ],
             },
-            "trigger": {"id": "449072ba-f7b6-4314-ac96-682123f225e5", "merge_behavior": "AWAIT_ATTRIBUTES"},
-            "ports": [{"id": "1879f33e-6efa-46a0-9281-e02bbbc1d413", "type": "DEFAULT", "name": "default"}],
+            "trigger": {"id": "e949426f-9f3c-425e-a4de-8c0c5f6a8945", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "ports": [{"id": "383dc10a-d8f3-4bac-b995-8b95bc6deb21", "type": "DEFAULT", "name": "default"}],
             "adornments": None,
             "attributes": [],
             "outputs": [
                 {
-                    "id": "db010db3-7076-4df9-ae1b-069caa16fa20",
+                    "id": "46e6e98e-9ecf-4880-86f9-6390f0851c31",
                     "name": "output",
                     "type": "STRING",
                     "value": {
                         "type": "NODE_OUTPUT",
-                        "node_id": "cd954d76-0b0a-4d9b-9bdf-347179c38cb6",
+                        "node_id": "21213d1e-991c-405a-b4fa-a1e01c4dd088",
                         "node_output_id": str(node_output_id),
                     },
                 }

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_ports_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_ports_serialization.py
@@ -15,16 +15,16 @@ class Inputs(BaseInputs):
     input: str
 
 
-class BasicGenericNode(BaseNode):
-    pass
-
-
 def test_serialize_node__basic(serialize_node):
+    class BasicGenericNode(BaseNode):
+        pass
+
     serialized_node = serialize_node(BasicGenericNode)
+
     assert not DeepDiff(
         {
-            "id": "c2ed23f7-f6cb-4a56-a91c-2e5f9d8fda7f",
-            "label": "BasicGenericNode",
+            "id": "8d7cbfe4-72ca-4367-a401-8d28723d2f00",
+            "label": "test_serialize_node__basic.<locals>.BasicGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -40,10 +40,10 @@ def test_serialize_node__basic(serialize_node):
                     "test_ports_serialization",
                 ],
             },
-            "trigger": {"id": "9d3a1b3d-4a38-4f2e-bbf1-dd8be152bce8", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "be19c63b-3492-46b1-be9d-16f8d2e6410b", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "89dccfa5-cc1a-4612-bd87-86cb444f6dd4",
+                    "id": "8bec8d0c-113f-4110-afcb-4a6e566e7236",
                     "name": "default",
                     "type": "DEFAULT",
                 }
@@ -57,12 +57,11 @@ def test_serialize_node__basic(serialize_node):
     )
 
 
-class IfGenericNode(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(Inputs.input.equals("hello"))
-
-
 def test_serialize_node__if(serialize_node):
+    class IfGenericNode(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(Inputs.input.equals("hello"))
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=IfGenericNode, global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)}
@@ -70,8 +69,8 @@ def test_serialize_node__if(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "31da54ae-1abb-4e9e-8a7d-6f4f30a78c72",
-            "label": "IfGenericNode",
+            "id": "bba4b15a-dea0-48c9-a79b-4e12e99db00f",
+            "label": "test_serialize_node__if.<locals>.IfGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -87,10 +86,10 @@ def test_serialize_node__if(serialize_node):
                     "test_ports_serialization",
                 ],
             },
-            "trigger": {"id": "a8afaebc-7333-4e3f-b221-24452b4a1d47", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "abe5abf8-9678-4606-be71-3104efc25c74", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "d713e346-b55a-4871-91de-f1470bfb3479",
+                    "id": "9889fe69-62f8-4bb3-aac6-425b75700bea",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
@@ -119,13 +118,12 @@ def test_serialize_node__if(serialize_node):
     )
 
 
-class IfElseGenericNode(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(Inputs.input.equals("hello"))
-        else_branch = Port.on_else()
-
-
 def test_serialize_node__if_else(serialize_node):
+    class IfElseGenericNode(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(Inputs.input.equals("hello"))
+            else_branch = Port.on_else()
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=IfElseGenericNode, global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)}
@@ -133,8 +131,8 @@ def test_serialize_node__if_else(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "1f499f82-8cc0-4060-bf4d-d20ac409d4aa",
-            "label": "IfElseGenericNode",
+            "id": "25c9c3f1-4014-47ac-90cf-5216de10d05c",
+            "label": "test_serialize_node__if_else.<locals>.IfElseGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -150,10 +148,10 @@ def test_serialize_node__if_else(serialize_node):
                     "test_ports_serialization",
                 ],
             },
-            "trigger": {"id": "5b4f6553-69ca-4844-bbe4-9e5594bc8cae", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "b5ef0133-0605-495f-a229-169d7490cd07", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "1b02eabf-f2bd-45bd-ab26-fe4034ed5978",
+                    "id": "6fd9edea-9c1f-4463-aeb9-bfdde3231ee0",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
@@ -173,7 +171,7 @@ def test_serialize_node__if_else(serialize_node):
                     },
                 },
                 {
-                    "id": "2c858834-8f65-4b6b-89d8-07b394764666",
+                    "id": "7f9ea016-22da-49b3-be46-b80fb96beedf",
                     "type": "ELSE",
                     "name": "else_branch",
                     "expression": None,
@@ -187,23 +185,23 @@ def test_serialize_node__if_else(serialize_node):
     )
 
 
-class IfElifElseGenericNode(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(Inputs.input.equals("hello"))
-        elif_branch = Port.on_elif(Inputs.input.equals("world"))
-        else_branch = Port.on_else()
-
-
 def test_serialize_node__if_elif_else(serialize_node):
+    class IfElifElseGenericNode(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(Inputs.input.equals("hello"))
+            elif_branch = Port.on_elif(Inputs.input.equals("world"))
+            else_branch = Port.on_else()
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=IfElifElseGenericNode,
         global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)},
     )
+
     assert not DeepDiff(
         {
-            "id": "21c49bfb-a90c-4565-a4e6-8eb5187e81ca",
-            "label": "IfElifElseGenericNode",
+            "id": "7b2b9cfc-12aa-432c-940d-cbe53e71de9c",
+            "label": "test_serialize_node__if_elif_else.<locals>.IfElifElseGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -219,10 +217,10 @@ def test_serialize_node__if_elif_else(serialize_node):
                     "test_ports_serialization",
                 ],
             },
-            "trigger": {"id": "22d55b5b-3545-4498-8658-9d0464202e78", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "d41d03f1-36f3-4cfe-ac9f-0f79a918a810", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "dcaa1d8e-01c6-48b4-a851-8828b49d0f57",
+                    "id": "19a1cc62-1f18-49b0-8026-7c82709e34db",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
@@ -242,7 +240,7 @@ def test_serialize_node__if_elif_else(serialize_node):
                     },
                 },
                 {
-                    "id": "e00351f8-f1f9-4f7b-bf7a-c24e3db40d6c",
+                    "id": "dc0b680e-d7b3-4a44-a37d-df22b310bda3",
                     "type": "ELIF",
                     "name": "elif_branch",
                     "expression": {
@@ -262,7 +260,7 @@ def test_serialize_node__if_elif_else(serialize_node):
                     },
                 },
                 {
-                    "id": "90caeb67-5ab7-46aa-b65e-01c27f549eed",
+                    "id": "16d0b698-1353-4eb3-9768-4a6e5ed4b1da",
                     "type": "ELSE",
                     "expression": None,
                     "name": "else_branch",
@@ -276,21 +274,18 @@ def test_serialize_node__if_elif_else(serialize_node):
     )
 
 
-class NodeWithOutput(BaseNode):
-    class Outputs(BaseNode.Outputs):
-        output = Inputs.input
-
-
-class NodeWithOutputDisplay(BaseNodeDisplay[NodeWithOutput]):
-    pass
-
-
-class GenericNodeReferencingOutput(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(NodeWithOutput.Outputs.output.equals("hello"))
-
-
 def test_serialize_node__node_output_reference(serialize_node):
+    class NodeWithOutput(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output = Inputs.input
+
+    class NodeWithOutputDisplay(BaseNodeDisplay[NodeWithOutput]):
+        pass
+
+    class GenericNodeReferencingOutput(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(NodeWithOutput.Outputs.output.equals("hello"))
+
     workflow_input_id = uuid4()
     node_output_id = uuid4()
     serialized_node = serialize_node(
@@ -304,8 +299,8 @@ def test_serialize_node__node_output_reference(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "c1e2ce60-ac3a-4b17-915e-abe861734e03",
-            "label": "GenericNodeReferencingOutput",
+            "id": "ac067acc-6a6f-44b1-ae84-428e965ce691",
+            "label": "test_serialize_node__node_output_reference.<locals>.GenericNodeReferencingOutput",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "definition": {
@@ -321,17 +316,17 @@ def test_serialize_node__node_output_reference(serialize_node):
                 ],
             },
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
-            "trigger": {"id": "449072ba-f7b6-4314-ac96-682123f225e5", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "e949426f-9f3c-425e-a4de-8c0c5f6a8945", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "eecccf2b-82af-4559-8a1b-0c5de5890ac2",
+                    "id": "500075dc-fc65-428a-b3c0-a410f8c7f8cf",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
                         "type": "BINARY_EXPRESSION",
                         "lhs": {
                             "type": "NODE_OUTPUT",
-                            "node_id": "cd954d76-0b0a-4d9b-9bdf-347179c38cb6",
+                            "node_id": "21213d1e-991c-405a-b4fa-a1e01c4dd088",
                             "node_output_id": str(node_output_id),
                         },
                         "operator": "=",
@@ -354,12 +349,11 @@ def test_serialize_node__node_output_reference(serialize_node):
     )
 
 
-class GenericNodeReferencingSecret(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(VellumSecretReference(name="hello").equals("hello"))
-
-
 def test_serialize_node__vellum_secret_reference(serialize_node):
+    class GenericNodeReferencingSecret(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(VellumSecretReference(name="hello").equals("hello"))
+
     workflow_input_id = uuid4()
     serialized_node = serialize_node(
         node_class=GenericNodeReferencingSecret,
@@ -368,8 +362,8 @@ def test_serialize_node__vellum_secret_reference(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "88272edd-fc81-403b-bb87-a116ef8f269e",
-            "label": "GenericNodeReferencingSecret",
+            "id": "feb4b331-e25f-4a5c-9840-c5575b1efd5c",
+            "label": "test_serialize_node__vellum_secret_reference.<locals>.GenericNodeReferencingSecret",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "definition": {
@@ -385,10 +379,10 @@ def test_serialize_node__vellum_secret_reference(serialize_node):
                 ],
             },
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
-            "trigger": {"id": "2709539b-352d-455a-bb86-dba070b59aa1", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "d762741b-c137-4df4-ade6-65f31ea5a624", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "b6387c9c-2cce-4667-9567-97e433503e72",
+                    "id": "3b6b4048-8622-446d-9772-2766357d7b18",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
@@ -414,20 +408,17 @@ def test_serialize_node__vellum_secret_reference(serialize_node):
     )
 
 
-class NodeWithExecutions(BaseNode):
-    pass
-
-
-class NodeWithExecutionsDisplay(BaseNodeDisplay[NodeWithExecutions]):
-    pass
-
-
-class GenericNodeReferencingExecutions(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(NodeWithExecutions.Execution.count.equals(5))
-
-
 def test_serialize_node__execution_count_reference(serialize_node):
+    class NodeWithExecutions(BaseNode):
+        pass
+
+    class NodeWithExecutionsDisplay(BaseNodeDisplay[NodeWithExecutions]):
+        pass
+
+    class GenericNodeReferencingExecutions(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(NodeWithExecutions.Execution.count.equals(5))
+
     workflow_input_id = uuid4()
     serialized_node = serialize_node(
         node_class=GenericNodeReferencingExecutions,
@@ -437,8 +428,8 @@ def test_serialize_node__execution_count_reference(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "6e4d2fb7-891e-492e-97a1-adf44693f518",
-            "label": "GenericNodeReferencingExecutions",
+            "id": "0b4fe8a6-6d0c-464e-9372-10110e2b0e13",
+            "label": "test_serialize_node__execution_count_reference.<locals>.GenericNodeReferencingExecutions",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "definition": {
@@ -454,17 +445,17 @@ def test_serialize_node__execution_count_reference(serialize_node):
                 ],
             },
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
-            "trigger": {"id": "68a91426-4c30-4194-a4c0-cff224d3c0f3", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "d6aa7eec-6f01-41c5-9f5c-d50c53259527", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "13ab561e-09c9-48ed-b22b-a4de4d9df887",
+                    "id": "79d0cfa3-c8f9-4434-a2f8-5e416d66437a",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
                         "type": "BINARY_EXPRESSION",
                         "lhs": {
                             "type": "EXECUTION_COUNTER",
-                            "node_id": "c09bd5a6-dc04-4036-90d4-580acd43c71f",
+                            "node_id": "235c66f9-c76b-4df0-9bff-cfba2ef1ad18",
                         },
                         "operator": "=",
                         "rhs": {
@@ -486,12 +477,11 @@ def test_serialize_node__execution_count_reference(serialize_node):
     )
 
 
-class NullGenericNode(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(Inputs.input.is_null())
-
-
 def test_serialize_node__null(serialize_node):
+    class NullGenericNode(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(Inputs.input.is_null())
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=NullGenericNode, global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)}
@@ -499,8 +489,8 @@ def test_serialize_node__null(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "d5fe72cd-a2bd-4f91-ae13-44e4c617815e",
-            "label": "NullGenericNode",
+            "id": "1838ce1f-9c07-4fd0-9fd4-2a3a841ea402",
+            "label": "test_serialize_node__null.<locals>.NullGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -516,10 +506,10 @@ def test_serialize_node__null(serialize_node):
                     "test_ports_serialization",
                 ],
             },
-            "trigger": {"id": "26b257ed-6a7d-4ca3-a5c8-d17ba1e776ba", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "f4dcf8a3-692c-4b7c-8625-1a54eaa16ff2", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "76a2867d-dd4c-409c-b97f-94b168a2233a",
+                    "id": "7f1fb75d-0c8b-4ebc-8c59-4ae68f1a68e1",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
@@ -541,16 +531,14 @@ def test_serialize_node__null(serialize_node):
     )
 
 
-class IntegerInputs(BaseInputs):
-    input: int
-
-
-class BetweenGenericNode(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(IntegerInputs.input.between(1, 10))
-
-
 def test_serialize_node__between(serialize_node):
+    class IntegerInputs(BaseInputs):
+        input: int
+
+    class BetweenGenericNode(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(IntegerInputs.input.between(1, 10))
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=BetweenGenericNode,
@@ -559,8 +547,8 @@ def test_serialize_node__between(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "3ef33a2a-6ad5-415c-be75-f38cc1403dfc",
-            "label": "BetweenGenericNode",
+            "id": "f2f5a1f2-a12d-4ce0-bfe9-42190ffe5328",
+            "label": "test_serialize_node__between.<locals>.BetweenGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -576,10 +564,10 @@ def test_serialize_node__between(serialize_node):
                     "test_ports_serialization",
                 ],
             },
-            "trigger": {"id": "086a355e-d9ef-4039-af35-9f1211497b32", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "12f79444-890b-4e5e-93b6-6c0efaee40db", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "71493245-0778-46f2-8bda-863af50d910d",
+                    "id": "b745c089-1023-46dc-b2b6-ba75ac37563a",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
@@ -615,12 +603,12 @@ def test_serialize_node__between(serialize_node):
     )
 
 
-class OrGenericNode(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(Inputs.input.equals("hello") | Inputs.input.equals("world"))
-
-
 def test_serialize_node__or(serialize_node):
+
+    class OrGenericNode(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(Inputs.input.equals("hello") | Inputs.input.equals("world"))
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=OrGenericNode, global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)}
@@ -628,8 +616,8 @@ def test_serialize_node__or(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "63900268-b9d0-4285-8ea4-7c478f4abf88",
-            "label": "OrGenericNode",
+            "id": "5386abad-3378-4378-b3a8-831b4b77dc23",
+            "label": "test_serialize_node__or.<locals>.OrGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -645,10 +633,10 @@ def test_serialize_node__or(serialize_node):
                     "test_ports_serialization",
                 ],
             },
-            "trigger": {"id": "dc245f37-9be7-4097-a50a-4f7196e24313", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "fb39e80b-4032-4538-83e4-59480b1ef7ff", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "9b4511aa-2d57-44f9-8156-d41dd8b5f98e",
+                    "id": "0bd64819-b866-4333-82e0-8ac672c09b79",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
@@ -696,14 +684,13 @@ def test_serialize_node__or(serialize_node):
     )
 
 
-class AndThenOrGenericNode(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(
-            Inputs.input.equals("hello") & Inputs.input.equals("then") | Inputs.input.equals("world")
-        )
-
-
 def test_serialize_node__and_then_or(serialize_node):
+    class AndThenOrGenericNode(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(
+                Inputs.input.equals("hello") & Inputs.input.equals("then") | Inputs.input.equals("world")
+            )
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=AndThenOrGenericNode,
@@ -712,8 +699,8 @@ def test_serialize_node__and_then_or(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "b3908206-e540-4dac-9c64-a2e12b847b15",
-            "label": "AndThenOrGenericNode",
+            "id": "4d3995b1-437b-48d9-8878-9f57a8b725f1",
+            "label": "test_serialize_node__and_then_or.<locals>.AndThenOrGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -729,10 +716,10 @@ def test_serialize_node__and_then_or(serialize_node):
                     "test_ports_serialization",
                 ],
             },
-            "trigger": {"id": "33cfa8f4-bfc5-40b3-8df8-ab86371c26e0", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "b2b040de-9fba-4204-a6a5-e17f6ab321b1", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "91174ae5-6ce0-4f6c-9c05-ecfbfb4058f6",
+                    "id": "8bb89da2-a752-4541-8f90-1276c44910a8",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
@@ -799,14 +786,13 @@ def test_serialize_node__and_then_or(serialize_node):
     )
 
 
-class ParenthesizedAndThenOrGenericNode(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(
-            Inputs.input.equals("hello") & (Inputs.input.equals("then") | Inputs.input.equals("world"))
-        )
-
-
 def test_serialize_node__parenthesized_and_then_or(serialize_node):
+    class ParenthesizedAndThenOrGenericNode(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(
+                Inputs.input.equals("hello") & (Inputs.input.equals("then") | Inputs.input.equals("world"))
+            )
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=ParenthesizedAndThenOrGenericNode,
@@ -815,8 +801,8 @@ def test_serialize_node__parenthesized_and_then_or(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "6ed0373a-13b1-4edb-b0c4-31642cf312f8",
-            "label": "ParenthesizedAndThenOrGenericNode",
+            "id": "223864c9-0088-4c05-9b7d-e5b1c9ec936d",
+            "label": "test_serialize_node__parenthesized_and_then_or.<locals>.ParenthesizedAndThenOrGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -832,10 +818,10 @@ def test_serialize_node__parenthesized_and_then_or(serialize_node):
                     "test_ports_serialization",
                 ],
             },
-            "trigger": {"id": "91ac3b05-c931-4a4c-bb48-c2ba0e883867", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "bfd1504d-f642-431d-a900-28b0709bd65c", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "915f923b-f398-48af-93a4-5f7e66b8aa76",
+                    "id": "30478083-924d-469e-ad55-df28bc282cdb",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
@@ -902,14 +888,13 @@ def test_serialize_node__parenthesized_and_then_or(serialize_node):
     )
 
 
-class OrThenAndGenericNode(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(
-            Inputs.input.equals("hello") | Inputs.input.equals("then") & Inputs.input.equals("world")
-        )
-
-
 def test_serialize_node__or_then_and(serialize_node):
+    class OrThenAndGenericNode(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(
+                Inputs.input.equals("hello") | Inputs.input.equals("then") & Inputs.input.equals("world")
+            )
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=OrThenAndGenericNode,
@@ -918,8 +903,8 @@ def test_serialize_node__or_then_and(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "a0e0a35b-132e-4168-ad7d-ceb04f3203f2",
-            "label": "OrThenAndGenericNode",
+            "id": "a946342e-4ede-4e96-8e3d-f396748d9f7c",
+            "label": "test_serialize_node__or_then_and.<locals>.OrThenAndGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -935,10 +920,10 @@ def test_serialize_node__or_then_and(serialize_node):
                     "test_ports_serialization",
                 ],
             },
-            "trigger": {"id": "dfa53d32-36cc-4b1d-adad-d4de21ac1e5a", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "9c59699a-edf9-4618-b6bc-1074f3bfae78", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "413bba3d-6a16-4f96-ba45-b5372f819277",
+                    "id": "7f442cce-0b99-482c-aec8-8eed6ccadde2",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {
@@ -1005,12 +990,12 @@ def test_serialize_node__or_then_and(serialize_node):
     )
 
 
-class ParseJsonGenericNode(BaseNode):
-    class Ports(BaseNode.Ports):
-        if_branch = Port.on_if(Inputs.input.parse_json().equals({"key": "value"}))
-
-
 def test_serialize_node__parse_json(serialize_node):
+
+    class ParseJsonGenericNode(BaseNode):
+        class Ports(BaseNode.Ports):
+            if_branch = Port.on_if(Inputs.input.parse_json().equals({"key": "value"}))
+
     input_id = uuid4()
     serialized_node = serialize_node(
         node_class=ParseJsonGenericNode,
@@ -1019,8 +1004,8 @@ def test_serialize_node__parse_json(serialize_node):
 
     assert not DeepDiff(
         {
-            "id": "60edd9b2-9bad-470f-832c-c5f1aa9a253e",
-            "label": "ParseJsonGenericNode",
+            "id": "bfc3f81b-242a-4f43-9e1c-648223d77768",
+            "label": "test_serialize_node__parse_json.<locals>.ParseJsonGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -1036,10 +1021,10 @@ def test_serialize_node__parse_json(serialize_node):
                     "test_ports_serialization",
                 ],
             },
-            "trigger": {"id": "0ccc19cb-174b-440b-8d08-6c84c571fb8f", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "1d3287e2-cc05-49d2-be99-150320264f24", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "abe1e6db-14df-4d3c-b059-d17933ab8c02",
+                    "id": "5a88bac8-89b3-4d81-b539-2f977a36a9c0",
                     "type": "IF",
                     "name": "if_branch",
                     "expression": {

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_trigger_serialization.py
@@ -9,16 +9,15 @@ class Inputs(BaseInputs):
     input: str
 
 
-class BasicGenericNode(BaseNode):
-    pass
-
-
 def test_serialize_node__basic(serialize_node):
+    class BasicGenericNode(BaseNode):
+        pass
+
     serialized_node = serialize_node(BasicGenericNode)
     assert not DeepDiff(
         {
-            "id": "c2ed23f7-f6cb-4a56-a91c-2e5f9d8fda7f",
-            "label": "BasicGenericNode",
+            "id": "8d7cbfe4-72ca-4367-a401-8d28723d2f00",
+            "label": "test_serialize_node__basic.<locals>.BasicGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -34,10 +33,10 @@ def test_serialize_node__basic(serialize_node):
                     "test_trigger_serialization",
                 ],
             },
-            "trigger": {"id": "9d3a1b3d-4a38-4f2e-bbf1-dd8be152bce8", "merge_behavior": "AWAIT_ATTRIBUTES"},
+            "trigger": {"id": "be19c63b-3492-46b1-be9d-16f8d2e6410b", "merge_behavior": "AWAIT_ATTRIBUTES"},
             "ports": [
                 {
-                    "id": "89dccfa5-cc1a-4612-bd87-86cb444f6dd4",
+                    "id": "8bec8d0c-113f-4110-afcb-4a6e566e7236",
                     "name": "default",
                     "type": "DEFAULT",
                 }
@@ -51,17 +50,16 @@ def test_serialize_node__basic(serialize_node):
     )
 
 
-class AwaitAnyGenericNode(BaseNode):
-    class Trigger(BaseNode.Trigger):
-        merge_behavior = MergeBehavior.AWAIT_ANY
-
-
 def test_serialize_node__await_any(serialize_node):
+    class AwaitAnyGenericNode(BaseNode):
+        class Trigger(BaseNode.Trigger):
+            merge_behavior = MergeBehavior.AWAIT_ANY
+
     serialized_node = serialize_node(AwaitAnyGenericNode)
     assert not DeepDiff(
         {
-            "id": "0ba67f76-aaff-4bd4-a20f-73a32ef5810d",
-            "label": "AwaitAnyGenericNode",
+            "id": "42e17f0e-8496-415f-9c72-f85250ba6f0b",
+            "label": "test_serialize_node__await_any.<locals>.AwaitAnyGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -77,10 +75,10 @@ def test_serialize_node__await_any(serialize_node):
                     "test_trigger_serialization",
                 ],
             },
-            "trigger": {"id": "ffa72187-9a18-453f-ae55-b77aad332630", "merge_behavior": "AWAIT_ANY"},
+            "trigger": {"id": "5bb6bb4c-4374-44c8-a7b5-7bb6c1060a5b", "merge_behavior": "AWAIT_ANY"},
             "ports": [
                 {
-                    "id": "38b83138-cb07-40cb-82d2-83982ded6883",
+                    "id": "d9a84db7-8bd6-4a15-9e3c-c2e898c26d16",
                     "name": "default",
                     "type": "DEFAULT",
                 }
@@ -94,17 +92,16 @@ def test_serialize_node__await_any(serialize_node):
     )
 
 
-class AwaitAllGenericNode(BaseNode):
-    class Trigger(BaseNode.Trigger):
-        merge_behavior = MergeBehavior.AWAIT_ALL
-
-
 def test_serialize_node__await_all(serialize_node):
+    class AwaitAllGenericNode(BaseNode):
+        class Trigger(BaseNode.Trigger):
+            merge_behavior = MergeBehavior.AWAIT_ALL
+
     serialized_node = serialize_node(AwaitAllGenericNode)
     assert not DeepDiff(
         {
-            "id": "09d06cd3-06ea-40cc-afd8-17ad88542271",
-            "label": "AwaitAllGenericNode",
+            "id": "b3e1145a-5f41-456b-9382-6d0a1e828c2f",
+            "label": "test_serialize_node__await_all.<locals>.AwaitAllGenericNode",
             "type": "GENERIC",
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
@@ -120,10 +117,10 @@ def test_serialize_node__await_all(serialize_node):
                     "test_trigger_serialization",
                 ],
             },
-            "trigger": {"id": "62074276-c817-476d-b59d-da523ae3f218", "merge_behavior": "AWAIT_ALL"},
+            "trigger": {"id": "124ba9cf-a30e-41ef-81bf-143708f8b1c3", "merge_behavior": "AWAIT_ALL"},
             "ports": [
                 {
-                    "id": "9edef179-a1c2-4624-b185-593bb84f08a0",
+                    "id": "fa73da35-0bf9-4f02-bf5b-0b0d1a6f1494",
                     "name": "default",
                     "type": "DEFAULT",
                 }


### PR DESCRIPTION
follow up: https://github.com/vellum-ai/vellum-python-sdks/pull/1141

Move local class into their test func, no logic changes