### PR TITLE
Make ExecutionContext::trace_id non-optional

### DIFF
--- a/src/vellum/workflows/context.py
+++ b/src/vellum/workflows/context.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from dataclasses import field
 import threading
-from uuid import UUID, uuid4
+from uuid import UUID
 from typing import Iterator, Optional, cast
 
 from vellum.client.core import UniversalBaseModel
@@ -9,7 +9,7 @@ from vellum.workflows.events.types import ParentContext
 
 
 class ExecutionContext(UniversalBaseModel):
-    trace_id: UUID = field(default_factory=uuid4)
+    trace_id: UUID = field(default_factory=lambda: UUID("00000000-0000-0000-0000-000000000000"))
     parent_context: Optional[ParentContext] = None
 
 
@@ -38,7 +38,11 @@ def execution_context(
 ) -> Iterator[None]:
     """Context manager for handling execution context."""
     prev_context = get_execution_context()
-    set_trace_id = prev_context.trace_id or trace_id
+    set_trace_id = (
+        prev_context.trace_id
+        if int(prev_context.trace_id)
+        else trace_id or UUID("00000000-0000-0000-0000-000000000000")
+    )
     set_parent_context = parent_context or prev_context.parent_context
     set_context = ExecutionContext(parent_context=set_parent_context, trace_id=set_trace_id)
     try:

--- a/src/vellum/workflows/context.py
+++ b/src/vellum/workflows/context.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
+from dataclasses import field
 import threading
-from uuid import UUID
+from uuid import UUID, uuid4
 from typing import Iterator, Optional, cast
 
 from vellum.client.core import UniversalBaseModel
@@ -8,8 +9,8 @@ from vellum.workflows.events.types import ParentContext
 
 
 class ExecutionContext(UniversalBaseModel):
+    trace_id: UUID = field(default_factory=uuid4)
     parent_context: Optional[ParentContext] = None
-    trace_id: Optional[UUID] = None
 
 
 _CONTEXT_KEY = "_execution_context"

--- a/src/vellum/workflows/nodes/displayable/tests/test_text_prompt_deployment_node.py
+++ b/src/vellum/workflows/nodes/displayable/tests/test_text_prompt_deployment_node.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from uuid import uuid4
 from typing import Any, Iterator, List
 
@@ -75,6 +76,6 @@ def test_text_prompt_deployment_node__basic(vellum_client):
         raw_overrides=OMIT,
         release_tag="LATEST",
         request_options={
-            "additional_body_parameters": {"execution_context": {"parent_context": None, "trace_id": None}}
+            "additional_body_parameters": {"execution_context": {"parent_context": None, "trace_id": mock.ANY}}
         },
     )

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -488,7 +488,7 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
                     workflow_inputs=workflow_inputs or self.get_default_inputs(),
                     trace_id=execution_context.trace_id,
                 )
-                if execution_context and execution_context.trace_id
+                if execution_context and int(execution_context.trace_id)
                 else StateMeta(
                     parent=self._parent_state,
                     workflow_inputs=workflow_inputs or self.get_default_inputs(),


### PR DESCRIPTION
Our Workflow Server has two references to trace_id in the request and we could delete one of them by making this required