### PR TITLE
Add some backwards compatible handling for code node dictionaries

### DIFF
--- a/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
@@ -777,3 +777,44 @@ def main():
 
     # AND the result should be the correct output
     assert outputs == {"result": "hello", "log": "<class 'int'>\n"}
+
+
+def test_run_node__execute_code__invalid_key_access():
+    # GIVEN a node that will access an invalid key
+    class ExampleCodeExecutionNode(CodeExecutionNode[BaseState, str]):
+        code = """\
+def main(arg1: list) -> str:
+    return arg1["invalid"]
+"""
+        code_inputs = {
+            "arg1": {"foo": "bar"},
+        }
+        runtime = "PYTHON_3_11_6"
+
+    # WHEN we run the node
+    with pytest.raises(NodeException) as exc_info:
+        node = ExampleCodeExecutionNode()
+        node.run()
+
+    # AND the result should be the correct output
+    assert exc_info.value.message == "dict has no key: 'invalid'"
+
+
+def test_run_node__execute_code__value_key_access():
+    # GIVEN a node that will access the value key before the nested key
+    class ExampleCodeExecutionNode(CodeExecutionNode[BaseState, str]):
+        code = """\
+def main(arg1: list) -> str:
+    return arg1["value"]["foo"]
+"""
+        code_inputs = {
+            "arg1": {"foo": "bar"},
+        }
+        runtime = "PYTHON_3_11_6"
+
+    # WHEN we run the node
+    node = ExampleCodeExecutionNode()
+    outputs = node.run()
+
+    # AND the result should be the correct output
+    assert outputs == {"result": "bar", "log": ""}

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
@@ -41,7 +41,12 @@ class DictWrapper(dict):
 
     def __getattr__(self, attr):
         if attr not in self:
-            raise AttributeError(f"Vellum object has no attribute '{attr}'")
+            if attr == "value":
+                # In order to be backwards compatible with legacy Workflows, which wrapped
+                # several values as VellumValue objects, we use the "value" key to return itself
+                return self
+
+            raise AttributeError(f"dict has no key: '{attr}'")
 
         item = super().__getitem__(attr)
         if not isinstance(item, DictWrapper) and not isinstance(item, ListWrapper):


### PR DESCRIPTION
- Clarifies the error message for invalid key access
- Adds some handling to smooth the cutover for legacy map nodes -> code nodes