### PR TITLE
Fix inspect.getfile within the context of vembda

### DIFF
--- a/ee/vellum_ee/workflows/server/virtual_file_loader.py
+++ b/ee/vellum_ee/workflows/server/virtual_file_loader.py
@@ -1,5 +1,7 @@
 import importlib
+from importlib.machinery import ModuleSpec
 import re
+import sys
 from typing import Optional
 
 
@@ -8,11 +10,20 @@ class VirtualFileLoader(importlib.abc.Loader):
         self.files = files
         self.namespace = namespace
 
-    def create_module(self, spec):
-        return None  # use default module creation
+    def create_module(self, spec: ModuleSpec):
+        """
+        We started with cpython/Lib/importlib/_bootstrap.py::FrozenImporter::create_module here
+
+        https://github.com/python/cpython/blob/053c285f6b41f92fbdd1d4ff0c959cceefacd7cd/Lib/importlib/_bootstrap.py#L1160C1-L1169C22
+
+        and reduced our needs to just updating the __file__ attribute directly.
+        """
+        module = type(sys)(spec.name)
+        module.__file__ = spec.origin
+        return module
 
     def exec_module(self, module):
-        module_info = self._resolve_module(module.__spec__.origin)
+        module_info = self._resolve_module(module.__spec__.name)
 
         if module_info:
             file_path, code = module_info
@@ -66,7 +77,8 @@ class VirtualFileFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
             return importlib.machinery.ModuleSpec(
                 fullname,
                 self.loader,
-                origin=fullname,
+                origin=file_path,
                 is_package=is_package,
             )
+
         return None

--- a/ee/vellum_ee/workflows/tests/test_server.py
+++ b/ee/vellum_ee/workflows/tests/test_server.py
@@ -4,9 +4,16 @@ from uuid import uuid4
 from typing import Type, cast
 
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
+from vellum.client.types.code_executor_response import CodeExecutorResponse
+from vellum.client.types.number_vellum_value import NumberVellumValue
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.nodes import BaseNode
 from vellum_ee.workflows.server.virtual_file_loader import VirtualFileFinder
+
+
+@pytest.fixture
+def mock_open(mocker):
+    return mocker.patch("vellum.workflows.nodes.displayable.code_execution_node.utils.open")
 
 
 def test_load_workflow_event_display_context():
@@ -72,9 +79,16 @@ class StartNode(BaseNode):
     assert start_node.foo.instance.name == "StartNode.Outputs.bar"
 
 
-@pytest.mark.skip(reason="Code execution inspect and get read file from path needs to be fixed")
-def test_load_from_module__ts_code_in_file_loader():
-    # GIVEN a workflow module with only a code execution node
+def test_load_from_module__ts_code_in_file_loader(
+    mock_open,
+    vellum_client,
+):
+    # GIVEN typescript code
+    ts_code = """async function main(): any {
+  return 5;
+}"""
+
+    # AND a workflow module with only a code execution node
     files = {
         "__init__.py": "",
         "workflow.py": """\
@@ -95,24 +109,29 @@ from typing import Any
 from vellum.workflows.nodes.displayable import CodeExecutionNode as BaseCodeExecutionNode
 from vellum.workflows.state import BaseState
 
-class CodeExecutionNode(BaseCodeExecutionNode[BaseState, Any]):
+class CodeExecutionNode(BaseCodeExecutionNode[BaseState, int]):
     filepath = "./script.ts"
     code_inputs = {}
     runtime = "TYPESCRIPT_5_3_3"
     packages = []
 """,
-        "nodes/code_execution_node/script.ts": """async function main(inputs: {
-  text: string,
-}): any {
-  const matches = inputs.text.match(/\\((.+?)\\)/gs);
-  return matches;
-}""",
+        "nodes/code_execution_node/script.ts": ts_code,
     }
 
     namespace = str(uuid4())
 
     # AND the virtual file loader is registered
     sys.meta_path.append(VirtualFileFinder(files, namespace))
+
+    # AND the open function returns our file content
+    mock_open.return_value.__enter__.return_value.read.return_value = ts_code
+
+    # AND we know what the Code Execution Node will respond with
+    mock_code_execution = CodeExecutorResponse(
+        log="hello",
+        output=NumberVellumValue(value=5),
+    )
+    vellum_client.execute_code.return_value = mock_code_execution
 
     # WHEN the workflow is loaded
     Workflow = BaseWorkflow.load_from_module(namespace)
@@ -122,4 +141,10 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, Any]):
     assert workflow
 
     event = workflow.run()
-    assert event.name == "workflow.execution.fulfilled"
+    assert event.name == "workflow.execution.fulfilled", event.model_dump_json()
+
+    # AND we pass in the correct file path to the open function
+    assert mock_open.call_args[0][0] == f"{namespace}/nodes/./script.ts"
+
+    # AND we invoke the Code Execution Node with the correct code
+    assert vellum_client.execute_code.call_args.kwargs["code"] == ts_code

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
@@ -14,10 +14,11 @@ def read_file_from_path(node_filepath: str, script_filepath: str) -> Union[str, 
     node_filepath_dir = os.path.dirname(node_filepath)
     full_filepath = os.path.join(node_filepath_dir, script_filepath)
 
-    if os.path.isfile(full_filepath):
+    try:
         with open(full_filepath) as file:
             return file.read()
-    return None
+    except (FileNotFoundError, IsADirectoryError):
+        return None
 
 
 class ListWrapper(list):


### PR DESCRIPTION
Getting Code nodes to be codegen'd for vembda is blocked on two issues:
- `inspect.getfile()`
- `open`

This PR solves the first, and updates our test to mock out the second