### PR TITLE
Fix Prompt Node bug where empty arrays are assumed to be chat history

### DIFF
--- a/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
@@ -140,8 +140,10 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
                         value=input_value,
                     )
                 )
-            elif isinstance(input_value, list) and all(
-                isinstance(message, (ChatMessage, ChatMessageRequest)) for message in input_value
+            elif (
+                input_value
+                and isinstance(input_value, list)
+                and all(isinstance(message, (ChatMessage, ChatMessageRequest)) for message in input_value)
             ):
                 chat_history = [
                     message if isinstance(message, ChatMessage) else ChatMessage.model_validate(message.model_dump())

--- a/src/vellum/workflows/nodes/displayable/bases/prompt_deployment_node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/prompt_deployment_node.py
@@ -91,8 +91,10 @@ class BasePromptDeploymentNode(BasePromptNode, Generic[StateType]):
                         value=input_value,
                     )
                 )
-            elif isinstance(input_value, list) and all(
-                isinstance(message, (ChatMessage, ChatMessageRequest)) for message in input_value
+            elif (
+                input_value
+                and isinstance(input_value, list)
+                and all(isinstance(message, (ChatMessage, ChatMessageRequest)) for message in input_value)
             ):
                 chat_history = [
                     (

--- a/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/inline_prompt_node/tests/test_node.py
@@ -44,6 +44,7 @@ def test_inline_prompt_node__json_inputs(vellum_adhoc_prompt_client):
             "a_list": [1, 2, 3],
             "a_dataclass": MyDataClass(hello="world"),
             "a_pydantic": MyPydantic(example="example"),
+            "an_empty_list": [],
         }
 
     # AND a known response from invoking an inline prompt
@@ -75,8 +76,9 @@ def test_inline_prompt_node__json_inputs(vellum_adhoc_prompt_client):
         PromptRequestJsonInput(key="a_list", type="JSON", value=[1, 2, 3]),
         PromptRequestJsonInput(key="a_dataclass", type="JSON", value={"hello": "world"}),
         PromptRequestJsonInput(key="a_pydantic", type="JSON", value={"example": "example"}),
+        PromptRequestJsonInput(key="an_empty_list", type="JSON", value=[]),
     ]
-    assert len(mock_api.call_args.kwargs["input_variables"]) == 4
+    assert len(mock_api.call_args.kwargs["input_variables"]) == 5
 
 
 def test_inline_prompt_node__function_definitions(vellum_adhoc_prompt_client):

--- a/src/vellum/workflows/nodes/displayable/prompt_deployment_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/prompt_deployment_node/tests/test_node.py
@@ -61,14 +61,22 @@ def test_run_node__chat_history_input(vellum_client, ChatMessageClass):
     ]
 
 
-def test_run_node__any_array_input(vellum_client):
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        ["apple", "banana", "cherry"],
+        [],
+    ],
+    ids=["non_empty_array", "empty_array"],
+)
+def test_run_node__any_array_input(vellum_client, input_value):
     """Confirm that we can successfully invoke a Prompt Deployment Node that uses any array input"""
 
     # GIVEN a Prompt Deployment Node
     class ExamplePromptDeploymentNode(PromptDeploymentNode):
         deployment = "example_prompt_deployment"
         prompt_inputs = {
-            "fruits": ["apple", "banana", "cherry"],
+            "fruits": input_value,
         }
 
     # AND we know what the Prompt Deployment will respond with
@@ -97,7 +105,7 @@ def test_run_node__any_array_input(vellum_client):
     # AND we should have invoked the Prompt Deployment with the expected inputs
     call_kwargs = vellum_client.execute_prompt_stream.call_args.kwargs
     assert call_kwargs["inputs"] == [
-        JsonInputRequest(name="fruits", value=["apple", "banana", "cherry"]),
+        JsonInputRequest(name="fruits", value=input_value),
     ]
 
 


### PR DESCRIPTION
Minimal repro workflow: https://app.vellum.ai/workflow-sandboxes/e50d9bbc-8bfb-4c24-a7ec-7bd67880cc38

Found debugging a customer's workflow

<img width="959" alt="Screenshot 2025-04-01 at 11 51 05 PM" src="https://github.com/user-attachments/assets/86e00ae4-fd2c-487d-a929-3bb0efefad66" />
