### PR TITLE
Output Displays should have default behavior

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -270,7 +270,7 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
 
     @property
     def _node(self) -> Type[NodeType]:
-        return self.__class__.infer_node_class()
+        return cast(Type[NodeType], self.__class__.infer_node_class())
 
     @classmethod
     def _get_explicit_node_display_attr(

--- a/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
+++ b/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.types.generics import NodeType
 from vellum.workflows.utils.uuids import uuid4_from_hash
-from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.types import NodeDisplayType
@@ -43,14 +42,6 @@ def get_node_display_class(
         return {}
 
     def exec_body(ns: Dict):
-        output_display = {
-            ref: NodeOutputDisplay(id=node_class.__output_ids__[ref.name], name=ref.name)
-            for ref in node_class.Outputs
-            if ref.name in node_class.__output_ids__
-        }
-        if output_display:
-            ns["output_display"] = output_display
-
         node_input_ids_by_name: Dict[str, UUID] = {}
         for ref in node_class:
             node_input_ids_by_name.update(_get_node_input_ids_by_ref(ref.name, ref.instance))

--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
@@ -76,9 +76,17 @@ class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Ge
             inner_cls.__annotate_node__()
 
             # 2. The node display class' output displays
-            old_outputs = list(inner_cls.output_display.keys())
-            for old_output in old_outputs:
-                new_output = getattr(wrapped_node_class.Outputs, old_output.name)
+            for old_output in node_class.Outputs:
+                new_output = getattr(wrapped_node_class.Outputs, old_output.name, None)
+                if new_output is None:
+                    # If the adornment is adding a new output, such as TryNode adding an "error" output,
+                    # we skip it, since it should not be included in the adorned node's output displays
+                    continue
+
+                if old_output not in inner_cls.output_display:
+                    # If the adorned node doesn't have an output display for this output, we skip it
+                    continue
+
                 inner_cls.output_display[new_output] = inner_cls.output_display.pop(old_output)
 
             # 3. The node display class' port displays

--- a/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
@@ -119,6 +119,29 @@ def test_get_event_display_context__node_display_filled_without_base_display():
     assert StartNode.__output_ids__ == node_event_display.output_display
 
 
+def test_get_event_display_context__node_display_filled_without_output_display():
+    # GIVEN a simple workflow
+    class StartNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            foo: str
+
+    class MyWorkflow(BaseWorkflow):
+        graph = StartNode
+
+    class StartNodeDisplay(BaseNodeDisplay[StartNode]):
+        pass
+
+    # WHEN we gather the event display context
+    display_context = VellumWorkflowDisplay(MyWorkflow).get_event_display_context()
+
+    # THEN the node display should be included
+    assert str(StartNode.__id__) in display_context.node_displays
+    node_event_display = display_context.node_displays[str(StartNode.__id__)]
+
+    # AND so should their output ids
+    assert node_event_display.output_display.keys() == {"foo"}
+
+
 def test_get_event_display_context__node_display_to_include_subworkflow_display():
     # GIVEN a simple workflow
     class InnerNode(BaseNode):

--- a/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
@@ -149,7 +149,8 @@ def test_get_event_display_context__node_display_for_adornment_nodes():
     # GIVEN a simple workflow with a retry node adornment
     @RetryNode.wrap(max_attempts=4)
     class MyNode(BaseNode):
-        pass
+        class Outputs(BaseNode.Outputs):
+            foo: str
 
     class MyWorkflow(BaseWorkflow):
         graph = MyNode


### PR DESCRIPTION
This PR makes it such that specifying `output_display` on a particular node is completely optional. This will become important for adornments since they are often specified as just `BaseRetryNodeDisplay.wrap()`

It also forces some cleanup by centralizing our class magic in our metaclass instead of spread across to the get_node_display_class helper