### PR TITLE
Log info stack traces for user errors

### DIFF
--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -321,6 +321,7 @@ class WorkflowRunner(Generic[StateType]):
                 )
             )
         except NodeException as e:
+            logger.info(e)
             self._workflow_event_inner_queue.put(
                 NodeExecutionRejectedEvent(
                     trace_id=node.state.meta.trace_id,
@@ -333,6 +334,7 @@ class WorkflowRunner(Generic[StateType]):
                 )
             )
         except WorkflowInitializationException as e:
+            logger.info(e)
             self._workflow_event_inner_queue.put(
                 NodeExecutionRejectedEvent(
                     trace_id=node.state.meta.trace_id,


### PR DESCRIPTION
Kinda annoying just seeing "internal server error" in the logs. I want the traces when I'm debugging. Could enable this for vembda only or move them up to where they are thrown.