### PR TITLE
Make doc index not found errors a warning

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
@@ -1,5 +1,43 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`TextSearchNode > 404 error handling > getNodeFile handles 404 error 1`] = `
+"from vellum import SearchResultMergingRequest, SearchWeightsRequest
+from vellum.workflows.nodes.displayable import SearchNode as BaseSearchNode
+from vellum.workflows.nodes.displayable.bases.types import (
+    MetadataLogicalCondition,
+    MetadataLogicalConditionGroup,
+    SearchFilters,
+)
+
+
+class SearchNode(BaseSearchNode):
+    query = None
+    document_index = "d5beca61-aacb-4b22-a70c-776a1e025aa4"
+    limit = 8
+    weights = SearchWeightsRequest(semantic_similarity=0.8, keywords=0.2)
+    result_merging = SearchResultMergingRequest(enabled=True)
+    filters = SearchFilters(
+        external_ids=None,
+        metadata=MetadataLogicalConditionGroup(
+            combinator="AND",
+            negated=False,
+            conditions=[
+                MetadataLogicalConditionGroup(
+                    combinator="AND",
+                    negated=False,
+                    conditions=[
+                        MetadataLogicalCondition(
+                            lhs_variable=None, operator="=", rhs_variable=None
+                        )
+                    ],
+                )
+            ],
+        ),
+    )
+    chunk_separator = "\\n\\n#####\\n\\n"
+"
+`;
+
 exports[`TextSearchNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -367,11 +367,14 @@ describe("TextSearchNode", () => {
 
     it("getNodeFile handles 404 error", async () => {
       node.getNodeFile().write(writer);
-      await writer.toStringFormatted();
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
 
-      expect(workflowContext.getErrors()[0]?.message).toEqual(
+      const error = workflowContext.getErrors()[0];
+      expect(error).toBeDefined();
+      expect(error?.message).toEqual(
         'Document Index "d5beca61-aacb-4b22-a70c-776a1e025aa4" not found.'
       );
+      expect(error?.severity).toEqual("WARNING");
     });
   });
 

--- a/ee/codegen/src/context/node-context/text-search-node.ts
+++ b/ee/codegen/src/context/node-context/text-search-node.ts
@@ -52,7 +52,8 @@ export class TextSearchNodeContext extends BaseNodeContext<SearchNode> {
           if (e instanceof VellumError && e.statusCode === 404) {
             this.workflowContext.addError(
               new EntityNotFoundError(
-                `Document Index "${rule.data.value?.toString()}" not found.`
+                `Document Index "${rule.data.value?.toString()}" not found.`,
+                "WARNING"
               )
             );
           } else {


### PR DESCRIPTION
Resolves this sentry error lighting up our channels: https://vellum.sentry.io/issues/6440634106/?alert_rule_id=15639644&alert_type=issue&notification_uuid=2dd0944a-53d8-48d8-94e2-940ec06121cb&project=4508362703634432