### PR TITLE
hoist up entrypoint display fields and generate util

### DIFF
--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -78,12 +78,13 @@ class EdgeDisplayOverrides(EdgeDisplay):
 
 
 @dataclass
-class EntrypointDisplayOverrides:
+class EntrypointDisplay:
     id: UUID
+    edge_display: EdgeDisplay
 
 
 @dataclass
-class EntrypointDisplay(EntrypointDisplayOverrides):
+class EntrypointDisplayOverrides(EntrypointDisplay):
     pass
 
 

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -8,6 +8,7 @@ from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference, StateValueReference, WorkflowInputReference
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
+    EntrypointDisplay,
     EntrypointDisplayType,
     StateValueDisplayType,
     WorkflowInputsDisplayType,
@@ -24,6 +25,7 @@ WorkflowDisplayType = TypeVar("WorkflowDisplayType", bound="BaseWorkflowDisplay"
 
 NodeDisplays = Dict[Type[BaseNode], BaseNodeDisplay]
 NodeOutputDisplays = Dict[OutputReference, Tuple[Type[BaseNode], NodeOutputDisplay]]
+EntrypointDisplays = Dict[Type[BaseNode], EntrypointDisplay]
 WorkflowOutputDisplays = Dict[BaseDescriptor, WorkflowOutputDisplay]
 EdgeDisplays = Dict[Tuple[Port, Type[BaseNode]], EdgeDisplay]
 PortDisplays = Dict[Port, PortDisplay]
@@ -48,7 +50,7 @@ class WorkflowDisplayContext(
     node_displays: NodeDisplays = field(default_factory=dict)
     global_node_displays: NodeDisplays = field(default_factory=dict)
     global_node_output_displays: NodeOutputDisplays = field(default_factory=dict)
-    entrypoint_displays: Dict[Type[BaseNode], EntrypointDisplayType] = field(default_factory=dict)
+    entrypoint_displays: EntrypointDisplays = field(default_factory=dict)
     workflow_output_displays: WorkflowOutputDisplays = field(default_factory=dict)
     edge_displays: EdgeDisplays = field(default_factory=dict)
     port_displays: PortDisplays = field(default_factory=dict)

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -4,9 +4,7 @@ from typing import List, Literal, Optional
 
 from vellum.core import UniversalBaseModel
 from vellum_ee.workflows.display.base import (
-    EdgeDisplay,
     EdgeDisplayOverrides,
-    EntrypointDisplay,
     EntrypointDisplayOverrides,
     StateValueDisplay,
     StateValueDisplayOverrides,
@@ -93,13 +91,21 @@ class EdgeVellumDisplay(EdgeVellumDisplayOverrides):
 
 
 @dataclass
-class EntrypointVellumDisplayOverrides(EntrypointDisplay, EntrypointDisplayOverrides):
-    edge_display: EdgeDisplay
+class EntrypointVellumDisplayOverrides(EntrypointDisplayOverrides):
+    """
+    DEPRECATED: Use EntrypointDisplay instead. Will be removed in 0.15.0
+    """
+
+    pass
 
 
 @dataclass
 class EntrypointVellumDisplay(EntrypointVellumDisplayOverrides):
-    edge_display: EdgeDisplay
+    """
+    DEPRECATED: Use EntrypointDisplay instead. Will be removed in 0.15.0
+    """
+
+    pass
 
 
 @dataclass

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -1,9 +1,8 @@
 import logging
 from uuid import UUID
-from typing import Dict, Optional, Type, cast
+from typing import Optional, cast
 
 from vellum.workflows.descriptors.base import BaseDescriptor
-from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
 from vellum.workflows.nodes.displayable.final_output_node import FinalOutputNode
 from vellum.workflows.nodes.utils import get_unadorned_node, get_unadorned_port
@@ -12,7 +11,6 @@ from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.utils.uuids import uuid4_from_hash
-from vellum_ee.workflows.display.base import WorkflowMetaDisplay
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
@@ -320,29 +318,3 @@ class VellumWorkflowDisplay(
             state_value_id = uuid4_from_hash(f"{self.workflow_id}|state_values|id|{state_value.name}")
 
         return StateValueVellumDisplay(id=state_value_id, name=name, required=required, color=color)
-
-    def _generate_entrypoint_display(
-        self,
-        entrypoint: Type[BaseNode],
-        workflow_display: WorkflowMetaDisplay,
-        node_displays: Dict[Type[BaseNode], BaseNodeDisplay],
-        overrides: Optional[EntrypointVellumDisplayOverrides] = None,
-    ) -> EntrypointVellumDisplay:
-        entrypoint_node_id = workflow_display.entrypoint_node_id
-
-        edge_display_overrides = overrides.edge_display if overrides else None
-        entrypoint_id = (
-            edge_display_overrides.id
-            if edge_display_overrides
-            else uuid4_from_hash(f"{self.workflow_id}|id|{entrypoint_node_id}")
-        )
-
-        entrypoint_target = get_unadorned_node(entrypoint)
-        target_node_display = node_displays[entrypoint_target]
-        target_node_id = target_node_display.node_id
-
-        edge_display = edge_display_overrides or self._generate_edge_display_from_source(
-            entrypoint_node_id, target_node_id
-        )
-
-        return EntrypointVellumDisplay(id=entrypoint_id, edge_display=edge_display)


### PR DESCRIPTION
PR we are eventually working towards: #1244

This PR just hoists all of the fields from EntrypointDisplayOverrides to EntrypointDisplay, deprecating the three redundant classes