### PR TITLE
[APO-254] Init output ids during dynamic output cls generation of inline subworkflows

### DIFF
--- a/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
+++ b/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
@@ -13,6 +13,7 @@ from vellum.workflows.state.base import BaseState
 from vellum.workflows.state.context import WorkflowContext
 from vellum.workflows.types.core import EntityInputsInterface
 from vellum.workflows.types.generics import InputsType, StateType
+from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum.workflows.workflows.event_filters import all_workflow_event_filter
 
 if TYPE_CHECKING:
@@ -140,3 +141,8 @@ class InlineSubworkflowNode(
         # Subclasses of InlineSubworkflowNode can override this method to provider their own
         # approach to annotating the outputs class based on the `subworkflow.Outputs`
         setattr(outputs_class, reference.name, reference)
+
+        if not hasattr(cls, "__output_ids__"):
+            cls.__output_ids__ = {}
+
+        cls.__output_ids__[reference.name] = uuid4_from_hash(f"{cls.__id__}|{reference.name}")

--- a/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
+++ b/src/vellum/workflows/nodes/core/inline_subworkflow_node/node.py
@@ -142,7 +142,7 @@ class InlineSubworkflowNode(
         # approach to annotating the outputs class based on the `subworkflow.Outputs`
         setattr(outputs_class, reference.name, reference)
 
-        if not hasattr(cls, "__output_ids__"):
+        if cls.__output_ids__ is None:
             cls.__output_ids__ = {}
 
         cls.__output_ids__[reference.name] = uuid4_from_hash(f"{cls.__id__}|{reference.name}")

--- a/src/vellum/workflows/nodes/core/inline_subworkflow_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/core/inline_subworkflow_node/tests/test_node.py
@@ -140,6 +140,6 @@ def test_inline_subworkflow_node__with_adornment():
 
     # AND when we run the node
     node = TestNode()
-    events = list(node.run())
+    outputs = list(node.run())
 
-    assert any(e.name == "final_output" and e.value == "hello" for e in events)
+    assert outputs[-1].name == "final_output" and outputs[-1].value == "hello"

--- a/src/vellum/workflows/nodes/core/inline_subworkflow_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/core/inline_subworkflow_node/tests/test_node.py
@@ -116,3 +116,30 @@ def test_inline_subworkflow_node__base_inputs_validation():
     # AND the error message should indicate the missing required input
     assert e.value.code == WorkflowErrorCode.INVALID_INPUTS
     assert "Required input variables required_input should have defined value" == str(e.value)
+
+
+def test_inline_subworkflow_node__with_adornment():
+    # GIVEN a simple inline subworkflow with an output
+    class InnerNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            final_output = "hello"
+
+    class TestSubworkflow(BaseWorkflow):
+        graph = InnerNode
+
+        class Outputs(BaseWorkflow.Outputs):
+            final_output = InnerNode.Outputs.final_output
+
+    # AND it's wrapped in a TryNode
+    @TryNode.wrap()
+    class TestNode(InlineSubworkflowNode):
+        subworkflow = TestSubworkflow
+
+    # THEN the wrapped node should have the correct output IDs
+    assert "final_output" in TestNode.__output_ids__
+
+    # AND when we run the node
+    node = TestNode()
+    events = list(node.run())
+
+    assert any(e.name == "final_output" and e.value == "hello" for e in events)


### PR DESCRIPTION
The original problem that surfaced was that we were getting key errors of final output when subworkflows have an adornment