### PR TITLE
[APO-320] Add error handling for invalid response

### DIFF
--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -151,68 +151,71 @@ def pull_command(
 
     error_content = ""
 
-    with zipfile.ZipFile(zip_buffer) as zip_file:
-        if METADATA_FILE_NAME in zip_file.namelist():
-            metadata_json: Optional[dict] = None
-            with zip_file.open(METADATA_FILE_NAME) as source:
-                metadata_json = json.load(source)
+    try:
+        with zipfile.ZipFile(zip_buffer) as zip_file:
+            if METADATA_FILE_NAME in zip_file.namelist():
+                metadata_json: Optional[dict] = None
+                with zip_file.open(METADATA_FILE_NAME) as source:
+                    metadata_json = json.load(source)
 
-            pull_contents_metadata = PullContentsMetadata.model_validate(metadata_json)
+                pull_contents_metadata = PullContentsMetadata.model_validate(metadata_json)
 
-            if pull_contents_metadata.runner_config:
-                workflow_config.container_image_name = pull_contents_metadata.runner_config.container_image_name
-                workflow_config.container_image_tag = pull_contents_metadata.runner_config.container_image_tag
-                if workflow_config.container_image_name and not workflow_config.container_image_tag:
-                    workflow_config.container_image_tag = "latest"
-            if not workflow_config.module and workflow_deployment and pull_contents_metadata.deployment_name:
-                workflow_config.module = snake_case(pull_contents_metadata.deployment_name)
-            if not workflow_config.module and pull_contents_metadata.label:
-                workflow_config.module = snake_case(pull_contents_metadata.label)
+                if pull_contents_metadata.runner_config:
+                    workflow_config.container_image_name = pull_contents_metadata.runner_config.container_image_name
+                    workflow_config.container_image_tag = pull_contents_metadata.runner_config.container_image_tag
+                    if workflow_config.container_image_name and not workflow_config.container_image_tag:
+                        workflow_config.container_image_tag = "latest"
+                if not workflow_config.module and workflow_deployment and pull_contents_metadata.deployment_name:
+                    workflow_config.module = snake_case(pull_contents_metadata.deployment_name)
+                if not workflow_config.module and pull_contents_metadata.label:
+                    workflow_config.module = snake_case(pull_contents_metadata.label)
 
-        if not workflow_config.module:
-            raise ValueError(f"Failed to resolve a module name for Workflow {pk}")
+            if not workflow_config.module:
+                raise ValueError(f"Failed to resolve a module name for Workflow {pk}")
 
-        # Use target_directory if provided, otherwise use current working directory
-        base_dir = os.path.join(os.getcwd(), target_directory) if target_directory else os.getcwd()
-        target_dir = os.path.join(base_dir, *workflow_config.module.split("."))
-        workflow_config.target_directory = target_dir if target_directory else None
+            # Use target_directory if provided, otherwise use current working directory
+            base_dir = os.path.join(os.getcwd(), target_directory) if target_directory else os.getcwd()
+            target_dir = os.path.join(base_dir, *workflow_config.module.split("."))
+            workflow_config.target_directory = target_dir if target_directory else None
 
-        # Delete files in target_dir that aren't in the zip file
-        if os.path.exists(target_dir):
-            ignore_patterns = (
-                workflow_config.ignore
-                if isinstance(workflow_config.ignore, list)
-                else [workflow_config.ignore] if isinstance(workflow_config.ignore, str) else []
-            )
-            existing_files = []
-            for root, _, files in os.walk(target_dir):
-                for file in files:
-                    rel_path = os.path.relpath(os.path.join(root, file), target_dir)
-                    existing_files.append(rel_path)
+            # Delete files in target_dir that aren't in the zip file
+            if os.path.exists(target_dir):
+                ignore_patterns = (
+                    workflow_config.ignore
+                    if isinstance(workflow_config.ignore, list)
+                    else [workflow_config.ignore] if isinstance(workflow_config.ignore, str) else []
+                )
+                existing_files = []
+                for root, _, files in os.walk(target_dir):
+                    for file in files:
+                        rel_path = os.path.relpath(os.path.join(root, file), target_dir)
+                        existing_files.append(rel_path)
 
-            for file in existing_files:
-                if any(Path(file).match(ignore_pattern) for ignore_pattern in ignore_patterns):
-                    continue
+                for file in existing_files:
+                    if any(Path(file).match(ignore_pattern) for ignore_pattern in ignore_patterns):
+                        continue
 
-                if file not in zip_file.namelist():
-                    file_path = os.path.join(target_dir, file)
-                    logger.info(f"Deleting {file_path}...")
-                    os.remove(file_path)
+                    if file not in zip_file.namelist():
+                        file_path = os.path.join(target_dir, file)
+                        logger.info(f"Deleting {file_path}...")
+                        os.remove(file_path)
 
-        for file_name in zip_file.namelist():
-            with zip_file.open(file_name) as source:
-                content = source.read().decode("utf-8")
-                if file_name == ERROR_LOG_FILE_NAME:
-                    error_content = content
-                    continue
-                if file_name == METADATA_FILE_NAME:
-                    continue
+            for file_name in zip_file.namelist():
+                with zip_file.open(file_name) as source:
+                    content = source.read().decode("utf-8")
+                    if file_name == ERROR_LOG_FILE_NAME:
+                        error_content = content
+                        continue
+                    if file_name == METADATA_FILE_NAME:
+                        continue
 
-                target_file = os.path.join(target_dir, file_name)
-                os.makedirs(os.path.dirname(target_file), exist_ok=True)
-                with open(target_file, "w") as target:
-                    logger.info(f"Writing to {target_file}...")
-                    target.write(content)
+                    target_file = os.path.join(target_dir, file_name)
+                    os.makedirs(os.path.dirname(target_file), exist_ok=True)
+                    with open(target_file, "w") as target:
+                        logger.info(f"Writing to {target_file}...")
+                        target.write(content)
+    except Exception:
+        raise Exception("Please check if API URL is set correctly.")
 
     if include_json:
         logger.warning(

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -214,8 +214,10 @@ def pull_command(
                     with open(target_file, "w") as target:
                         logger.info(f"Writing to {target_file}...")
                         target.write(content)
-    except Exception:
-        raise Exception("Please check if API URL is set correctly.")
+    except zipfile.BadZipFile:
+        raise Exception(
+            "The API we tried to pull from returned an invalid zip file. Please make sure your `VELLUM_API_URL` environment variable is set correctly."  # noqa: E501
+        )
 
     if include_json:
         logger.warning(

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -875,3 +875,18 @@ def test_pull__module_name_from_deployment_name(vellum_client):
     assert os.path.exists(workflow_py)
     with open(workflow_py) as f:
         assert f.read() == "print('hello')"
+
+
+def test_pull__invalid_zip_file(vellum_client):
+    workflow_deployment = "test-workflow-deployment-id"
+
+    # GIVEN a workflow pull API call returns an invalid zip file
+    vellum_client.workflows.pull.return_value = iter([b"invalid"])  # Return bytes instead of string
+
+    # WHEN the user runs the pull command
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["workflows", "pull", "--workflow-deployment", workflow_deployment])
+
+    # THEN the command returns an error
+    assert result.exit_code == 1
+    assert str(result.exception) == "Please check if API URL is set correctly."

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -889,4 +889,7 @@ def test_pull__invalid_zip_file(vellum_client):
 
     # THEN the command returns an error
     assert result.exit_code == 1
-    assert str(result.exception) == "Please check if API URL is set correctly."
+    assert (
+        str(result.exception)
+        == "The API we tried to pull from returned an invalid zip file. Please make sure your `VELLUM_API_URL` environment variable is set correctly."  # noqa: E501
+    )


### PR DESCRIPTION
this should only happen if users send a request to `app.vellum.ai` instead of the valid API endpoint, other endpoint will return error like

`  <p>The requested URL <code>/v1/workflows/f1477885-2a17-4c60-ab6e-6ce3aec94822/pull</code> was not found on this server.  <ins>That’s all we know.</ins>`

but `app.vellum.ai` will send back 200 with an invalid zip file
                