### PR TITLE
Hoist up NodeDisplayData to WorkflowMetaDisplay

### DIFF
--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -5,6 +5,7 @@ from typing import TypeVar
 from pydantic import Field
 
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
+from vellum_ee.workflows.display.editor.types import NodeDisplayData
 
 
 class WorkflowDisplayDataViewport(UniversalBaseModel):
@@ -21,6 +22,7 @@ class WorkflowDisplayData(UniversalBaseModel):
 class WorkflowMetaDisplay:
     entrypoint_node_id: UUID
     entrypoint_node_source_handle_id: UUID
+    entrypoint_node_display: NodeDisplayData = Field(default_factory=NodeDisplayData)
     display_data: WorkflowDisplayData = field(default_factory=WorkflowDisplayData)
 
 

--- a/ee/vellum_ee/workflows/display/editor/types.py
+++ b/ee/vellum_ee/workflows/display/editor/types.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+from pydantic import Field
+
+from vellum.client.core.pydantic_utilities import UniversalBaseModel
+
+
+class NodeDisplayPosition(UniversalBaseModel):
+    x: float = 0.0
+    y: float = 0.0
+
+
+class NodeDisplayComment(UniversalBaseModel):
+    value: Optional[str] = None
+    expanded: Optional[bool] = None
+
+
+class NodeDisplayData(UniversalBaseModel):
+    position: NodeDisplayPosition = Field(default_factory=NodeDisplayPosition)
+    width: Optional[int] = None
+    height: Optional[int] = None
+    comment: Optional[NodeDisplayComment] = None

--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -17,6 +17,7 @@ from typing import (
     get_origin,
 )
 
+from vellum.client.types.code_resource_definition import CodeResourceDefinition
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.constants import undefined
 from vellum.workflows.descriptors.base import BaseDescriptor
@@ -45,11 +46,11 @@ from vellum.workflows.types.utils import get_original_base
 from vellum.workflows.utils.names import pascal_to_title_case
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
+from vellum_ee.workflows.display.editor.types import NodeDisplayData
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.utils.expressions import get_child_descriptor
 from vellum_ee.workflows.display.utils.vellum import convert_descriptor_to_operator, primitive_to_vellum_value
-from vellum_ee.workflows.display.vellum import CodeResourceDefinition, NodeDisplayData
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.types import WorkflowDisplayContext

--- a/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
@@ -4,9 +4,9 @@ from typing import ClassVar, Dict, Optional
 from vellum.workflows.nodes.utils import get_unadorned_node
 from vellum.workflows.ports import Port
 from vellum.workflows.types.generics import NodeType
+from vellum_ee.workflows.display.editor.types import NodeDisplayComment, NodeDisplayData
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayComment, NodeDisplayData
 
 
 class BaseNodeVellumDisplay(BaseNodeDisplay[NodeType]):

--- a/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
@@ -8,7 +8,7 @@ from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeV
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum_ee.workflows.display.vellum import WorkspaceSecretPointer
+from vellum_ee.workflows.display.utils.vellum import WorkspaceSecretPointer
 
 _APINodeType = TypeVar("_APINodeType", bound=APINode)
 

--- a/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
@@ -15,7 +15,8 @@ from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeV
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum_ee.workflows.display.vellum import InputVariablePointer, NodeInput
+from vellum_ee.workflows.display.utils.vellum import InputVariablePointer
+from vellum_ee.workflows.display.vellum import NodeInput
 
 _SearchNodeType = TypeVar("_SearchNodeType", bound=SearchNode)
 

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_utils.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_utils.py
@@ -8,21 +8,20 @@ from vellum.workflows.inputs import BaseInputs
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.outputs import BaseOutputs
 from vellum.workflows.references import LazyReference
