### PR TITLE
Hoist up state displays from VellumWorkflowDisplay to BaseWorkflowDisplay

### DIFF
--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from uuid import UUID
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 from pydantic import Field
 
@@ -50,12 +50,18 @@ WorkflowInputsDisplayOverridesType = TypeVar("WorkflowInputsDisplayOverridesType
 
 
 @dataclass
-class StateValueDisplayOverrides:
+class StateValueDisplay:
     id: UUID
+    name: Optional[str] = None
+    color: Optional[str] = None
 
 
 @dataclass
-class StateValueDisplay(StateValueDisplayOverrides):
+class StateValueDisplayOverrides(StateValueDisplay):
+    """
+    DEPRECATED: Use StateValueDisplay instead. Will be removed in 0.15.0
+    """
+
     pass
 
 
@@ -85,6 +91,10 @@ class EntrypointDisplay:
 
 @dataclass
 class EntrypointDisplayOverrides(EntrypointDisplay):
+    """
+    DEPRECATED: Use EntrypointDisplay instead. Will be removed in 0.15.0
+    """
+
     pass
 
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
@@ -1,19 +1,20 @@
 import pytest
 from uuid import uuid4
-from typing import Any, Dict, Tuple, Type
+from typing import Any, Dict, Type
 
-from vellum.workflows.nodes.bases.base import BaseNode
-from vellum.workflows.references.output import OutputReference
-from vellum.workflows.references.state_value import StateValueReference
 from vellum.workflows.references.workflow_input import WorkflowInputReference
 from vellum.workflows.types.core import JsonObject
 from vellum.workflows.types.generics import NodeType
-from vellum_ee.workflows.display.base import StateValueDisplayType, WorkflowInputsDisplayType
+from vellum_ee.workflows.display.base import WorkflowInputsDisplayType
 from vellum_ee.workflows.display.editor.types import NodeDisplayData
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
-from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
-from vellum_ee.workflows.display.types import WorkflowDisplayContext
+from vellum_ee.workflows.display.types import (
+    NodeDisplays,
+    NodeOutputDisplays,
+    StateValueDisplays,
+    WorkflowDisplayContext,
+)
 from vellum_ee.workflows.display.vellum import WorkflowMetaVellumDisplay
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
@@ -24,9 +25,9 @@ def serialize_node():
         node_class: Type[NodeType],
         base_class: type[BaseNodeDisplay[Any]] = BaseNodeDisplay,
         global_workflow_input_displays: Dict[WorkflowInputReference, WorkflowInputsDisplayType] = {},
-        global_state_value_displays: Dict[StateValueReference, StateValueDisplayType] = {},
-        global_node_displays: Dict[Type[BaseNode], BaseNodeDisplay] = {},
-        global_node_output_displays: Dict[OutputReference, Tuple[Type[BaseNode], NodeOutputDisplay]] = {},
+        global_state_value_displays: StateValueDisplays = {},
+        global_node_displays: NodeDisplays = {},
+        global_node_output_displays: NodeOutputDisplays = {},
     ) -> JsonObject:
         node_display_class = get_node_display_class(base_class, node_class)
         node_display = node_display_class()

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_default_state_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_default_state_serialization.py
@@ -50,7 +50,7 @@ def test_serialize_workflow():
                 "key": "example",
                 "type": "NUMBER",
                 "default": {"type": "NUMBER", "value": 5.0},
-                "required": True,
+                "required": False,
                 "extensions": {"color": None},
             },
         ],

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -9,6 +9,7 @@ from vellum.workflows.references import OutputReference, StateValueReference, Wo
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
     EntrypointDisplay,
+    StateValueDisplay,
     StateValueDisplayType,
     WorkflowInputsDisplayType,
     WorkflowMetaDisplay,
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
 
 WorkflowDisplayType = TypeVar("WorkflowDisplayType", bound="BaseWorkflowDisplay")
 
+StateValueDisplays = Dict[StateValueReference, StateValueDisplay]
 NodeDisplays = Dict[Type[BaseNode], BaseNodeDisplay]
 NodeOutputDisplays = Dict[OutputReference, Tuple[Type[BaseNode], NodeOutputDisplay]]
 EntrypointDisplays = Dict[Type[BaseNode], EntrypointDisplay]
