### PR TITLE
Pass the adornment's id as that node's id

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -205,7 +205,10 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.api_node import APINode
 
 
-@BaseTryNodeDisplay.wrap(error_output_id=UUID("af589f73-effe-4a80-b48f-fb912ac6ce67"))
+@BaseTryNodeDisplay.wrap(
+    node_id=UUID("af589f73-effe-4a80-b48f-fb912ac6ce67"),
+    error_output_id=UUID("af589f73-effe-4a80-b48f-fb912ac6ce67"),
+)
 class APINodeDisplay(BaseAPINodeDisplay[APINode]):
     label = "API Node"
     node_id = UUID("2cd960a3-cb8a-43ed-9e3f-f003fc480951")

--- a/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
@@ -133,7 +133,10 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.guardrail_node import GuardrailNode
 
 
-@BaseTryNodeDisplay.wrap(error_output_id=UUID("38361ff1-c826-49b8-aa8d-28179c3684cc"))
+@BaseTryNodeDisplay.wrap(
+    node_id=UUID("38361ff1-c826-49b8-aa8d-28179c3684cc"),
+    error_output_id=UUID("38361ff1-c826-49b8-aa8d-28179c3684cc"),
+)
 class GuardrailNodeDisplay(BaseGuardrailNodeDisplay[GuardrailNode]):
     label = "Guardrail Node"
     node_id = UUID("metric")

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node-retry.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node-retry.test.ts.snap
@@ -16,7 +16,7 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.prompt_node import PromptNode
 
 
-@BaseRetryNodeDisplay.wrap()
+@BaseRetryNodeDisplay.wrap(node_id=UUID("cc79c784-d936-44c2-a811-b86a53e6ff68"))
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
@@ -92,8 +92,11 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.prompt_node import PromptNode
 
 
-@BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
-@BaseRetryNodeDisplay.wrap()
+@BaseTryNodeDisplay.wrap(
+    node_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+    error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+)
+@BaseRetryNodeDisplay.wrap(node_id=UUID("e5de8d57-ae0d-4a4a-afb3-eb4cd6bdb0ac"))
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
@@ -170,7 +173,7 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.prompt_node import PromptNode
 
 
-@BaseRetryNodeDisplay.wrap()
+@BaseRetryNodeDisplay.wrap(node_id=UUID("2076aea8-be38-4ff1-8c68-cb853e352d66"))
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -202,7 +202,10 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.prompt_node import PromptNode
 
 
-@BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
+@BaseTryNodeDisplay.wrap(
+    node_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+    error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+)
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
@@ -441,7 +444,10 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.prompt_node import PromptNode
 
 
-@BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
+@BaseTryNodeDisplay.wrap(
+    node_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+    error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+)
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
@@ -655,7 +661,10 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.prompt_node import PromptNode
 
 
-@BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
+@BaseTryNodeDisplay.wrap(
+    node_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+    error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+)
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
@@ -880,7 +889,10 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.prompt_node import PromptNode
 
 
-@BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
+@BaseTryNodeDisplay.wrap(
+    node_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+    error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+)
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")
@@ -1099,7 +1111,10 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.prompt_node import PromptNode
 
 
-@BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
+@BaseTryNodeDisplay.wrap(
+    node_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+    error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+)
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt Node"
     node_id = UUID("7e09927b-6d6f-4829-92c9-54e66bdcaf80")

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -27,7 +27,7 @@ from .nodes import *
 from .workflow import *
 
 
-@BaseRetryNodeDisplay.wrap()
+@BaseRetryNodeDisplay.wrap(node_id=UUID("ae49ef72-6ad7-441a-a20d-76c71ad851ef"))
 class MyNodeDisplay(BaseInlineSubworkflowNodeDisplay[MyNode]):
     label = "My node"
     node_id = UUID("14fee4a0-ad25-402f-b942-104d3a5a0824")

