### PR TITLE
[APO-218] Add codegen support for ml model attribute on inline prompt node

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -465,6 +465,7 @@ export function inlinePromptNodeDataInlineVariantFactory({
   defaultBlock,
   adornments,
   outputs,
+  attributes,
 }: {
   blockType?: string;
   errorOutputId?: string;
@@ -472,6 +473,7 @@ export function inlinePromptNodeDataInlineVariantFactory({
   defaultBlock?: PromptTemplateBlock;
   adornments?: AdornmentNode[];
   outputs?: NodeOutput[];
+  attributes?: NodeAttribute[];
 }): PromptNode {
   const block = defaultBlock ?? generateBlockGivenType(blockType ?? "JINJA");
   const nodeData: PromptNode = {
@@ -530,6 +532,7 @@ export function inlinePromptNodeDataInlineVariantFactory({
     // Add adornments if provided
     adornments,
     outputs,
+    attributes,
   };
   return nodeData;
 }

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -1297,3 +1297,32 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     )
 "
 `;
+
+exports[`InlinePromptNode > with ml model node attribute defined > getNodeFile 1`] = `
+"from vellum import JinjaPromptBlock, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
+from ..inputs import Inputs
+
+
+class PromptNode(InlinePromptNode):
+    ml_model = "gpt-4"
+    blocks = [
+        JinjaPromptBlock(template="""Summarize what this means {{ INPUT_VARIABLE }}"""),
+    ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
+    parameters = PromptParameters(
+        stop=[],
+        temperature=0,
+        max_tokens=1000,
+        top_p=1,
+        top_k=0,
+        frequency_penalty=0,
+        presence_penalty=0,
+        logit_bias={},
+        custom_parameters={},
+    )
+"
+`;

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -11,6 +11,7 @@ import { createNodeContext, WorkflowContext } from "src/context";
 import { InlinePromptNodeContext } from "src/context/node-context/inline-prompt-node";
 import { InlinePromptNode } from "src/generators/nodes/inline-prompt-node";
 import {
+  NodeAttribute as NodeAttributeType,
   NodeOutput as NodeOutputType,
   PromptTemplateBlock,
 } from "src/types/vellum";
@@ -229,6 +230,44 @@ describe("InlinePromptNode", () => {
 
     it(`getNodeDisplayFile`, async () => {
       node.getNodeDisplayFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+
+  describe("with ml model node attribute defined", async () => {
+    let node: InlinePromptNode;
+    beforeEach(async () => {
+      const randomMlModelAttrId = "some-ml-mlmodel-attr-id";
+      const nodeAttributes: NodeAttributeType[] = [
+        {
+          id: randomMlModelAttrId,
+          name: "ml_model",
+          value: {
+            type: "CONSTANT_VALUE",
+            value: {
+              type: "STRING",
+              value: "gpt-4",
+            },
+          },
+        },
+      ];
+      const nodeData = inlinePromptNodeDataInlineVariantFactory({
+        attributes: nodeAttributes,
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as InlinePromptNodeContext;
+
+      node = new InlinePromptNode({
+        workflowContext,
+        nodeContext,
+      });
+    });
+
+    it(`getNodeFile`, async () => {
+      node.getNodeFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -1,4 +1,5 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
+import { v4 as uuidv4 } from "uuid";
 import { beforeEach } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
@@ -237,7 +238,7 @@ describe("InlinePromptNode", () => {
   describe("with ml model node attribute defined", async () => {
     let node: InlinePromptNode;
     beforeEach(async () => {
-      const randomMlModelAttrId = "some-ml-mlmodel-attr-id";
+      const randomMlModelAttrId = uuidv4();
       const nodeAttributes: NodeAttributeType[] = [
         {
           id: randomMlModelAttrId,

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -866,6 +866,7 @@ export declare namespace BaseDisplayableWorkflowNodeSerializer {
     inputs: NodeInputSerializer.Raw[];
     adornments?: AdornmentNodeSerializer.Raw[] | null;
     outputs?: NodeOutputSerializer.Raw[] | null;
+    attributes?: NodeAttributeSerializer.Raw[] | null;
   }
 }
 
@@ -1164,6 +1165,7 @@ export const PromptNodeSerializer: ObjectSchema<
   definition: CodeResourceDefinitionSerializer.optional(),
   adornments: listSchema(AdornmentNodeSerializer).optional(),
   outputs: listSchema(NodeOutputSerializer).optional(),
+  attributes: listSchema(NodeAttributeSerializer).optional(),
 });
 
 export declare namespace PromptNodeSerializer {

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -231,6 +231,7 @@ export interface BaseDisplayableWorkflowNode extends BaseWorkflowNode {
   base?: CodeResourceDefinition;
   adornments?: AdornmentNode[];
   outputs?: NodeOutput[];
+  attributes?: NodeAttribute[];
 }
 
 export interface EntrypointNodeData {


### PR DESCRIPTION
This is part 1 of sdk support on transitioning inline prompt node `ml_model` attr derivation. I will do another PR for the serialization side