### PR TITLE
Start codegenning the new Entrypoint Display

### DIFF
--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -335,10 +335,8 @@ export class Workflow {
                 }),
                 value: python.instantiateClass({
                   classReference: python.reference({
-                    name: "EntrypointVellumDisplayOverrides",
-                    modulePath:
-                      this.workflowContext.sdkModulePathNames
-                        .VELLUM_TYPES_MODULE_PATH,
+                    name: "EntrypointDisplay",
+                    modulePath: VELLUM_WORKFLOWS_DISPLAY_BASE_PATH,
                   }),
                   arguments_: [
                     python.methodArgument({

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -44,7 +43,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     entrypoint_displays = {
-        MostRecentMessage: EntrypointVellumDisplayOverrides(
+        MostRecentMessage: EntrypointDisplay(
             id=UUID("81ec43d2-49ec-47ce-b953-faaec3a22c63"),
             edge_display=EdgeDisplay(id=UUID("2ea073be-8a97-431d-8878-27309f0ac8c0")),
         )

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -31,7 +30,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     entrypoint_displays = {
-        ApiNode: EntrypointVellumDisplayOverrides(
+        ApiNode: EntrypointDisplay(
             id=UUID("c4ef480d-635a-49c8-900f-6583c4b79fb5"),
             edge_display=EdgeDisplay(id=UUID("8fbc728e-7408-4456-a932-001423ae8efa")),
         )

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -31,7 +30,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     entrypoint_displays = {
-        CodeExecutionNode: EntrypointVellumDisplayOverrides(
+        CodeExecutionNode: EntrypointDisplay(
             id=UUID("d49107fe-1424-42ba-9413-9ab5ce398077"),
             edge_display=EdgeDisplay(id=UUID("f9ff5d09-50a3-46bc-bca6-9f77886cc0e7")),
         )

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -34,7 +33,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         ),
     }
     entrypoint_displays = {
-        ConditionalNode: EntrypointVellumDisplayOverrides(
+        ConditionalNode: EntrypointDisplay(
             id=UUID("6dbd327c-3b96-4da4-9063-5b36dab7f6d0"),
             edge_display=EdgeDisplay(id=UUID("549da4b2-e72a-468f-b233-34efbbae75ae")),
         )

--- a/ee/codegen_integration/fixtures/simple_error_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_error_node/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -30,7 +29,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     entrypoint_displays = {
-        ErrorNode: EntrypointVellumDisplayOverrides(
+        ErrorNode: EntrypointDisplay(
             id=UUID("27a1723c-e892-4303-bbf0-c1a0428af295"),
             edge_display=EdgeDisplay(id=UUID("bcd998c4-0df4-4f59-8b15-ed1f64c5c157")),
         )

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -34,7 +33,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         ),
     }
     entrypoint_displays = {
-        GuardrailNode: EntrypointVellumDisplayOverrides(
+        GuardrailNode: EntrypointDisplay(
             id=UUID("872c757c-9544-4ad6-ada5-5ee574f1fe5e"),
             edge_display=EdgeDisplay(id=UUID("26e54d68-9d79-4551-87a4-b4e0a3dd000e")),
         )

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -1,12 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
-from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
-    WorkflowDisplayData,
-    WorkflowDisplayDataViewport,
-)
+from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 from ....nodes.subworkflow_node.nodes.final_output import FinalOutput
@@ -25,7 +21,7 @@ class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkfl
     )
     inputs_display = {}
     entrypoint_displays = {
-        SearchNode: EntrypointVellumDisplayOverrides(
+        SearchNode: EntrypointDisplay(
             id=UUID("c48f318d-4d87-44da-be54-0ecf537608f6"),
             edge_display=EdgeDisplay(id=UUID("96f14f30-7984-4bbf-af02-baf07ce38116")),
         )

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -31,7 +30,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     entrypoint_displays = {
-        SubworkflowNode: EntrypointVellumDisplayOverrides(
+        SubworkflowNode: EntrypointDisplay(
             id=UUID("48134634-f654-4a45-9f00-4e9378ab1f32"),
             edge_display=EdgeDisplay(id=UUID("ff1e812c-a62d-4ab2-90cb-0f2617d2121b")),
         )

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -38,7 +37,7 @@ class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
         ),
     }
     entrypoint_displays = {
-        TemplatingNode: EntrypointVellumDisplayOverrides(
+        TemplatingNode: EntrypointDisplay(
             id=UUID("79145e96-23c3-4763-ad7e-f3c6529fe535"),
             edge_display=EdgeDisplay(id=UUID("09c7b24f-a133-4c71-971a-15b696abfe32")),
         )

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -35,7 +34,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         ),
     }
     entrypoint_displays = {
-        CodeExecutionNode: EntrypointVellumDisplayOverrides(
+        CodeExecutionNode: EntrypointDisplay(
             id=UUID("77325e35-b73e-4596-bfb0-3cf3ddf11a2e"),
             edge_display=EdgeDisplay(id=UUID("ec1f1cb3-7221-4f7d-aaa2-0675665e201b")),
         )

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -1,12 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
-from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
-    WorkflowDisplayData,
-    WorkflowDisplayDataViewport,
-)
+from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 from ..nodes.final_output import FinalOutput
@@ -28,11 +24,11 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     )
     inputs_display = {}
     entrypoint_displays = {
-        TemplatingNode2: EntrypointVellumDisplayOverrides(
+        TemplatingNode2: EntrypointDisplay(
             id=UUID("b8b9eb69-4af1-4953-b576-aa59eb138696"),
             edge_display=EdgeDisplay(id=UUID("22106f5d-fd97-431d-9615-48278f7a954b")),
         ),
-        TemplatingNode1: EntrypointVellumDisplayOverrides(
+        TemplatingNode1: EntrypointDisplay(
             id=UUID("b8b9eb69-4af1-4953-b576-aa59eb138696"),
             edge_display=EdgeDisplay(id=UUID("2c4d2583-af8d-4fd8-972b-c850325d4158")),
         ),

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -31,7 +30,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     entrypoint_displays = {
-        PromptNode: EntrypointVellumDisplayOverrides(
+        PromptNode: EntrypointDisplay(
             id=UUID("1c05df03-f699-42e4-9816-9b1b3757c10e"),
             edge_display=EdgeDisplay(id=UUID("d56e2ecf-5a82-4e37-879c-531fdecf12f6")),
         )

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -31,7 +30,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     entrypoint_displays = {
-        PromptNode: EntrypointVellumDisplayOverrides(
+        PromptNode: EntrypointDisplay(
             id=UUID("fedbe8f4-aa63-405b-aefa-0e40e65d547e"),
             edge_display=EdgeDisplay(id=UUID("52729326-646f-454e-8940-d8d65e659d0a")),
         )

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -34,7 +33,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         ),
     }
     entrypoint_displays = {
-        SearchNode: EntrypointVellumDisplayOverrides(
+        SearchNode: EntrypointDisplay(
             id=UUID("27a1723c-e892-4303-bbf0-c1a0428af295"),
             edge_display=EdgeDisplay(id=UUID("bcd998c4-0df4-4f59-8b15-ed1f64c5c157")),
         )

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -31,7 +30,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     entrypoint_displays = {
-        SubworkflowDeployment: EntrypointVellumDisplayOverrides(
+        SubworkflowDeployment: EntrypointDisplay(
             id=UUID("39a5155a-d137-4a56-be36-d525802df463"),
             edge_display=EdgeDisplay(id=UUID("fbf75594-70e8-4e03-ae3d-a64f573df51f")),
         )

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -1,12 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
-from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
-    WorkflowDisplayData,
-    WorkflowDisplayDataViewport,
-)
+from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 from ..nodes.final_output import FinalOutput
@@ -25,7 +21,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
     )
     inputs_display = {}
     entrypoint_displays = {
-        TemplatingNode: EntrypointVellumDisplayOverrides(
+        TemplatingNode: EntrypointDisplay(
             id=UUID("6b52893a-e649-434d-aedd-e8ad73d78dce"),
             edge_display=EdgeDisplay(id=UUID("662141c0-23b1-4513-9b8a-e382e56c4021")),
         )

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
-from vellum_ee.workflows.display.base import EdgeDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplayOverrides,
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
     WorkflowInputsVellumDisplayOverrides,
@@ -31,7 +30,7 @@ class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
         )
     }
     entrypoint_displays = {
-        TemplatingNode: EntrypointVellumDisplayOverrides(
+        TemplatingNode: EntrypointDisplay(
             id=UUID("39a5155a-d137-4a56-be36-d525802df463"),
             edge_display=EdgeDisplay(id=UUID("e659e56b-89a7-49d0-b792-b27006242fe1")),
         )

--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -88,10 +88,6 @@ class EntrypointDisplayOverrides(EntrypointDisplay):
     pass
 
 
-EntrypointDisplayType = TypeVar("EntrypointDisplayType", bound=EntrypointDisplay)
-EntrypointDisplayOverridesType = TypeVar("EntrypointDisplayOverridesType", bound=EntrypointDisplayOverrides)
-
-
 @dataclass
 class WorkflowOutputDisplay:
     id: UUID

--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -31,6 +31,7 @@ from vellum.workflows.expressions.is_undefined import IsUndefinedExpression
 from vellum.workflows.expressions.not_between import NotBetweenExpression
 from vellum.workflows.expressions.parse_json import ParseJsonExpression
 from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
 from vellum.workflows.nodes.utils import get_wrapped_node
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference
@@ -50,7 +51,7 @@ from vellum_ee.workflows.display.editor.types import NodeDisplayData
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay, PortDisplayOverrides
 from vellum_ee.workflows.display.utils.expressions import get_child_descriptor
-from vellum_ee.workflows.display.utils.vellum import convert_descriptor_to_operator, primitive_to_vellum_value
+from vellum_ee.workflows.display.utils.vellum import convert_descriptor_to_operator
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.types import WorkflowDisplayContext

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -9,7 +9,6 @@ from vellum.workflows.references import OutputReference, StateValueReference, Wo
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
     EntrypointDisplay,
-    EntrypointDisplayType,
     StateValueDisplayType,
     WorkflowInputsDisplayType,
     WorkflowMetaDisplay,
@@ -36,7 +35,6 @@ class WorkflowDisplayContext(
     Generic[
         WorkflowInputsDisplayType,
         StateValueDisplayType,
-        EntrypointDisplayType,
     ]
 ):
     workflow_display_class: Type["BaseWorkflowDisplay"]

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -20,8 +20,6 @@ from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
     EntrypointDisplay,
-    EntrypointDisplayOverridesType,
-    EntrypointDisplayType,
     StateValueDisplayOverridesType,
     StateValueDisplayType,
     WorkflowInputsDisplayOverridesType,
@@ -56,8 +54,6 @@ class BaseWorkflowDisplay(
         WorkflowInputsDisplayOverridesType,
         StateValueDisplayType,
         StateValueDisplayOverridesType,
-        EntrypointDisplayType,
-        EntrypointDisplayOverridesType,
     ]
 ):
     # Used to specify the display data for a workflow.
@@ -96,7 +92,6 @@ class BaseWorkflowDisplay(
             WorkflowDisplayContext[
                 WorkflowInputsDisplayType,
                 StateValueDisplayType,
-                EntrypointDisplayType,
             ]
         ] = None,
         dry_run: bool = False,
@@ -191,7 +186,6 @@ class BaseWorkflowDisplay(
     ) -> WorkflowDisplayContext[
         WorkflowInputsDisplayType,
         StateValueDisplayType,
-        EntrypointDisplayType,
     ]:
         workflow_meta_display = self._generate_workflow_meta_display()
 

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -11,14 +11,12 @@ from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.utils.uuids import uuid4_from_hash
+from vellum_ee.workflows.display.editor.types import NodeDisplayData
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.utils.vellum import infer_vellum_variable_type
 from vellum_ee.workflows.display.vellum import (
-    EntrypointVellumDisplay,
-    EntrypointVellumDisplayOverrides,
-    NodeDisplayData,
     StateValueVellumDisplay,
     StateValueVellumDisplayOverrides,
     WorkflowInputsVellumDisplay,
@@ -36,8 +34,6 @@ class VellumWorkflowDisplay(
         WorkflowInputsVellumDisplayOverrides,
         StateValueVellumDisplay,
         StateValueVellumDisplayOverrides,
-        EntrypointVellumDisplay,
-        EntrypointVellumDisplayOverrides,
     ]
 ):
     node_display_base_class = BaseNodeDisplay


### PR DESCRIPTION
PR we are eventually working towards: #1244

This PR starts codegenning the lone EntrypointDisplay type. I'm actually going to cut off the above PR here, as some of the node input stuff in that PR is less certain and likely will look different once we start generalizing all node attributes -> node inputs