### PR TITLE
Codegen WorkflowMetaDisplay instead of WorkflowMetaVellumDisplayOverrides

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -38,8 +38,8 @@ class SecondNode(BaseNode):
 `;
 
 exports[`WorkflowProjectGenerator > Nodes present but not in graph > should still generate a file for the second node 3`] = `
-"from vellum_ee.workflows.display.nodes import BaseNodeDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+"from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseNodeDisplay
 
 from ...nodes.second_node import SecondNode
 

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -75,13 +75,12 @@ class TestWorkflow(BaseWorkflow):
 exports[`Workflow > write > should generate correct display code when there are input variables with escape characters 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.base import WorkflowMetaDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import (
     VellumWorkflowDisplay,
@@ -92,7 +91,7 @@ from ..workflow import TestWorkflow
 
 
 class TestWorkflowDisplay(VellumWorkflowDisplay[TestWorkflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("entrypoint"),
         entrypoint_node_source_handle_id=UUID("<source_handle_id>"),
         entrypoint_node_display=NodeDisplayData(

--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`ApiNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseAPINodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.api_node import APINode
 
@@ -188,12 +188,12 @@ class APINode(BaseAPINode):
 exports[`ApiNode > reject on error enabled > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseAPINodeDisplay, BaseTryNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.api_node import APINode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`CodeExecutionNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.code_execution_node import CodeExecutionNode
 
@@ -172,12 +172,12 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
 exports[`CodeExecutionNode > log output id > should not generate log output id if not given 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.code_execution_node import CodeExecutionNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
@@ -40,12 +40,12 @@ class ConditionalNode(BaseConditionalNode):
 exports[`ConditionalNode > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
     ConditionId,
     RuleIdMap,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.conditional_node import ConditionalNode
 
@@ -145,12 +145,12 @@ class ConditionalNode(BaseConditionalNode):
 exports[`ConditionalNode with invalid uuid for field and value node input ids > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
     ConditionId,
     RuleIdMap,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.conditional_node import ConditionalNode
 
@@ -215,12 +215,12 @@ class ConditionalNode(BaseConditionalNode):
 exports[`ConditionalNode with null operator > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
     ConditionId,
     RuleIdMap,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.conditional_node import ConditionalNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`ErrorNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.error_node import ErrorNode
 
@@ -37,8 +37,8 @@ class ErrorNode(BaseErrorNode):
 exports[`ErrorNode > should codegen successfully without error source inputs > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.error_node import ErrorNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
@@ -3,9 +3,9 @@
 exports[`FinalOutputNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output_node import FinalOutputNode
 
@@ -47,9 +47,9 @@ class FinalOutputNode(BaseFinalOutputNode[BaseState, str]):
 exports[`FinalOutputNode > should codegen successfully without node input > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output_node import FinalOutputNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/guardrail-node.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`GuardrailNode > basic > getNodeDisplayFile - multiple output variables 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseGuardrailNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.guardrail_node import GuardrailNode
 
@@ -47,12 +47,12 @@ class GuardrailNodeDisplay(BaseGuardrailNodeDisplay[GuardrailNode]):
 exports[`GuardrailNode > basic > getNodeDisplayFile - single output variable 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseGuardrailNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.guardrail_node import GuardrailNode
 
@@ -120,6 +120,7 @@ class GuardrailNode(BaseGuardrailNode):
 exports[`GuardrailNode > reject on error enabled > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import (
     BaseGuardrailNodeDisplay,
     BaseTryNodeDisplay,
@@ -128,7 +129,6 @@ from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.guardrail_node import GuardrailNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node-retry.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node-retry.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`InlinePromptRetryNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseRetryNodeDisplay,
@@ -11,7 +12,6 @@ from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -77,6 +77,7 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptRetryNode > basic retry adornment and try adornment > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseRetryNodeDisplay,
@@ -86,7 +87,6 @@ from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -158,6 +158,7 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptRetryNode > basic retry adornment with delay > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseRetryNodeDisplay,
@@ -166,7 +167,6 @@ from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`InlinePromptNode > CHAT_MESSAGE block type > basic > getNodeDisplayFile for CHAT_MESSAGE block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -95,12 +95,12 @@ Summarize the following text:
 exports[`InlinePromptNode > CHAT_MESSAGE block type > legacy prompt variant > getNodeDisplayFile for CHAT_MESSAGE block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -187,6 +187,7 @@ Summarize the following text:
 exports[`InlinePromptNode > CHAT_MESSAGE block type > reject on error enabled > getNodeDisplayFile for CHAT_MESSAGE block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseTryNodeDisplay,
@@ -195,7 +196,6 @@ from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -288,12 +288,12 @@ Summarize the following text:
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > basic > getNodeDisplayFile for FUNCTION_DEFINITION block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -357,12 +357,12 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > legacy prompt variant > getNodeDisplayFile for FUNCTION_DEFINITION block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -426,6 +426,7 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > FUNCTION_DEFINITION block type > reject on error enabled > getNodeDisplayFile for FUNCTION_DEFINITION block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseTryNodeDisplay,
@@ -434,7 +435,6 @@ from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -504,12 +504,12 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > JINJA block type > basic > getNodeDisplayFile for JINJA block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -572,12 +572,12 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > JINJA block type > legacy prompt variant > getNodeDisplayFile for JINJA block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -640,6 +640,7 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > JINJA block type > reject on error enabled > getNodeDisplayFile for JINJA block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseTryNodeDisplay,
@@ -648,7 +649,6 @@ from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -717,12 +717,12 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > RICH_TEXT block type > basic > getNodeDisplayFile for RICH_TEXT block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -791,12 +791,12 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > RICH_TEXT block type > legacy prompt variant > getNodeDisplayFile for RICH_TEXT block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -865,6 +865,7 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > RICH_TEXT block type > reject on error enabled > getNodeDisplayFile for RICH_TEXT block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseTryNodeDisplay,
@@ -873,7 +874,6 @@ from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -948,12 +948,12 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > VARIABLE block type > basic > getNodeDisplayFile for VARIABLE block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -1016,12 +1016,12 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > VARIABLE block type > legacy prompt variant > getNodeDisplayFile for VARIABLE block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -1084,6 +1084,7 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > VARIABLE block type > reject on error enabled > getNodeDisplayFile for VARIABLE block type 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import (
     BaseInlinePromptNodeDisplay,
     BaseTryNodeDisplay,
@@ -1092,7 +1093,6 @@ from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 
@@ -1227,12 +1227,12 @@ class PromptNode(InlinePromptNode):
 exports[`InlinePromptNode > with json output id defined > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -18,9 +18,9 @@ exports[`InlineSubworkflowNode > adornments > should generate adornments 2`] = `
 
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay, BaseRetryNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ....nodes.my_node import MyNode
 from .nodes import *
@@ -49,9 +49,9 @@ exports[`InlineSubworkflowNode > basic > inline subworkflow node display file 1`
 
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ....nodes.inline_subworkflow_node import InlineSubworkflowNode
 from .nodes import *
@@ -103,9 +103,9 @@ exports[`InlineSubworkflowNode > name collision > should handle subworkflow with
 
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ....nodes.my_node import MyNode
 from .nodes import *
@@ -142,9 +142,9 @@ class MyNode1(TemplatingNode[BaseState, str]):
 exports[`InlineSubworkflowNode > name collision > should handle subworkflow with same name as internal node 4`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from .....nodes.my_node.nodes.my_node import MyNode1
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/map-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/map-node.test.ts.snap
@@ -5,9 +5,9 @@ exports[`MapNode > basic > map node display file 1`] = `
 
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ....nodes.map_node import MapNode
 from .nodes import *
@@ -51,9 +51,9 @@ exports[`MapNode > with additional output > map node display file 1`] = `
 
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ....nodes.map_node import MapNode
 from .nodes import *

--- a/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
@@ -3,9 +3,9 @@
 exports[`MergeNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseMergeNodeDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.merge_node import MergeNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
@@ -18,12 +18,12 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
 exports[`InlinePromptNode referenced by Conditional Node > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
     ConditionId,
     RuleIdMap,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.conditional_node import ConditionalNode
 
@@ -92,12 +92,12 @@ class ConditionalNode(BaseConditionalNode):
 exports[`InlinePromptNode referenced by Templating Node > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node import TemplatingNode
 
@@ -144,12 +144,12 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
 exports[`Non-existent Subworkflow Deployment Node referenced by Templating Node > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node import TemplatingNode
 
@@ -196,12 +196,12 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDisplayFile with 'takes array output id' 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
     ConditionId,
     RuleIdMap,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.conditional_node import ConditionalNode
 
@@ -256,12 +256,12 @@ class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDisplayFile with 'takes error output id' 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
     ConditionId,
     RuleIdMap,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.conditional_node import ConditionalNode
 
@@ -316,12 +316,12 @@ class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
 exports[`Prompt Deployment Node referenced by Conditional Node > getNodeDisplayFile with 'takes output id' 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import (
     ConditionId,
     RuleIdMap,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.conditional_node import ConditionalNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`NoteNode > basic > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseNoteNodeDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+"from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseNoteNodeDisplay
 
 from ...nodes.note_node import NoteNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`PromptDeploymentNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BasePromptDeploymentNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_deployment_node import PromptDeploymentNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/search-node.test.ts.snap
@@ -41,12 +41,12 @@ class SearchNode(BaseSearchNode):
 exports[`TextSearchNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.search_node import SearchNode
 
@@ -185,12 +185,12 @@ class SearchNode(BaseSearchNode):
 exports[`TextSearchNode > metadata filters > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.search_node import SearchNode
 
@@ -295,12 +295,12 @@ class SearchNode(BaseSearchNode):
 exports[`TextSearchNode > reject on error enabled > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay, BaseTryNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.search_node import SearchNode
 
@@ -403,12 +403,12 @@ class SearchNode(BaseSearchNode):
 exports[`TextSearchNode > should codegen successfully without document index id input > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.search_node import SearchNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`SubworkflowDeploymentNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.subworkflow_node import SubworkflowNode
 
@@ -59,9 +59,9 @@ class SubworkflowNode(SubworkflowDeploymentNode):
 exports[`SubworkflowDeploymentNode > failure > should generate subworkflow deployment node display as much as possible for non strict workflow contexts 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.subworkflow_node import SubworkflowNode
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/templating-node.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`TemplatingNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node import TemplatingNode
 
@@ -48,12 +48,12 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
 exports[`TemplatingNode > basic with json output type > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node import TemplatingNode
 
@@ -107,6 +107,7 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
 exports[`TemplatingNode > reject on error enabled > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import (
     BaseTemplatingNodeDisplay,
     BaseTryNodeDisplay,
@@ -115,7 +116,6 @@ from vellum_ee.workflows.display.nodes.types import (
     NodeOutputDisplay,
     PortDisplayOverrides,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node import TemplatingNode
 

--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`GenericNode > basic > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseNodeDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+"from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseNodeDisplay
 
 from ...nodes.my_custom_node import MyCustomNode
 
@@ -36,13 +36,13 @@ class MyCustomNode(BaseNode):
 exports[`GenericNode > basic with adornments > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import (
     BaseMapNodeDisplay,
     BaseNodeDisplay,
     BaseRetryNodeDisplay,
     BaseTryNodeDisplay,
 )
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.my_custom_node import MyCustomNode
 
@@ -115,8 +115,8 @@ class MyCustomNode(BaseNode):
 `;
 
 exports[`GenericNode > basic with node output as attribute > getNodeDisplayFile 1`] = `
-"from vellum_ee.workflows.display.nodes import BaseNodeDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
+"from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseNodeDisplay
 
 from ...nodes.my_custom_node import MyCustomNode
 

--- a/ee/codegen/src/constants.ts
+++ b/ee/codegen/src/constants.ts
@@ -30,6 +30,12 @@ export const VELLUM_WORKFLOWS_DISPLAY_BASE_PATH = [
   "display",
   "base",
 ] as const;
+export const VELLUM_WORKFLOW_EDITOR_TYPES_PATH = [
+  "vellum_ee",
+  "workflows",
+  "display",
+  "editor",
+] as const;
 /* Class names */
 export const OUTPUTS_CLASS_NAME = "Outputs";
 export const PORTS_CLASS_NAME = "Ports";

--- a/ee/codegen/src/generators/node-display-data.ts
+++ b/ee/codegen/src/generators/node-display-data.ts
@@ -2,6 +2,7 @@ import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
 
+import { VELLUM_WORKFLOW_EDITOR_TYPES_PATH } from "src/constants";
 import { WorkflowContext } from "src/context";
 import { NodeDisplayData as NodeDisplayDataType } from "src/types/vellum";
 import { isNilOrEmpty } from "src/utils/typing";
@@ -37,8 +38,7 @@ export class NodeDisplayData extends AstNode {
         value: python.instantiateClass({
           classReference: python.reference({
             name: "NodeDisplayPosition",
-            modulePath:
-              this.workflowContext.sdkModulePathNames.VELLUM_TYPES_MODULE_PATH,
+            modulePath: VELLUM_WORKFLOW_EDITOR_TYPES_PATH,
           }),
           arguments_: [
             python.methodArgument({
@@ -78,8 +78,7 @@ export class NodeDisplayData extends AstNode {
     const clazz = python.instantiateClass({
       classReference: python.reference({
         name: "NodeDisplayData",
-        modulePath:
-          this.workflowContext.sdkModulePathNames.VELLUM_TYPES_MODULE_PATH,
+        modulePath: VELLUM_WORKFLOW_EDITOR_TYPES_PATH,
       }),
       arguments_: args,
     });
@@ -122,8 +121,7 @@ export class NodeDisplayData extends AstNode {
       value: python.instantiateClass({
         classReference: python.reference({
           name: "NodeDisplayComment",
-          modulePath:
-            this.workflowContext.sdkModulePathNames.VELLUM_TYPES_MODULE_PATH,
+          modulePath: VELLUM_WORKFLOW_EDITOR_TYPES_PATH,
         }),
         arguments_: commentArgs,
       }),

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -169,9 +169,8 @@ export class Workflow {
         name: "workflow_display",
         initializer: python.instantiateClass({
           classReference: python.reference({
-            name: "WorkflowMetaVellumDisplayOverrides",
-            modulePath:
-              this.workflowContext.sdkModulePathNames.VELLUM_TYPES_MODULE_PATH,
+            name: "WorkflowMetaDisplay",
+            modulePath: VELLUM_WORKFLOWS_DISPLAY_BASE_PATH,
           }),
           arguments_: [
             python.methodArgument({

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/api_node.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/api_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseAPINodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.api_node import APINode
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/conditional_node.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/conditional_node.py
@@ -1,9 +1,9 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import ConditionId, RuleIdMap
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.conditional_node import ConditionalNode
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/faa_document_store.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/faa_document_store.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.faa_document_store import FAADocumentStore
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/final_output_2.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/final_output_2.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output_2 import FinalOutput2
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/formatted_search_results.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/formatted_search_results.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.formatted_search_results import FormattedSearchResults
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/most_recent_message.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/most_recent_message.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.most_recent_message import MostRecentMessage
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_14.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_14.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node_14 import PromptNode14
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_16.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_16.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node_16 import PromptNode16
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_18.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_18.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node_18 import PromptNode18
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_19.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_19.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node_19 import PromptNode19
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_9.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_9.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node_9 import PromptNode9
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/subworkflow_node.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/subworkflow_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.subworkflow_node import SubworkflowNode
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/templating_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node import TemplatingNode
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/templating_node_15.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/templating_node_15.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node_15 import TemplatingNode15
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -32,7 +30,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("81ec43d2-49ec-47ce-b953-faaec3a22c63"),
         entrypoint_node_source_handle_id=UUID("6888c8eb-9dba-42b4-94d4-52900edcfeea"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=0, y=388.75), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/nodes/api_node.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/nodes/api_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayComment, NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseAPINodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayComment, NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.api_node import ApiNode
 

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -19,7 +17,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("c4ef480d-635a-49c8-900f-6583c4b79fb5"),
         entrypoint_node_source_handle_id=UUID("0465edea-e797-4558-aabb-65bce040e095"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/nodes/code_execution_node.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/nodes/code_execution_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayComment, NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayComment, NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.code_execution_node import CodeExecutionNode
 

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -19,7 +17,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("d49107fe-1424-42ba-9413-9ab5ce398077"),
         entrypoint_node_source_handle_id=UUID("08d78489-ce80-4743-a22d-2d5f62b575ac"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/nodes/conditional_node.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/nodes/conditional_node.py
@@ -1,9 +1,9 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
 from vellum_ee.workflows.display.nodes.vellum.conditional_node import ConditionId, RuleIdMap
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.conditional_node import ConditionalNode
 

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -19,7 +17,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("6dbd327c-3b96-4da4-9063-5b36dab7f6d0"),
         entrypoint_node_source_handle_id=UUID("498eed8e-38d5-48b8-bbc4-f45411100502"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_error_node/code/display/nodes/error_node.py
+++ b/ee/codegen_integration/fixtures/simple_error_node/code/display/nodes/error_node.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.error_node import ErrorNode
 

--- a/ee/codegen_integration/fixtures/simple_error_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_error_node/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -18,7 +16,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("27a1723c-e892-4303-bbf0-c1a0428af295"),
         entrypoint_node_source_handle_id=UUID("6cbf47ee-84ef-42cb-b1df-7b9e0fee2bee"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/nodes/guardrail_node.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/nodes/guardrail_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseGuardrailNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.guardrail_node import GuardrailNode
 

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -19,7 +17,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("872c757c-9544-4ad6-ada5-5ee574f1fe5e"),
         entrypoint_node_source_handle_id=UUID("5751330f-60a8-4d6a-88aa-a35b968db364"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
@@ -2,9 +2,9 @@
 
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ....nodes.subworkflow_node import SubworkflowNode
 from .nodes import *

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from .....nodes.subworkflow_node.nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/nodes/search_node.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/nodes/search_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from .....nodes.subworkflow_node.nodes.search_node import SearchNode
 

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -1,13 +1,11 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -17,7 +15,7 @@ from ....nodes.subworkflow_node.workflow import SubworkflowNodeWorkflow
 
 
 class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("c48f318d-4d87-44da-be54-0ecf537608f6"),
         entrypoint_node_source_handle_id=UUID("cfec8bf4-d335-4681-a5c6-cbd53ffbd0d1"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -19,7 +17,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("48134634-f654-4a45-9f00-4e9378ab1f32"),
         entrypoint_node_source_handle_id=UUID("c1eca197-d299-4feb-906b-a9f4647e759c"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/code_execution_node.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/code_execution_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.code_execution_node import CodeExecutionNode
 

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/__init__.py
@@ -2,9 +2,9 @@
 
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ....nodes.map_node import MapNode
 from .nodes import *

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from .....nodes.map_node.nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/search_node.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/search_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from .....nodes.map_node.nodes.search_node import SearchNode
 

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/templating_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from .....nodes.map_node.nodes.templating_node import TemplatingNode
 

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -20,7 +18,7 @@ from ....nodes.map_node.workflow import MapNodeWorkflow
 
 
 class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("79145e96-23c3-4763-ad7e-f3c6529fe535"),
         entrypoint_node_source_handle_id=UUID("b4b974ea-716d-4187-a5fb-808284272fe2"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -20,7 +18,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("77325e35-b73e-4596-bfb0-3cf3ddf11a2e"),
         entrypoint_node_source_handle_id=UUID("f342d075-e79a-46ea-8de9-e40ed8152070"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=0, y=151.5), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/merge_node.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/merge_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseMergeNodeDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.merge_node import MergeNode
 

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_1.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_1.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node_1 import TemplatingNode1
 

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_2.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_2.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node_2 import TemplatingNode2
 

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_3.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/templating_node_3.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node_3 import TemplatingNode3
 

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -1,13 +1,11 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -20,7 +18,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("b8b9eb69-4af1-4953-b576-aa59eb138696"),
         entrypoint_node_source_handle_id=UUID("1095ae85-1e2f-4433-aacf-fac30fe12ff3"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/prompt_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay, BaseTryNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -19,7 +17,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("1c05df03-f699-42e4-9816-9b1b3757c10e"),
         entrypoint_node_source_handle_id=UUID("4ee49c3a-68ef-4134-b73d-c1754abaac44"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/nodes/prompt_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.prompt_node import PromptNode
 

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -19,7 +17,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("fedbe8f4-aa63-405b-aefa-0e40e65d547e"),
         entrypoint_node_source_handle_id=UUID("4d6a6de9-d3d6-4b8f-9a71-caf53c2f31c3"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/nodes/search_node.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/nodes/search_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSearchNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.search_node import SearchNode
 

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -19,7 +17,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("27a1723c-e892-4303-bbf0-c1a0428af295"),
         entrypoint_node_source_handle_id=UUID("6cbf47ee-84ef-42cb-b1df-7b9e0fee2bee"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/subworkflow_deployment.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/subworkflow_deployment.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseSubworkflowDeploymentNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.subworkflow_deployment import SubworkflowDeployment
 

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -19,7 +17,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("39a5155a-d137-4a56-be36-d525802df463"),
         entrypoint_node_source_handle_id=UUID("beddfefc-dc34-483d-b313-f6a2a2e0737e"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/templating_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node import TemplatingNode
 

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -1,13 +1,11 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -17,7 +15,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("6b52893a-e649-434d-aedd-e8ad73d78dce"),
         entrypoint_node_source_handle_id=UUID("b4f25dad-17c6-464d-b347-9945065f17e4"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/nodes/final_output.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.final_output import FinalOutput
 

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/nodes/templating_node.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/nodes/templating_node.py
@@ -1,8 +1,8 @@
 from uuid import UUID
 
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
-from vellum_ee.workflows.display.vellum import NodeDisplayData, NodeDisplayPosition
 
 from ...nodes.templating_node import TemplatingNode
 

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
@@ -1,14 +1,12 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
     EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
-    NodeDisplayPosition,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -19,7 +17,7 @@ from ..workflow import Workflow
 
 
 class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
-    workflow_display = WorkflowMetaVellumDisplayOverrides(
+    workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("39a5155a-d137-4a56-be36-d525802df463"),
         entrypoint_node_source_handle_id=UUID("beddfefc-dc34-483d-b313-f6a2a2e0737e"),
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1545, y=330), width=124, height=48),

--- a/ee/vellum_ee/workflows/display/editor/__init__.py
+++ b/ee/vellum_ee/workflows/display/editor/__init__.py
@@ -1,0 +1,7 @@
+from .types import NodeDisplayComment, NodeDisplayData, NodeDisplayPosition
+
+__all__ = [
+    "NodeDisplayComment",
+    "NodeDisplayData",
+    "NodeDisplayPosition",
+]

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -11,7 +11,7 @@ from vellum_ee.workflows.display.base import (
     EntrypointDisplayType,
     StateValueDisplayType,
     WorkflowInputsDisplayType,
-    WorkflowMetaDisplayType,
+    WorkflowMetaDisplay,
     WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
@@ -32,14 +32,13 @@ PortDisplays = Dict[Port, PortDisplay]
 @dataclass
 class WorkflowDisplayContext(
     Generic[
-        WorkflowMetaDisplayType,
         WorkflowInputsDisplayType,
         StateValueDisplayType,
         EntrypointDisplayType,
     ]
 ):
     workflow_display_class: Type["BaseWorkflowDisplay"]
-    workflow_display: WorkflowMetaDisplayType
+    workflow_display: WorkflowMetaDisplay
     workflow_input_displays: Dict[WorkflowInputReference, WorkflowInputsDisplayType] = field(default_factory=dict)
     global_workflow_input_displays: Dict[WorkflowInputReference, WorkflowInputsDisplayType] = field(
         default_factory=dict

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -25,8 +25,7 @@ from vellum_ee.workflows.display.base import (
     StateValueDisplayType,
     WorkflowInputsDisplayOverridesType,
     WorkflowInputsDisplayType,
-    WorkflowMetaDisplayOverridesType,
-    WorkflowMetaDisplayType,
+    WorkflowMetaDisplay,
     WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
@@ -50,8 +49,6 @@ logger = logging.getLogger(__name__)
 class BaseWorkflowDisplay(
     Generic[
         WorkflowType,
-        WorkflowMetaDisplayType,
-        WorkflowMetaDisplayOverridesType,
         WorkflowInputsDisplayType,
         WorkflowInputsDisplayOverridesType,
         StateValueDisplayType,
@@ -61,7 +58,7 @@ class BaseWorkflowDisplay(
     ]
 ):
     # Used to specify the display data for a workflow.
-    workflow_display: Optional[WorkflowMetaDisplayOverridesType] = None
+    workflow_display: Optional[WorkflowMetaDisplay] = None
 
     # Used to explicitly specify display data for a workflow's inputs.
     inputs_display: Dict[WorkflowInputReference, WorkflowInputsDisplayOverridesType] = {}
@@ -94,7 +91,6 @@ class BaseWorkflowDisplay(
         *,
         parent_display_context: Optional[
             WorkflowDisplayContext[
-                WorkflowMetaDisplayType,
                 WorkflowInputsDisplayType,
                 StateValueDisplayType,
                 EntrypointDisplayType,
@@ -190,7 +186,6 @@ class BaseWorkflowDisplay(
     def display_context(
         self,
     ) -> WorkflowDisplayContext[
-        WorkflowMetaDisplayType,
         WorkflowInputsDisplayType,
         StateValueDisplayType,
         EntrypointDisplayType,
@@ -311,7 +306,7 @@ class BaseWorkflowDisplay(
         )
 
     @abstractmethod
-    def _generate_workflow_meta_display(self) -> WorkflowMetaDisplayType:
+    def _generate_workflow_meta_display(self) -> WorkflowMetaDisplay:
         pass
 
     @abstractmethod
@@ -330,7 +325,7 @@ class BaseWorkflowDisplay(
     def _generate_entrypoint_display(
         self,
         entrypoint: Type[BaseNode],
-        workflow_display: WorkflowMetaDisplayType,
+        workflow_display: WorkflowMetaDisplay,
         node_displays: Dict[Type[BaseNode], BaseNodeDisplay],
         overrides: Optional[EntrypointDisplayOverridesType] = None,
     ) -> EntrypointDisplayType:

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -12,6 +12,7 @@ from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.utils.uuids import uuid4_from_hash
+from vellum_ee.workflows.display.base import WorkflowMetaDisplay
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
@@ -25,7 +26,6 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowInputsVellumDisplay,
     WorkflowInputsVellumDisplayOverrides,
     WorkflowMetaVellumDisplay,
-    WorkflowMetaVellumDisplayOverrides,
 )
 from vellum_ee.workflows.display.workflows.base_workflow_display import BaseWorkflowDisplay
 
@@ -35,8 +35,6 @@ logger = logging.getLogger(__name__)
 class VellumWorkflowDisplay(
     BaseWorkflowDisplay[
         WorkflowType,
-        WorkflowMetaVellumDisplay,
-        WorkflowMetaVellumDisplayOverrides,
         WorkflowInputsVellumDisplay,
         WorkflowInputsVellumDisplayOverrides,
         StateValueVellumDisplay,
@@ -346,7 +344,7 @@ class VellumWorkflowDisplay(
     def _generate_entrypoint_display(
         self,
         entrypoint: Type[BaseNode],
-        workflow_display: WorkflowMetaVellumDisplay,
+        workflow_display: WorkflowMetaDisplay,
         node_displays: Dict[Type[BaseNode], BaseNodeDisplay],
         overrides: Optional[EntrypointVellumDisplayOverrides] = None,
     ) -> EntrypointVellumDisplay:


### PR DESCRIPTION
This PR simply codegens our new classes:
- `WorkflowMetaDisplay` instead of `WorkflowMetaVellumDisplayOverrides`
- New module paths for `NodeDisplayData`,`NodeDisplayComment`,`NodeDisplayPosition`

I would only review changes in `ee/vellum_ee/workflows/display` folder