### PR TITLE
Add support for any future parent context

### DIFF
--- a/src/vellum/workflows/events/tests/test_event.py
+++ b/src/vellum/workflows/events/tests/test_event.py
@@ -419,3 +419,38 @@ mock_node_uuid = str(uuid4_from_hash(MockNode.__qualname__))
 )
 def test_event_serialization(event, expected_json):
     assert not DeepDiff(event.model_dump(mode="json"), expected_json)
+
+
+def test_event__deserialize_from_json__invalid_parent_context():
+    # GIVEN an event with a parent context that Vellum is introducing in the future
+    data = {
+        "id": "123e4567-e89b-12d3-a456-426614174000",
+        "api_version": "2024-10-25",
+        "timestamp": "2024-01-01T12:00:00",
+        "trace_id": "123e4567-e89b-12d3-a456-426614174000",
+        "span_id": "123e4567-e89b-12d3-a456-426614174000",
+        "name": "node.execution.fulfilled",
+        "body": {
+            "node_definition": {
+                "id": mock_node_uuid,
+                "name": "MockNode",
+                "module": module_root + ["events", "tests", "test_event"],
+            },
+            "outputs": {},
+        },
+        "parent": {
+            "type": "SOME_FUTURE_ENTITY",
+            "span_id": "123e4567-e89b-12d3-a456-426614174000",
+            "some_randome_field": "some_random_value",
+            "parent": None,
+        },
+    }
+
+    # WHEN the event is deserialized
+    event = NodeExecutionFulfilledEvent.model_validate(data)
+
+    # THEN the event is deserialized correctly
+    assert event.parent
+    assert event.parent.type == "UNKNOWN"
+    assert event.parent.span_id == "123e4567-e89b-12d3-a456-426614174000"
+    assert event.parent.parent is None


### PR DESCRIPTION
Last time we introduce a new parent context, it took down (live) workflows.

This should make all _future_ added parent contexts, which we know we need to soon add (test suite, test case, metric), so that we are always backwards compatible and casting to some safer `UNKNOWN` parent context, that uses just the span id.