### PR TITLE
Fix vellumApiEnvironment types

### DIFF
--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -1,4 +1,4 @@
-import { VellumEnvironment } from "vellum-ai";
+import { VellumEnvironment, VellumEnvironmentUrls } from 'vellum-ai';
 import { MlModels } from "vellum-ai/api/resources/mlModels/client/Client";
 
 import { GENERATED_WORKFLOW_MODULE_NAME } from "src/constants";
@@ -50,7 +50,7 @@ export declare namespace WorkflowContext {
     workflowsSdkModulePath?: readonly string[];
     portContextByName?: PortContextById;
     vellumApiKey: string;
-    vellumApiEnvironment?: VellumEnvironment;
+    vellumApiEnvironment?: VellumEnvironmentUrls;
     workflowRawData: WorkflowRawData;
     strict: boolean;
     codeExecutionNodeCodeRepresentationOverride: "STANDALONE" | "INLINE";
@@ -113,7 +113,7 @@ export class WorkflowContext {
 
   // Used by the vellum api client
   public readonly vellumApiKey: string;
-  public readonly vellumApiEnvironment?: VellumEnvironment;
+  public readonly vellumApiEnvironment?: VellumEnvironmentUrls;
   private readonly mlModelNamesById: Record<string, string> = {};
   private readonly errors: BaseCodegenError[] = [];
 

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -1,4 +1,4 @@
-import { VellumEnvironment, VellumEnvironmentUrls } from 'vellum-ai';
+import { VellumEnvironmentUrls } from "vellum-ai";
 import { MlModels } from "vellum-ai/api/resources/mlModels/client/Client";
 
 import { GENERATED_WORKFLOW_MODULE_NAME } from "src/constants";

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -5,7 +5,7 @@ import { python } from "@fern-api/python-ast";
 import { Comment } from "@fern-api/python-ast/Comment";
 import { StarImport } from "@fern-api/python-ast/StarImport";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { VellumEnvironment, VellumEnvironmentUrls } from 'vellum-ai';
+import { VellumEnvironmentUrls } from "vellum-ai";
 
 import * as codegen from "./codegen";
 import {

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -5,7 +5,7 @@ import { python } from "@fern-api/python-ast";
 import { Comment } from "@fern-api/python-ast/Comment";
 import { StarImport } from "@fern-api/python-ast/StarImport";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { VellumEnvironment } from "vellum-ai";
+import { VellumEnvironment, VellumEnvironmentUrls } from 'vellum-ai';
 
 import * as codegen from "./codegen";
 import {
@@ -112,7 +112,7 @@ export declare namespace WorkflowProjectGenerator {
     workflowsSdkModulePath?: readonly string[];
     workflowVersionExecConfigData: unknown;
     vellumApiKey?: string;
-    vellumApiEnvironment?: VellumEnvironment;
+    vellumApiEnvironment?: VellumEnvironmentUrls;
     sandboxInputs?: WorkflowSandboxInputs[];
     options?: WorkflowProjectGeneratorOptions;
   }


### PR DESCRIPTION
VellumEnvironment has static string types as it's = `typeof VellumEnvironment.Production` and isn't useable by codegen service