### PR TITLE
Workaround for inline code node codegen escaping problem

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1315,11 +1315,13 @@ export function codeExecutionNodeFactory({
   codeOutputValueType,
   runtimeInput,
   generateLogOutputId = true,
+  code,
 }: {
   codeInputValueRule?: NodeInputValuePointerRule;
   codeOutputValueType?: VellumVariableType;
   runtimeInput?: NodeInput;
   generateLogOutputId?: boolean;
+  code?: string;
 } = {}): CodeExecutionNode {
   const runtime =
     runtimeInput ??
@@ -1367,7 +1369,7 @@ export function codeExecutionNodeFactory({
                   type: "CONSTANT_VALUE",
                   data: {
                     type: "STRING",
-                    value: "print('Hello, World!')",
+                    value: code ?? "print('Hello, World!')",
                   },
                 },
               ],

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -94,11 +94,11 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
 "
 `;
 
-exports[`CodeExecutionNode > code representation override > should generate the correct node class when the override is INLINE 1`] = `
+exports[`CodeExecutionNode > code representation override: Base case > should generate the correct node class when the override is INLINE 1`] = `
 "from vellum.workflows.nodes.displayable import CodeExecutionNode as BaseCodeExecutionNode
 from vellum.workflows.state import BaseState
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
-    code = "async function main(inputs: {\\n  question: string\\n}) {\\n  inputs = {\\n    \\"question\\": \\"{\\\\"text_explanation\\\\":\\\\"First, \\\\\\\\\\(\\\\\\\\\\frac{1}{40}\\\\\\\\\\).\\\\\\"\\n  }\\n  const test = \\"\\\\frac\\".replace(/\\\\\\frac/g, \\'\\\\\\dfrac\\');\\n  return {};\\n} \\n"
+    code = "print(\\'Hello, World!\\')"
     code_inputs = {}
     runtime = "PYTHON_3_11_6"
     packages = None
@@ -106,7 +106,7 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
 "
 `;
 
-exports[`CodeExecutionNode > code representation override > should generate the correct node class when the override is STANDALONE 1`] = `
+exports[`CodeExecutionNode > code representation override: Base case > should generate the correct node class when the override is STANDALONE 1`] = `
 "from vellum.workflows.nodes.displayable import (
     CodeExecutionNode as BaseCodeExecutionNode,
 )
