### PR TITLE
Support codegen for prefixed templating node inputs

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
@@ -107,7 +107,7 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
     target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
     node_input_ids_by_name = {
-        "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
+        "inputs.text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
         "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),
     }
     output_display = {
@@ -159,7 +159,7 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     node_id = UUID("46e221ab-a749-41a2-9242-b1f5bf31f3a5")
     target_handle_id = UUID("3960c8e1-9baa-4b9c-991d-e399d16a45aa")
     node_input_ids_by_name = {
-        "text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
+        "inputs.text": UUID("9feb7b5e-5947-496d-b56f-1e2627730796"),
         "template": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616"),
     }
     output_display = {

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -154,6 +154,13 @@ export abstract class BaseNode<
   }
 
   protected getNodeAttributeNameByNodeInputKey(nodeInputKey: string): string {
+    /**
+     * This method drives how we map the key to a legacy node input to the new
+     * node attribute name in the SDK.
+     *
+     * By default, we just pass through. However, legacy nodes can extend this
+     * method to customize their specific mappings.
+     */
     return nodeInputKey;
   }
 

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -41,6 +41,7 @@ export abstract class BaseNode<
 
   protected readonly nodeInputsByKey: Map<string, NodeInput>;
   protected readonly nodeInputsById: Map<string, NodeInput>;
+  protected readonly nodeAttributeNameByNodeInputId: Map<string, string>;
 
   private readonly errorOutputId: string | undefined;
 
@@ -49,7 +50,11 @@ export abstract class BaseNode<
     this.nodeContext = nodeContext;
     this.nodeData = nodeContext.nodeData;
 
-    [this.nodeInputsByKey, this.nodeInputsById] = this.generateNodeInputs();
+    [
+      this.nodeInputsByKey,
+      this.nodeInputsById,
+      this.nodeAttributeNameByNodeInputId,
+    ] = this.generateNodeInputs();
     this.errorOutputId = this.getErrorOutputId();
   }
 
@@ -148,15 +153,21 @@ export abstract class BaseNode<
     return this.nodeContext.nodeDisplayModulePath;
   }
 
+  protected getNodeAttributeNameByNodeInputKey(nodeInputKey: string): string {
+    return nodeInputKey;
+  }
+
   private generateNodeInputs(): [
     Map<string, NodeInput>,
-    Map<string, NodeInput>
+    Map<string, NodeInput>,
+    Map<string, string>
   ] {
     const nodeInputsByKey = new Map<string, NodeInput>();
     const nodeInputsById = new Map<string, NodeInput>();
+    const nodeAttributeNameByNodeInputId = new Map<string, string>();
 
     if (!("inputs" in this.nodeData)) {
-      return [nodeInputsByKey, nodeInputsById];
+      return [nodeInputsByKey, nodeInputsById, nodeAttributeNameByNodeInputId];
     }
 
     this.nodeData.inputs.forEach((nodeInputData) => {
@@ -169,6 +180,13 @@ export abstract class BaseNode<
         if (!isNilOrEmpty(nodeInput.nodeInputValuePointer.rules)) {
           nodeInputsByKey.set(nodeInputData.key, nodeInput);
           nodeInputsById.set(nodeInputData.id, nodeInput);
+          const nodeAttributeName = this.getNodeAttributeNameByNodeInputKey(
+            nodeInputData.key
+          );
+          nodeAttributeNameByNodeInputId.set(
+            nodeInputData.id,
+            nodeAttributeName
+          );
         }
       } catch (error) {
         if (error instanceof BaseCodegenError) {
@@ -183,7 +201,7 @@ export abstract class BaseNode<
       }
     });
 
-    return [nodeInputsByKey, nodeInputsById];
+    return [nodeInputsByKey, nodeInputsById, nodeAttributeNameByNodeInputId];
   }
 
   protected getPortDisplay(): python.Field | undefined {
@@ -448,8 +466,11 @@ export abstract class BaseNode<
           key: AstNode;
           value: AstNode;
         }>(([key, nodeInput]) => {
+          const nodeAttributeName = this.nodeAttributeNameByNodeInputId.get(
+            nodeInput.nodeInputData.id
+          );
           return {
-            key: python.TypeInstantiation.str(key),
+            key: python.TypeInstantiation.str(nodeAttributeName ?? key),
             value: new UuidOrString(nodeInput.nodeInputData.id),
           };
         })

