### PR TITLE
Support Event Display context for try node's error output id

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
@@ -86,6 +86,7 @@ class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Ge
                 if new_output is None:
                     # If the adornment is adding a new output, such as TryNode adding an "error" output,
                     # we skip it, since it should not be included in the adorned node's output displays
+                    wrapped_node_display_class.output_display.pop(old_output, None)
                     continue
 
                 if old_output not in wrapped_node_display_class.output_display:

--- a/src/vellum/workflows/nodes/core/retry_node/node.py
+++ b/src/vellum/workflows/nodes/core/retry_node/node.py
@@ -85,7 +85,7 @@ Message: {terminal_event.error.message}""",
     @classmethod
     def wrap(
         cls,
-        max_attempts: int,
+        max_attempts: int = 3,
         delay: Optional[float] = None,
         retry_on_error_code: Optional[WorkflowErrorCode] = None,
         retry_on_condition: Optional[BaseDescriptor] = None,

--- a/src/vellum/workflows/nodes/core/try_node/node.py
+++ b/src/vellum/workflows/nodes/core/try_node/node.py
@@ -102,4 +102,4 @@ Message: {event.error.message}""",
         if reference.name == "error":
             raise ValueError("`error` is a reserved name for TryNode.Outputs")
 
-        setattr(outputs_class, reference.name, reference)
+        super().__annotate_outputs_class__(outputs_class, reference)


### PR DESCRIPTION
Supports proper event display context's for try node adornments. We have everything we need to now publish and start applying handling on the vellum side