### PR TITLE
Fix workflow generic node port name

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -279,8 +279,8 @@ exports[`Workflow > graph > should handle a simple edge of generic nodes 1`] = `
 
 exports[`Workflow > graph > should properly format UUID-like port names in graph references 1`] = `
 "{
-    GenericNode.Ports._7d813792_04c2_4d26_a126_16de4c4cebaf >> FirstNode,
-    GenericNode.Ports._6f909cc6_887c_46d8_966b_46547900fc9c >> SecondNode,
+    GenericNode.Ports.port_7d813792_04c2_4d26_a126_16de4c4cebaf >> FirstNode,
+    GenericNode.Ports.port_6f909cc6_887c_46d8_966b_46547900fc9c >> SecondNode,
 }
 "
 `;

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -1,5 +1,3 @@
-import { isEmpty, isNil } from "lodash";
-
 import { VELLUM_WORKFLOW_NODES_MODULE_PATH } from "src/constants";
 import { WorkflowContext } from "src/context";
 import { PortContext } from "src/context/port-context";
@@ -129,36 +127,12 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
     return toPythonSafeSnakeCase(nodeOutputName, "output");
   }
 
-  private isPortNameUsed(portName: string): boolean {
+  public isPortNameUsed(portName: string): boolean {
     return this.nodePortNames.has(portName);
   }
 
-  private addUsedPortName(portName: string): void {
+  public addUsedPortName(portName: string): void {
     this.nodePortNames.add(portName);
-  }
-
-  public generateSanitizedPortName(portName: string): string {
-    const defaultName = "port_";
-    const rawPortName = portName;
-
-    const initialPortName =
-      !isNil(rawPortName) && !isEmpty(rawPortName)
-        ? toPythonSafeSnakeCase(rawPortName, "port")
-        : defaultName;
-
-    // Deduplicate the port variable name if it's already in use
-    let sanitizedName = initialPortName;
-    let numRenameAttempts = 0;
-    while (this.isPortNameUsed(sanitizedName)) {
-      sanitizedName = `${initialPortName}${
-        initialPortName.endsWith("_") ? "" : "_"
-      }${numRenameAttempts + 1}`;
-      numRenameAttempts += 1;
-    }
-
-    this.addUsedPortName(sanitizedName);
-
-    return sanitizedName;
   }
 
   /**

--- a/ee/codegen/src/generators/node-port.ts
+++ b/ee/codegen/src/generators/node-port.ts
@@ -50,7 +50,7 @@ export class NodePorts extends AstNode {
       if (portExpression) {
         fields.push(
           python.field({
-            name: this.nodeContext.generateSanitizedPortName(port.name),
+            name: this.getSanitizedPortName(port),
             initializer: portExpression,
           })
         );
@@ -76,6 +76,12 @@ export class NodePorts extends AstNode {
     fields.forEach((field) => clazz.add(field));
 
     return clazz;
+  }
+
+  private getSanitizedPortName(port: NodePortType): string {
+    const portContext = this.nodeContext.portContextsById.get(port.id);
+
+    return portContext?.portName ?? port.name;
   }
 
   write(writer: Writer): void {


### PR DESCRIPTION
This PR solves the issue that workflow generic port name does not use the sanitized name but genric node does
- handle sanitization at context level (same as input/output)
- use the sanitized name when writing workflow