### PR TITLE
Add node output inference for dynamic conditional use case

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1002,9 +1002,13 @@ export interface ApiNodeFactoryProps {
   url?: string | null;
   method?: string;
   body?: Record<string, unknown> | null;
+  statusCodeOutputId?: string;
+  id?: string;
 }
 
 export function apiNodeFactory({
+  id,
+  statusCodeOutputId,
   errorOutputId,
   bearerToken,
   apiKeyHeaderValue,
@@ -1249,7 +1253,7 @@ export function apiNodeFactory({
   ];
 
   const nodeData: ApiNode = {
-    id: "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
+    id: id ?? "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
     type: "API",
     data: {
       label: "API Node",
@@ -1269,7 +1273,8 @@ export function apiNodeFactory({
       })),
       textOutputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
       jsonOutputId: "af576eaa-d39d-4c19-8992-1f01a65a709a",
-      statusCodeOutputId: "69250713-617d-42a4-9326-456c70d0ef20",
+      statusCodeOutputId:
+        statusCodeOutputId ?? "69250713-617d-42a4-9326-456c70d0ef20",
       errorOutputId,
       targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
       sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",

--- a/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
@@ -62,6 +62,20 @@ class ConditionalNode(BaseConditionalNode):
 "
 `;
 
+exports[`Conditional Node with equals operator to numeric lhs should cast rhs to NUMBER > getNodeFile 2`] = `
+"from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
+from vellum.workflows.ports import Port
+
+from .api_node import APINode
+
+
+class ConditionalNode(BaseConditionalNode):
+    class Ports(BaseConditionalNode.Ports):
+        branch_1 = Port.on_if(APINode.Outputs.status_code.equals(200))
+        branch_2 = Port.on_else()
+"
+`;
+
 exports[`Conditional Node with numeric operator casts rhs to NUMBER > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port

--- a/ee/codegen/src/context/node-context/api-node.ts
+++ b/ee/codegen/src/context/node-context/api-node.ts
@@ -1,3 +1,4 @@
+import { VellumVariableType } from "vellum-ai/api";
 import { VellumError } from "vellum-ai/errors";
 
 import { BaseNodeContext } from "src/context/node-context/base";
@@ -20,6 +21,17 @@ export class ApiNodeContext extends BaseNodeContext<ApiNodeType> {
       [this.nodeData.data.textOutputId]: "text",
       ...(this.nodeData.data.errorOutputId
         ? { [this.nodeData.data.errorOutputId]: "error" }
+        : {}),
+    };
+  }
+
+  getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    return {
+      [this.nodeData.data.jsonOutputId]: "JSON",
+      [this.nodeData.data.statusCodeOutputId]: "NUMBER",
+      [this.nodeData.data.textOutputId]: "STRING",
+      ...(this.nodeData.data.errorOutputId
+        ? { [this.nodeData.data.errorOutputId]: "ERROR" }
         : {}),
     };
   }

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -1,3 +1,5 @@
+import { VellumVariableType } from "vellum-ai/api";
+
 import { VELLUM_WORKFLOW_NODES_MODULE_PATH } from "src/constants";
 import { WorkflowContext } from "src/context";
 import { PortContext } from "src/context/port-context";
@@ -90,6 +92,10 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
   }
 
   protected abstract getNodeOutputNamesById(): Record<string, string>;
+  protected abstract getNodeOutputTypesById(): Record<
+    string,
+    VellumVariableType
+  >;
   protected abstract createPortContexts(): PortContext[];
 
   public getNodeLabel(): string {
@@ -125,6 +131,14 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
     }
 
     return toPythonSafeSnakeCase(nodeOutputName, "output");
+  }
+
+  public getNodeOutputTypeById(
+    outputId: string
+  ): VellumVariableType | undefined {
+    const nodeOutputTypesById = this.getNodeOutputTypesById();
+
+    return nodeOutputTypesById[outputId];
   }
 
   public isPortNameUsed(portName: string): boolean {

--- a/ee/codegen/src/context/node-context/code-execution-node.ts
+++ b/ee/codegen/src/context/node-context/code-execution-node.ts
@@ -1,4 +1,4 @@
-import { CodeExecutionRuntime } from "vellum-ai/api";
+import { CodeExecutionRuntime, VellumVariableType } from "vellum-ai/api";
 import { VellumError } from "vellum-ai/errors";
 
 import { BaseNodeContext } from "./base";
@@ -31,6 +31,15 @@ export class CodeExecutionContext extends BaseNodeContext<CodeExecutionNodeType>
       [this.nodeData.data.outputId]: "result",
       ...(this.nodeData.data.logOutputId
         ? { [this.nodeData.data.logOutputId]: "logs" }
+        : {}),
+    };
+  }
+
+  getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    return {
+      [this.nodeData.data.outputId]: this.nodeData.data.outputType,
+      ...(this.nodeData.data.logOutputId
+        ? { [this.nodeData.data.logOutputId]: "STRING" }
         : {}),
     };
   }

