### PR TITLE
Add subclass error handler

### DIFF
--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -113,8 +113,7 @@ class _BaseWorkflowMeta(type):
             elif inspect.isclass(graph_item) and issubclass(graph_item, BaseNode):
                 nodes.add(graph_item)
             else:
-                # We should never get here, but just in case
-                raise ValueError(f"Unexpected graph type: {graph_item.__class__}")
+                raise TypeError(f"Unexpected graph type: {graph_item.__class__}")
             return nodes
 
         graph_nodes = collect_nodes(dct.get("graph", set()))

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -110,9 +110,10 @@ class _BaseWorkflowMeta(type):
                         nodes.update(node for node in item.nodes)
                     elif inspect.isclass(item) and issubclass(item, BaseNode):
                         nodes.add(item)
-            elif issubclass(graph_item, BaseNode):
+            elif inspect.isclass(graph_item) and issubclass(graph_item, BaseNode):
                 nodes.add(graph_item)
             else:
+                # We should never get here, but just in case
                 raise ValueError(f"Unexpected graph type: {graph_item.__class__}")
             return nodes
 

--- a/src/vellum/workflows/workflows/tests/test_base_workflow.py
+++ b/src/vellum/workflows/workflows/tests/test_base_workflow.py
@@ -304,3 +304,13 @@ def test_workflow__node_in_both_graph_and_unused():
 
     # THEN it should raise an error
     assert "Node(s) NodeA cannot appear in both graph and unused_graphs" in str(exc_info.value)
+
+
+def test_workflow__unsupported_graph_item():
+    with pytest.raises(TypeError) as exc_info:
+        # GIVEN a workflow with an unsupported graph item
+        class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+            graph = 1  # type: ignore
+
+    # THEN it should raise an error
+    assert "Unexpected graph type: <class 'int'>" in str(exc_info.value)


### PR DESCRIPTION
follow up: https://github.com/vellum-ai/vellum-python-sdks/pull/1225

if we pass in something wrong then it would raise an error (expected). The subclass error is due to we pass in {} and it call `issubclass` on it