### PR TITLE
Define automatic output displays for wrapped nodes of adornment nodes

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
@@ -3,7 +3,6 @@ import types
 from uuid import UUID
 from typing import Any, Callable, Dict, Generic, Optional, Type, TypeVar, cast
 
-from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.bases.base_adornment_node import BaseAdornmentNode
 from vellum.workflows.nodes.utils import get_wrapped_node
 from vellum.workflows.types.core import JsonArray, JsonObject
@@ -12,6 +11,7 @@ from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
 _BaseAdornmentNodeType = TypeVar("_BaseAdornmentNodeType", bound=BaseAdornmentNode)
@@ -47,9 +47,14 @@ class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Ge
     def wrap(cls, node_id: Optional[UUID] = None, **kwargs: Any) -> Callable[..., Type[BaseNodeDisplay]]:
         NodeDisplayType = TypeVar("NodeDisplayType", bound=BaseNodeDisplay)
 
-        def decorator(inner_cls: Type[NodeDisplayType]) -> Type[NodeDisplayType]:
-            node_class = inner_cls.infer_node_class()
-            wrapped_node_class = cast(Type[BaseNode], node_class.__wrapped_node__)
+        def decorator(wrapped_node_display_class: Type[NodeDisplayType]) -> Type[NodeDisplayType]:
+            node_class = wrapped_node_display_class.infer_node_class()
+            if not issubclass(node_class, BaseAdornmentNode):
+                raise ValueError(f"Node {node_class.__name__} must be wrapped with a {BaseAdornmentNode.__name__}")
+
+            wrapped_node_class = node_class.__wrapped_node__
+            if not wrapped_node_class:
+                raise ValueError(f"Node {node_class.__name__} must be used as an adornment with the `wrap` method.")
 
             # `mypy` is wrong here, `cls` is indexable bc it's Generic
             BaseAdornmentDisplay = cls[node_class]  # type: ignore[index]
@@ -64,16 +69,16 @@ class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Ge
                 re.sub(r"^Base", "", cls.__name__), bases=(BaseAdornmentDisplay,), exec_body=exec_body
             )
 
-            setattr(inner_cls, "__adorned_by__", AdornmentDisplay)
+            setattr(wrapped_node_display_class, "__adorned_by__", AdornmentDisplay)
 
             # We must edit the node display class to use __wrapped_node__ everywhere it
             # references the adorned node class, which is three places:
 
             # 1. The node display class' parameterized type
-            original_base_node_display = get_original_base(inner_cls)
+            original_base_node_display = get_original_base(wrapped_node_display_class)
             original_base_node_display.__args__ = (wrapped_node_class,)
-            inner_cls._node_display_registry[wrapped_node_class] = inner_cls
-            inner_cls.__annotate_node__()
+            wrapped_node_display_class._node_display_registry[wrapped_node_class] = wrapped_node_display_class
+            wrapped_node_display_class.__annotate_node__()
 
             # 2. The node display class' output displays
             for old_output in node_class.Outputs:
@@ -83,18 +88,25 @@ class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Ge
                     # we skip it, since it should not be included in the adorned node's output displays
                     continue
 
-                if old_output not in inner_cls.output_display:
-                    # If the adorned node doesn't have an output display for this output, we skip it
-                    continue
-
-                inner_cls.output_display[new_output] = inner_cls.output_display.pop(old_output)
+                if old_output not in wrapped_node_display_class.output_display:
+                    # If the adorned node doesn't have an output display defined for this output, we define one
+                    wrapped_node_display_class.output_display[new_output] = NodeOutputDisplay(
+                        id=wrapped_node_class.__output_ids__[old_output.name],
+                        name=old_output.name,
+                    )
+                else:
+                    wrapped_node_display_class.output_display[new_output] = (
+                        wrapped_node_display_class.output_display.pop(old_output)
+                    )
 
             # 3. The node display class' port displays
-            old_ports = list(inner_cls.port_displays.keys())
+            old_ports = list(wrapped_node_display_class.port_displays.keys())
             for old_port in old_ports:
                 new_port = getattr(wrapped_node_class.Ports, old_port.name)
-                inner_cls.port_displays[new_port] = inner_cls.port_displays.pop(old_port)
+                wrapped_node_display_class.port_displays[new_port] = wrapped_node_display_class.port_displays.pop(
+                    old_port
+                )
 
-            return inner_cls
+            return wrapped_node_display_class
 
         return decorator

--- a/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
@@ -195,6 +195,10 @@ def test_get_event_display_context__node_display_for_adornment_nodes():
     assert node_event_display.subworkflow_display is not None
     assert str(inner_node_id) in node_event_display.subworkflow_display.node_displays
 
+    # AND the inner node should have the correct outputs
+    inner_node_display = node_event_display.subworkflow_display.node_displays[str(inner_node_id)]
+    assert inner_node_display.output_display.keys() == {"foo"}
+
 
 def test_get_event_display_context__templating_node_input_display():
     # GIVEN a simple workflow with a templating node referencing another node output


### PR DESCRIPTION
This PR enables nodes that are within adornments to define its output displays automatically.

Last piece we'll need is to then propagate these up to the adornment node's outputs 