### PR TITLE
Clean up legacy State Value Display types

### DIFF
--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -65,10 +65,6 @@ class StateValueDisplayOverrides(StateValueDisplay):
     pass
 
 
-StateValueDisplayType = TypeVar("StateValueDisplayType", bound=StateValueDisplay)
-StateValueDisplayOverridesType = TypeVar("StateValueDisplayOverridesType", bound=StateValueDisplayOverrides)
-
-
 @dataclass
 class EdgeDisplay:
     id: UUID

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -10,7 +10,6 @@ from vellum_ee.workflows.display.base import (
     EdgeDisplay,
     EntrypointDisplay,
     StateValueDisplay,
-    StateValueDisplayType,
     WorkflowInputsDisplayType,
     WorkflowMetaDisplay,
     WorkflowOutputDisplay,
@@ -33,12 +32,7 @@ PortDisplays = Dict[Port, PortDisplay]
 
 
 @dataclass
-class WorkflowDisplayContext(
-    Generic[
-        WorkflowInputsDisplayType,
-        StateValueDisplayType,
-    ]
-):
+class WorkflowDisplayContext(Generic[WorkflowInputsDisplayType,]):
     workflow_display_class: Type["BaseWorkflowDisplay"]
     workflow_display: WorkflowMetaDisplay
     workflow_input_displays: Dict[WorkflowInputReference, WorkflowInputsDisplayType] = field(default_factory=dict)

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -13,7 +13,7 @@ from vellum.workflows.events.workflow import NodeEventDisplayContext, WorkflowEv
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.utils import get_unadorned_node, get_wrapped_node
 from vellum.workflows.ports import Port
-from vellum.workflows.references import OutputReference, StateValueReference, WorkflowInputReference
+from vellum.workflows.references import OutputReference, WorkflowInputReference
 from vellum.workflows.types.core import JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.utils.uuids import uuid4_from_hash
@@ -21,8 +21,6 @@ from vellum_ee.workflows.display.base import (
     EdgeDisplay,
     EntrypointDisplay,
     StateValueDisplay,
-    StateValueDisplayOverridesType,
-    StateValueDisplayType,
     WorkflowInputsDisplayOverridesType,
     WorkflowInputsDisplayType,
     WorkflowMetaDisplay,
@@ -54,8 +52,6 @@ class BaseWorkflowDisplay(
         WorkflowType,
         WorkflowInputsDisplayType,
         WorkflowInputsDisplayOverridesType,
-        StateValueDisplayType,
-        StateValueDisplayOverridesType,
     ]
 ):
     # Used to specify the display data for a workflow.
@@ -65,7 +61,7 @@ class BaseWorkflowDisplay(
     inputs_display: Dict[WorkflowInputReference, WorkflowInputsDisplayOverridesType] = {}
 
     # Used to explicitly specify display data for a workflow's state values.
-    state_value_displays: Dict[StateValueReference, StateValueDisplayOverridesType] = {}
+    state_value_displays: StateValueDisplays = {}
 
     # Used to explicitly specify display data for a workflow's entrypoints.
     entrypoint_displays: EntrypointDisplays = {}
@@ -90,12 +86,7 @@ class BaseWorkflowDisplay(
         self,
         workflow: Type[WorkflowType],
         *,
-        parent_display_context: Optional[
-            WorkflowDisplayContext[
-                WorkflowInputsDisplayType,
-                StateValueDisplayType,
-            ]
-        ] = None,
+        parent_display_context: Optional[WorkflowDisplayContext[WorkflowInputsDisplayType,]] = None,
         dry_run: bool = False,
     ):
         self._workflow = workflow
@@ -185,10 +176,7 @@ class BaseWorkflowDisplay(
     @cached_property
     def display_context(
         self,
-    ) -> WorkflowDisplayContext[
-        WorkflowInputsDisplayType,
-        StateValueDisplayType,
-    ]:
+    ) -> WorkflowDisplayContext[WorkflowInputsDisplayType]:
         workflow_meta_display = self._generate_workflow_meta_display()
 
         global_node_output_displays: NodeOutputDisplays = (

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -15,12 +15,7 @@ from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.utils.vellum import infer_vellum_variable_type
-from vellum_ee.workflows.display.vellum import (
-    StateValueVellumDisplay,
-    StateValueVellumDisplayOverrides,
-    WorkflowInputsVellumDisplay,
-    WorkflowInputsVellumDisplayOverrides,
-)
+from vellum_ee.workflows.display.vellum import WorkflowInputsVellumDisplay, WorkflowInputsVellumDisplayOverrides
 from vellum_ee.workflows.display.workflows.base_workflow_display import BaseWorkflowDisplay
 
 logger = logging.getLogger(__name__)
@@ -31,8 +26,6 @@ class VellumWorkflowDisplay(
         WorkflowType,
         WorkflowInputsVellumDisplay,
         WorkflowInputsVellumDisplayOverrides,
-        StateValueVellumDisplay,
-        StateValueVellumDisplayOverrides,
     ]
 ):
     node_display_base_class = BaseNodeDisplay


### PR DESCRIPTION
This PR was originally going to fix codegen for StateValueDisplays, but I realized that we aren't codegenning StateValueDisplays atm. So this PR just cleans up the remaining legacy StateValueDisplay generics