### PR TITLE
Simplify execution context serialization across relevant nodes

### DIFF
--- a/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
@@ -87,15 +87,11 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
 
     def _get_prompt_event_stream(self) -> Iterator[AdHocExecutePromptEvent]:
         input_variables, input_values = self._compile_prompt_inputs()
-        current_context = get_execution_context()
-        parent_context = (
-            current_context.parent_context.model_dump(mode="json") if current_context.parent_context else None
-        )
-        trace_id = current_context.trace_id
+        execution_context = get_execution_context()
         request_options = self.request_options or RequestOptions()
 
         request_options["additional_body_parameters"] = {
-            "execution_context": {"parent_context": parent_context, "trace_id": trace_id},
+            "execution_context": execution_context.model_dump(mode="json"),
             **request_options.get("additional_body_parameters", {}),
         }
         normalized_functions = (

--- a/src/vellum/workflows/nodes/displayable/bases/prompt_deployment_node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/prompt_deployment_node.py
@@ -55,12 +55,10 @@ class BasePromptDeploymentNode(BasePromptNode, Generic[StateType]):
         merge_behavior = MergeBehavior.AWAIT_ANY
 
     def _get_prompt_event_stream(self) -> Iterator[ExecutePromptEvent]:
-        current_context = get_execution_context()
-        trace_id = current_context.trace_id
-        parent_context = current_context.parent_context.model_dump() if current_context.parent_context else None
+        execution_context = get_execution_context()
         request_options = self.request_options or RequestOptions()
         request_options["additional_body_parameters"] = {
-            "execution_context": {"parent_context": parent_context, "trace_id": trace_id},
+            "execution_context": execution_context.model_dump(mode="json"),
             **request_options.get("additional_body_parameters", {}),
         }
         return self._context.vellum_client.execute_prompt_stream(

--- a/src/vellum/workflows/nodes/displayable/subworkflow_deployment_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/subworkflow_deployment_node/node.py
@@ -122,13 +122,10 @@ class SubworkflowDeploymentNode(BaseNode[StateType], Generic[StateType]):
         return compiled_inputs
 
     def run(self) -> Iterator[BaseOutput]:
-        current_context = get_execution_context()
-        parent_context = (
-            current_context.parent_context.model_dump(mode="json") if current_context.parent_context else None
-        )
+        execution_context = get_execution_context()
         request_options = self.request_options or RequestOptions()
         request_options["additional_body_parameters"] = {
-            "execution_context": {"parent_context": parent_context, "trace_id": current_context.trace_id},
+            "execution_context": execution_context.model_dump(mode="json"),
             **request_options.get("additional_body_parameters", {}),
         }
 

--- a/tests/workflows/basic_prompt_deployment/tests/test_workflow.py
+++ b/tests/workflows/basic_prompt_deployment/tests/test_workflow.py
@@ -88,10 +88,9 @@ def test_run_workflow__happy_path(vellum_client):
     )
     trace_id = call_kwargs["request_options"]["additional_body_parameters"]["execution_context"]["trace_id"]
     assert trace_id is not None
-    assert (
-        parent_context["node_definition"]
-        == VellumCodeResourceDefinition.encode(ExamplePromptDeploymentNode).model_dump()
-    )
+    assert parent_context["node_definition"] == VellumCodeResourceDefinition.encode(
+        ExamplePromptDeploymentNode
+    ).model_dump(mode="json")
 
 
 def test_run_workflow_return_only_function_call__happy_path(vellum_client):
@@ -154,10 +153,9 @@ def test_run_workflow_return_only_function_call__happy_path(vellum_client):
         "parent_context"
     )
     assert call_kwargs["request_options"]["additional_body_parameters"]["execution_context"]["trace_id"] is not None
-    assert (
-        parent_context["node_definition"]
-        == VellumCodeResourceDefinition.encode(ExamplePromptDeploymentNode).model_dump()
-    )
+    assert parent_context["node_definition"] == VellumCodeResourceDefinition.encode(
+        ExamplePromptDeploymentNode
+    ).model_dump(mode="json")
 
 
 def test_stream_workflow__happy_path(vellum_client):

--- a/tests/workflows/basic_text_prompt_deployment/tests/test_workflow.py
+++ b/tests/workflows/basic_text_prompt_deployment/tests/test_workflow.py
@@ -83,10 +83,9 @@ def test_run_workflow__happy_path(vellum_client):
     parent_context = call_kwargs["request_options"]["additional_body_parameters"]["execution_context"].get(
         "parent_context"
     )
-    assert (
-        parent_context["node_definition"]
-        == VellumCodeResourceDefinition.encode(ExamplePromptDeploymentNode).model_dump()
-    )
+    assert parent_context["node_definition"] == VellumCodeResourceDefinition.encode(
+        ExamplePromptDeploymentNode
+    ).model_dump(mode="json")
 
 
 def test_stream_workflow__happy_path(vellum_client):


### PR DESCRIPTION
cleans up our execution context serialization to just model dumping from the jump