@@ -43,8 +45,8 @@ class WorkflowDisplayContext(
     global_workflow_input_displays: Dict[WorkflowInputReference, WorkflowInputsDisplayType] = field(
         default_factory=dict
     )
-    state_value_displays: Dict[StateValueReference, StateValueDisplayType] = field(default_factory=dict)
-    global_state_value_displays: Dict[StateValueReference, StateValueDisplayType] = field(default_factory=dict)
+    state_value_displays: StateValueDisplays = field(default_factory=dict)
+    global_state_value_displays: StateValueDisplays = field(default_factory=dict)
     node_displays: NodeDisplays = field(default_factory=dict)
     global_node_displays: NodeDisplays = field(default_factory=dict)
     global_node_output_displays: NodeOutputDisplays = field(default_factory=dict)

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -6,7 +6,6 @@ from vellum.core import UniversalBaseModel
 from vellum_ee.workflows.display.base import (
     EdgeDisplayOverrides,
     EntrypointDisplayOverrides,
-    StateValueDisplay,
     StateValueDisplayOverrides,
     WorkflowInputsDisplay,
     WorkflowInputsDisplayOverrides,
@@ -57,14 +56,20 @@ class WorkflowInputsVellumDisplay(WorkflowInputsVellumDisplayOverrides):
 
 
 @dataclass
-class StateValueVellumDisplayOverrides(StateValueDisplay, StateValueDisplayOverrides):
-    name: Optional[str] = None
+class StateValueVellumDisplayOverrides(StateValueDisplayOverrides):
+    """
+    DEPRECATED: Use StateValueDisplay instead. Will be removed in 0.15.0
+    """
+
     required: Optional[bool] = None
-    color: Optional[str] = None
 
 
 @dataclass
 class StateValueVellumDisplay(StateValueVellumDisplayOverrides):
+    """
+    DEPRECATED: Use StateValueDisplay instead. Will be removed in 0.15.0
+    """
+
     pass
 
 

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -20,6 +20,7 @@ from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
     EntrypointDisplay,
+    StateValueDisplay,
     StateValueDisplayOverridesType,
     StateValueDisplayType,
     WorkflowInputsDisplayOverridesType,
@@ -39,6 +40,7 @@ from vellum_ee.workflows.display.types import (
     NodeDisplays,
     NodeOutputDisplays,
     PortDisplays,
+    StateValueDisplays,
     WorkflowDisplayContext,
     WorkflowOutputDisplays,
 )
@@ -232,7 +234,7 @@ class BaseWorkflowDisplay(
             workflow_input_displays[workflow_input] = input_display
             global_workflow_input_displays[workflow_input] = input_display
 
-        state_value_displays: Dict[StateValueReference, StateValueDisplayType] = {}
+        state_value_displays: StateValueDisplays = {}
         global_state_value_displays = (
             copy(self._parent_display_context.global_state_value_displays) if self._parent_display_context else {}
         )
@@ -327,11 +329,20 @@ class BaseWorkflowDisplay(
     ) -> WorkflowInputsDisplayType:
         pass
 
-    @abstractmethod
     def _generate_state_value_display(
-        self, state_value: StateValueReference, overrides: Optional[StateValueDisplayOverridesType] = None
-    ) -> StateValueDisplayType:
-        pass
+        self, state_value: BaseDescriptor, overrides: Optional[StateValueDisplay] = None
+    ) -> StateValueDisplay:
+        state_value_id: UUID
+        name = None
+        color = None
+        if overrides:
+            state_value_id = overrides.id
+            name = overrides.name
+            color = overrides.color
+        else:
+            state_value_id = uuid4_from_hash(f"{self.workflow_id}|state_values|id|{state_value.name}")
+
+        return StateValueDisplay(id=state_value_id, name=name, color=color)
 
     def _generate_entrypoint_display(
         self,


### PR DESCRIPTION
A continuation of a lot of our display consolidation work - this time for state displays.

After this will just be input displays and we could then remove `VellumWorkflowDisplay` entirely, `BaseVellumNodeDisplay` soon after