### PR TITLE
Clean up redundant display attributes on prompt display

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node-retry.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node-retry.test.ts.snap
@@ -23,7 +23,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -103,7 +102,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -180,7 +178,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -19,7 +19,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -112,7 +111,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -212,7 +210,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -307,7 +304,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -377,7 +373,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -454,7 +449,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -526,7 +520,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -595,7 +588,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -671,7 +663,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -742,7 +733,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -817,7 +807,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -899,7 +888,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -976,7 +964,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -1045,7 +1032,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -1121,7 +1107,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(
@@ -1258,7 +1243,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(

--- a/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
@@ -18,12 +18,7 @@ class PromptDeploymentNodeDisplay(
 ):
     label = "Prompt Deployment Node"
     node_id = UUID("947cc337-9a53-4c12-9a38-4f65c04c6317")
-    output_id = UUID("fa015382-7e5b-404e-b073-1c5f01832169")
-    array_output_id = UUID("4d257095-e908-4fc3-8159-a6ac0018e1f1")
     target_handle_id = UUID("e1f8a351-ab12-4167-93ee-d2dd72c8d15c")
-    prompt_input_ids_by_name = {
-        "my_var_1": UUID("3911bd2e-eaaf-4805-9ffc-e5d6a71c91a7")
-    }
     node_input_ids_by_name = {}
     output_display = {
         PromptDeploymentNode.Outputs.text: NodeOutputDisplay(

--- a/ee/codegen/src/generators/nodes/inline-prompt-node.ts
+++ b/ee/codegen/src/generators/nodes/inline-prompt-node.ts
@@ -140,15 +140,6 @@ export class InlinePromptNode extends BaseSingleFileNode<
         initializer: python.TypeInstantiation.uuid(
           this.nodeData.data.targetHandleId
         ),
-      }),
-      python.field({
-        name: "prompt_input_ids_by_name",
-        initializer: python.TypeInstantiation.dict(
-          this.nodeData.inputs.map((input) => ({
-            key: python.TypeInstantiation.str(input.key),
-            value: python.TypeInstantiation.uuid(input.id),
-          }))
-        ),
       })
     );
 

--- a/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
@@ -89,28 +89,9 @@ export class PromptDeploymentNode extends BaseSingleFileNode<
         initializer: python.TypeInstantiation.uuid(this.nodeData.id),
       }),
       python.field({
-        name: "output_id",
-        initializer: python.TypeInstantiation.uuid(this.nodeData.data.outputId),
-      }),
-      python.field({
-        name: "array_output_id",
-        initializer: python.TypeInstantiation.uuid(
-          this.nodeData.data.arrayOutputId
-        ),
-      }),
-      python.field({
         name: "target_handle_id",
         initializer: python.TypeInstantiation.uuid(
           this.nodeData.data.targetHandleId
-        ),
-      }),
-      python.field({
-        name: "prompt_input_ids_by_name",
-        initializer: python.TypeInstantiation.dict(
-          this.nodeData.inputs.map((input) => ({
-            key: python.TypeInstantiation.str(input.key),
-            value: python.TypeInstantiation.uuid(input.id),
-          }))
         ),
       })
     );

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node.py
@@ -13,7 +13,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("f7e45a43-f55c-4c19-8fe6-c3ce1308a076")
     array_output_id = UUID("63213d3c-547c-43df-905f-082aeb7dac61")
     target_handle_id = UUID("b14f0322-965d-43c9-96d4-7bce9fd87067")
