### PR TITLE
Generate output ids for adornment nodes

### DIFF
--- a/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
@@ -198,6 +198,7 @@ def test_get_event_display_context__node_display_for_adornment_nodes():
     # AND the inner node should have the correct outputs
     inner_node_display = node_event_display.subworkflow_display.node_displays[str(inner_node_id)]
     assert inner_node_display.output_display.keys() == {"foo"}
+    assert node_event_display.output_display.keys() == {"foo"}
 
 
 def test_get_event_display_context__templating_node_input_display():

--- a/src/vellum/workflows/nodes/bases/base_adornment_node.py
+++ b/src/vellum/workflows/nodes/bases/base_adornment_node.py
@@ -73,3 +73,5 @@ class BaseAdornmentNode(
         # Subclasses of BaseAdornableNode can override this method to provider their own
         # approach to annotating the outputs class based on the `subworkflow.Outputs`
         setattr(outputs_class, reference.name, reference)
+        if cls.__wrapped_node__:
+            cls.__output_ids__[reference.name] = cls.__wrapped_node__.__output_ids__[reference.name]


### PR DESCRIPTION
This PR finally makes it such that we emit output ids in the display context for adornment nodes, which will enable those events to start appearing for adornment nodes again