### PR TITLE
[APO-314] Use deployment name as module in pull

### DIFF
--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -105,6 +105,7 @@ def pull_command(
     include_sandbox: Optional[bool] = None,
     target_directory: Optional[str] = None,
 ) -> None:
+    print("pull_command", module, workflow_sandbox_id, workflow_deployment, include_json, exclude_code, strict, include_sandbox, target_directory)
     load_dotenv()
     logger = load_cli_logger()
     config = load_vellum_cli_config()
@@ -164,12 +165,16 @@ def pull_command(
                 workflow_config.container_image_tag = pull_contents_metadata.runner_config.container_image_tag
                 if workflow_config.container_image_name and not workflow_config.container_image_tag:
                     workflow_config.container_image_tag = "latest"
+            print("pull_contents_metadata", pull_contents_metadata)
             if not workflow_config.module and workflow_deployment and pull_contents_metadata.deployment_name:
                 workflow_config.module = snake_case(pull_contents_metadata.deployment_name)
             if not workflow_config.module and pull_contents_metadata.label:
                 workflow_config.module = snake_case(pull_contents_metadata.label)
 
         if not workflow_config.module:
+            print("================================================")
+            print("workflow_config", workflow_config)
+            print("================================================")
             raise ValueError(f"Failed to resolve a module name for Workflow {pk}")
 
         # Use target_directory if provided, otherwise use current working directory

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -162,7 +162,7 @@ def pull_command(
             metadata_json: Optional[dict] = None
             with zip_file.open(METADATA_FILE_NAME) as source:
                 metadata_json = json.load(source)
-            print("metadata_json: ", metadata_json)
+
             pull_contents_metadata = PullContentsMetadata.model_validate(metadata_json)
 
             if pull_contents_metadata.runner_config:

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -79,13 +79,8 @@ def _resolve_workflow_config(
             pk=workflow_config.workflow_sandbox_id,
         )
     elif workflow_deployment:
-        module = (
-            f"workflow_{workflow_deployment.split('-')[0]}"
-            if is_valid_uuid(workflow_deployment)
-            else snake_case(workflow_deployment)
-        )
         workflow_config = WorkflowConfig(
-            module=module,
+            module="",
         )
         config.workflows.append(workflow_config)
         return WorkflowConfigResolutionResult(
@@ -170,7 +165,7 @@ def pull_command(
                 workflow_config.container_image_tag = pull_contents_metadata.runner_config.container_image_tag
                 if workflow_config.container_image_name and not workflow_config.container_image_tag:
                     workflow_config.container_image_tag = "latest"
-            if workflow_deployment and pull_contents_metadata.deployment_name:
+            if not workflow_config.module and workflow_deployment and pull_contents_metadata.deployment_name:
                 workflow_config.module = snake_case(pull_contents_metadata.deployment_name)
             if not workflow_config.module and pull_contents_metadata.label:
                 workflow_config.module = snake_case(pull_contents_metadata.label)

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -9,7 +9,6 @@ from dotenv import load_dotenv
 from pydash import snake_case
 
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
-from vellum.utils.uuid import is_valid_uuid
 from vellum.workflows.vellum_client import create_vellum_client
 from vellum_cli.config import VellumCliConfig, WorkflowConfig, load_vellum_cli_config
 from vellum_cli.logger import load_cli_logger

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -105,7 +105,6 @@ def pull_command(
     include_sandbox: Optional[bool] = None,
     target_directory: Optional[str] = None,
 ) -> None:
-    print("pull_command", module, workflow_sandbox_id, workflow_deployment, include_json, exclude_code, strict, include_sandbox, target_directory)
     load_dotenv()
     logger = load_cli_logger()
     config = load_vellum_cli_config()
@@ -165,16 +164,12 @@ def pull_command(
                 workflow_config.container_image_tag = pull_contents_metadata.runner_config.container_image_tag
                 if workflow_config.container_image_name and not workflow_config.container_image_tag:
                     workflow_config.container_image_tag = "latest"
-            print("pull_contents_metadata", pull_contents_metadata)
             if not workflow_config.module and workflow_deployment and pull_contents_metadata.deployment_name:
                 workflow_config.module = snake_case(pull_contents_metadata.deployment_name)
             if not workflow_config.module and pull_contents_metadata.label:
                 workflow_config.module = snake_case(pull_contents_metadata.label)
 
         if not workflow_config.module:
-            print("================================================")
-            print("workflow_config", workflow_config)
-            print("================================================")
             raise ValueError(f"Failed to resolve a module name for Workflow {pk}")
 
         # Use target_directory if provided, otherwise use current working directory

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -338,7 +338,13 @@ def test_pull__workflow_deployment_with_no_config(vellum_client):
     workflow_deployment = "my-deployment"
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
+    vellum_client.workflows.pull.return_value = iter(
+        [
+            _zip_file_map(
+                {"workflow.py": "print('hello')", "metadata.json": json.dumps({"deployment_name": workflow_deployment})}
+            )
+        ]
+    )
 
     # AND we are currently in a new directory
     current_dir = os.getcwd()
@@ -833,7 +839,11 @@ def test_pull__module_name_from_deployment_name(vellum_client):
     vellum_client.workflows.pull.return_value = iter(
         [
             _zip_file_map(
-                {"workflow.py": "print('hello')", "metadata.json": json.dumps({"deployment_name": deployment_name})}
+                {
+                    "workflow.py": "print('hello')",
+                    "metadata.json": json.dumps({"deployment_name": deployment_name}),
+                    "label": "Some Label",
+                }
             )
         ]
     )

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -359,8 +359,6 @@ def test_pull__workflow_deployment_with_no_config(vellum_client):
     result = runner.invoke(cli_main, ["workflows", "pull", "--workflow-deployment", workflow_deployment])
     os.chdir(current_dir)
 
-    print("result", result)
-
     # THEN the command returns successfully
     assert result.exit_code == 0
 

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -341,7 +341,7 @@ def test_pull__workflow_deployment_with_no_config(vellum_client):
     vellum_client.workflows.pull.return_value = iter(
         [
             _zip_file_map(
-                {"workflow.py": "print('hello')", "metadata.json": json.dumps({"deployment_name": workflow_deployment})}
+                {"workflow.py": "print('hello')", "metadata.json": json.dumps({"deployment_name": workflow_deployment, "label": "Some Label"})}
             )
         ]
     )
@@ -355,6 +355,8 @@ def test_pull__workflow_deployment_with_no_config(vellum_client):
     runner = CliRunner()
     result = runner.invoke(cli_main, ["workflows", "pull", "--workflow-deployment", workflow_deployment])
     os.chdir(current_dir)
+    
+    print("result", result)
 
     # THEN the command returns successfully
     assert result.exit_code == 0
@@ -841,8 +843,7 @@ def test_pull__module_name_from_deployment_name(vellum_client):
             _zip_file_map(
                 {
                     "workflow.py": "print('hello')",
-                    "metadata.json": json.dumps({"deployment_name": deployment_name}),
-                    "label": "Some Label",
+                    "metadata.json": json.dumps({"deployment_name": deployment_name, "label": "Some Label"}),
                 }
             )
         ]

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -338,16 +338,7 @@ def test_pull__workflow_deployment_with_no_config(vellum_client):
     workflow_deployment = "my-deployment"
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter(
-        [
-            _zip_file_map(
-                {
-                    "workflow.py": "print('hello')",
-                    "metadata.json": json.dumps({"deployment_name": workflow_deployment}),
-                }
-            )
-        ]
-    )
+    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
 
     # AND we are currently in a new directory
     current_dir = os.getcwd()

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -341,7 +341,10 @@ def test_pull__workflow_deployment_with_no_config(vellum_client):
     vellum_client.workflows.pull.return_value = iter(
         [
             _zip_file_map(
-                {"workflow.py": "print('hello')", "metadata.json": json.dumps({"deployment_name": workflow_deployment, "label": "Some Label"})}
+                {
+                    "workflow.py": "print('hello')",
+                    "metadata.json": json.dumps({"deployment_name": workflow_deployment, "label": "Some Label"}),
+                }
             )
         ]
     )
@@ -355,7 +358,7 @@ def test_pull__workflow_deployment_with_no_config(vellum_client):
     runner = CliRunner()
     result = runner.invoke(cli_main, ["workflows", "pull", "--workflow-deployment", workflow_deployment])
     os.chdir(current_dir)
-    
+
     print("result", result)
 
     # THEN the command returns successfully

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -338,7 +338,16 @@ def test_pull__workflow_deployment_with_no_config(vellum_client):
     workflow_deployment = "my-deployment"
 
     # AND the workflow pull API call returns a zip file
-    vellum_client.workflows.pull.return_value = iter([_zip_file_map({"workflow.py": "print('hello')"})])
+    vellum_client.workflows.pull.return_value = iter(
+        [
+            _zip_file_map(
+                {
+                    "workflow.py": "print('hello')",
+                    "metadata.json": json.dumps({"deployment_name": workflow_deployment}),
+                }
+            )
+        ]
+    )
 
     # AND we are currently in a new directory
     current_dir = os.getcwd()
@@ -822,3 +831,44 @@ def test_pull__multiple_instances_of_same_module__keep_when_pulling_another_modu
     with open(lock_json) as f:
         lock_data = json.load(f)
         assert len(lock_data["workflows"]) == 3
+
+
+def test_pull__module_name_from_deployment_name(vellum_client):
+    # GIVEN a workflow deployment
+    workflow_deployment = "test-workflow-deployment-id"
+
+    # AND the workflow pull API call returns a zip file with metadata containing a deployment_name
+    deployment_name = "Test Deployment"
+    vellum_client.workflows.pull.return_value = iter(
+        [
+            _zip_file_map(
+                {"workflow.py": "print('hello')", "metadata.json": json.dumps({"deployment_name": deployment_name})}
+            )
+        ]
+    )
+
+    # AND we are currently in a new directory
+    current_dir = os.getcwd()
+    temp_dir = tempfile.mkdtemp()
+    os.chdir(temp_dir)
+
+    # WHEN the user runs the pull command with the workflow deployment
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["workflows", "pull", "--workflow-deployment", workflow_deployment])
+    os.chdir(current_dir)
+
+    # THEN the command returns successfully
+    assert result.exit_code == 0
+
+    # AND the module name is derived from the deployment_name in metadata.json (snake_cased)
+    vellum_lock_json = os.path.join(temp_dir, "vellum.lock.json")
+    assert os.path.exists(vellum_lock_json)
+    with open(vellum_lock_json) as f:
+        lock_data = json.loads(f.read())
+        assert lock_data["workflows"][0]["module"] == "test_deployment"
+
+    # AND the workflow.py file is written to the module directory with the correct name
+    workflow_py = os.path.join(temp_dir, "test_deployment", "workflow.py")
+    assert os.path.exists(workflow_py)
+    with open(workflow_py) as f:
+        assert f.read() == "print('hello')"


### PR DESCRIPTION
fast follow fix in main repo to include deployment name in` metadata.json`. 

Override the default module name if it's pulling `workflow_deployment` and the response include `deployment_name`

https://github.com/user-attachments/assets/e90de6c3-733b-497c-8306-71be41e0f152