--- a/ee/codegen/src/context/node-context/conditional-node.ts
+++ b/ee/codegen/src/context/node-context/conditional-node.ts
@@ -1,3 +1,5 @@
+import { VellumVariableType } from "vellum-ai/api";
+
 import { BaseNodeContext } from "src/context/node-context/base";
 import { PortContext } from "src/context/port-context";
 import { ConditionalNode } from "src/types/vellum";
@@ -7,6 +9,10 @@ export class ConditionalNodeContext extends BaseNodeContext<ConditionalNode> {
   baseNodeDisplayClassName = "BaseConditionalNodeDisplay";
 
   protected getNodeOutputNamesById(): Record<string, string> {
+    return {};
+  }
+
+  protected getNodeOutputTypesById(): Record<string, VellumVariableType> {
     return {};
   }
 

--- a/ee/codegen/src/context/node-context/error-node.ts
+++ b/ee/codegen/src/context/node-context/error-node.ts
@@ -1,3 +1,5 @@
+import { VellumVariableType } from "vellum-ai/api";
+
 import { BaseNodeContext } from "./base";
 
 import { PortContext } from "src/context/port-context";
@@ -11,6 +13,12 @@ export class ErrorNodeContext extends BaseNodeContext<ErrorNode> {
   getNodeOutputNamesById(): Record<string, string> {
     return {
       [this.nodeData.data.errorOutputId]: "error",
+    };
+  }
+
+  getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    return {
+      [this.nodeData.data.errorOutputId]: "ERROR",
     };
   }
 

--- a/ee/codegen/src/context/node-context/final-output-node.ts
+++ b/ee/codegen/src/context/node-context/final-output-node.ts
@@ -1,3 +1,5 @@
+import { VellumVariableType } from "vellum-ai/api";
+
 import { BaseNodeContext } from "src/context/node-context/base";
 import { PortContext } from "src/context/port-context";
 import { FinalOutputNode } from "src/types/vellum";
@@ -9,6 +11,12 @@ export class FinalOutputNodeContext extends BaseNodeContext<FinalOutputNode> {
   protected getNodeOutputNamesById(): Record<string, string> {
     return {
       [this.nodeData.data.outputId]: "value",
+    };
+  }
+
+  protected getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    return {
+      [this.nodeData.data.outputId]: this.nodeData.data.outputType,
     };
   }
 

--- a/ee/codegen/src/context/node-context/generic-node.ts
+++ b/ee/codegen/src/context/node-context/generic-node.ts
@@ -1,3 +1,5 @@
+import { VellumVariableType } from "vellum-ai/api";
+
 import { BaseNodeContext } from "src/context/node-context/base";
 import { PortContext } from "src/context/port-context";
 import { GenericNode as GenericNodeType } from "src/types/vellum";
@@ -9,6 +11,12 @@ export class GenericNodeContext extends BaseNodeContext<GenericNodeType> {
   getNodeOutputNamesById(): Record<string, string> {
     return Object.fromEntries(
       this.nodeData.outputs.map((output) => [output.id, output.name])
+    );
+  }
+
+  getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    return Object.fromEntries(
+      this.nodeData.outputs.map((output) => [output.id, output.type])
     );
   }
 

--- a/ee/codegen/src/context/node-context/guardrail-node.ts
+++ b/ee/codegen/src/context/node-context/guardrail-node.ts
@@ -1,4 +1,4 @@
-import { MetricDefinitionHistoryItem } from "vellum-ai/api";
+import { MetricDefinitionHistoryItem, VellumVariableType } from "vellum-ai/api";
 import { MetricDefinitions as MetricDefinitionsClient } from "vellum-ai/api/resources/metricDefinitions/client/Client";
 import { VellumError } from "vellum-ai/errors";
 
@@ -26,6 +26,19 @@ export class GuardrailNodeContext extends BaseNodeContext<GuardrailNodeType> {
         return acc;
       },
       {} as Record<string, string>
+    );
+  }
+
+  getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    if (!this.metricDefinitionsHistoryItem) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      this.metricDefinitionsHistoryItem.outputVariables.map((variable) => [
+        variable.id,
+        variable.type,
+      ])
     );
   }
 