--- a/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
@@ -267,7 +267,10 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.search_node import SearchNode
 
 
-@BaseTryNodeDisplay.wrap(error_output_id=UUID("af589f73-effe-4a80-b48f-fb912ac6ce67"))
+@BaseTryNodeDisplay.wrap(
+    node_id=UUID("af589f73-effe-4a80-b48f-fb912ac6ce67"),
+    error_output_id=UUID("af589f73-effe-4a80-b48f-fb912ac6ce67"),
+)
 class SearchNodeDisplay(BaseSearchNodeDisplay[SearchNode]):
     label = "Search Node"
     node_id = UUID("search")

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -122,7 +122,10 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.templating_node import TemplatingNode
 
 
-@BaseTryNodeDisplay.wrap(error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"))
+@BaseTryNodeDisplay.wrap(
+    node_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+    error_output_id=UUID("e7a1fbea-f5a7-4b31-a9ff-0d26c3de021f"),
+)
 class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")

--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
@@ -34,7 +34,9 @@ class MyCustomNode(BaseNode):
 `;
 
 exports[`GenericNode > basic with adornments > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import (
+"from uuid import UUID
+
+from vellum_ee.workflows.display.nodes import (
     BaseMapNodeDisplay,
     BaseNodeDisplay,
     BaseRetryNodeDisplay,
@@ -45,9 +47,9 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.my_custom_node import MyCustomNode
 
 
-@BaseTryNodeDisplay.wrap()
-@BaseMapNodeDisplay.wrap()
-@BaseRetryNodeDisplay.wrap()
+@BaseTryNodeDisplay.wrap(node_id=UUID("adornment-1"))
+@BaseMapNodeDisplay.wrap(node_id=UUID("adornment-2"))
+@BaseRetryNodeDisplay.wrap(node_id=UUID("adornment-3"))
 class MyCustomNodeDisplay(BaseNodeDisplay[MyCustomNode]):
     node_input_ids_by_name = {}
     display_data = NodeDisplayData(

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node-retry.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node-retry.test.ts
@@ -36,7 +36,7 @@ describe("InlinePromptRetryNode", () => {
         blockType: "JINJA",
         adornments: [
           {
-            id: uuidv4(),
+            id: "cc79c784-d936-44c2-a811-b86a53e6ff68",
             label: "RetryNodeLabel",
             base: {
               name: "RetryNode",
@@ -94,7 +94,7 @@ describe("InlinePromptRetryNode", () => {
         blockType: "JINJA",
         adornments: [
           {
-            id: uuidv4(),
+            id: "2076aea8-be38-4ff1-8c68-cb853e352d66",
             label: "RetryNodeLabel",
             base: {
               name: "RetryNode",
@@ -167,7 +167,7 @@ describe("InlinePromptRetryNode", () => {
         errorOutputId: ERROR_OUTPUT_ID,
         adornments: [
           {
-            id: uuidv4(),
+            id: "e5de8d57-ae0d-4a4a-afb3-eb4cd6bdb0ac",
             label: "RetryNodeLabel",
             base: {
               name: "RetryNode",

--- a/ee/codegen/src/__test__/nodes/inline-subworkflow-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-subworkflow-node.test.ts
@@ -152,7 +152,7 @@ describe("InlineSubworkflowNode", () => {
         nodes: [templatingNodeFactory({ label: "My node" })],
         adornments: [
           {
-            id: uuidv4(),
+            id: "ae49ef72-6ad7-441a-a20d-76c71ad851ef",
             label: "RetryNodeLabel",
             base: {
               name: "RetryNode",

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -382,6 +382,13 @@ export abstract class BaseNode<
                   .NODE_DISPLAY_MODULE_PATH,
             }),
             arguments_: [
+              // TODO: Node id and error output id are the same here for legacy reasons. Will no longer be the
+              // case once we define output transformations for node adornments and could remove error output id.
+              // https://linear.app/vellum/issue/APO-213/define-output-transformations-for-node-adornments
+              new MethodArgument({
+                name: "node_id",
+                value: python.TypeInstantiation.uuid(errorOutputId),
+              }),
               new MethodArgument({
                 name: "error_output_id",
                 value: python.TypeInstantiation.uuid(errorOutputId),
@@ -410,8 +417,14 @@ export abstract class BaseNode<
                   this.workflowContext.sdkModulePathNames
                     .NODE_DISPLAY_MODULE_PATH,
               }),
-              // When we define output transformations, that's what we'd use here. eg, `error_output_id`.
-              arguments_: [],
+              // TODO: When we define output transformations, that's what we'd use here. eg, `error_output_id`.
+              // https://linear.app/vellum/issue/APO-213/define-output-transformations-for-node-adornments
+              arguments_: [
+                new MethodArgument({
+                  name: "node_id",
+                  value: python.TypeInstantiation.uuid(adornment.id),
+                }),
+              ],
             }),
           })
         );

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/prompt_node.py
@@ -7,7 +7,9 @@ from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosit
 from ...nodes.prompt_node import PromptNode
 
 
-@BaseTryNodeDisplay.wrap(error_output_id=UUID("42823c15-2ba6-4c85-a0d7-74a4e0541a42"))
+@BaseTryNodeDisplay.wrap(
+    node_id=UUID("42823c15-2ba6-4c85-a0d7-74a4e0541a42"), error_output_id=UUID("42823c15-2ba6-4c85-a0d7-74a4e0541a42")
+)
 class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     label = "Prompt"
     node_id = UUID("1645c7e7-1b5f-4ca3-9610-0c5ac30a77ff")

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
@@ -143,7 +143,7 @@
           ],
           "name": "TryNode"
         },
-        "adornments": [{"id": "3344083c-a32c-4a32-920b-0fb5093448fa", "label": "TryNode", "base": {"name": "TryNode", "module": ["vellum", "workflows", "nodes", "core", "try_node", "node"]}, "attributes": [{"id": "ab2fbab0-e2a0-419b-b1ef-ce11ecf11e90", "name": "on_error_code", "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": null}}}]}]
+        "adornments": [{"id": "42823c15-2ba6-4c85-a0d7-74a4e0541a42", "label": "TryNode", "base": {"name": "TryNode", "module": ["vellum", "workflows", "nodes", "core", "try_node", "node"]}, "attributes": [{"id": "55821c68-5207-4a5b-8345-e89dee65f71a", "name": "on_error_code", "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": null}}}]}]
       },
       {
         "id": "54803ff7-9afd-4eb1-bff3-242345d3443d",

--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
@@ -44,7 +44,7 @@ class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Ge
         return serialized_wrapped_node
 
     @classmethod
-    def wrap(cls, **kwargs: Any) -> Callable[..., Type[BaseNodeDisplay]]:
+    def wrap(cls, node_id: Optional[UUID] = None, **kwargs: Any) -> Callable[..., Type[BaseNodeDisplay]]:
         NodeDisplayType = TypeVar("NodeDisplayType", bound=BaseNodeDisplay)
 
         def decorator(inner_cls: Type[NodeDisplayType]) -> Type[NodeDisplayType]:
@@ -58,8 +58,7 @@ class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Ge
                 for key, kwarg in kwargs.items():
                     ns[key] = kwarg
 
-                if "node_id" not in kwargs:
-                    ns["node_id"] = uuid4_from_hash(node_class.__qualname__)
+                ns["node_id"] = node_id or uuid4_from_hash(node_class.__qualname__)
 
             AdornmentDisplay = types.new_class(
                 re.sub(r"^Base", "", cls.__name__), bases=(BaseAdornmentDisplay,), exec_body=exec_body

--- a/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
@@ -155,9 +155,10 @@ def test_get_event_display_context__node_display_for_adornment_nodes():
         graph = MyNode
 
     # AND a display class for the node
+    adornment_node_id = uuid4()
     inner_node_id = uuid4()
 
-    @BaseRetryNodeDisplay.wrap()
+    @BaseRetryNodeDisplay.wrap(node_id=adornment_node_id)
     class MyNodeDisplay(BaseNodeDisplay[MyNode]):
         node_id = inner_node_id
 
@@ -165,8 +166,8 @@ def test_get_event_display_context__node_display_for_adornment_nodes():
     display_context = VellumWorkflowDisplay(MyWorkflow).get_event_display_context()
 
     # THEN the subworkflow display should be included
-    assert str(MyNode.__id__) in display_context.node_displays
-    node_event_display = display_context.node_displays[str(MyNode.__id__)]
+    assert str(adornment_node_id) in display_context.node_displays
+    node_event_display = display_context.node_displays[str(adornment_node_id)]
     assert node_event_display.subworkflow_display is not None
     assert str(inner_node_id) in node_event_display.subworkflow_display.node_displays
 


### PR DESCRIPTION
Uses the display class for our adornments to track the node id for that specific adornment. Allows for the stable node ids of adornments themselves