### PR TITLE
[APO-387] Generate | instead of or in condition node

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
@@ -33,10 +33,8 @@ from vellum.workflows.references.constant import ConstantValueReference
 class ConditionalNode(BaseConditionalNode):
     class Ports(BaseConditionalNode.Ports):
         branch_1 = Port.on_if(
-            (
-                ConstantValueReference("text").equals("val-1")
-                | ConstantValueReference("text").equals("val-2")
-            )
+            ConstantValueReference("text").equals("val-1")
+            | ConstantValueReference("text").equals("val-2")
         )
 "
 `;

--- a/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/conditional-node.test.ts.snap
@@ -24,6 +24,23 @@ class ConditionalNode(BaseConditionalNode):
 "
 `;
 
+exports[`Conditional Node with OR combinator generates pipe operator > should generate code with pipe operator for OR conditions 1`] = `
+"from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
+from vellum.workflows.ports import Port
+from vellum.workflows.references.constant import ConstantValueReference
+
+
+class ConditionalNode(BaseConditionalNode):
+    class Ports(BaseConditionalNode.Ports):
+        branch_1 = Port.on_if(
+            (
+                ConstantValueReference("text").equals("val-1")
+                | ConstantValueReference("text").equals("val-2")
+            )
+        )
+"
+`;
+
 exports[`Conditional Node with constant value string base > getNodeFile 1`] = `
 "from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
 from vellum.workflows.ports import Port

--- a/ee/codegen/src/__test__/nodes/conditional-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/conditional-node.test.ts
@@ -886,3 +886,139 @@ describe("Conditional Node with constant value string base", () => {
     expect(await writer.toStringFormatted()).toMatchSnapshot();
   });
 });
+
+describe("Conditional Node with OR combinator generates pipe operator", () => {
+  let workflowContext: WorkflowContext;
+  let writer: Writer;
+  let node: ConditionalNode;
+
+  beforeEach(async () => {
+    workflowContext = workflowContextFactory();
+    writer = new Writer();
+
+    const nodeData: ConditionalNodeType = {
+      id: "b81a4453-7b80-41ea-bd55-c62df8878fd3",
+      type: WorkflowNodeType.CONDITIONAL,
+      data: {
+        label: "Conditional Node",
+        targetHandleId: "842b9dda-7977-47ad-a322-eb15b4c7069d",
+        conditions: [
+          {
+            id: "8d0d8b56-6c17-4684-9f16-45dd6ce23060",
+            type: "IF",
+            sourceHandleId: "63345ab5-1a4d-48a1-ad33-91bec41f92a5",
+            data: {
+              id: "fa50fb0c-8d62-40e3-bd88-080b52efd4b2",
+              rules: [
+                {
+                  id: "rule1",
+                  fieldNodeInputId: "field1",
+                  operator: "=",
+                  valueNodeInputId: "value1",
+                },
+                {
+                  id: "rule2",
+                  fieldNodeInputId: "field2",
+                  operator: "=",
+                  valueNodeInputId: "value2",
+                },
+              ],
+              combinator: "OR",
+            },
+          },
+        ],
+        version: "2",
+      },
+      inputs: [
+        {
+          id: "field1",
+          key: "rule1.field",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "text",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "value1",
+          key: "rule1.value",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "val-1",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "field2",
+          key: "rule2.field",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "text",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+        {
+          id: "value2",
+          key: "rule2.value",
+          value: {
+            rules: [
+              {
+                type: "CONSTANT_VALUE",
+                data: {
+                  type: "STRING",
+                  value: "val-2",
+                },
+              },
+            ],
+            combinator: "OR",
+          },
+        },
+      ],
+      displayData: {
+        width: 480,
+        height: 180,
+        position: {
+          x: 2247.2797390213086,
+          y: 30.917121251477084,
+        },
+      },
+    };
+
+    const nodeContext = (await createNodeContext({
+      workflowContext,
+      nodeData,
+    })) as ConditionalNodeContext;
+
+    node = new ConditionalNode({
+      workflowContext,
+      nodeContext,
+    });
+  });
+
+  it("should generate code with pipe operator for OR conditions", async () => {
+    node.getNodeFile().write(writer);
+    const generatedCode = await writer.toStringFormatted();
+    expect(generatedCode).toMatchSnapshot();
+  });
+});

--- a/ee/codegen/src/generators/conditional-node-port.ts
+++ b/ee/codegen/src/generators/conditional-node-port.ts
@@ -7,6 +7,7 @@ import { isNil } from "lodash";
 import { VellumVariableType } from "vellum-ai/api";
 
 import { NodePortGenerationError, ValueGenerationError } from "./errors";
+import { PipeExpression } from "./extensions";
 
 import * as codegen from "src/codegen";
 import { PortContext } from "src/context/port-context";
@@ -118,11 +119,7 @@ export class ConditionalNodePort extends AstNode {
             });
           }
         : (lhs: AstNode, rhs: AstNode): AstNode => {
-            return python.operator({
-              operator: OperatorType.Or,
-              lhs: lhs,
-              rhs: rhs,
-            });
+            return new PipeExpression(lhs, rhs);
           };
 
     return otherConditions.length > 0

--- a/ee/codegen/src/generators/extensions/protected-python-file.ts
+++ b/ee/codegen/src/generators/extensions/protected-python-file.ts
@@ -321,10 +321,8 @@ export class PipeExpression extends AstNode {
   }
 
   write(writer: Writer): void {
-    writer.write("(");
     this.lhs.write(writer);
     writer.write(" | ");
     this.rhs.write(writer);
-    writer.write(")");
   }
 }

--- a/ee/codegen/src/generators/extensions/protected-python-file.ts
+++ b/ee/codegen/src/generators/extensions/protected-python-file.ts
@@ -307,3 +307,24 @@ export class PythonFile extends AstNode {
     );
   }
 }
+
+export class PipeExpression extends AstNode {
+  private lhs: AstNode;
+  private rhs: AstNode;
+
+  constructor(lhs: AstNode, rhs: AstNode) {
+    super();
+    this.lhs = lhs;
+    this.rhs = rhs;
+    this.inheritReferences(lhs);
+    this.inheritReferences(rhs);
+  }
+
+  write(writer: Writer): void {
+    writer.write("(");
+    this.lhs.write(writer);
+    writer.write(" | ");
+    this.rhs.write(writer);
+    writer.write(")");
+  }
+}


### PR DESCRIPTION
`branch_1 = Port.on_if(Inputs.text.equals("aaa") or Inputs.text.equals("ddd"))`

`or` operator will only return the first condition that evaluates to True, because Python checks for truthiness and short-circuits.

We manually wrote the pipe condition using `|`, since Fern doesn't support the `|` operator.
