### PR TITLE
[APO-271] Update codegen to now always persist standalone script files for code execution nodes

### DIFF
--- a/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
+++ b/ee/codegen/src/__test__/helpers/workflow-context-factory.ts
@@ -7,7 +7,6 @@ export function workflowContextFactory({
   moduleName,
   workflowClassName,
   workflowRawData,
-  codeExecutionNodeCodeRepresentationOverride = "STANDALONE",
   strict = true,
   disableFormatting = true,
 }: Partial<WorkflowContext.Args> = {}): WorkflowContext {
@@ -22,7 +21,6 @@ export function workflowContextFactory({
       edges: [],
     },
     strict,
-    codeExecutionNodeCodeRepresentationOverride,
     disableFormatting,
   });
 }

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -196,6 +196,32 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
 "
 `;
 
+exports[`CodeExecutionNode > code representation: Base case > should generate the correct node class 1`] = `
+"from vellum.workflows.nodes.displayable import CodeExecutionNode as BaseCodeExecutionNode
+from vellum.workflows.state import BaseState
+
+
+class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
+    filepath = "./script.py"
+    code_inputs = {}
+    runtime = "PYTHON_3_11_6"
+    packages = None
+"
+`;
+
+exports[`CodeExecutionNode > code representation: Escaped case > should generate the correct node class 1`] = `
+"from vellum.workflows.nodes.displayable import CodeExecutionNode as BaseCodeExecutionNode
+from vellum.workflows.state import BaseState
+
+
+class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
+    filepath = "./script.py"
+    code_inputs = {}
+    runtime = "PYTHON_3_11_6"
+    packages = None
+"
+`;
+
 exports[`CodeExecutionNode > failure cases > fallback to python 3.11.6 if runtime input is not valid 1`] = `
 "from vellum.workflows.nodes.displayable import (
     CodeExecutionNode as BaseCodeExecutionNode,

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -55,7 +55,6 @@ export declare namespace WorkflowContext {
     vellumApiEnvironment?: VellumEnvironmentUrls;
     workflowRawData: WorkflowRawData;
     strict: boolean;
-    codeExecutionNodeCodeRepresentationOverride: "STANDALONE" | "INLINE";
     disableFormatting: boolean;
     classNames?: Set<string>;
   };
@@ -124,10 +123,6 @@ export class WorkflowContext {
 
   public readonly workflowRawData: WorkflowRawData;
 
-  public readonly codeExecutionNodeCodeRepresentationOverride:
-    | "STANDALONE"
-    | "INLINE";
-
   public readonly disableFormatting: boolean;
 
   // Track what class names are used within this workflow so that we can ensure name uniqueness
@@ -153,7 +148,6 @@ export class WorkflowContext {
     vellumApiEnvironment,
     workflowRawData,
     strict,
-    codeExecutionNodeCodeRepresentationOverride,
     disableFormatting,
     classNames,
   }: WorkflowContext.Args) {
@@ -185,9 +179,6 @@ export class WorkflowContext {
 
     this.strict = strict;
     this.errors = [];
-
-    this.codeExecutionNodeCodeRepresentationOverride =
-      codeExecutionNodeCodeRepresentationOverride;
 
     this.disableFormatting = disableFormatting;
 
@@ -222,8 +213,6 @@ export class WorkflowContext {
       vellumApiKey: this.vellumApiKey,
       vellumApiEnvironment: this.vellumApiEnvironment,
       workflowRawData,
-      codeExecutionNodeCodeRepresentationOverride:
-        this.codeExecutionNodeCodeRepresentationOverride,
       strict: this.strict,
       disableFormatting: this.disableFormatting,
       classNames,

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -183,9 +183,6 @@ ${errors.slice(0, 3).map((err) => {
         vellumApiEnvironment: rest.vellumApiEnvironment,
         workflowRawData: this.workflowVersionExecConfig.workflowRawData,
         strict: rest.strict ?? false,
-        codeExecutionNodeCodeRepresentationOverride:
-          rest.options?.codeExecutionNodeCodeRepresentationOverride ??
-          "STANDALONE",
         disableFormatting: rest.options?.disableFormatting ?? false,
       });
       this.sandboxInputs = rest.sandboxInputs;


### PR DESCRIPTION
This is the final follow piece for https://github.com/vellum-ai/vellum-python-sdks/pull/1310

Now we can rip out the logic of standalone vs inline and just have codegen always persist the script file as standalone and vembda can read from this