--- a/ee/codegen/src/generators/nodes/templating-node.ts
+++ b/ee/codegen/src/generators/nodes/templating-node.ts
@@ -10,10 +10,21 @@ import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base"
 import { TemplatingNode as TemplatingNodeType } from "src/types/vellum";
 import { getVellumVariablePrimitiveType } from "src/utils/vellum-variables";
 
+const TEMPLATING_INPUT_KEY = "template";
+const INPUTS_PREFIX = "inputs";
+
 export class TemplatingNode extends BaseSingleFileNode<
   TemplatingNodeType,
   TemplatingNodeContext
 > {
+  protected getNodeAttributeNameByNodeInputKey(nodeInputKey: string): string {
+    if (nodeInputKey === TEMPLATING_INPUT_KEY) {
+      return nodeInputKey;
+    }
+
+    return `${INPUTS_PREFIX}.${nodeInputKey}`;
+  }
+
   protected getNodeBaseGenericTypes(): AstNode[] {
     const baseStateClassReference = new BaseState({
       workflowContext: this.workflowContext,
@@ -36,14 +47,14 @@ export class TemplatingNode extends BaseSingleFileNode<
 
     statements.push(
       python.field({
-        name: "template",
+        name: TEMPLATING_INPUT_KEY,
         initializer: this.getTemplatingInput(),
       })
     );
 
     statements.push(
       python.field({
-        name: "inputs",
+        name: INPUTS_PREFIX,
         initializer: python.TypeInstantiation.dict(
           otherInputs.map((codeInput) => ({
             key: python.TypeInstantiation.str(codeInput.nodeInputData.key),

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/templating_node.py
@@ -12,9 +12,9 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     node_id = UUID("24153572-e27b-4cea-a541-4d9e82f28b4e")
     target_handle_id = UUID("d1b8ef3d-1474-4cfb-8fb0-164f7b238a07")
     node_input_ids_by_name = {
-        "example_var": UUID("5ec0a342-0d78-4717-bda3-e70805234cad"),
+        "inputs.example_var": UUID("5ec0a342-0d78-4717-bda3-e70805234cad"),
         "template": UUID("1cfb8efb-ac81-478a-ab46-46ed5536bd6f"),
-        "var_1": UUID("73ff2e75-bebc-4f5a-970b-8ed733cc215c"),
+        "inputs.var_1": UUID("73ff2e75-bebc-4f5a-970b-8ed733cc215c"),
     }
     output_display = {
         TemplatingNode.Outputs.result: NodeOutputDisplay(id=UUID("2e275abe-4e00-443b-9898-2afed7c13826"), name="result")

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_3.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_3.py
@@ -13,8 +13,8 @@ class TemplatingNode3Display(BaseTemplatingNodeDisplay[TemplatingNode3]):
     target_handle_id = UUID("2c1e39e0-ce3e-4c2d-8baf-c5d93b244997")
     node_input_ids_by_name = {
         "template": UUID("c1cc89c9-7cb7-498d-9dda-e9e5f36fe556"),
-        "input_a": UUID("56ff5b3f-41e1-492d-80a0-493f170452a1"),
-        "input_b": UUID("553fe161-a16e-48d1-b07c-b51fe7d10bf3"),
+        "inputs.input_a": UUID("56ff5b3f-41e1-492d-80a0-493f170452a1"),
+        "inputs.input_b": UUID("553fe161-a16e-48d1-b07c-b51fe7d10bf3"),
     }
     output_display = {
         TemplatingNode3.Outputs.result: NodeOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/nodes/templating_node.py
@@ -12,7 +12,7 @@ class TemplatingNodeDisplay(BaseTemplatingNodeDisplay[TemplatingNode]):
     node_id = UUID("d0538e54-b623-4a71-a5cd-24b1ed5ce223")
     target_handle_id = UUID("62e924f8-3f80-475f-b6f0-bda3420a50bc")
     node_input_ids_by_name = {
-        "example_var_1": UUID("5e8396fe-1803-405f-ab1b-95132b592552"),
+        "inputs.example_var_1": UUID("5e8396fe-1803-405f-ab1b-95132b592552"),
         "template": UUID("e7904d49-cb35-4bc8-8dd6-3c8e243353d2"),
     }
     output_display = {


### PR DESCRIPTION
Last piece needed on the SDK side to solve the templating node inputs bug.

We use codegen to solidify `node_input_ids_by_name` being a mapping from attribute name to node input id