### PR TITLE
Serialize code inputs with proper input path prefix

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
@@ -24,17 +24,20 @@ class BaseCodeExecutionNodeDisplay(BaseNodeVellumDisplay[_CodeExecutionNodeType]
         node = self._node
         node_id = self.node_id
         raw_code = raise_if_descriptor(node.code)
+        filepath = raise_if_descriptor(node.filepath)
 
         code_value: Optional[str]
         if raw_code:
             code_value = raw_code
-        else:
+        elif filepath:
             node_file_path = inspect.getfile(node)
             file_code = read_file_from_path(
                 node_filepath=node_file_path,
-                script_filepath=(raise_if_descriptor(node.filepath)),  # type: ignore
+                script_filepath=filepath,
             )
             code_value = file_code
+        else:
+            code_value = ""
 
         code_inputs = raise_if_descriptor(node.code_inputs)
 
@@ -44,7 +47,8 @@ class BaseCodeExecutionNodeDisplay(BaseNodeVellumDisplay[_CodeExecutionNodeType]
                 input_name=variable_name,
                 value=variable_value,
                 display_context=display_context,
-                input_id=self.node_input_ids_by_name.get(variable_name),
+                input_id=self.node_input_ids_by_name.get(f"{CodeExecutionNode.code_inputs.name}.{variable_name}")
+                or self.node_input_ids_by_name.get(variable_name),
             )
             for variable_name, variable_value in code_inputs.items()
         ]

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_code_execution_node.py
@@ -1,0 +1,113 @@
+import pytest
+from uuid import UUID
+from typing import Type
+
+from vellum.workflows.nodes.displayable.code_execution_node.node import CodeExecutionNode
+from vellum.workflows.workflows.base import BaseWorkflow
+from vellum_ee.workflows.display.nodes.vellum.code_execution_node import BaseCodeExecutionNodeDisplay
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+
+
+def _no_display_class(Node: Type[CodeExecutionNode]):
+    return None
+
+
+def _display_class_with_node_input_ids_by_name(Node: Type[CodeExecutionNode]):
+    class CodeExecutionNodeDisplay(BaseCodeExecutionNodeDisplay[Node]):  # type: ignore[valid-type]
+        node_input_ids_by_name = {"foo": UUID("fba6a4d5-835a-4e99-afb7-f6a4aed15110")}
+
+    return CodeExecutionNodeDisplay
+
+
+def _display_class_with_node_input_ids_by_name_with_inputs_prefix(Node: Type[CodeExecutionNode]):
+    class CodeExecutionNodeDisplay(BaseCodeExecutionNodeDisplay[Node]):  # type: ignore[valid-type]
+        node_input_ids_by_name = {"code_inputs.foo": UUID("fba6a4d5-835a-4e99-afb7-f6a4aed15110")}
+
+    return CodeExecutionNodeDisplay
+
+
+@pytest.mark.parametrize(
+    ["GetDisplayClass", "expected_input_id"],
+    [
+        (_no_display_class, "e3cdb222-324e-4ad1-abb2-bdd7881b3a0e"),
+        (_display_class_with_node_input_ids_by_name, "fba6a4d5-835a-4e99-afb7-f6a4aed15110"),
+        (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "fba6a4d5-835a-4e99-afb7-f6a4aed15110"),
+    ],
+    ids=[
+        "no_display_class",
+        "display_class_with_node_input_ids_by_name",
+        "display_class_with_node_input_ids_by_name_with_inputs_prefix",
+    ],
+)
+def test_serialize_node__code_node_inputs(GetDisplayClass, expected_input_id):
+    # GIVEN a code node with inputs
+    class MyCodeExecutionNode(CodeExecutionNode):
+        code_inputs = {"foo": "bar"}
+
+    # AND a workflow with the code node
+    class Workflow(BaseWorkflow):
+        graph = MyCodeExecutionNode
+
+    # AND a display class
+    GetDisplayClass(MyCodeExecutionNode)
+
+    # WHEN the workflow is serialized
+    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=Workflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    # THEN the node should properly serialize the inputs
+    my_code_execution_node = next(
+        node for node in serialized_workflow["workflow_raw_data"]["nodes"] if node["type"] == "CODE_EXECUTION"
+    )
+
+    assert my_code_execution_node["inputs"] == [
+        {
+            "id": expected_input_id,
+            "key": "foo",
+            "value": {
+                "combinator": "OR",
+                "rules": [
+                    {
+                        "type": "CONSTANT_VALUE",
+                        "data": {
+                            "type": "STRING",
+                            "value": "bar",
+                        },
+                    }
+                ],
+            },
+        },
+        {
+            "id": "9774d864-c76d-4a1a-8181-b632ed3ab87c",
+            "key": "code",
+            "value": {
+                "combinator": "OR",
+                "rules": [
+                    {
+                        "type": "CONSTANT_VALUE",
+                        "data": {
+                            "type": "STRING",
+                            "value": "",
+                        },
+                    }
+                ],
+            },
+        },
+        {
+            "id": "34742235-5699-45cd-9d34-bce3745e743d",
+            "key": "runtime",
+            "value": {
+                "combinator": "OR",
+                "rules": [
+                    {
+                        "type": "CONSTANT_VALUE",
+                        "data": {
+                            "type": "STRING",
+                            "value": "PYTHON_3_11_6",
+                        },
+                    }
+                ],
+            },
+        },
+    ]

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
@@ -78,7 +78,7 @@ class CodeExecutionNode(BaseNode[StateType], Generic[StateType, _OutputType], me
     filepath: ClassVar[Optional[str]] = None
     code: ClassVar[Optional[str]] = None
 
-    code_inputs: ClassVar[EntityInputsInterface]
+    code_inputs: ClassVar[EntityInputsInterface] = {}
     runtime: CodeExecutionRuntime = "PYTHON_3_11_6"
     packages: Optional[Sequence[CodeExecutionPackage]] = None
 


### PR DESCRIPTION
Same PR as https://github.com/vellum-ai/vellum-python-sdks/pull/1180, but for code exec node inputs. This will eventually build up to proper initiated event display in Vellum