### PR TITLE
Templating node serialization should support the inputs. prefix

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
@@ -37,7 +37,8 @@ class BaseTemplatingNodeDisplay(BaseNodeVellumDisplay[_TemplatingNodeType], Gene
                 input_name=variable_name,
                 value=variable_value,
                 display_context=display_context,
-                input_id=self.node_input_ids_by_name.get(variable_name),
+                input_id=self.node_input_ids_by_name.get(f"{TemplatingNode.inputs.name}.{variable_name}")
+                or self.node_input_ids_by_name.get(variable_name),
             )
             for variable_name, variable_value in template_node_inputs.items()
             if variable_name != TEMPLATE_INPUT_NAME

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_templating_node.py
@@ -1,0 +1,96 @@
+import pytest
+from uuid import UUID
+
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes.core.templating_node.node import TemplatingNode
+from vellum_ee.workflows.display.nodes.vellum.templating_node import BaseTemplatingNodeDisplay
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+
+
+def _no_display_class(TemplatingNode):
+    return None
+
+
+def _display_class_with_node_input_ids_by_name(TemplatingNode):
+    class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
+        node_input_ids_by_name = {"foo": UUID("fba6a4d5-835a-4e99-afb7-f6a4aed15110")}
+
+    return TemplatingNodeDisplay
+
+
+def _display_class_with_node_input_ids_by_name_with_inputs_prefix(TemplatingNode):
+    class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
+        node_input_ids_by_name = {"inputs.foo": UUID("fba6a4d5-835a-4e99-afb7-f6a4aed15110")}
+
+    return TemplatingNodeDisplay
+
+
+@pytest.mark.parametrize(
+    ["GetDisplayClass", "expected_input_id"],
+    [
+        (_no_display_class, "d3519cec-590c-416d-8eb1-96051aed5ddd"),
+        (_display_class_with_node_input_ids_by_name, "fba6a4d5-835a-4e99-afb7-f6a4aed15110"),
+        (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "fba6a4d5-835a-4e99-afb7-f6a4aed15110"),
+    ],
+    ids=[
+        "no_display_class",
+        "display_class_with_node_input_ids_by_name",
+        "display_class_with_node_input_ids_by_name_with_inputs_prefix",
+    ],
+)
+def test_serialize_node__templating_node_inputs(GetDisplayClass, expected_input_id):
+    # GIVEN a templating node with inputs
+    class MyTemplatingNode(TemplatingNode):
+        inputs = {"foo": "bar"}
+
+    # AND a workflow with the templating node
+    class Workflow(BaseWorkflow):
+        graph = MyTemplatingNode
+
+    # AND a display class
+    GetDisplayClass(MyTemplatingNode)
+
+    # WHEN the workflow is serialized
+    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=Workflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    # THEN the node should properly serialize the inputs
+    my_templating_node = next(
+        node for node in serialized_workflow["workflow_raw_data"]["nodes"] if node["type"] == "TEMPLATING"
+    )
+
+    assert my_templating_node["inputs"] == [
+        {
+            "id": "b7d971ee-9156-46b2-9bf0-9292875211f8",
+            "key": "template",
+            "value": {
+                "combinator": "OR",
+                "rules": [
+                    {
+                        "type": "CONSTANT_VALUE",
+                        "data": {
+                            "type": "STRING",
+                            "value": "",
+                        },
+                    }
+                ],
+            },
+        },
+        {
+            "id": expected_input_id,
+            "key": "foo",
+            "value": {
+                "combinator": "OR",
+                "rules": [
+                    {
+                        "type": "CONSTANT_VALUE",
+                        "data": {
+                            "type": "STRING",
+                            "value": "bar",
+                        },
+                    }
+                ],
+            },
+        },
+    ]

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_templating_node.py
@@ -1,5 +1,6 @@
 import pytest
 from uuid import UUID
+from typing import Type
 
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.nodes.core.templating_node.node import TemplatingNode
@@ -8,19 +9,19 @@ from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class imp
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
-def _no_display_class(TemplatingNode):
+def _no_display_class(Node: Type[TemplatingNode]):
     return None
 
 
-def _display_class_with_node_input_ids_by_name(TemplatingNode):
-    class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
+def _display_class_with_node_input_ids_by_name(Node: Type[TemplatingNode]):
+    class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[Node]):  # type: ignore[valid-type]
         node_input_ids_by_name = {"foo": UUID("fba6a4d5-835a-4e99-afb7-f6a4aed15110")}
 
     return TemplatingNodeDisplay
 
 
-def _display_class_with_node_input_ids_by_name_with_inputs_prefix(TemplatingNode):
-    class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
+def _display_class_with_node_input_ids_by_name_with_inputs_prefix(Node: Type[TemplatingNode]):
+    class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[Node]):  # type: ignore[valid-type]
         node_input_ids_by_name = {"inputs.foo": UUID("fba6a4d5-835a-4e99-afb7-f6a4aed15110")}
 
     return TemplatingNodeDisplay

--- a/ee/vellum_ee/workflows/display/nodes/vellum/utils.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/utils.py
@@ -54,7 +54,7 @@ def create_node_input_value_pointer_rules(
 
     if isinstance(value, BaseDescriptor):
         if isinstance(value, NodeReference):
-            if not value.instance:
+            if value.instance is None:
                 raise ValueError(f"Expected NodeReference {value.name} to have an instance")
             value = cast(BaseDescriptor, value.instance)
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_templating_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_templating_node_serialization.py
@@ -85,7 +85,7 @@ def test_serialize_workflow():
                     },
                 },
                 {
-                    "id": "bb712499-4265-4d71-bc14-0c3d8ca6a7de",
+                    "id": "e6c9d062-1a4f-4d4d-a258-59b75c6062fc",
                     "key": "info",
                     "value": {
                         "rules": [

--- a/src/vellum/workflows/nodes/core/templating_node/node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/node.py
@@ -51,7 +51,7 @@ class TemplatingNode(BaseNode[StateType], Generic[StateType, _OutputType], metac
     template: ClassVar[str] = ""
 
     # The inputs to render the template with.
-    inputs: ClassVar[EntityInputsInterface]
+    inputs: ClassVar[EntityInputsInterface] = {}
 
     jinja_globals: Dict[str, Any] = DEFAULT_JINJA_GLOBALS
     jinja_custom_filters: Mapping[str, FilterFunc] = DEFAULT_JINJA_CUSTOM_FILTERS


### PR DESCRIPTION
Templating node inputs have keys that look like `'foo'` in the UI.

However, they have keys that look like `'inputs.foo'` in the SDK.

Prompt, Code exec, and Subworkflow nodes all have a similar disparity. This disparity prevents inputs from rendering in our monitoring.

In order to align, our serialization needs read from the correct spot. Next PR will update our codegen. `node_input_ids_by_name` will now be a map of attribute path names to node input ids for legacy nodes. 