### PR TITLE
Add error handling for invalid api endpoint

### DIFF
--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -8,6 +8,7 @@ from typing import Optional
 from dotenv import load_dotenv
 from pydash import snake_case
 
+from vellum.client.core.api_error import ApiError
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
 from vellum.workflows.vellum_client import create_vellum_client
 from vellum_cli.config import VellumCliConfig, WorkflowConfig, load_vellum_cli_config
@@ -146,12 +147,11 @@ def pull_command(
         request_options={"additional_query_parameters": query_parameters},
     )
 
-    zip_bytes = b"".join(response)
-    zip_buffer = io.BytesIO(zip_bytes)
-
-    error_content = ""
-
     try:
+        zip_bytes = b"".join(response)
+        zip_buffer = io.BytesIO(zip_bytes)
+
+        error_content = ""
         with zipfile.ZipFile(zip_buffer) as zip_file:
             if METADATA_FILE_NAME in zip_file.namelist():
                 metadata_json: Optional[dict] = None
@@ -217,6 +217,10 @@ def pull_command(
     except zipfile.BadZipFile:
         raise Exception(
             "The API we tried to pull from returned an invalid zip file. Please make sure your `VELLUM_API_URL` environment variable is set correctly."  # noqa: E501
+        )
+    except ApiError:
+        raise Exception(
+            "The API we tried to pull is invalid. Please make sure your `VELLUM_API_URL` environment variable is set correctly."  # noqa: E501
         )
 
     if include_json:

--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -149,9 +149,14 @@ def pull_command(
 
     try:
         zip_bytes = b"".join(response)
-        zip_buffer = io.BytesIO(zip_bytes)
+    except ApiError:
+        raise Exception(
+            "The API we tried to pull is invalid. Please make sure your `VELLUM_API_URL` environment variable is set correctly."  # noqa: E501
+        )
 
-        error_content = ""
+    zip_buffer = io.BytesIO(zip_bytes)
+    error_content = ""
+    try:
         with zipfile.ZipFile(zip_buffer) as zip_file:
             if METADATA_FILE_NAME in zip_file.namelist():
                 metadata_json: Optional[dict] = None
@@ -217,10 +222,6 @@ def pull_command(
     except zipfile.BadZipFile:
         raise Exception(
             "The API we tried to pull from returned an invalid zip file. Please make sure your `VELLUM_API_URL` environment variable is set correctly."  # noqa: E501
-        )
-    except ApiError:
-        raise Exception(
-            "The API we tried to pull is invalid. Please make sure your `VELLUM_API_URL` environment variable is set correctly."  # noqa: E501
         )
 
     if include_json:

--- a/ee/vellum_cli/tests/test_pull.py
+++ b/ee/vellum_cli/tests/test_pull.py
@@ -893,3 +893,29 @@ def test_pull__invalid_zip_file(vellum_client):
         str(result.exception)
         == "The API we tried to pull from returned an invalid zip file. Please make sure your `VELLUM_API_URL` environment variable is set correctly."  # noqa: E501
     )
+
+
+def test_pull__json_decode_error(vellum_client):
+    workflow_deployment = "test-workflow-deployment-id"
+
+    # GIVEN a workflow pull API call that returns a generator which raises an error when consumed
+    def mock_error_generator():
+        # This generator yields nothing but raises when consumed
+        if False:  # This ensures the generator is created but yields nothing
+            yield b""
+        from vellum.client.core.api_error import ApiError
+
+        raise ApiError(status_code=400, body="Invalid JSON")
+
+    vellum_client.workflows.pull.return_value = mock_error_generator()
+
+    # WHEN the user runs the pull command
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["workflows", "pull", "--workflow-deployment", workflow_deployment])
+
+    # THEN the command returns an error
+    assert result.exit_code == 1
+    assert (
+        str(result.exception)
+        == "The API we tried to pull is invalid. Please make sure your `VELLUM_API_URL` environment variable is set correctly."  # noqa: E501
+    )


### PR DESCRIPTION
follow up: https://github.com/vellum-ai/vellum-python-sdks/pull/1316

this PR handles invalid api endpoint (non `app.vellum.ai`)