--- a/ee/codegen/src/context/node-context/inline-prompt-node.ts
+++ b/ee/codegen/src/context/node-context/inline-prompt-node.ts
@@ -1,3 +1,5 @@
+import { VellumVariableType } from "vellum-ai/api";
+
 import { BaseNodeContext } from "src/context/node-context/base";
 import { PortContext } from "src/context/port-context";
 import { NodeDefinitionGenerationError } from "src/generators/errors";
@@ -23,6 +25,21 @@ export class InlinePromptNodeContext extends BaseNodeContext<InlinePromptNodeTyp
         : {}),
       [this.nodeData.data.arrayOutputId]: "results",
       ...(jsonOutput ? { [jsonOutput.id]: "json" } : {}),
+    };
+  }
+
+  protected getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    const jsonOutput = this.nodeData.outputs?.find(
+      (output) => output.type === "JSON"
+    );
+
+    return {
+      [this.nodeData.data.outputId]: "STRING",
+      ...(this.nodeData.data.errorOutputId
+        ? { [this.nodeData.data.errorOutputId]: "ERROR" }
+        : {}),
+      [this.nodeData.data.arrayOutputId]: "ARRAY",
+      ...(jsonOutput ? { [jsonOutput.id]: "JSON" } : {}),
     };
   }
 

--- a/ee/codegen/src/context/node-context/inline-subworkflow-node.ts
+++ b/ee/codegen/src/context/node-context/inline-subworkflow-node.ts
@@ -1,3 +1,5 @@
+import { VellumVariableType } from "vellum-ai/api";
+
 import { BaseNodeContext } from "./base";
 
 import { PortContext } from "src/context/port-context";
@@ -21,6 +23,22 @@ export class InlineSubworkflowNodeContext extends BaseNodeContext<SubworkflowNod
       acc[variable.id] = variable.key;
       return acc;
     }, {} as Record<string, string>);
+  }
+
+  getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    const subworkflowNodeData = this.nodeData.data;
+    if (subworkflowNodeData.variant !== "INLINE") {
+      throw new NodeDefinitionGenerationError(
+        `SubworkflowNode only supports INLINE variant. Received: ${this.nodeData.data.variant}`
+      );
+    }
+
+    return Object.fromEntries(
+      subworkflowNodeData.outputVariables.map((variable) => [
+        variable.id,
+        variable.type,
+      ])
+    );
   }
 
   createPortContexts(): PortContext[] {

--- a/ee/codegen/src/context/node-context/map-node.ts
+++ b/ee/codegen/src/context/node-context/map-node.ts
@@ -1,3 +1,5 @@
+import { VellumVariableType } from "vellum-ai/api";
+
 import { BaseNodeContext } from "./base";
 
 import { PortContext } from "src/context/port-context";
@@ -21,6 +23,22 @@ export class MapNodeContext extends BaseNodeContext<MapNodeType> {
       acc[variable.id] = variable.key;
       return acc;
     }, {} as Record<string, string>);
