### PR TITLE
Deprecate legacy API Node display attributes

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -17,13 +17,6 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
     label = "API Node"
     node_id = UUID("2cd960a3-cb8a-43ed-9e3f-f003fc480951")
     target_handle_id = UUID("06573a05-e6f0-48b9-bc6e-07e06d0bc1b1")
-    url_input_id = UUID("480a4c12-22d6-4223-a38a-85db5eda118c")
-    method_input_id = UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
-    body_input_id = UUID("74865eb7-cdaf-4d40-a499-0a6505e72680")
-    authorization_type_input_id = UUID("de330dac-05b1-4e78-bee7-7452203af3d5")
-    bearer_token_value_input_id = UUID("931502c1-23a5-4e2a-a75e-80736c42f3c9")
-    api_key_header_key_input_id = UUID("96c8343d-cc94-4df0-9001-eb2905a00be7")
-    api_key_header_value_input_id = UUID("bfc2e790-66fd-42fd-acf7-3b2c785c1a0a")
     additional_header_key_input_ids = {
         "foo": UUID("8ad006f3-d19e-4af1-931f-3e955152cd91"),
         "bar": UUID("3075be8c-248b-421d-9266-7779297be883"),
@@ -37,7 +30,7 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
     node_input_ids_by_name = {
         "method": UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc"),
         "url": UUID("480a4c12-22d6-4223-a38a-85db5eda118c"),
-        "body": UUID("74865eb7-cdaf-4d40-a499-0a6505e72680"),
+        "json": UUID("74865eb7-cdaf-4d40-a499-0a6505e72680"),
         "authorization_type": UUID("de330dac-05b1-4e78-bee7-7452203af3d5"),
         "bearer_token_value": UUID("931502c1-23a5-4e2a-a75e-80736c42f3c9"),
         "api_key_header_key": UUID("96c8343d-cc94-4df0-9001-eb2905a00be7"),
@@ -213,13 +206,6 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
     label = "API Node"
     node_id = UUID("2cd960a3-cb8a-43ed-9e3f-f003fc480951")
     target_handle_id = UUID("06573a05-e6f0-48b9-bc6e-07e06d0bc1b1")
-    url_input_id = UUID("480a4c12-22d6-4223-a38a-85db5eda118c")
-    method_input_id = UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
-    body_input_id = UUID("74865eb7-cdaf-4d40-a499-0a6505e72680")
-    authorization_type_input_id = UUID("de330dac-05b1-4e78-bee7-7452203af3d5")
-    bearer_token_value_input_id = UUID("931502c1-23a5-4e2a-a75e-80736c42f3c9")
-    api_key_header_key_input_id = UUID("96c8343d-cc94-4df0-9001-eb2905a00be7")
-    api_key_header_value_input_id = UUID("bfc2e790-66fd-42fd-acf7-3b2c785c1a0a")
     additional_header_key_input_ids = {
         "foo": UUID("8ad006f3-d19e-4af1-931f-3e955152cd91"),
         "bar": UUID("3075be8c-248b-421d-9266-7779297be883"),
@@ -233,7 +219,7 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
     node_input_ids_by_name = {
         "method": UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc"),
         "url": UUID("480a4c12-22d6-4223-a38a-85db5eda118c"),
-        "body": UUID("74865eb7-cdaf-4d40-a499-0a6505e72680"),
+        "json": UUID("74865eb7-cdaf-4d40-a499-0a6505e72680"),
         "authorization_type": UUID("de330dac-05b1-4e78-bee7-7452203af3d5"),
         "bearer_token_value": UUID("931502c1-23a5-4e2a-a75e-80736c42f3c9"),
         "api_key_header_key": UUID("96c8343d-cc94-4df0-9001-eb2905a00be7"),

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -9,7 +9,19 @@ import { NodeAttributeGenerationError } from "src/generators/errors";
 import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base";
 import { ApiNode as ApiNodeType, ConstantValuePointer } from "src/types/vellum";
 
+const BODY_INPUT_KEY = "body";
+const JSON_ATTRIBUTE_NAME = "json";
+
 export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
+  protected getNodeAttributeNameByNodeInputKey(nodeInputKey: string): string {
+    if (nodeInputKey === BODY_INPUT_KEY) {
+      // This field was renamed in the SDK for consistency with `requests` pip package
+      return JSON_ATTRIBUTE_NAME;
+    }
+
+    return nodeInputKey;
+  }
+
   getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 
@@ -188,83 +200,6 @@ export class ApiNode extends BaseSingleFileNode<ApiNodeType, ApiNodeContext> {
         ),
       })
     );
-
-    if (!isNil(this.nodeData.data.urlInputId)) {
-      statements.push(
-        python.field({
-          name: "url_input_id",
-          initializer: python.TypeInstantiation.uuid(
-            this.nodeData.data.urlInputId
-          ),
-        })
-      );
-    }
-
-    if (!isNil(this.nodeData.data.methodInputId)) {
-      statements.push(
-        python.field({
-          name: "method_input_id",
-          initializer: python.TypeInstantiation.uuid(
-            this.nodeData.data.methodInputId
-          ),
-        })
-      );
-    }
-
-    if (!isNil(this.nodeData.data.bodyInputId)) {
-      statements.push(
-        python.field({
-          name: "body_input_id",
-          initializer: python.TypeInstantiation.uuid(
-            this.nodeData.data.bodyInputId
-          ),
-        })
-      );
-    }
-
-    if (!isNil(this.nodeData.data.authorizationTypeInputId)) {
-      statements.push(
-        python.field({
-          name: "authorization_type_input_id",
-          initializer: python.TypeInstantiation.uuid(
-            this.nodeData.data.authorizationTypeInputId
-          ),
-        })
-      );
-    }
-
-    if (!isNil(this.nodeData.data.bearerTokenValueInputId)) {
-      statements.push(
-        python.field({
-          name: "bearer_token_value_input_id",
-          initializer: python.TypeInstantiation.uuid(
-            this.nodeData.data.bearerTokenValueInputId
-          ),
-        })
-      );
-    }
-
-    if (!isNil(this.nodeData.data.apiKeyHeaderKeyInputId)) {
-      statements.push(
-        python.field({
-          name: "api_key_header_key_input_id",
-          initializer: python.TypeInstantiation.uuid(
-            this.nodeData.data.apiKeyHeaderKeyInputId
-          ),
-        })
-      );
-    }
-
-    if (!isNil(this.nodeData.data.apiKeyHeaderValueInputId)) {
-      statements.push(
-        python.field({
-          name: "api_key_header_value_input_id",
-          initializer: python.TypeInstantiation.uuid(
-            this.nodeData.data.apiKeyHeaderValueInputId
-          ),
-        })
-      );
-    }
 
     if (!isNil(this.nodeData.data.additionalHeaders)) {
       statements.push(

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/api_node.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/api_node.py
@@ -11,19 +11,12 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
     label = "API Node"
     node_id = UUID("81246ab6-153a-4c87-9f28-b6c28c915cf1")
     target_handle_id = UUID("8f6f1b95-dd80-46dd-b1f6-167196baf697")
-    url_input_id = UUID("20932275-1a55-455f-b481-5895f9e28123")
-    method_input_id = UUID("96d6ea69-24b7-4e5a-94ed-4c4eb3fcfe69")
-    body_input_id = UUID("379f9c64-cad2-4b7d-ba30-32599ec1fe64")
-    authorization_type_input_id = UUID("e29070d6-bd22-46c8-ae18-b6f056ca15ad")
-    bearer_token_value_input_id = UUID("a596f1fc-01a8-467e-9007-19073a98660d")
-    api_key_header_key_input_id = UUID("bcf3aac0-536e-42d5-b666-22cfe40eae98")
-    api_key_header_value_input_id = UUID("bc73ee61-ca29-48fe-b3f2-fea5d8f638f6")
     additional_header_key_input_ids = {}
     additional_header_value_input_ids = {}
     node_input_ids_by_name = {
         "url": UUID("20932275-1a55-455f-b481-5895f9e28123"),
         "method": UUID("96d6ea69-24b7-4e5a-94ed-4c4eb3fcfe69"),
-        "body": UUID("379f9c64-cad2-4b7d-ba30-32599ec1fe64"),
+        "json": UUID("379f9c64-cad2-4b7d-ba30-32599ec1fe64"),
         "authorization_type": UUID("e29070d6-bd22-46c8-ae18-b6f056ca15ad"),
         "bearer_token_value": UUID("a596f1fc-01a8-467e-9007-19073a98660d"),
         "api_key_header_key": UUID("bcf3aac0-536e-42d5-b666-22cfe40eae98"),

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/nodes/api_node.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/nodes/api_node.py
@@ -11,13 +11,6 @@ class ApiNodeDisplay(BaseAPINodeDisplay[ApiNode]):
     label = "API Node"
     node_id = UUID("743aec59-2aa9-402c-963a-d9b86a80a1c2")
     target_handle_id = UUID("fd10e0db-0130-4fdc-8fc7-146eafe1b470")
-    url_input_id = UUID("d2f4547b-eaa3-4b9a-a0f7-0da0975d4e11")
-    method_input_id = UUID("4bc3ec8f-f889-45c2-bad0-5498f28cc8af")
-    body_input_id = UUID("65dbcf74-183a-49e0-b553-2a3d25ad741d")
-    authorization_type_input_id = UUID("c9b08ce9-2dfc-4cbe-9e65-0bf6f8e248c0")
-    bearer_token_value_input_id = UUID("6d330109-ec8e-4c39-af30-63d77f07c35d")
-    api_key_header_key_input_id = UUID("908e1fb5-bcba-4388-ae1d-a53d256eda97")
-    api_key_header_value_input_id = UUID("efefc4f7-6c95-4561-b7a0-b48533e0c68f")
     additional_header_key_input_ids = {
         "test": UUID("7dbd1729-ec2e-4be5-a868-e542ba421115"),
         "nom": UUID("4e7557f4-16ec-4fec-97a6-fe221eae1ee5"),
@@ -29,7 +22,7 @@ class ApiNodeDisplay(BaseAPINodeDisplay[ApiNode]):
     node_input_ids_by_name = {
         "method": UUID("4bc3ec8f-f889-45c2-bad0-5498f28cc8af"),
         "url": UUID("d2f4547b-eaa3-4b9a-a0f7-0da0975d4e11"),
-        "body": UUID("65dbcf74-183a-49e0-b553-2a3d25ad741d"),
+        "json": UUID("65dbcf74-183a-49e0-b553-2a3d25ad741d"),
         "authorization_type": UUID("c9b08ce9-2dfc-4cbe-9e65-0bf6f8e248c0"),
         "bearer_token_value": UUID("6d330109-ec8e-4c39-af30-63d77f07c35d"),
         "api_key_header_key": UUID("908e1fb5-bcba-4388-ae1d-a53d256eda97"),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
@@ -14,15 +14,6 @@ _APINodeType = TypeVar("_APINodeType", bound=APINode)
 
 
 class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeType]):
-    url_input_id: ClassVar[Optional[UUID]] = None
-    method_input_id: ClassVar[Optional[UUID]] = None
-    body_input_id: ClassVar[Optional[UUID]] = None
-
-    authorization_type_input_id: ClassVar[Optional[UUID]] = None
-    bearer_token_value_input_id: ClassVar[Optional[UUID]] = None
-    api_key_header_key_input_id: ClassVar[Optional[UUID]] = None
-    api_key_header_value_input_id: ClassVar[Optional[UUID]] = None
-
     # A mapping between node input keys and their ids for inputs representing additional header keys
     additional_header_key_input_ids: ClassVar[Optional[Dict[str, UUID]]] = None
 
@@ -41,7 +32,7 @@ class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeTy
             input_name="url",
             value=node_url,
             display_context=display_context,
-            input_id=self.url_input_id,
+            input_id=self.node_input_ids_by_name.get(APINode.url.name),
         )
 
         node_method = raise_if_descriptor(node.method)
@@ -50,7 +41,7 @@ class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeTy
             input_name="method",
             value=node_method,
             display_context=display_context,
-            input_id=self.method_input_id,
+            input_id=self.node_input_ids_by_name.get(APINode.method.name),
         )
 
         node_data = raise_if_descriptor(node.data)
@@ -60,7 +51,9 @@ class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeTy
             input_name="body",
             value=node_data if node_data else node_json,
             display_context=display_context,
-            input_id=self.body_input_id,
+            input_id=self.node_input_ids_by_name.get(APINode.json.name)
+            # Kept for backwards compatibility with a bug in previous versions of SDK serialization
+            or self.node_input_ids_by_name.get("body"),
         )
 
         headers = raise_if_descriptor(node.headers)
@@ -75,7 +68,7 @@ class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeTy
                 input_name="authorization_type",
                 value=authorization_type,
                 display_context=display_context,
-                input_id=self.authorization_type_input_id,
+                input_id=self.node_input_ids_by_name.get(APINode.authorization_type.name),
             )
             if authorization_type
             else None