+from vellum_ee.workflows.display.editor.types import NodeDisplayData
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input_value_pointer_rules
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum_ee.workflows.display.vellum import (
+from vellum_ee.workflows.display.utils.vellum import (
     ConstantValuePointer,
     InputVariableData,
     InputVariablePointer,
-    NodeDisplayData,
     NodeInputValuePointerRule,
     NodeOutputData,
     NodeOutputPointer,
-    WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplay,
 )
+from vellum_ee.workflows.display.vellum import WorkflowInputsVellumDisplayOverrides, WorkflowMetaVellumDisplay
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
@@ -68,41 +67,36 @@ class MyNodeB(BaseNode):
             MyNodeB.fallback_example,
             [
                 NodeOutputPointer(
-                    type="NODE_OUTPUT",
                     data=NodeOutputData(
                         node_id="b48fa5e0-d7d3-4fe3-ae48-615415011cc5",
                         output_id="4b16a629-11a1-4b3f-a965-a57b872d13b8",
                     ),
                 ),
                 InputVariablePointer(
-                    type="INPUT_VARIABLE",
                     data=InputVariableData(input_variable_id="a154c29d-fac0-4cd0-ba88-bc52034f5470"),
                 ),
-                ConstantValuePointer(type="CONSTANT_VALUE", data=StringVellumValue(value="fallback")),
+                ConstantValuePointer(data=StringVellumValue(value="fallback")),
             ],
         ),
         (
             MyNodeB.constant_coalesce,
             [
                 InputVariablePointer(
-                    type="INPUT_VARIABLE",
                     data=InputVariableData(input_variable_id="a154c29d-fac0-4cd0-ba88-bc52034f5470"),
                 ),
-                ConstantValuePointer(type="CONSTANT_VALUE", data=StringVellumValue(value="default_value")),
+                ConstantValuePointer(data=StringVellumValue(value="default_value")),
             ],
         ),
         (
             MyNodeB.lazy_coalesce,
             [
                 NodeOutputPointer(
-                    type="NODE_OUTPUT",
                     data=NodeOutputData(
                         node_id="b48fa5e0-d7d3-4fe3-ae48-615415011cc5",
                         output_id="4b16a629-11a1-4b3f-a965-a57b872d13b8",
                     ),
                 ),
                 InputVariablePointer(
-                    type="INPUT_VARIABLE",
                     data=InputVariableData(input_variable_id="a154c29d-fac0-4cd0-ba88-bc52034f5470"),
                 ),
             ],

--- a/ee/vellum_ee/workflows/display/nodes/vellum/utils.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/utils.py
@@ -9,19 +9,18 @@ from vellum.workflows.references.lazy import LazyReference
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum_ee.workflows.display.utils.expressions import get_child_descriptor
-from vellum_ee.workflows.display.utils.vellum import create_node_input_value_pointer_rule
-from vellum_ee.workflows.display.vellum import (
+from vellum_ee.workflows.display.utils.vellum import (
     ConstantValuePointer,
     ExecutionCounterData,
     ExecutionCounterPointer,
     InputVariableData,
     InputVariablePointer,
-    NodeInput,
-    NodeInputValuePointer,
     NodeInputValuePointerRule,
     WorkspaceSecretData,
     WorkspaceSecretPointer,
+    create_node_input_value_pointer_rule,
 )
+from vellum_ee.workflows.display.vellum import NodeInput, NodeInputValuePointer
 
 
 def create_node_input(

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
@@ -9,11 +9,12 @@ from vellum.workflows.references.workflow_input import WorkflowInputReference
 from vellum.workflows.types.core import JsonObject
 from vellum.workflows.types.generics import NodeType
 from vellum_ee.workflows.display.base import StateValueDisplayType, WorkflowInputsDisplayType
+from vellum_ee.workflows.display.editor.types import NodeDisplayData
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum_ee.workflows.display.vellum import NodeDisplayData, WorkflowMetaVellumDisplay
+from vellum_ee.workflows.display.vellum import WorkflowMetaVellumDisplay
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 

--- a/ee/vellum_ee/workflows/display/utils/vellum.py
+++ b/ee/vellum_ee/workflows/display/utils/vellum.py
@@ -1,6 +1,9 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
+from vellum.client.core.pydantic_utilities import UniversalBaseModel
+from vellum.client.types.array_vellum_value import ArrayVellumValue
 from vellum.client.types.logical_operator import LogicalOperator
+from vellum.client.types.vellum_value import VellumValue
 from vellum.client.types.vellum_variable_type import VellumVariableType
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.expressions.and_ import AndExpression
@@ -39,21 +42,64 @@ from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
 from vellum.workflows.vellum_client import create_vellum_client
 from vellum_ee.workflows.display.utils.expressions import get_child_descriptor
-from vellum_ee.workflows.display.vellum import (
-    ConstantValuePointer,
-    ExecutionCounterData,
-    ExecutionCounterPointer,
-    InputVariableData,
-    InputVariablePointer,
-    NodeInputValuePointerRule,
-    NodeOutputData,
-    NodeOutputPointer,
-    WorkspaceSecretData,
-    WorkspaceSecretPointer,
-)
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.types import WorkflowDisplayContext
+
+
+class ConstantValuePointer(UniversalBaseModel):
+    type: Literal["CONSTANT_VALUE"] = "CONSTANT_VALUE"
+    data: VellumValue
+
+
+ArrayVellumValue.model_rebuild()
+
+
+class NodeOutputData(UniversalBaseModel):
+    node_id: str
+    output_id: str
+
+
+class NodeOutputPointer(UniversalBaseModel):
+    type: Literal["NODE_OUTPUT"] = "NODE_OUTPUT"
+    data: NodeOutputData
+
+
+class InputVariableData(UniversalBaseModel):
+    input_variable_id: str
+
+
+class InputVariablePointer(UniversalBaseModel):
+    type: Literal["INPUT_VARIABLE"] = "INPUT_VARIABLE"
+    data: InputVariableData
+
+
+class WorkspaceSecretData(UniversalBaseModel):
+    type: VellumVariableType
+    workspace_secret_id: Optional[str] = None
+
+
+class WorkspaceSecretPointer(UniversalBaseModel):
+    type: Literal["WORKSPACE_SECRET"] = "WORKSPACE_SECRET"
+    data: WorkspaceSecretData
+
+
+class ExecutionCounterData(UniversalBaseModel):
+    node_id: str
+
+
+class ExecutionCounterPointer(UniversalBaseModel):
+    type: Literal["EXECUTION_COUNTER"] = "EXECUTION_COUNTER"
+    data: ExecutionCounterData
+
+
+NodeInputValuePointerRule = Union[
+    NodeOutputPointer,
+    InputVariablePointer,
+    ConstantValuePointer,
+    WorkspaceSecretPointer,
+    ExecutionCounterPointer,
+]
 
 
 def infer_vellum_variable_type(value: Any) -> VellumVariableType:

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -1,12 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional
 
-from pydantic import Field
-
-from vellum import VellumVariableType
-from vellum.client.types.array_vellum_value import ArrayVellumValue
-from vellum.client.types.vellum_value import VellumValue
 from vellum.core import UniversalBaseModel
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
@@ -22,23 +17,10 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.base import WorkflowDisplayData  # noqa: F401 - Remove in 0.15.0
 from vellum_ee.workflows.display.base import WorkflowDisplayDataViewport  # noqa: F401 - Remove in 0.15.0
-
-
-class NodeDisplayPosition(UniversalBaseModel):
-    x: float = 0.0
-    y: float = 0.0
-
-
-class NodeDisplayComment(UniversalBaseModel):
-    value: Optional[str] = None
-    expanded: Optional[bool] = None
-
-
-class NodeDisplayData(UniversalBaseModel):
-    position: NodeDisplayPosition = Field(default_factory=NodeDisplayPosition)
-    width: Optional[int] = None
-    height: Optional[int] = None
-    comment: Optional[NodeDisplayComment] = None
+from vellum_ee.workflows.display.editor.types import NodeDisplayComment  # noqa: F401 - Remove in 0.15.0
+from vellum_ee.workflows.display.editor.types import NodeDisplayData
+from vellum_ee.workflows.display.editor.types import NodeDisplayPosition  # noqa: F401 - Remove in 0.15.0
+from vellum_ee.workflows.display.utils.vellum import NodeInputValuePointerRule
 
 
 class CodeResourceDefinition(UniversalBaseModel):
@@ -48,7 +30,11 @@ class CodeResourceDefinition(UniversalBaseModel):
 
 @dataclass
 class WorkflowMetaVellumDisplayOverrides(WorkflowMetaDisplayOverrides):
-    entrypoint_node_display: NodeDisplayData = Field(default_factory=NodeDisplayData)
+    """
+    DEPRECATED: Use WorkflowMetaDisplay instead. Will be removed in 0.15.0
+    """
+
+    pass
 
 
 @dataclass
@@ -135,61 +121,6 @@ class WorkflowOutputVellumDisplay(WorkflowOutputVellumDisplayOverrides):
     """
 
     pass
-
-
-class ConstantValuePointer(UniversalBaseModel):
-    type: Literal["CONSTANT_VALUE"] = "CONSTANT_VALUE"
-    data: VellumValue
-
-
-ArrayVellumValue.model_rebuild()
-
-
-class NodeOutputData(UniversalBaseModel):
-    node_id: str
-    output_id: str
-
-
-class NodeOutputPointer(UniversalBaseModel):
-    type: Literal["NODE_OUTPUT"] = "NODE_OUTPUT"
-    data: NodeOutputData
-
-
-class InputVariableData(UniversalBaseModel):
-    input_variable_id: str
-
-
-class InputVariablePointer(UniversalBaseModel):
-    type: Literal["INPUT_VARIABLE"] = "INPUT_VARIABLE"
-    data: InputVariableData
-
-
-class WorkspaceSecretData(UniversalBaseModel):
-    type: VellumVariableType
-    workspace_secret_id: Optional[str] = None
-
-
-class WorkspaceSecretPointer(UniversalBaseModel):
-    type: Literal["WORKSPACE_SECRET"] = "WORKSPACE_SECRET"
-    data: WorkspaceSecretData
-
-
-class ExecutionCounterData(UniversalBaseModel):
-    node_id: str
-
-
-class ExecutionCounterPointer(UniversalBaseModel):
-    type: Literal["EXECUTION_COUNTER"] = "EXECUTION_COUNTER"
-    data: ExecutionCounterData
-
-
-NodeInputValuePointerRule = Union[
-    NodeOutputPointer,
-    InputVariablePointer,
-    ConstantValuePointer,
-    WorkspaceSecretPointer,
-    ExecutionCounterPointer,
-]
 
 
 class NodeInputValuePointer(UniversalBaseModel):

--- a/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
@@ -7,10 +7,10 @@ from vellum.workflows.nodes.core.retry_node.node import RetryNode
 from vellum.workflows.nodes.core.templating_node.node import TemplatingNode
 from vellum.workflows.nodes.core.try_node.node import TryNode
 from vellum.workflows.workflows.base import BaseWorkflow
+from vellum_ee.workflows.display.editor.types import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.retry_node import BaseRetryNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.try_node import BaseTryNodeDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 


### PR DESCRIPTION
PR we are eventually working towards: https://github.com/vellum-ai/vellum-python-sdks/pull/1244

This PR just hoists up the last field from `WorkflowMetaVellumDisplayOverrides` to `WorkflowMetaDisplay`, which will allow us to cutover in the next PR in codegen