+  }
+
+  getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    const subworkflowNodeData = this.nodeData.data;
+    if (subworkflowNodeData.variant !== "INLINE") {
+      throw new NodeDefinitionGenerationError(
+        `MapNode only supports INLINE variant. Received: ${this.nodeData.data.variant}`
+      );
+    }
+
+    return Object.fromEntries(
+      subworkflowNodeData.outputVariables.map((variable) => [
+        variable.id,
+        "ARRAY",
+      ])
+    );
   }
 
   createPortContexts(): PortContext[] {

--- a/ee/codegen/src/context/node-context/merge-node.ts
+++ b/ee/codegen/src/context/node-context/merge-node.ts
@@ -1,3 +1,5 @@
+import { VellumVariableType } from "vellum-ai/api";
+
 import { BaseNodeContext } from "./base";
 
 import { PortContext } from "src/context/port-context";
@@ -8,6 +10,10 @@ export class MergeNodeContext extends BaseNodeContext<MergeNode> {
   baseNodeDisplayClassName = "BaseMergeNodeDisplay";
 
   getNodeOutputNamesById(): Record<string, string> {
+    return {};
+  }
+
+  getNodeOutputTypesById(): Record<string, VellumVariableType> {
     return {};
   }
 

--- a/ee/codegen/src/context/node-context/note-node.ts
+++ b/ee/codegen/src/context/node-context/note-node.ts
@@ -1,3 +1,5 @@
+import { VellumVariableType } from "vellum-ai/api";
+
 import { BaseNodeContext } from "./base";
 
 import { PortContext } from "src/context/port-context";
@@ -8,6 +10,10 @@ export class NoteNodeContext extends BaseNodeContext<NoteNode> {
   baseNodeDisplayClassName = "BaseNoteNodeDisplay";
 
   getNodeOutputNamesById(): Record<string, string> {
+    return {};
+  }
+
+  getNodeOutputTypesById(): Record<string, VellumVariableType> {
     return {};
   }
 

--- a/ee/codegen/src/context/node-context/prompt-deployment-node.ts
+++ b/ee/codegen/src/context/node-context/prompt-deployment-node.ts
@@ -1,4 +1,4 @@
-import { DeploymentHistoryItem } from "vellum-ai/api";
+import { DeploymentHistoryItem, VellumVariableType } from "vellum-ai/api";
 import { Deployments as DeploymentsClient } from "vellum-ai/api/resources/deployments/client/Client";
 
 import { BaseNodeContext } from "src/context/node-context/base";
@@ -20,6 +20,16 @@ export class PromptDeploymentNodeContext extends BaseNodeContext<PromptNode> {
         ? { [this.nodeData.data.errorOutputId]: "error" }
         : {}),
       [this.nodeData.data.arrayOutputId]: "results",
+    };
+  }
+
+  protected getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    return {
+      [this.nodeData.data.outputId]: "STRING",
+      ...(this.nodeData.data.errorOutputId
+        ? { [this.nodeData.data.errorOutputId]: "ERROR" }
+        : {}),
+      [this.nodeData.data.arrayOutputId]: "ARRAY",
     };
   }
 

--- a/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
@@ -1,4 +1,7 @@
-import { WorkflowDeploymentHistoryItem } from "vellum-ai/api";
+import {
+  VellumVariableType,
+  WorkflowDeploymentHistoryItem,
+} from "vellum-ai/api";
 import { WorkflowDeployments as WorkflowDeploymentsClient } from "vellum-ai/api/resources/workflowDeployments/client/Client";
 
 import { BaseNodeContext } from "./base";
