### PR TITLE
Remove nested import in WorkflowDisplayContext types file

### DIFF
--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, Generic, Tuple, Type, TypeVar
+from typing import Dict, Generic, Tuple, Type, TypeVar
 
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.events.workflow import WorkflowEventDisplayContext  # noqa: F401
@@ -14,11 +14,9 @@ from vellum_ee.workflows.display.base import (
     WorkflowMetaDisplayType,
     WorkflowOutputDisplay,
 )
-
-if TYPE_CHECKING:
-    from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
-    from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay
-    from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
+from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 WorkflowDisplayType = TypeVar("WorkflowDisplayType", bound="BaseWorkflowDisplay")
 
@@ -40,12 +38,12 @@ class WorkflowDisplayContext(
     )
     state_value_displays: Dict[StateValueReference, StateValueDisplayType] = field(default_factory=dict)
     global_state_value_displays: Dict[StateValueReference, StateValueDisplayType] = field(default_factory=dict)
-    node_displays: Dict[Type[BaseNode], "BaseNodeDisplay"] = field(default_factory=dict)
-    global_node_displays: Dict[Type[BaseNode], "BaseNodeDisplay"] = field(default_factory=dict)
-    global_node_output_displays: Dict[OutputReference, Tuple[Type[BaseNode], "NodeOutputDisplay"]] = field(
+    node_displays: Dict[Type[BaseNode], BaseNodeDisplay] = field(default_factory=dict)
+    global_node_displays: Dict[Type[BaseNode], BaseNodeDisplay] = field(default_factory=dict)
+    global_node_output_displays: Dict[OutputReference, Tuple[Type[BaseNode], NodeOutputDisplay]] = field(
         default_factory=dict
     )
     entrypoint_displays: Dict[Type[BaseNode], EntrypointDisplayType] = field(default_factory=dict)
     workflow_output_displays: Dict[BaseDescriptor, WorkflowOutputDisplay] = field(default_factory=dict)
     edge_displays: Dict[Tuple[Port, Type[BaseNode]], EdgeDisplay] = field(default_factory=dict)
-    port_displays: Dict[Port, "PortDisplay"] = field(default_factory=dict)
+    port_displays: Dict[Port, PortDisplay] = field(default_factory=dict)

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, Generic, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Dict, Generic, Tuple, Type, TypeVar
 
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.events.workflow import WorkflowEventDisplayContext  # noqa: F401
@@ -16,7 +16,9 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay
-from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
+
+if TYPE_CHECKING:
+    from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 WorkflowDisplayType = TypeVar("WorkflowDisplayType", bound="BaseWorkflowDisplay")
 

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -1,9 +1,13 @@
+from typing import TYPE_CHECKING
+
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.references.lazy import LazyReference
-from vellum_ee.workflows.display.types import WorkflowDisplayContext
+
+if TYPE_CHECKING:
+    from vellum_ee.workflows.display.types import WorkflowDisplayContext
 
 
-def get_child_descriptor(value: LazyReference, display_context: WorkflowDisplayContext) -> BaseDescriptor:
+def get_child_descriptor(value: LazyReference, display_context: "WorkflowDisplayContext") -> BaseDescriptor:
     if isinstance(value._get, str):
         reference_parts = value._get.split(".")
         if len(reference_parts) < 3:


### PR DESCRIPTION
Going to be continue cleaning up BaseWorkflowDisplay and VellumWorkflowDisplay in parallel to bug fixing. I expect to export some types from this file in a future PR, so making not part of an circular dependency will make it easier to work with