-    prompt_input_ids_by_name = {"var_1": UUID("183b03e5-b903-4d39-abe4-9267c78285f6")}
     node_input_ids_by_name = {"var_1": UUID("183b03e5-b903-4d39-abe4-9267c78285f6")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(id=UUID("f7e45a43-f55c-4c19-8fe6-c3ce1308a076"), name="text"),

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_14.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_14.py
@@ -13,7 +13,6 @@ class PromptNode14Display(BaseInlinePromptNodeDisplay[PromptNode14]):
     output_id = UUID("8e2d57c3-85a3-4acb-b4d3-998c6906e389")
     array_output_id = UUID("43cd2bcf-4c99-4f7a-ace7-e27d986dd041")
     target_handle_id = UUID("3485b3fb-e4ee-47c9-b567-c5eab60c01f9")
-    prompt_input_ids_by_name = {"chat_history": UUID("b6524b5f-7697-4923-8b87-f85baadb505a")}
     node_input_ids_by_name = {"chat_history": UUID("b6524b5f-7697-4923-8b87-f85baadb505a")}
     output_display = {
         PromptNode14.Outputs.text: NodeOutputDisplay(id=UUID("8e2d57c3-85a3-4acb-b4d3-998c6906e389"), name="text"),

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_16.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_16.py
@@ -13,7 +13,6 @@ class PromptNode16Display(BaseInlinePromptNodeDisplay[PromptNode16]):
     output_id = UUID("4d31e604-6711-4a12-b618-476bfc304f09")
     array_output_id = UUID("4dba2219-6714-4ca7-9076-5bb01ee0b340")
     target_handle_id = UUID("ba029d72-7fc2-4e82-a5ad-6f364c84d72f")
-    prompt_input_ids_by_name = {"most_recent_message": UUID("0f0f394c-dc7d-46a1-9217-24c1e59b273a")}
     node_input_ids_by_name = {"most_recent_message": UUID("0f0f394c-dc7d-46a1-9217-24c1e59b273a")}
     output_display = {
         PromptNode16.Outputs.text: NodeOutputDisplay(id=UUID("4d31e604-6711-4a12-b618-476bfc304f09"), name="text"),

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_18.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_18.py
@@ -13,7 +13,6 @@ class PromptNode18Display(BaseInlinePromptNodeDisplay[PromptNode18]):
     output_id = UUID("df6d8990-e05b-45e1-9294-ccf58252757b")
     array_output_id = UUID("7bba9fdb-bb9e-457d-9755-a8f7ae0af959")
     target_handle_id = UUID("371cc948-bf59-4eba-9356-b21649f76b5e")
-    prompt_input_ids_by_name = {"text": UUID("fbd03331-bbef-45f3-98fd-2106fd3cdb8a")}
     node_input_ids_by_name = {"text": UUID("fbd03331-bbef-45f3-98fd-2106fd3cdb8a")}
     output_display = {
         PromptNode18.Outputs.text: NodeOutputDisplay(id=UUID("df6d8990-e05b-45e1-9294-ccf58252757b"), name="text"),

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_19.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_19.py
@@ -13,7 +13,6 @@ class PromptNode19Display(BaseInlinePromptNodeDisplay[PromptNode19]):
     output_id = UUID("7b1ca9d1-d829-4329-b9f3-a864c3ce4230")
     array_output_id = UUID("17c0ef53-62bf-459f-8df8-2ff3f6b8852a")
     target_handle_id = UUID("35b77bfb-91d3-4e5b-8032-9786b9cc05c3")
-    prompt_input_ids_by_name = {}
     node_input_ids_by_name = {}
     output_display = {
         PromptNode19.Outputs.text: NodeOutputDisplay(id=UUID("7b1ca9d1-d829-4329-b9f3-a864c3ce4230"), name="text"),

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_9.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_9.py
@@ -13,10 +13,6 @@ class PromptNode9Display(BaseInlinePromptNodeDisplay[PromptNode9]):
     output_id = UUID("e9c9ddb8-4057-4755-bbbd-6ca0291aac9a")
     array_output_id = UUID("3e174b5c-2e40-4bda-ba0c-eae3e617c988")
     target_handle_id = UUID("785dc582-83b3-46d1-87ec-9e8a10f4b00f")
-    prompt_input_ids_by_name = {
-        "question": UUID("c583f59e-2a5e-47c0-b244-2894b90d3d21"),
-        "context": UUID("ded72461-3d6a-4633-a45e-e7cc9189941b"),
-    }
     node_input_ids_by_name = {
         "question": UUID("c583f59e-2a5e-47c0-b244-2894b90d3d21"),
         "context": UUID("ded72461-3d6a-4633-a45e-e7cc9189941b"),

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/prompt_node.py
@@ -16,7 +16,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("13e677d3-14e7-4b0c-ab36-834bb99c930c")
     array_output_id = UUID("01976625-90e7-4ecb-b752-454b2cd0bb67")
     target_handle_id = UUID("e31c38be-ef5a-4c20-ab8b-9315f3e75ff8")
-    prompt_input_ids_by_name = {"text": UUID("b2bc9402-6e50-4982-800c-1662c188899b")}
     node_input_ids_by_name = {"text": UUID("b2bc9402-6e50-4982-800c-1662c188899b")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(id=UUID("13e677d3-14e7-4b0c-ab36-834bb99c930c"), name="text"),

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/nodes/prompt_node.py
@@ -13,7 +13,6 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     output_id = UUID("2d4f1826-de75-499a-8f84-0a690c8136ad")
     array_output_id = UUID("771c6fba-5b4a-4092-9d52-693242d7b92c")
     target_handle_id = UUID("3feb7e71-ec63-4d58-82ba-c3df829a2948")
-    prompt_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     node_input_ids_by_name = {"text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     output_display = {
         PromptNode.Outputs.text: NodeOutputDisplay(id=UUID("2d4f1826-de75-499a-8f84-0a690c8136ad"), name="text"),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from typing import Callable, ClassVar, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Callable, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
 
 from vellum import FunctionDefinition, PromptBlock, RichTextChildBlock, VellumVariable
 from vellum.workflows.nodes import InlinePromptNode
@@ -17,10 +17,6 @@ _InlinePromptNodeType = TypeVar("_InlinePromptNodeType", bound=InlinePromptNode)
 
 
 class BaseInlinePromptNodeDisplay(BaseNodeVellumDisplay[_InlinePromptNodeType], Generic[_InlinePromptNodeType]):
-    output_id: ClassVar[Optional[UUID]] = None
-    array_output_id: ClassVar[Optional[UUID]] = None
-    prompt_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
-
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
     ) -> JsonObject:
@@ -98,7 +94,7 @@ class BaseInlinePromptNodeDisplay(BaseNodeVellumDisplay[_InlinePromptNodeType], 
                 input_name=variable_name,
                 value=variable_value,
                 display_context=display_context,
-                input_id=self.prompt_input_ids_by_name.get(variable_name),
+                input_id=self.node_input_ids_by_name.get(variable_name),
             )
             vellum_variable_type = infer_vellum_variable_type(variable_value)
             node_inputs.append(node_input)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from typing import ClassVar, Dict, Generic, Optional, TypeVar, cast
+from typing import Generic, Optional, TypeVar, cast
 
 from vellum.workflows.nodes.displayable.prompt_deployment_node import PromptDeploymentNode
 from vellum.workflows.references import OutputReference
@@ -16,10 +16,6 @@ _PromptDeploymentNodeType = TypeVar("_PromptDeploymentNodeType", bound=PromptDep
 class BasePromptDeploymentNodeDisplay(
     BaseNodeVellumDisplay[_PromptDeploymentNodeType], Generic[_PromptDeploymentNodeType]
 ):
-    output_id: ClassVar[Optional[UUID]] = None
-    array_output_id: ClassVar[Optional[UUID]] = None
-    prompt_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
-
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
     ) -> JsonObject:
@@ -34,7 +30,7 @@ class BasePromptDeploymentNodeDisplay(
                     input_name=variable_name,
                     value=variable_value,
                     display_context=display_context,
-                    input_id=self.prompt_input_ids_by_name.get(variable_name),
+                    input_id=self.node_input_ids_by_name.get(variable_name),
                 )
                 for variable_name, variable_value in prompt_inputs.items()
             ]


### PR DESCRIPTION
Same PR as https://github.com/vellum-ai/vellum-python-sdks/pull/1190 but for our two prompt nodes.

Note that we can also clean up `*_output_id` display class attributes bc of our `BaseNodeDisplay.output_display` field