@@ -27,6 +30,19 @@ export class SubworkflowDeploymentNodeContext extends BaseNodeContext<Subworkflo
       acc[output.id] = toPythonSafeSnakeCase(output.key, "output");
       return acc;
     }, {});
+  }
+
+  getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    if (!this.workflowDeploymentHistoryItem) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      this.workflowDeploymentHistoryItem.outputVariables.map((variable) => [
+        variable.id,
+        variable.type,
+      ])
+    );
   }
 
   createPortContexts(): PortContext[] {

--- a/ee/codegen/src/context/node-context/templating-node.ts
+++ b/ee/codegen/src/context/node-context/templating-node.ts
@@ -1,3 +1,5 @@
+import { VellumVariableType } from "vellum-ai/api";
+
 import { BaseNodeContext } from "src/context/node-context/base";
 import { PortContext } from "src/context/port-context";
 import { TemplatingNode } from "src/types/vellum";
@@ -12,6 +14,15 @@ export class TemplatingNodeContext extends BaseNodeContext<TemplatingNode> {
       [this.nodeData.data.outputId]: "result",
       ...(this.nodeData.data.errorOutputId
         ? { [this.nodeData.data.errorOutputId]: "error" }
+        : {}),
+    };
+  }
+
+  protected getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    return {
+      [this.nodeData.data.outputId]: this.nodeData.data.outputType,
+      ...(this.nodeData.data.errorOutputId
+        ? { [this.nodeData.data.errorOutputId]: "ERROR" }
         : {}),
     };
   }

--- a/ee/codegen/src/context/node-context/text-search-node.ts
+++ b/ee/codegen/src/context/node-context/text-search-node.ts
@@ -1,4 +1,4 @@
-import { DocumentIndexRead } from "vellum-ai/api";
+import { DocumentIndexRead, VellumVariableType } from "vellum-ai/api";
 import { DocumentIndexes as DocumentIndexesClient } from "vellum-ai/api/resources/documentIndexes/client/Client";
 import { VellumError } from "vellum-ai/errors";
 
@@ -19,6 +19,16 @@ export class TextSearchNodeContext extends BaseNodeContext<SearchNode> {
       [this.nodeData.data.textOutputId]: "text",
       ...(this.nodeData.data.errorOutputId
         ? { [this.nodeData.data.errorOutputId]: "error" }
+        : {}),
+    };
+  }
+
+  getNodeOutputTypesById(): Record<string, VellumVariableType> {
+    return {
+      [this.nodeData.data.resultsOutputId]: "ARRAY",
+      [this.nodeData.data.textOutputId]: "STRING",
+      ...(this.nodeData.data.errorOutputId
+        ? { [this.nodeData.data.errorOutputId]: "ERROR" }
         : {}),
     };
   }

--- a/ee/codegen/src/generators/conditional-node-port.ts
+++ b/ee/codegen/src/generators/conditional-node-port.ts
@@ -281,12 +281,11 @@ export class ConditionalNodePort extends AstNode {
         rule.data.nodeId
       );
       if (nodeContext) {
-        const outputName = nodeContext.getNodeOutputNameById(
+        const outputType = nodeContext.getNodeOutputTypeById(
           rule.data.outputId
         );
-        if (outputName) {
-          // TODO: We need to flesh out the node output types
-          return "JSON";
+        if (outputType) {
+          return outputType;
         }
       }
     }


### PR DESCRIPTION
With this PR, users could now specify if status code == 200 in our legacy conditional nodes. I think the effort was worth it because:
1. The UX is pretty dreadful and unintuitive without it (`<= 200` works but not `= 200`??)
2. The node output type inferencing that this encouraged could be used in the future to help solve similar problems