@@ -85,7 +78,7 @@ class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeTy
             input_name="bearer_token_value",
             value=bearer_token_value,
             display_context=display_context,
-            input_id=self.bearer_token_value_input_id,
+            input_id=self.node_input_ids_by_name.get(APINode.bearer_token_value.name),
             pointer_type=WorkspaceSecretPointer,
         )
         api_key_header_key_node_input = (
@@ -94,7 +87,7 @@ class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeTy
                 input_name="api_key_header_key",
                 value=api_key_header_key,
                 display_context=display_context,
-                input_id=self.api_key_header_key_input_id,
+                input_id=self.node_input_ids_by_name.get(APINode.api_key_header_key.name),
             )
             if api_key_header_key
             else None
@@ -104,7 +97,7 @@ class BaseAPINodeDisplay(BaseNodeVellumDisplay[_APINodeType], Generic[_APINodeTy
             input_name="api_key_header_value",
             value=api_key_header_value,
             display_context=display_context,
-            input_id=self.api_key_header_value_input_id,
+            input_id=self.node_input_ids_by_name.get(APINode.api_key_header_value.name),
             pointer_type=WorkspaceSecretPointer,
         )
 

--- a/src/vellum/workflows/nodes/displayable/bases/api_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/api_node/node.py
@@ -28,7 +28,7 @@ class BaseAPINode(BaseNode, Generic[StateType]):
     class Trigger(BaseNode.Trigger):
         merge_behavior = MergeBehavior.AWAIT_ANY
 
-    url: str
+    url: str = ""
     method: Optional[APIRequestMethod] = APIRequestMethod.GET
     data: Optional[str] = None
     json: Optional[Json] = None


### PR DESCRIPTION
Similar to the line of work for other nodes here: https://github.com/vellum-ai/vellum-python-sdks/pull/1198

API Node body's are not showing up in inputs. This cleans that up, while also removing display attributes that we don't need since we have `node_input_ids_by_name`. Deleting these fields helps unify all node displays eventually to `BaseNodeDisplay`