### PR TITLE
Remove code_input_id and runtime_input_id from CodeNode Display classes

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -17,8 +17,6 @@ class CodeExecutionNodeDisplay(BaseCodeExecutionNodeDisplay[CodeExecutionNode]):
     label = "Code Execution Node"
     node_id = UUID("2cd960a3-cb8a-43ed-9e3f-f003fc480951")
     target_handle_id = UUID("06573a05-e6f0-48b9-bc6e-07e06d0bc1b1")
-    code_input_id = UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
-    runtime_input_id = UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e")
     output_id = UUID("81b270c0-4deb-4db3-aae5-138f79531b2b")
     log_output_id = UUID("46abb839-400b-4766-997e-9c463b526139")
     node_input_ids_by_name = {
@@ -188,8 +186,6 @@ class CodeExecutionNodeDisplay(BaseCodeExecutionNodeDisplay[CodeExecutionNode]):
     label = "Code Execution Node"
     node_id = UUID("2cd960a3-cb8a-43ed-9e3f-f003fc480951")
     target_handle_id = UUID("06573a05-e6f0-48b9-bc6e-07e06d0bc1b1")
-    code_input_id = UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
-    runtime_input_id = UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e")
     output_id = UUID("81b270c0-4deb-4db3-aae5-138f79531b2b")
     node_input_ids_by_name = {
         "code": UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc"),

--- a/ee/codegen/src/generators/nodes/code-execution-node.ts
+++ b/ee/codegen/src/generators/nodes/code-execution-node.ts
@@ -182,20 +182,6 @@ export class CodeExecutionNode extends BaseSingleFileNode<
 
     statements.push(
       python.field({
-        name: "code_input_id",
-        initializer: python.TypeInstantiation.uuid(nodeData.codeInputId),
-      })
-    );
-
-    statements.push(
-      python.field({
-        name: "runtime_input_id",
-        initializer: python.TypeInstantiation.uuid(nodeData.runtimeInputId),
-      })
-    );
-
-    statements.push(
-      python.field({
         name: "output_id",
         initializer: python.TypeInstantiation.uuid(nodeData.outputId),
       })

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/nodes/code_execution_node.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/nodes/code_execution_node.py
@@ -11,8 +11,6 @@ class CodeExecutionNodeDisplay(BaseCodeExecutionNodeDisplay[CodeExecutionNode]):
     label = "Code Execution Node"
     node_id = UUID("97240cb9-94a0-4a1a-b69e-3c2d96ebb1e2")
     target_handle_id = UUID("dba6c62b-8519-48ba-b888-ed2ca346fba8")
-    code_input_id = UUID("19b05769-cee3-4659-80d1-66fcae4e27c3")
-    runtime_input_id = UUID("ebcd1dc6-b0cc-4e67-af67-a42993cf038b")
     output_id = UUID("9d1dae27-6e6a-40bf-a401-611c974d4143")
     log_output_id = UUID("b57399ac-93ce-4225-8543-10bac4fe82f4")
     node_input_ids_by_name = {

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/code_execution_node.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/code_execution_node.py
@@ -11,8 +11,6 @@ class CodeExecutionNodeDisplay(BaseCodeExecutionNodeDisplay[CodeExecutionNode]):
     label = "Code Execution Node"
     node_id = UUID("cdec50ed-5cfc-418e-ad1f-45ef7a0abe4b")
     target_handle_id = UUID("3a82ede9-4b1b-42fc-84a0-10e91de602dc")
-    code_input_id = UUID("e5a9379e-871d-4a8f-88cd-b3ea832577dc")
-    runtime_input_id = UUID("611d4cd9-dca8-4821-8d3b-899439c556bb")
     output_id = UUID("98ef146c-6603-4930-85c2-8a637a58476c")
     log_output_id = UUID("ce51ac26-1e30-4434-9915-429b55ed9f06")
     node_input_ids_by_name = {

--- a/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
@@ -15,9 +15,6 @@ _CodeExecutionNodeType = TypeVar("_CodeExecutionNodeType", bound=CodeExecutionNo
 
 
 class BaseCodeExecutionNodeDisplay(BaseNodeVellumDisplay[_CodeExecutionNodeType], Generic[_CodeExecutionNodeType]):
-    code_input_id: ClassVar[Optional[UUID]] = None
-    runtime_input_id: ClassVar[Optional[UUID]] = None
-
     output_id: ClassVar[Optional[UUID]] = None
     log_output_id: ClassVar[Optional[UUID]] = None
 
@@ -52,19 +49,22 @@ class BaseCodeExecutionNodeDisplay(BaseNodeVellumDisplay[_CodeExecutionNodeType]
             for variable_name, variable_value in code_inputs.items()
         ]
 
+        code_input_id = self.node_input_ids_by_name.get(CodeExecutionNode.code.name)
         code_node_input = create_node_input(
             node_id=node_id,
             input_name="code",
             value=code_value,
             display_context=display_context,
-            input_id=self.code_input_id,
+            input_id=code_input_id,
         )
+
+        runtime_input_id = self.node_input_ids_by_name.get(CodeExecutionNode.runtime.name)
         runtime_node_input = create_node_input(
             node_id=node_id,
             input_name="runtime",
             value=node.runtime,
             display_context=display_context,
-            input_id=self.runtime_input_id,
+            input_id=runtime_input_id,
         )
         inputs.extend([code_node_input, runtime_node_input])
 
@@ -84,8 +84,8 @@ class BaseCodeExecutionNodeDisplay(BaseNodeVellumDisplay[_CodeExecutionNodeType]
                 "error_output_id": str(error_output_id) if error_output_id else None,
                 "source_handle_id": str(self.get_source_handle_id(display_context.port_displays)),
                 "target_handle_id": str(self.get_target_handle_id()),
-                "code_input_id": str(self.code_input_id) if self.code_input_id else code_node_input.id,
-                "runtime_input_id": str(self.runtime_input_id) if self.runtime_input_id else runtime_node_input.id,
+                "code_input_id": code_node_input.id,
+                "runtime_input_id": runtime_node_input.id,
                 "output_type": output_type,
                 "packages": [package.dict() for package in packages] if packages is not None else [],
                 "output_id": str(self.output_id) if self.output_id else str(output_display.id),


### PR DESCRIPTION
Same rationale as: https://github.com/vellum-ai/vellum-python-sdks/pull/1177

Simplifying gets us closer to treating this like a generic node display class, removes redundancy, and will eventually fix code inputs node events