@@ -121,7 +121,49 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
 "
 `;
 
-exports[`CodeExecutionNode > code representation override > should generate the correct node class when the override is undefined 1`] = `
+exports[`CodeExecutionNode > code representation override: Base case > should generate the correct node class when the override is undefined 1`] = `
+"from vellum.workflows.nodes.displayable import (
+    CodeExecutionNode as BaseCodeExecutionNode,
+)
+from vellum.workflows.state import BaseState
+
+
+class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
+    filepath = "./script.py"
+    code_inputs = {}
+    runtime = "PYTHON_3_11_6"
+    packages = None
+"
+`;
+
+exports[`CodeExecutionNode > code representation override: Escaped case > should generate the correct node class when the override is INLINE 1`] = `
+"from vellum.workflows.nodes.displayable import CodeExecutionNode as BaseCodeExecutionNode
+from vellum.workflows.state import BaseState
+class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
+    code = "async function main(inputs: {\\n  question: string\\n}) {\\n  inputs = {\\n    \\"question\\": \\"{\\\\"text_explanation\\\\":\\\\"First, \\\\\\\\\\(\\\\\\\\\\frac{1}{40}\\\\\\\\\\).\\\\\\"\\n  }\\n  const test = \\"\\\\frac\\".replace(/\\\\\\frac/g, \\'\\\\\\dfrac\\');\\n  return {};\\n} \\n"
+    code_inputs = {}
+    runtime = "PYTHON_3_11_6"
+    packages = None
+
+"
+`;
+
+exports[`CodeExecutionNode > code representation override: Escaped case > should generate the correct node class when the override is STANDALONE 1`] = `
+"from vellum.workflows.nodes.displayable import (
+    CodeExecutionNode as BaseCodeExecutionNode,
+)
+from vellum.workflows.state import BaseState
+
+
+class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
+    filepath = "./script.py"
+    code_inputs = {}
+    runtime = "PYTHON_3_11_6"
+    packages = None
+"
+`;
+
+exports[`CodeExecutionNode > code representation override: Escaped case > should generate the correct node class when the override is undefined 1`] = `
 "from vellum.workflows.nodes.displayable import (
     CodeExecutionNode as BaseCodeExecutionNode,
 )

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -140,7 +140,7 @@ exports[`CodeExecutionNode > code representation override: Escaped case > should
 "from vellum.workflows.nodes.displayable import CodeExecutionNode as BaseCodeExecutionNode
 from vellum.workflows.state import BaseState
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
-    code = "async function main(inputs: {\\n  question: string\\n}) {\\n  inputs = {\\n    \\"question\\": \\"{\\\\"text_explanation\\\\":\\\\"First, \\\\\\\\\\(\\\\\\\\\\frac{1}{40}\\\\\\\\\\).\\\\\\"\\n  }\\n  const test = \\"\\\\frac\\".replace(/\\\\\\frac/g, \\'\\\\\\dfrac\\');\\n  return {};\\n} \\n"
+    code = "async function main(inputs: {\\n  question: string\\n}) {\\n  inputs = {\\n\\"question\\": \\"{\\\\"text_explanation\\\\":\\\\"First, \\\\\\\\\\(\\\\\\\\\\frac{1}{40}\\\\\\\\\\).\\\\\\"\\n  }\\nconst test = \\"\\\\frac\\".replace(/\\\\\\frac/g, \\'\\\\\\dfrac\\');\\n  return {};\\n} \\n"
     code_inputs = {}
     runtime = "PYTHON_3_11_6"
     packages = None

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -95,17 +95,14 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
 `;
 
 exports[`CodeExecutionNode > code representation override > should generate the correct node class when the override is INLINE 1`] = `
-"from vellum.workflows.nodes.displayable import (
-    CodeExecutionNode as BaseCodeExecutionNode,
-)
+"from vellum.workflows.nodes.displayable import CodeExecutionNode as BaseCodeExecutionNode
 from vellum.workflows.state import BaseState
-
-
 class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
-    code = """print(\\'Hello, World!\\')"""
+    code = "async function main(inputs: {\\n  question: string\\n}) {\\n  inputs = {\\n    \\"question\\": \\"{\\\\"text_explanation\\\\":\\\\"First, \\\\\\\\\\(\\\\\\\\\\frac{1}{40}\\\\\\\\\\).\\\\\\"\\n  }\\n  const test = \\"\\\\frac\\".replace(/\\\\\\frac/g, \\'\\\\\\dfrac\\');\\n  return {};\\n} \\n"
     code_inputs = {}
     runtime = "PYTHON_3_11_6"
     packages = None
