### PR TITLE
Support pydantic <2.5

### DIFF
--- a/src/vellum/plugins/pydantic.py
+++ b/src/vellum/plugins/pydantic.py
@@ -1,16 +1,19 @@
 from functools import lru_cache
 from typing import Any, Dict, Literal, Optional, Tuple, Union
+from typing_extensions import TypeAlias
 
 from pydantic.fields import FieldInfo
 from pydantic.plugin import (
     PydanticPluginProtocol,
-    SchemaKind,
     SchemaTypePath,
     ValidateJsonHandlerProtocol,
     ValidatePythonHandlerProtocol,
     ValidateStringsHandlerProtocol,
 )
 from pydantic_core import CoreSchema
+
+# Redefined manually instead of imported from pydantic to support versions < 2.5
+SchemaKind: TypeAlias = Literal["BaseModel", "TypeAdapter", "dataclass", "create_model", "validate_call"]
 
 
 @lru_cache(maxsize=1)

--- a/src/vellum/plugins/pydantic.py
+++ b/src/vellum/plugins/pydantic.py
@@ -1,11 +1,10 @@
 from functools import lru_cache
-from typing import Any, Dict, Literal, Optional, Tuple, Union
+from typing import Any, Dict, Literal, NamedTuple, Optional, Tuple, Union
 from typing_extensions import TypeAlias
 
 from pydantic.fields import FieldInfo
 from pydantic.plugin import (
     PydanticPluginProtocol,
-    SchemaTypePath,
     ValidateJsonHandlerProtocol,
     ValidatePythonHandlerProtocol,
     ValidateStringsHandlerProtocol,
@@ -14,6 +13,14 @@ from pydantic_core import CoreSchema
 
 # Redefined manually instead of imported from pydantic to support versions < 2.5
 SchemaKind: TypeAlias = Literal["BaseModel", "TypeAdapter", "dataclass", "create_model", "validate_call"]
+
+
+# Redefined manually instead of imported from pydantic to support versions < 2.5
+class SchemaTypePath(NamedTuple):
+    """Path defining where `schema_type` was defined, or where `TypeAdapter` was called."""
+
+    module: str
+    name: str
 
 
 @lru_cache(maxsize=1)
@@ -84,7 +91,7 @@ class VellumPydanticPlugin(PydanticPluginProtocol):
         self,
         schema: CoreSchema,
         schema_type: Any,
-        schema_type_path: SchemaTypePath,
+        schema_type_path: SchemaTypePath,  # type: ignore
         schema_kind: SchemaKind,
         config: Any,
         plugin_settings: Dict[str, Any],


### PR DESCRIPTION
`SchemaKind` was introduced later than some of our users' versions, and we're not really using it. So just redefining inline.

NOTE: I was trying to repro this in our prototype repo locally and was unable to get my venv to work. I'd encourage whoever takes this over the line to manually ensure none of the other pydantic imports in this file will cause problems