### PR TITLE
Consolidate Entrypoint Edge Display

### DIFF
--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -350,10 +350,8 @@ export class Workflow {
                       name: "edge_display",
                       value: python.instantiateClass({
                         classReference: python.reference({
-                          name: "EdgeVellumDisplayOverrides",
-                          modulePath:
-                            this.workflowContext.sdkModulePathNames
-                              .VELLUM_TYPES_MODULE_PATH,
+                          name: "EdgeDisplay",
+                          modulePath: VELLUM_WORKFLOWS_DISPLAY_BASE_PATH,
                         }),
                         arguments_: [
                           python.methodArgument({

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -36,7 +36,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         ApiNode: EntrypointVellumDisplayOverrides(
             id=UUID("c4ef480d-635a-49c8-900f-6583c4b79fb5"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("8fbc728e-7408-4456-a932-001423ae8efa")),
+            edge_display=EdgeDisplay(id=UUID("8fbc728e-7408-4456-a932-001423ae8efa")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -36,7 +36,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         CodeExecutionNode: EntrypointVellumDisplayOverrides(
             id=UUID("d49107fe-1424-42ba-9413-9ab5ce398077"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("f9ff5d09-50a3-46bc-bca6-9f77886cc0e7")),
+            edge_display=EdgeDisplay(id=UUID("f9ff5d09-50a3-46bc-bca6-9f77886cc0e7")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -39,7 +39,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         ConditionalNode: EntrypointVellumDisplayOverrides(
             id=UUID("6dbd327c-3b96-4da4-9063-5b36dab7f6d0"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("549da4b2-e72a-468f-b233-34efbbae75ae")),
+            edge_display=EdgeDisplay(id=UUID("549da4b2-e72a-468f-b233-34efbbae75ae")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_error_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_error_node/code/display/workflow.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import EdgeDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -34,7 +34,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         ErrorNode: EntrypointVellumDisplayOverrides(
             id=UUID("27a1723c-e892-4303-bbf0-c1a0428af295"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("bcd998c4-0df4-4f59-8b15-ed1f64c5c157")),
+            edge_display=EdgeDisplay(id=UUID("bcd998c4-0df4-4f59-8b15-ed1f64c5c157")),
         )
     }
     output_displays = {}

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -39,7 +39,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         GuardrailNode: EntrypointVellumDisplayOverrides(
             id=UUID("872c757c-9544-4ad6-ada5-5ee574f1fe5e"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("26e54d68-9d79-4551-87a4-b4e0a3dd000e")),
+            edge_display=EdgeDisplay(id=UUID("26e54d68-9d79-4551-87a4-b4e0a3dd000e")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -30,7 +30,7 @@ class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkfl
     entrypoint_displays = {
         SearchNode: EntrypointVellumDisplayOverrides(
             id=UUID("c48f318d-4d87-44da-be54-0ecf537608f6"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("96f14f30-7984-4bbf-af02-baf07ce38116")),
+            edge_display=EdgeDisplay(id=UUID("96f14f30-7984-4bbf-af02-baf07ce38116")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -36,7 +36,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         SubworkflowNode: EntrypointVellumDisplayOverrides(
             id=UUID("48134634-f654-4a45-9f00-4e9378ab1f32"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("ff1e812c-a62d-4ab2-90cb-0f2617d2121b")),
+            edge_display=EdgeDisplay(id=UUID("ff1e812c-a62d-4ab2-90cb-0f2617d2121b")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -43,7 +43,7 @@ class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
     entrypoint_displays = {
         TemplatingNode: EntrypointVellumDisplayOverrides(
             id=UUID("79145e96-23c3-4763-ad7e-f3c6529fe535"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("09c7b24f-a133-4c71-971a-15b696abfe32")),
+            edge_display=EdgeDisplay(id=UUID("09c7b24f-a133-4c71-971a-15b696abfe32")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -40,7 +40,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         CodeExecutionNode: EntrypointVellumDisplayOverrides(
             id=UUID("77325e35-b73e-4596-bfb0-3cf3ddf11a2e"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("ec1f1cb3-7221-4f7d-aaa2-0675665e201b")),
+            edge_display=EdgeDisplay(id=UUID("ec1f1cb3-7221-4f7d-aaa2-0675665e201b")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -33,11 +33,11 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         TemplatingNode2: EntrypointVellumDisplayOverrides(
             id=UUID("b8b9eb69-4af1-4953-b576-aa59eb138696"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("22106f5d-fd97-431d-9615-48278f7a954b")),
+            edge_display=EdgeDisplay(id=UUID("22106f5d-fd97-431d-9615-48278f7a954b")),
         ),
         TemplatingNode1: EntrypointVellumDisplayOverrides(
             id=UUID("b8b9eb69-4af1-4953-b576-aa59eb138696"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("2c4d2583-af8d-4fd8-972b-c850325d4158")),
+            edge_display=EdgeDisplay(id=UUID("2c4d2583-af8d-4fd8-972b-c850325d4158")),
         ),
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -36,7 +36,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         PromptNode: EntrypointVellumDisplayOverrides(
             id=UUID("1c05df03-f699-42e4-9816-9b1b3757c10e"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("d56e2ecf-5a82-4e37-879c-531fdecf12f6")),
+            edge_display=EdgeDisplay(id=UUID("d56e2ecf-5a82-4e37-879c-531fdecf12f6")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -36,7 +36,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         PromptNode: EntrypointVellumDisplayOverrides(
             id=UUID("fedbe8f4-aa63-405b-aefa-0e40e65d547e"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("52729326-646f-454e-8940-d8d65e659d0a")),
+            edge_display=EdgeDisplay(id=UUID("52729326-646f-454e-8940-d8d65e659d0a")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -39,7 +39,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         SearchNode: EntrypointVellumDisplayOverrides(
             id=UUID("27a1723c-e892-4303-bbf0-c1a0428af295"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("bcd998c4-0df4-4f59-8b15-ed1f64c5c157")),
+            edge_display=EdgeDisplay(id=UUID("bcd998c4-0df4-4f59-8b15-ed1f64c5c157")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -30,7 +30,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         TemplatingNode: EntrypointVellumDisplayOverrides(
             id=UUID("6b52893a-e649-434d-aedd-e8ad73d78dce"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("662141c0-23b1-4513-9b8a-e382e56c4021")),
+            edge_display=EdgeDisplay(id=UUID("662141c0-23b1-4513-9b8a-e382e56c4021")),
         )
     }
     edge_displays = {

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
     EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
@@ -36,7 +36,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         TemplatingNode: EntrypointVellumDisplayOverrides(
             id=UUID("39a5155a-d137-4a56-be36-d525802df463"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("e659e56b-89a7-49d0-b792-b27006242fe1")),
+            edge_display=EdgeDisplay(id=UUID("e659e56b-89a7-49d0-b792-b27006242fe1")),
         )
     }
     edge_displays = {

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -108,7 +108,7 @@ class EdgeVellumDisplay(EdgeVellumDisplayOverrides):
 
 @dataclass
 class EntrypointVellumDisplayOverrides(EntrypointDisplay, EntrypointDisplayOverrides):
-    edge_display: EdgeVellumDisplayOverrides
+    edge_display: EdgeDisplay
 
 
 @dataclass

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -19,6 +19,7 @@ from vellum.workflows.types.core import JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.base import (
+    EdgeDisplay,
     EntrypointDisplayOverridesType,
     EntrypointDisplayType,
     StateValueDisplayOverridesType,
@@ -475,7 +476,7 @@ class BaseWorkflowDisplay(
         source_handle_id: UUID,
         target_node_id: UUID,
         target_handle_id: UUID,
-        overrides: Optional[EdgeVellumDisplayOverrides] = None,
+        overrides: Optional[EdgeDisplay] = None,
     ) -> EdgeVellumDisplay:
         edge_id: UUID
         if overrides:


### PR DESCRIPTION
We are eventually building up to [this](https://github.com/vellum-ai/vellum-python-sdks/pull/new/vargas/entrypoint-edge-display) PR, where we consolidate all of the Edge*Display classes to a single one, deprecating the rest, with the eventual goal of deprecating VellumWorkflowDisplay