+
 "
 `;
 

--- a/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
@@ -80,6 +80,8 @@ describe("CodeExecutionNode", () => {
   describe.each([
     ["Base case", "print('Hello, World!')"],
     [
+      // This code triggers some things with the way fern does escapes that we need to test is escaping correctly
+      // as it sometimes does not escape correctly for inline mode which is used by vembda.
       "Escaped case",
       "async function main(inputs: {\n  question: string\n}) {\n  inputs = {\n" +
         '"question": "{\\"text_explanation\\":\\"First, \\\\\\\\(\\\\\\\\frac{1}{40}\\\\\\\\).\\\\"\n  }\n' +
@@ -100,8 +102,6 @@ describe("CodeExecutionNode", () => {
         });
 
         const nodeData = codeExecutionNodeFactory({
-          // This code triggers some things with the way fern does escapes that we need to test is escaping correctly
-          // as it sometimes does not escape correctly for inline mode which is used by vembda.
           code,
         });
 

--- a/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
@@ -84,7 +84,7 @@ describe("CodeExecutionNode", () => {
 
         const nodeData = codeExecutionNodeFactory({
           // This code triggers some things with the way fern does escapes that we need to test is escaping correctly
-          // as it sometimes does not for inline mode which is used by vembda.
+          // as it sometimes does not escape correctly for inline mode which is used by vembda.
           code:
             "async function main(inputs: {\n  question: string\n}) {\n  inputs = {\n    " +
             '"question": "{\\"text_explanation\\":\\"First, \\\\\\\\(\\\\\\\\frac{1}{40}\\\\\\\\).\\\\"\n  }\n  ' +

--- a/ee/codegen/src/generators/base-persisted-file.ts
+++ b/ee/codegen/src/generators/base-persisted-file.ts
@@ -182,7 +182,7 @@ export abstract class BasePersistedFile extends AstNode {
     file.write(writer);
   }
 
-  public async persist(): Promise<void> {
+  public async persist(skipFormatting: boolean = false): Promise<void> {
     const absolutePathToModuleDirectory =
       this.workflowContext.absolutePathToOutputDirectory;
 
@@ -206,8 +206,14 @@ export abstract class BasePersistedFile extends AstNode {
 
     let contents: string;
     try {
-      contents = await writer.toStringFormatted({ line_width: 120 });
-      contents = this.postprocessDocstrings(contents);
+      if (skipFormatting) {
+        // Sometimes we need to disable formatting because of fern problems, this isn't strictly necessary because
+        // of the catch statement below but it will let us avoid an unneeded error log and sentry report.
+        contents = writer.toString();
+      } else {
+        contents = await writer.toStringFormatted({ line_width: 120 });
+        contents = this.postprocessDocstrings(contents);
+      }
     } catch (error) {
       console.error("Error formatting", fileName, "with error", error);
       contents = writer.toString();

--- a/ee/codegen/src/generators/nodes/bases/single-file-base.ts
+++ b/ee/codegen/src/generators/nodes/bases/single-file-base.ts
@@ -10,9 +10,11 @@ export abstract class BaseSingleFileNode<
   T extends WorkflowDataNode,
   V extends BaseNodeContext<T>
 > extends BaseNode<T, V> {
+  skipFormatting: boolean = false;
+
   public async persist(): Promise<void> {
     await Promise.all([
-      this.getNodeFile().persist(),
+      this.getNodeFile().persist(this.skipFormatting),
       this.getNodeDisplayFile().persist(),
     ]);
   }

--- a/ee/codegen/src/generators/nodes/code-execution-node.ts
+++ b/ee/codegen/src/generators/nodes/code-execution-node.ts
@@ -35,6 +35,12 @@ export class CodeExecutionNode extends BaseSingleFileNode<
     this.codeRepresentationOverride =
       workflowContext.codeExecutionNodeCodeRepresentationOverride;
     this.scriptFileContents = this.generateScriptFileContents();
+
+    // When using a single line string for INLINE representation which is used by vembda, fern
+    // will error when using toStringFormatted.
+    if (this.codeRepresentationOverride === "INLINE") {
+      this.skipFormatting = true;
+    }
   }
 
   protected getNodeAttributeNameByNodeInputKey(nodeInputKey: string): string {
@@ -95,7 +101,10 @@ export class CodeExecutionNode extends BaseSingleFileNode<
         python.field({
           name: CODE_INPUT_KEY,
           initializer: python.TypeInstantiation.str(this.scriptFileContents, {
-            multiline: true,
+            // Fern will garble the escaping when using python multiline for inline so we disable it.
+            // Inline code generation is currently only used by vembda and likely to remain that way
+            // so skipping over pretty formatting is acceptable.
+            multiline: false,
             startOnNewLine: true,
             endWithNewLine: true,
           }),


### PR DESCRIPTION
When running codegen in vembda mode with a code node with typescript with a bunch of escaping and regex fern is generating incorrectly escaped multiline strings for some reason. To sidestep this problem without having to get up to speed for fern internals I am switching it to use a single line when generating code in Inline mode which is really only useful for vembda.  I'm also disabling the formatting for this case because it triggers another fern bug. Another approach might be to add another layer of escaping before passing the string to fern and unescaping it in the runner by that is a bit gross or doing something to the string to make fern not maim it.

We should go forward with this less than ideal fix because it is actively impacting customers.