### PR TITLE
Create a pass through store so that workflow server doesn't store events

### DIFF
--- a/src/vellum/workflows/state/store.py
+++ b/src/vellum/workflows/state/store.py
@@ -26,3 +26,11 @@ class Store:
     @property
     def state_snapshots(self) -> Iterator[BaseState]:
         return iter(self._state_snapshots)
+
+
+class PassThroughStore(Store):
+    def append_event(self, event: WorkflowEvent) -> None:
+        pass
+
+    def append_state_snapshot(self, state: BaseState) -> None:
+        pass

--- a/src/vellum/workflows/state/store.py
+++ b/src/vellum/workflows/state/store.py
@@ -28,7 +28,12 @@ class Store:
         return iter(self._state_snapshots)
 
 
-class PassThroughStore(Store):
+class EmptyStore(Store):
+    """
+    A store that does not record any events or state snapshots, for workflows
+    that want to opt out of the memory footprint of the traditional store entirely.
+    """
+
     def append_event(self, event: WorkflowEvent) -> None:
         pass
 

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -165,12 +165,13 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
         parent_state: Optional[BaseState] = None,
         emitters: Optional[List[BaseWorkflowEmitter]] = None,
         resolvers: Optional[List[BaseWorkflowResolver]] = None,
+        store: Optional[Store] = None,
     ):
         self._parent_state = parent_state
         self.emitters = emitters or (self.emitters if hasattr(self, "emitters") else [])
         self.resolvers = resolvers or (self.resolvers if hasattr(self, "resolvers") else [])
         self._context = context or WorkflowContext()
-        self._store = Store()
+        self._store = store or Store()
         self._execution_context = self._context.execution_context
 
         self.validate()

--- a/tests/workflows/empty_store/tests/test_workflow.py
+++ b/tests/workflows/empty_store/tests/test_workflow.py
@@ -1,12 +1,12 @@
-from vellum.workflows.state.store import PassThroughStore
+from vellum.workflows.state.store import EmptyStore
 
-from tests.workflows.pass_through_store.workflow import WorkflowWithPassThroughStore
+from tests.workflows.empty_store.workflow import WorkflowWithEmptyStore
 
 
 def test_run_workflow__happy_path():
     # GIVEN a trivial workflow with access to a pass through store
-    workflow = WorkflowWithPassThroughStore(
-        store=PassThroughStore(),
+    workflow = WorkflowWithEmptyStore(
+        store=EmptyStore(),
     )
 
     # WHEN the workflow is run

--- a/tests/workflows/empty_store/workflow.py
+++ b/tests/workflows/empty_store/workflow.py
@@ -6,5 +6,5 @@ class StartNode(BaseNode):
     pass
 
 
-class WorkflowWithPassThroughStore(BaseWorkflow):
+class WorkflowWithEmptyStore(BaseWorkflow):
     graph = StartNode

--- a/tests/workflows/pass_through_store/tests/test_workflow.py
+++ b/tests/workflows/pass_through_store/tests/test_workflow.py
@@ -1,0 +1,20 @@
+from vellum.workflows.state.store import PassThroughStore
+
+from tests.workflows.pass_through_store.workflow import WorkflowWithPassThroughStore
+
+
+def test_run_workflow__happy_path():
+    # GIVEN a trivial workflow with access to a pass through store
+    workflow = WorkflowWithPassThroughStore(
+        store=PassThroughStore(),
+    )
+
+    # WHEN the workflow is run
+    terminal_event = workflow.run()
+
+    # THEN the workflow is executed and the store is passed through
+    assert terminal_event.name == "workflow.execution.fulfilled"
+
+    # AND no events or state snapshots are recorded
+    assert list(workflow._store.events) == []
+    assert list(workflow._store.state_snapshots) == []

--- a/tests/workflows/pass_through_store/workflow.py
+++ b/tests/workflows/pass_through_store/workflow.py
@@ -1,0 +1,10 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes.bases import BaseNode
+
+
+class StartNode(BaseNode):
+    pass
+
+
+class WorkflowWithPassThroughStore(BaseWorkflow):
+    graph = StartNode


### PR DESCRIPTION
This enables our Python Workflow Server to opt out of storing events in memory, far decreasing the memory footprint of each workflow execution