### PR TITLE
Cast RHS based on the inferred equality type of LHS

### DIFF
--- a/ee/codegen/src/__test__/nodes/conditional-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/conditional-node.test.ts
@@ -461,8 +461,7 @@ describe("Conditional Node with numeric operator casts rhs to NUMBER", () => {
 });
 
 describe("Conditional Node with equals operator to numeric lhs should cast rhs to NUMBER", () => {
-  // TODO: Solve as part of https://linear.app/vellum/issue/APO-313/update-conditional-expression-codegen-to-support-equality-of-numbers
-  it.skip("getNodeFile", async () => {
+  it("getNodeFile", async () => {
     const workflowContext = workflowContextFactory();
     const writer = new Writer();
 


### PR DESCRIPTION
We use new type inference logic to be able to infer when we should cast our right hand sides to support numeric equality. We scope out inferring node outputs, since that will be its own challenge