### PR TITLE
Fully deprecate EdgeVellumDisplay

### DIFF
--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -59,10 +59,6 @@ class EdgeDisplayOverrides(EdgeDisplay):
     pass
 
 
-EdgeDisplayType = TypeVar("EdgeDisplayType", bound=EdgeDisplay)
-EdgeDisplayOverridesType = TypeVar("EdgeDisplayOverridesType", bound=EdgeDisplayOverrides)
-
-
 @dataclass
 class EntrypointDisplayOverrides:
     id: UUID

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -7,6 +7,7 @@ from vellum.workflows.nodes import BaseNode
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference, StateValueReference, WorkflowInputReference
 from vellum_ee.workflows.display.base import (
+    EdgeDisplay,
     EntrypointDisplayType,
     StateValueDisplayType,
     WorkflowInputsDisplayType,
@@ -17,7 +18,6 @@ from vellum_ee.workflows.display.base import (
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
     from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay
-    from vellum_ee.workflows.display.vellum import EdgeVellumDisplay
     from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 WorkflowDisplayType = TypeVar("WorkflowDisplayType", bound="BaseWorkflowDisplay")
@@ -47,5 +47,5 @@ class WorkflowDisplayContext(
     )
     entrypoint_displays: Dict[Type[BaseNode], EntrypointDisplayType] = field(default_factory=dict)
     workflow_output_displays: Dict[BaseDescriptor, WorkflowOutputDisplay] = field(default_factory=dict)
-    edge_displays: Dict[Tuple[Port, Type[BaseNode]], "EdgeVellumDisplay"] = field(default_factory=dict)
+    edge_displays: Dict[Tuple[Port, Type[BaseNode]], EdgeDisplay] = field(default_factory=dict)
     port_displays: Dict[Port, "PortDisplay"] = field(default_factory=dict)

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -121,7 +121,7 @@ class EntrypointVellumDisplayOverrides(EntrypointDisplay, EntrypointDisplayOverr
 
 @dataclass
 class EntrypointVellumDisplay(EntrypointVellumDisplayOverrides):
-    edge_display: EdgeVellumDisplay
+    edge_display: EdgeDisplay
 
 
 @dataclass

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -351,7 +351,6 @@ class VellumWorkflowDisplay(
         overrides: Optional[EntrypointVellumDisplayOverrides] = None,
     ) -> EntrypointVellumDisplay:
         entrypoint_node_id = workflow_display.entrypoint_node_id
-        source_handle_id = workflow_display.entrypoint_node_source_handle_id
 
         edge_display_overrides = overrides.edge_display if overrides else None
         entrypoint_id = (
@@ -363,10 +362,9 @@ class VellumWorkflowDisplay(
         entrypoint_target = get_unadorned_node(entrypoint)
         target_node_display = node_displays[entrypoint_target]
         target_node_id = target_node_display.node_id
-        target_handle_id = target_node_display.get_target_handle_id_by_source_node_id(entrypoint_node_id)
 
         edge_display = self._generate_edge_display_from_source(
-            entrypoint_node_id, source_handle_id, target_node_id, target_handle_id, overrides=edge_display_overrides
+            entrypoint_node_id, target_node_id, overrides=edge_display_overrides
         )
 
         return EntrypointVellumDisplay(id=entrypoint_id, edge_display=edge_display)

--- a/ee/vellum_ee/workflows/tests/local_workflow/display/workflow.py
+++ b/ee/vellum_ee/workflows/tests/local_workflow/display/workflow.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.base import EdgeDisplay
 from vellum_ee.workflows.display.vellum import (
-    EdgeVellumDisplayOverrides,
     EntrypointVellumDisplayOverrides,
     NodeDisplayData,
     NodeDisplayPosition,
@@ -36,13 +36,11 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     entrypoint_displays = {
         TemplatingNode: EntrypointVellumDisplayOverrides(
             id=UUID("0bf86989-13f2-438c-ab9c-d172e5771d31"),
-            edge_display=EdgeVellumDisplayOverrides(id=UUID("38532a0e-9432-4ed2-8a34-48a29fd6984d")),
+            edge_display=EdgeDisplay(id=UUID("38532a0e-9432-4ed2-8a34-48a29fd6984d")),
         )
     }
     edge_displays = {
-        (TemplatingNode.Ports.default, FinalOutput): EdgeVellumDisplayOverrides(
-            id=UUID("417c56a4-cdc1-4f9d-a10c-b535163f51e8")
-        )
+        (TemplatingNode.Ports.default, FinalOutput): EdgeDisplay(id=UUID("417c56a4-cdc1-4f9d-a10c-b535163f51e8"))
     }
     output_displays = {
         Workflow.Outputs.final_output: WorkflowOutputVellumDisplayOverrides(


### PR DESCRIPTION
Last Major PR on the road to merging: https://github.com/vellum-ai/vellum-python-sdks/pull/1191

This PR fully deprecated `EdgeVellumDisplay`, replacing all usages with `EdgeDisplay`