### PR TITLE
clean up template_input_id from BaseTemplatingNodeDisplay

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -153,7 +153,6 @@ class MyNode1Display(BaseTemplatingNodeDisplay[MyNode1]):
     label = "My node"
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
     target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
-    template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
     node_input_ids_by_name = {"template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         MyNode1.Outputs.result: NodeOutputDisplay(id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="result")

--- a/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
@@ -106,7 +106,6 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
     target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
-    template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
     node_input_ids_by_name = {
         "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
         "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),
@@ -159,7 +158,6 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
     target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
-    template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
     node_input_ids_by_name = {
         "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
         "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -17,7 +17,6 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
     target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
-    template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
     node_input_ids_by_name = {"template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         TemplatingNode.Outputs.result: NodeOutputDisplay(
@@ -63,7 +62,6 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
     target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
-    template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
     node_input_ids_by_name = {"template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         TemplatingNode.Outputs.result: NodeOutputDisplay(
@@ -130,7 +128,6 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
     target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
-    template_input_id = UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")
     node_input_ids_by_name = {"template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         TemplatingNode.Outputs.result: NodeOutputDisplay(

--- a/ee/codegen/src/generators/nodes/templating-node.ts
+++ b/ee/codegen/src/generators/nodes/templating-node.ts
@@ -82,12 +82,6 @@ export class TemplatingNode extends BaseSingleFileNode<
         initializer: python.TypeInstantiation.uuid(
           this.nodeData.data.targetHandleId
         ),
-      }),
-      python.field({
-        name: "template_input_id",
-        initializer: python.TypeInstantiation.uuid(
-          this.nodeData.data.templateNodeInputId
-        ),
       })
     );
 

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/templating_node.py
@@ -11,7 +11,6 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("24153572-e27b-4cea-a541-4d9e82f28b4e")
     target_handle_id = UUID("d1b8ef3d-1474-4cfb-8fb0-164f7b238a07")
-    template_input_id = UUID("1cfb8efb-ac81-478a-ab46-46ed5536bd6f")
     node_input_ids_by_name = {
         "example_var": UUID("5ec0a342-0d78-4717-bda3-e70805234cad"),
         "template": UUID("1cfb8efb-ac81-478a-ab46-46ed5536bd6f"),

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_1.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_1.py
@@ -11,7 +11,6 @@ class TemplatingNode1Display(BaseTemplatingNodeDisplay[TemplatingNode1]):
     label = "Templating Node"
     node_id = UUID("6c5017d1-9aa3-4f34-9a6a-fbe2f7029473")
     target_handle_id = UUID("2d2c5559-983f-469c-a1d0-c2fe9f8f3639")
-    template_input_id = UUID("3981811f-6e33-48b6-b7c5-c32ba9a97dc8")
     node_input_ids_by_name = {"template": UUID("3981811f-6e33-48b6-b7c5-c32ba9a97dc8")}
     output_display = {
         TemplatingNode1.Outputs.result: NodeOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_2.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_2.py
@@ -11,7 +11,6 @@ class TemplatingNode2Display(BaseTemplatingNodeDisplay[TemplatingNode2]):
     label = "Templating Node"
     node_id = UUID("5b7d7b3f-e10d-4334-a217-9099dececd8d")
     target_handle_id = UUID("f9a55e22-2cbd-4492-8755-36760320f0d9")
-    template_input_id = UUID("6567617f-57e4-4c11-9175-557108fcf07e")
     node_input_ids_by_name = {"template": UUID("6567617f-57e4-4c11-9175-557108fcf07e")}
     output_display = {
         TemplatingNode2.Outputs.result: NodeOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_3.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_3.py
@@ -11,7 +11,6 @@ class TemplatingNode3Display(BaseTemplatingNodeDisplay[TemplatingNode3]):
     label = "Templating Node"
     node_id = UUID("7f7823e9-b97a-4bbe-bfcf-40aed8db24c9")
     target_handle_id = UUID("2c1e39e0-ce3e-4c2d-8baf-c5d93b244997")
-    template_input_id = UUID("c1cc89c9-7cb7-498d-9dda-e9e5f36fe556")
     node_input_ids_by_name = {
         "template": UUID("c1cc89c9-7cb7-498d-9dda-e9e5f36fe556"),
         "input_a": UUID("56ff5b3f-41e1-492d-80a0-493f170452a1"),

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/templating_node.py
@@ -11,7 +11,6 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("7dffcbb1-0a5c-4149-a6e9-f83095b0a871")
     target_handle_id = UUID("3522e32d-6735-499b-8d45-c0c6488ae92f")
-    template_input_id = UUID("5d2f0f48-4504-4979-8e24-92a8c08c23a4")
     node_input_ids_by_name = {"template": UUID("5d2f0f48-4504-4979-8e24-92a8c08c23a4")}
     output_display = {
         TemplatingNode.Outputs.result: NodeOutputDisplay(id=UUID("4d39036a-fd6d-4a51-b410-7c0623375ebd"), name="result")

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/nodes/templating_node.py
@@ -11,7 +11,6 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     label = "Templating Node"
     node_id = UUID("d0538e54-b623-4a71-a5cd-24b1ed5ce223")
     target_handle_id = UUID("62e924f8-3f80-475f-b6f0-bda3420a50bc")
-    template_input_id = UUID("e7904d49-cb35-4bc8-8dd6-3c8e243353d2")
     node_input_ids_by_name = {
         "example_var_1": UUID("5e8396fe-1803-405f-ab1b-95132b592552"),
         "template": UUID("e7904d49-cb35-4bc8-8dd6-3c8e243353d2"),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from typing import ClassVar, Generic, Optional, TypeVar
+from typing import Generic, Optional, TypeVar
 
 from vellum.workflows.nodes.core.templating_node import TemplatingNode
 from vellum.workflows.types.core import JsonObject
@@ -11,23 +11,21 @@ from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
 _TemplatingNodeType = TypeVar("_TemplatingNodeType", bound=TemplatingNode)
 
-TEMPLATE_INPUT_NAME = "template"
+TEMPLATE_INPUT_NAME = TemplatingNode.template.name
 
 
 class BaseTemplatingNodeDisplay(BaseNodeVellumDisplay[_TemplatingNodeType], Generic[_TemplatingNodeType]):
-    template_input_id: ClassVar[Optional[UUID]] = None
-
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
     ) -> JsonObject:
         node = self._node
         node_id = self.node_id
 
-        template_input_id = self.template_input_id or self.node_input_ids_by_name.get(TEMPLATE_INPUT_NAME)
+        template_input_id = self.node_input_ids_by_name.get(TEMPLATE_INPUT_NAME)
 
         template_node_input = create_node_input(
             node_id=node_id,
-            input_name="template",
+            input_name=TEMPLATE_INPUT_NAME,
             value=node.template,
             display_context=display_context,
             input_id=template_input_id,

--- a/src/vellum/workflows/nodes/core/templating_node/node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/node.py
@@ -48,7 +48,7 @@ class TemplatingNode(BaseNode[StateType], Generic[StateType, _OutputType], metac
     """
 
     # The Jinja template to render.
-    template: ClassVar[str]
+    template: ClassVar[str] = ""
 
     # The inputs to render the template with.
     inputs: ClassVar[EntityInputsInterface]


### PR DESCRIPTION
Quick cleanup opp I noticed while working on https://linear.app/vellum/issue/APO-179/inputs-tab-blank-in-sdk-template-nodes-when-sdk-is-disabled

we should be driving all attribute/input id mapping generically going forward. This allows us to remove a redundant field from our display class, and we likely need to continue doing so throughout our other display classes