### PR TITLE
Build resilience to code execution node workspace secret not found errors

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -94,6 +94,24 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
 "
 `;
 
+exports[`CodeExecutionNode > basic secret node > should be resilient to invalid secret ids 1`] = `
+"from vellum.workflows.nodes.displayable import (
+    CodeExecutionNode as BaseCodeExecutionNode,
+)
+from vellum.workflows.references import VellumSecretReference
+from vellum.workflows.state import BaseState
+
+
+class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
+    filepath = "./script.py"
+    code_inputs = {
+        "secret_arg": VellumSecretReference("5678"),
+    }
+    runtime = "PYTHON_3_11_6"
+    packages = None
+"
+`;
+
 exports[`CodeExecutionNode > code representation override: Base case > should generate the correct node class when the override is INLINE 1`] = `
 "from vellum.workflows.nodes.displayable import CodeExecutionNode as BaseCodeExecutionNode
 from vellum.workflows.state import BaseState

--- a/ee/codegen/src/context/node-context/api-node.ts
+++ b/ee/codegen/src/context/node-context/api-node.ts
@@ -1,4 +1,3 @@
-import { WorkspaceSecrets as WorkspaceSecretsClient } from "vellum-ai/api/resources/workspaceSecrets/client/Client";
 import { VellumError } from "vellum-ai/errors";
 
 import { BaseNodeContext } from "src/context/node-context/base";
@@ -43,11 +42,9 @@ export class ApiNodeContext extends BaseNodeContext<ApiNodeType> {
       return;
     }
     try {
-      const tokenItem = await new WorkspaceSecretsClient({
-        apiKey: this.workflowContext.vellumApiKey,
-        environment: this.workflowContext.vellumApiEnvironment,
-      }).retrieve(inputRule.data.workspaceSecretId);
-      inputRule.data.workspaceSecretId = tokenItem.name;
+      await this.workflowContext.loadWorkspaceSecret(
+        inputRule.data.workspaceSecretId
+      );
     } catch (e) {
       if (e instanceof VellumError && e.statusCode === 404) {
         this.workflowContext.addError(

--- a/ee/codegen/src/context/node-context/code-execution-node.ts
+++ b/ee/codegen/src/context/node-context/code-execution-node.ts
@@ -1,5 +1,4 @@
 import { CodeExecutionRuntime } from "vellum-ai/api";
-import { WorkspaceSecrets as WorkspaceSecretsClient } from "vellum-ai/api/resources/workspaceSecrets/client/Client";
 import { VellumError } from "vellum-ai/errors";
 
 import { BaseNodeContext } from "./base";
@@ -114,15 +113,16 @@ export class CodeExecutionContext extends BaseNodeContext<CodeExecutionNodeType>
       return;
     }
     try {
-      const tokenItem = await new WorkspaceSecretsClient({
-        apiKey: this.workflowContext.vellumApiKey,
-        environment: this.workflowContext.vellumApiEnvironment,
-      }).retrieve(inputRule.data.workspaceSecretId);
-      inputRule.data.workspaceSecretId = tokenItem.name;
+      await this.workflowContext.loadWorkspaceSecret(
+        inputRule.data.workspaceSecretId
+      );
     } catch (e) {
       if (e instanceof VellumError && e.statusCode === 404) {
         this.workflowContext.addError(
-          new EntityNotFoundError(`Workspace Secret "${input.key}" not found.`)
+          new EntityNotFoundError(
+            `Workspace Secret mapped to input "${input.key}" not found.`,
+            "WARNING"
+          )
         );
       } else {
         throw e;

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -525,11 +525,7 @@ export class WorkflowContext {
     this.loadedWorkspaceSecretsById[workspaceSecretId] = workspaceSecret;
   }
 
-  public getWorkspaceSecretName(workspaceSecretId?: string): string {
-    if (!workspaceSecretId) {
-      return "";
-    }
-
+  public getWorkspaceSecretName(workspaceSecretId: string): string {
     return (
       this.loadedWorkspaceSecretsById[workspaceSecretId]?.name ??
       workspaceSecretId

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.ts
@@ -9,7 +9,9 @@ export class WorkspaceSecretPointerRule extends BaseNodeInputValuePointerRule<Wo
   getAstNode(): python.AstNode {
     const workspaceSecretPointerData = this.nodeInputValuePointerRule.data;
 
-    const workspaceSecretName = workspaceSecretPointerData.workspaceSecretId;
+    const workspaceSecretName = this.workflowContext.getWorkspaceSecretName(
+      workspaceSecretPointerData.workspaceSecretId
+    );
 
     if (isNil(workspaceSecretName)) {
       return python.TypeInstantiation.none();

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.ts
@@ -9,6 +9,10 @@ export class WorkspaceSecretPointerRule extends BaseNodeInputValuePointerRule<Wo
   getAstNode(): python.AstNode {
     const workspaceSecretPointerData = this.nodeInputValuePointerRule.data;
 
+    if (!workspaceSecretPointerData.workspaceSecretId) {
+      return python.TypeInstantiation.none();
+    }
+
     const workspaceSecretName = this.workflowContext.getWorkspaceSecretName(
       workspaceSecretPointerData.workspaceSecretId
     );


### PR DESCRIPTION
Gonna start burning down the files in this PR to prevent these errors from failing codegen and appearing in sentry: https://github.com/vellum-ai/vellum-python-sdks/pull/1003/files

This one focuses on Workspace Secret loading in codegen, and additionally introduces Workflow level entity caching