### PR TITLE
[APO-1] Add none log output ID handling for CodeExecutionNode

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1301,10 +1301,12 @@ export function codeExecutionNodeFactory({
   codeInputValueRule,
   codeOutputValueType,
   runtimeInput,
+  generateLogOutputId = true,
 }: {
   codeInputValueRule?: NodeInputValuePointerRule;
   codeOutputValueType?: VellumVariableType;
   runtimeInput?: NodeInput;
+  generateLogOutputId?: boolean;
 } = {}): CodeExecutionNode {
   const runtime =
     runtimeInput ??
@@ -1332,7 +1334,9 @@ export function codeExecutionNodeFactory({
       codeInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
       outputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
       outputType: codeOutputValueType ?? "STRING",
-      logOutputId: "46abb839-400b-4766-997e-9c463b526139",
+      logOutputId: generateLogOutputId
+        ? "46abb839-400b-4766-997e-9c463b526139"
+        : undefined,
       runtimeInputId: runtime.id,
       targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
       sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1332,6 +1332,7 @@ export function codeExecutionNodeFactory({
       codeInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
       outputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
       outputType: codeOutputValueType ?? "STRING",
+      logOutputId: "46abb839-400b-4766-997e-9c463b526139",
       runtimeInputId: runtime.id,
       targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
       sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -171,7 +171,7 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
 "
 `;
 
-exports[`CodeExecutionNode > log output id > should not generate log output id 1`] = `
+exports[`CodeExecutionNode > log output id > should not generate log output id if not given 1`] = `
 "from uuid import UUID
 
 from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -20,7 +20,7 @@ class CodeExecutionNodeDisplay(BaseCodeExecutionNodeDisplay[CodeExecutionNode]):
     code_input_id = UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
     runtime_input_id = UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e")
     output_id = UUID("81b270c0-4deb-4db3-aae5-138f79531b2b")
-    log_output_id = None
+    log_output_id = UUID("46abb839-400b-4766-997e-9c463b526139")
     node_input_ids_by_name = {
         "code": UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc"),
         "runtime": UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e"),
@@ -29,7 +29,9 @@ class CodeExecutionNodeDisplay(BaseCodeExecutionNodeDisplay[CodeExecutionNode]):
         CodeExecutionNode.Outputs.result: NodeOutputDisplay(
             id=UUID("81b270c0-4deb-4db3-aae5-138f79531b2b"), name="result"
         ),
-        CodeExecutionNode.Outputs.log: NodeOutputDisplay(id=None, name="log"),
+        CodeExecutionNode.Outputs.log: NodeOutputDisplay(
+            id=UUID("46abb839-400b-4766-997e-9c463b526139"), name="log"
+        ),
     }
     port_displays = {
         CodeExecutionNode.Ports.default: PortDisplayOverrides(
@@ -166,6 +168,48 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
     code_inputs = {}
     runtime = "PYTHON_3_11_6"
     packages = None
+"
+`;
+
+exports[`CodeExecutionNode > log output id > should not generate log output id 1`] = `
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
+from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+
+from ...nodes.code_execution_node import CodeExecutionNode
+
+
+class CodeExecutionNodeDisplay(BaseCodeExecutionNodeDisplay[CodeExecutionNode]):
+    label = "Code Execution Node"
+    node_id = UUID("2cd960a3-cb8a-43ed-9e3f-f003fc480951")
+    target_handle_id = UUID("06573a05-e6f0-48b9-bc6e-07e06d0bc1b1")
+    code_input_id = UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
+    runtime_input_id = UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e")
+    output_id = UUID("81b270c0-4deb-4db3-aae5-138f79531b2b")
+    node_input_ids_by_name = {
+        "code": UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc"),
+        "runtime": UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e"),
+    }
+    output_display = {
+        CodeExecutionNode.Outputs.result: NodeOutputDisplay(
+            id=UUID("81b270c0-4deb-4db3-aae5-138f79531b2b"), name="result"
+        )
+    }
+    port_displays = {
+        CodeExecutionNode.Ports.default: PortDisplayOverrides(
+            id=UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e")
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=2075.7067885117494, y=234.65663468515768),
+        width=462,
+        height=288,
+    )
 "
 `;
 

--- a/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
@@ -281,7 +281,7 @@ describe("CodeExecutionNode", () => {
     );
   });
   describe("log output id", () => {
-    it("should not generate log output id", async () => {
+    it("should not generate log output id if not given", async () => {
       const nodeData = codeExecutionNodeFactory();
 
       // GIVEN a node without a log output id

--- a/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
@@ -282,11 +282,9 @@ describe("CodeExecutionNode", () => {
   });
   describe("log output id", () => {
     it("should not generate log output id if not given", async () => {
-      const nodeData = codeExecutionNodeFactory();
-
-      // GIVEN a node without a log output id
-      nodeData.data.logOutputId = undefined;
-
+      const nodeData = codeExecutionNodeFactory({
+        generateLogOutputId: false,
+      });
       const nodeContext = (await createNodeContext({
         workflowContext,
         nodeData,

--- a/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
@@ -280,4 +280,25 @@ describe("CodeExecutionNode", () => {
       }
     );
   });
+  describe("log output id", () => {
+    it("should not generate log output id", async () => {
+      const nodeData = codeExecutionNodeFactory();
+
+      // GIVEN a node without a log output id
+      nodeData.data.logOutputId = undefined;
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as CodeExecutionContext;
+
+      node = new CodeExecutionNode({
+        workflowContext: workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeDisplayFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
linear: https://linear.app/vellum/issue/APO-1/try-node-wrapped-code-node-display-is-code-genning-none-for-log-output

Resilience for `none` in log output id