### PR TITLE
Hoist up edge display utilities to the root BaseWorkflowDisplay

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
+++ b/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
@@ -7,12 +7,12 @@ from vellum.workflows.types.generics import NodeType
 from vellum.workflows.utils.uuids import uuid4_from_hash
 
 if TYPE_CHECKING:
-    from vellum_ee.workflows.display.types import NodeDisplayType
+    from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 
 
 def get_node_display_class(
-    base_class: Type["NodeDisplayType"], node_class: Type[NodeType], root_node_class: Optional[Type[NodeType]] = None
-) -> Type["NodeDisplayType"]:
+    base_class: Type["BaseNodeDisplay"], node_class: Type[NodeType], root_node_class: Optional[Type[NodeType]] = None
+) -> Type["BaseNodeDisplay"]:
     node_display_class = base_class.get_from_node_display_registry(node_class)
     if node_display_class:
         if not issubclass(node_display_class, base_class):

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
@@ -12,7 +12,7 @@ from vellum_ee.workflows.display.base import StateValueDisplayType, WorkflowInpu
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.types import NodeDisplayType, WorkflowDisplayContext
+from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum_ee.workflows.display.vellum import NodeDisplayData, WorkflowMetaVellumDisplay
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -24,7 +24,7 @@ def serialize_node():
         base_class: type[BaseNodeDisplay[Any]] = BaseNodeDisplay,
         global_workflow_input_displays: Dict[WorkflowInputReference, WorkflowInputsDisplayType] = {},
         global_state_value_displays: Dict[StateValueReference, StateValueDisplayType] = {},
-        global_node_displays: Dict[Type[BaseNode], NodeDisplayType] = {},
+        global_node_displays: Dict[Type[BaseNode], BaseNodeDisplay] = {},
         global_node_output_displays: Dict[OutputReference, Tuple[Type[BaseNode], NodeOutputDisplay]] = {},
     ) -> JsonObject:
         node_display_class = get_node_display_class(base_class, node_class)

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -7,7 +7,6 @@ from vellum.workflows.nodes import BaseNode
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference, StateValueReference, WorkflowInputReference
 from vellum_ee.workflows.display.base import (
-    EdgeDisplayType,
     EntrypointDisplayType,
     StateValueDisplayType,
     WorkflowInputsDisplayType,
@@ -18,9 +17,9 @@ from vellum_ee.workflows.display.base import (
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
     from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay
+    from vellum_ee.workflows.display.vellum import EdgeVellumDisplay
     from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
-NodeDisplayType = TypeVar("NodeDisplayType", bound="BaseNodeDisplay")
 WorkflowDisplayType = TypeVar("WorkflowDisplayType", bound="BaseWorkflowDisplay")
 
 
@@ -30,9 +29,7 @@ class WorkflowDisplayContext(
         WorkflowMetaDisplayType,
         WorkflowInputsDisplayType,
         StateValueDisplayType,
-        NodeDisplayType,
         EntrypointDisplayType,
-        EdgeDisplayType,
     ]
 ):
     workflow_display_class: Type["BaseWorkflowDisplay"]
@@ -43,12 +40,12 @@ class WorkflowDisplayContext(
     )
     state_value_displays: Dict[StateValueReference, StateValueDisplayType] = field(default_factory=dict)
     global_state_value_displays: Dict[StateValueReference, StateValueDisplayType] = field(default_factory=dict)
-    node_displays: Dict[Type[BaseNode], "NodeDisplayType"] = field(default_factory=dict)
-    global_node_displays: Dict[Type[BaseNode], NodeDisplayType] = field(default_factory=dict)
+    node_displays: Dict[Type[BaseNode], "BaseNodeDisplay"] = field(default_factory=dict)
+    global_node_displays: Dict[Type[BaseNode], "BaseNodeDisplay"] = field(default_factory=dict)
     global_node_output_displays: Dict[OutputReference, Tuple[Type[BaseNode], "NodeOutputDisplay"]] = field(
         default_factory=dict
     )
     entrypoint_displays: Dict[Type[BaseNode], EntrypointDisplayType] = field(default_factory=dict)
     workflow_output_displays: Dict[BaseDescriptor, WorkflowOutputDisplay] = field(default_factory=dict)
-    edge_displays: Dict[Tuple[Port, Type[BaseNode]], EdgeDisplayType] = field(default_factory=dict)
+    edge_displays: Dict[Tuple[Port, Type[BaseNode]], "EdgeVellumDisplay"] = field(default_factory=dict)
     port_displays: Dict[Port, "PortDisplay"] = field(default_factory=dict)


### PR DESCRIPTION
We are eventually building up to [this](https://github.com/vellum-ai/vellum-python-sdks/pull/1191) PR, where we deprecate the other three Edge*Display classes. Long term, we are looking to remove all of those classes including VellumWorkflowDisplay to consolidate around just BaseWorkflowDisplay.

In this PR, we are simply hoisting up the utility methods from VellumWorkflowDisplay -> BaseWorkflowDisplay, removing some generics along the way