### PR TITLE
Codegen EdgeDisplay instead of EdgeVellumDisplayOverrides

### DIFF
--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -430,10 +430,8 @@ export class Workflow {
               ]),
               value: python.instantiateClass({
                 classReference: python.reference({
-                  name: "EdgeVellumDisplayOverrides",
-                  modulePath:
-                    this.workflowContext.sdkModulePathNames
-                      .VELLUM_TYPES_MODULE_PATH,
+                  name: "EdgeDisplay",
+                  modulePath: VELLUM_WORKFLOWS_DISPLAY_BASE_PATH,
                 }),
                 arguments_: [
                   python.methodArgument({

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -39,11 +38,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
             edge_display=EdgeDisplay(id=UUID("8fbc728e-7408-4456-a932-001423ae8efa")),
         )
     }
-    edge_displays = {
-        (ApiNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("dc149e06-f71f-48ba-be58-0c3f6be13719")
-        )
-    }
+    edge_displays = {(ApiNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("dc149e06-f71f-48ba-be58-0c3f6be13719"))}
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(
             id=UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62"), name="final-output"

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -40,9 +39,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     edge_displays = {
-        (CodeExecutionNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("3936972b-ad88-4cc0-85a1-61b931ca3431")
-        )
+        (CodeExecutionNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("3936972b-ad88-4cc0-85a1-61b931ca3431"))
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -43,9 +42,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     edge_displays = {
-        (ConditionalNode.Ports.branch_1, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("97779960-7685-4a9d-ba40-f748131fb4f2")
-        )
+        (ConditionalNode.Ports.branch_1, FinalOutput): EdgeDisplay(id=UUID("97779960-7685-4a9d-ba40-f748131fb4f2"))
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -43,9 +42,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     edge_displays = {
-        (GuardrailNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("cfda52fa-313b-4aa4-b673-28b74ed5f290")
-        )
+        (GuardrailNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("cfda52fa-313b-4aa4-b673-28b74ed5f290"))
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -34,9 +33,7 @@ class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkfl
         )
     }
     edge_displays = {
-        (SearchNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("39582ae7-0a7b-4063-8d67-0e2e8ad45a1e")
-        )
+        (SearchNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("39582ae7-0a7b-4063-8d67-0e2e8ad45a1e"))
     }
     output_displays = {
         SubworkflowNodeWorkflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -40,9 +39,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     edge_displays = {
-        (SubworkflowNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("d6c3d222-a05c-43b2-8d21-462f94fd3b1e")
-        )
+        (SubworkflowNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("d6c3d222-a05c-43b2-8d21-462f94fd3b1e"))
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -47,12 +46,8 @@ class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
         )
     }
     edge_displays = {
-        (TemplatingNode.Ports.default, SearchNode): EdgeVellumDisplayOverrides(
-            id=UUID("d9cc06ea-07fb-413e-b11d-619e29dfbf84")
-        ),
-        (SearchNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("41499fe7-2ec8-4f35-9fd7-34cb26e57464")
-        ),
+        (TemplatingNode.Ports.default, SearchNode): EdgeDisplay(id=UUID("d9cc06ea-07fb-413e-b11d-619e29dfbf84")),
+        (SearchNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("41499fe7-2ec8-4f35-9fd7-34cb26e57464")),
     }
     output_displays = {
         MapNodeWorkflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -44,12 +43,8 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     edge_displays = {
-        (CodeExecutionNode.Ports.default, MapNode): EdgeVellumDisplayOverrides(
-            id=UUID("c1ed7a7c-b278-4a4e-a8d0-53366bfa4a3d")
-        ),
-        (MapNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("2e2e5cdc-94be-4df2-9e00-23467e2ea209")
-        ),
+        (CodeExecutionNode.Ports.default, MapNode): EdgeDisplay(id=UUID("c1ed7a7c-b278-4a4e-a8d0-53366bfa4a3d")),
+        (MapNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("2e2e5cdc-94be-4df2-9e00-23467e2ea209")),
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -41,18 +40,10 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         ),
     }
     edge_displays = {
-        (TemplatingNode2.Ports.default, MergeNode): EdgeVellumDisplayOverrides(
-            id=UUID("114b1eab-ad2a-4612-b590-35f6ebdd87bc")
-        ),
-        (MergeNode.Ports.default, TemplatingNode3): EdgeVellumDisplayOverrides(
-            id=UUID("fba82107-15bc-4033-9b38-6a8b0094aa7f")
-        ),
-        (TemplatingNode3.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("0c6ddc01-1db6-4b0f-ac7c-8b43ca4cf3c2")
-        ),
-        (TemplatingNode1.Ports.default, MergeNode): EdgeVellumDisplayOverrides(
-            id=UUID("20c8d251-bcf1-497e-8d37-668e661ccabc")
-        ),
+        (TemplatingNode2.Ports.default, MergeNode): EdgeDisplay(id=UUID("114b1eab-ad2a-4612-b590-35f6ebdd87bc")),
+        (MergeNode.Ports.default, TemplatingNode3): EdgeDisplay(id=UUID("fba82107-15bc-4033-9b38-6a8b0094aa7f")),
+        (TemplatingNode3.Ports.default, FinalOutput): EdgeDisplay(id=UUID("0c6ddc01-1db6-4b0f-ac7c-8b43ca4cf3c2")),
+        (TemplatingNode1.Ports.default, MergeNode): EdgeDisplay(id=UUID("20c8d251-bcf1-497e-8d37-668e661ccabc")),
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -40,9 +39,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     edge_displays = {
-        (PromptNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("95b7bf4b-6447-438a-88a5-1f47ec9b3d3c")
-        )
+        (PromptNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("95b7bf4b-6447-438a-88a5-1f47ec9b3d3c"))
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -40,9 +39,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     edge_displays = {
-        (PromptNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("6afd37dc-47f1-4b99-b1cc-47ff6128247b")
-        )
+        (PromptNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("6afd37dc-47f1-4b99-b1cc-47ff6128247b"))
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -43,9 +42,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     edge_displays = {
-        (SearchNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("2fb36bc6-ac91-4aad-bb58-fbc6c95ed6e3")
-        )
+        (SearchNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("2fb36bc6-ac91-4aad-bb58-fbc6c95ed6e3"))
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -34,9 +33,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     edge_displays = {
-        (TemplatingNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("6deb7d8b-b4cc-488f-aa30-e3e5f0957882")
-        )
+        (TemplatingNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("6deb7d8b-b4cc-488f-aa30-e3e5f0957882"))
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -40,9 +39,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     edge_displays = {
-        (TemplatingNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("dd79b52e-5a4d-4e62-9f83-9dd2468ca891")
-        )
+        (TemplatingNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("dd79b52e-5a4d-4e62-9f83-9dd2468ca891"))
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputDisplay(

--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -46,12 +46,16 @@ StateValueDisplayOverridesType = TypeVar("StateValueDisplayOverridesType", bound
 
 
 @dataclass
-class EdgeDisplayOverrides:
+class EdgeDisplay:
     id: UUID
 
 
 @dataclass
-class EdgeDisplay(EdgeDisplayOverrides):
+class EdgeDisplayOverrides(EdgeDisplay):
+    """
+    DEPRECATED: Use EdgeDisplay instead. Will be removed in 0.15.0
+    """
+
     pass
 
 

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -93,12 +93,20 @@ class StateValueVellumDisplay(StateValueVellumDisplayOverrides):
 
 
 @dataclass
-class EdgeVellumDisplayOverrides(EdgeDisplay, EdgeDisplayOverrides):
+class EdgeVellumDisplayOverrides(EdgeDisplayOverrides):
+    """
+    DEPRECATED: Use EdgeDisplay instead. Will be removed in 0.15.0
+    """
+
     pass
 
 
 @dataclass
 class EdgeVellumDisplay(EdgeVellumDisplayOverrides):
+    """
+    DEPRECATED: Use EdgeDisplay instead. Will be removed in 0.15.0
+    """
+
     source_node_id: UUID
     source_handle_id: UUID
     target_node_id: UUID

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -36,7 +36,7 @@ from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_di
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum_ee.workflows.display.vellum import EdgeVellumDisplay, EdgeVellumDisplayOverrides
+from vellum_ee.workflows.display.vellum import EdgeVellumDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 logger = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ class BaseWorkflowDisplay(
     output_displays: Dict[BaseDescriptor, WorkflowOutputDisplay] = {}
 
     # Used to explicitly specify display data for a workflow's edges.
-    edge_displays: Dict[Tuple[Port, Type[BaseNode]], EdgeVellumDisplayOverrides] = {}
+    edge_displays: Dict[Tuple[Port, Type[BaseNode]], EdgeDisplay] = {}
 
     # Used to explicitly specify display data for a workflow's ports.
     port_displays: Dict[Port, PortDisplayOverrides] = {}
@@ -449,7 +449,7 @@ class BaseWorkflowDisplay(
         edge: Edge,
         node_displays: Dict[Type[BaseNode], BaseNodeDisplay],
         port_displays: Dict[Port, PortDisplay],
-        overrides: Optional[EdgeVellumDisplayOverrides] = None,
+        overrides: Optional[EdgeDisplay] = None,
     ) -> EdgeVellumDisplay:
         source_node = get_unadorned_node(edge.from_port.node_class)
         target_node = get_unadorned_node(edge.to_node)


### PR DESCRIPTION
We eventually building up to [this](https://github.com/vellum-ai/vellum-python-sdks/pull/1191/files) PR. We are now only codegenning EdgeDisplay and marking the other classes for deprecation