### PR TITLE
Remove exclusion from subworkflow deployment node in project.test.ts

### DIFF
--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -105,6 +105,7 @@ describe("WorkflowProjectGenerator", () => {
           "simple_merge_node",
           "simple_api_node",
           "simple_node_with_try_wrap",
+          "simple_subworkflow_deployment_node",
           "simple_workflow_node_with_output_values",
           "faa_q_and_a_bot",
         ],

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/subworkflow_deployment.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/subworkflow_deployment.py
@@ -13,8 +13,8 @@ class SubworkflowDeploymentDisplay(BaseSubworkflowDeploymentNodeDisplay[Subworkf
     target_handle_id = UUID("30771282-5c0a-4a98-a3a8-4c7eeda30d23")
     node_input_ids_by_name = {"test": UUID("97b63d71-5413-417f-9cf5-49e1b4fd56e4")}
     output_display = {
-        SubworkflowDeployment.Outputs.final_output: NodeOutputDisplay(
-            id=UUID("61759cf7-da3d-45a3-9f73-68d3907207ae"), name="final-output"
+        SubworkflowDeployment.Outputs.chat_history: NodeOutputDisplay(
+            id=UUID("53970e88-0bf6-4364-86b3-840d78a2afe5"), name="chat_history"
         )
     }
     port_displays = {

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -9,7 +9,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplayOverrides,
-    WorkflowOutputVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -36,17 +35,14 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         SubworkflowDeployment: EntrypointVellumDisplayOverrides(
             id=UUID("39a5155a-d137-4a56-be36-d525802df463"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("fbf75594-70e8-4e03-ae3d-a64f573df51f")),
+            edge_display=EdgeDisplay(id=UUID("fbf75594-70e8-4e03-ae3d-a64f573df51f")),
         )
     }
     edge_displays = {
-        (SubworkflowDeployment.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("85970a9b-4ce7-46a5-b539-66aaeef080df")
-        )
+        (SubworkflowDeployment.Ports.default, FinalOutput): EdgeDisplay(id=UUID("85970a9b-4ce7-46a5-b539-66aaeef080df"))
     }
     output_displays = {
-        Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(
-            id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"),
-            name="final-output",
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"), name="final-output"
         )
     }

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/nodes/subworkflow_deployment.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/nodes/subworkflow_deployment.py
@@ -4,11 +4,11 @@ from ..inputs import Inputs
 
 
 class SubworkflowDeployment(SubworkflowDeploymentNode):
-    deployment = "deployment-test"
+    deployment = "mocked-workflow-deployment-history-item-name"
     release_tag = "LATEST"
     subworkflow_inputs = {
         "test": Inputs.test,
     }
 
     class Outputs(SubworkflowDeploymentNode.Outputs):
-        final_output: str
+        chat_history: str


### PR DESCRIPTION
We are eventually building up to [this](https://github.com/vellum-ai/vellum-python-sdks/pull/1191/files) PR where we consolidate our EdgeDisplay classes.

In this PR, we add back `"simple_subworkflow_deployment_node",` to the `project.test.ts`