### PR TITLE
Fix codegen to generate correct ImageChatMessageContent object

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/chat-message-content.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/chat-message-content.test.ts.snap
@@ -69,10 +69,12 @@ exports[`ChatMessageContent > FUNCTION_CALL > should write a function call conte
 
 exports[`ChatMessageContent > IMAGE > should write an image content correctly 1`] = `
 "ImageChatMessageContent(
-    src="https://example.com/image.png",
-    metadata={
-        "key": "value",
-    },
+    value=VellumImage(
+        src="https://example.com/image.png",
+        metadata={
+            "key": "value",
+        },
+    )
 )
 "
 `;

--- a/ee/codegen/src/__test__/chat-message-content.test.ts
+++ b/ee/codegen/src/__test__/chat-message-content.test.ts
@@ -148,7 +148,7 @@ describe("ChatMessageContent", () => {
       });
       chatMessageContent.write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
-      expect(chatMessageContent.getReferences()).toHaveLength(1);
+      expect(chatMessageContent.getReferences()).toHaveLength(2);
     });
   });
 });

--- a/ee/codegen/src/generators/chat-message-content.ts
+++ b/ee/codegen/src/generators/chat-message-content.ts
@@ -203,7 +203,7 @@ class ImageChatMessageContent extends AstNode {
       modulePath: VELLUM_CLIENT_MODULE_PATH,
     });
 
-    const arguments_ = [
+    const imageArgs = [
       python.methodArgument({
         name: "src",
         value: python.TypeInstantiation.str(value.src),
@@ -212,13 +212,26 @@ class ImageChatMessageContent extends AstNode {
 
     if (!isNil(value.metadata)) {
       const metadataJson = new Json(value.metadata);
-      arguments_.push(
+      imageArgs.push(
         python.methodArgument({
           name: "metadata",
           value: metadataJson,
         })
       );
     }
+
+    const arguments_ = [
+      python.methodArgument({
+        name: "value",
+        value: python.instantiateClass({
+          classReference: python.reference({
+            name: "VellumImage" + (isRequestType ? "Request" : ""),
+            modulePath: VELLUM_CLIENT_MODULE_PATH,
+          }),
+          arguments_: imageArgs,
+        }),
+      }),
+    ];
 
     const astNode = python.instantiateClass({
       classReference: imageChatMessageContentRequestRef,


### PR DESCRIPTION
Context: While debugging https://vellum-ai.slack.com/archives/C081CFHPESE/p1743701472326479 I encountered a pydantic issue when running the workflow locally

Before our codegen was codegening this shape:

```
ImageChatMessageContent(
    src="foo",
      metadata={
            "bar": "baz"  },
       ),
)
```

but the shape for this object is:
https://github.com/vellum-ai/vellum-python-sdks/blob/main/src/vellum/client/types/image_chat_message_content.py
```
ImageChatMessageContent(
   value=VellumImage(
     src="foo",
     metadata={
            "bar": "baz"  },
     ),
)
)
```