### PR TITLE
Simplify workflow Output display construction logic to enable display context emission

### DIFF
--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -10,7 +10,6 @@ from vellum.workflows import BaseWorkflow
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.edges import Edge
 from vellum.workflows.events.workflow import NodeEventDisplayContext, WorkflowEventDisplayContext
-from vellum.workflows.expressions.coalesce_expression import CoalesceExpression
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.utils import get_unadorned_node, get_wrapped_node
 from vellum.workflows.ports import Port
@@ -290,11 +289,6 @@ class BaseWorkflowDisplay(
 
             if not isinstance(workflow_output, OutputReference):
                 raise ValueError(f"{workflow_output} must be an {OutputReference.__name__}")
-
-            if not workflow_output.instance or not isinstance(
-                workflow_output.instance, (OutputReference, CoalesceExpression)
-            ):
-                raise ValueError("Expected to find a descriptor instance on the workflow output")
 
             workflow_output_display = self.output_displays.get(workflow_output)
             workflow_output_displays[workflow_output] = (

--- a/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
@@ -275,3 +275,17 @@ def test_get_event_display_context__node_display_for_mutiple_adornments():
     assert innermost_node_id in inner_node_event_display.subworkflow_display.node_displays
     innermost_node_event_display = inner_node_event_display.subworkflow_display.node_displays[innermost_node_id]
     assert not innermost_node_event_display.subworkflow_display
+
+
+def test_get_event_display_context__workflow_output_display_with_none():
+    # GIVEN a workflow with a workflow output that is None
+    class MyWorkflow(BaseWorkflow):
+        class Outputs(BaseWorkflow.Outputs):
+            foo = None
+            bar = "baz"
+
+    # WHEN we gather the event display context
+    display_context = VellumWorkflowDisplay(MyWorkflow).get_event_display_context()
+
+    # THEN the workflow output display should be included
+    assert display_context.workflow_outputs.keys() == {"foo", "bar"}


### PR DESCRIPTION
These exceptions was preventing us from generating display event context (and I think would fail serialization unnecessarily). The value of failing is unclear to me, and no tests regress'd, so we just remove.