### PR TITLE
Add normalized score field to guard rail node output

### DIFF
--- a/src/vellum/workflows/nodes/displayable/guardrail_node/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/guardrail_node/test_node.py
@@ -3,6 +3,8 @@ import pytest
 from vellum import TestSuiteRunMetricNumberOutput
 from vellum.client.types.metric_definition_execution import MetricDefinitionExecution
 from vellum.client.types.test_suite_run_metric_string_output import TestSuiteRunMetricStringOutput
+from vellum.workflows.errors import WorkflowErrorCode
+from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.displayable.guardrail_node.node import GuardrailNode
 
 
@@ -36,3 +38,64 @@ def test_run_guardrail_node__empty_log(vellum_client, log_value):
     # THEN the workflow should have completed successfully
     assert outputs.score == 0.6
     assert outputs.log == ""
+
+
+def test_run_guardrail_node__normalized_score(vellum_client):
+    """Confirm that we can successfully invoke a Guardrail Node"""
+
+    # GIVEN a Guardrail Node
+    class MyGuard(GuardrailNode):
+        metric_definition = "example_metric_definition"
+        metric_inputs = {}
+
+    # AND we know that the guardrail node will return a normalized score
+    mock_metric_execution = MetricDefinitionExecution(
+        outputs=[
+            TestSuiteRunMetricNumberOutput(
+                name="score",
+                value=0.6,
+            ),
+            TestSuiteRunMetricNumberOutput(
+                name="normalized_score",
+                value=1.0,
+            ),
+        ],
+    )
+    vellum_client.metric_definitions.execute_metric_definition.return_value = mock_metric_execution
+
+    # WHEN we run the Guardrail Node
+    outputs = MyGuard().run()
+
+    # THEN the workflow should have completed successfully
+    assert outputs.score == 0.6
+    assert outputs.normalized_score == 1.0
+
+
+def test_run_guardrail_node__normalized_score_null(vellum_client):
+    # GIVEN a Guardrail Node
+    class MyGuard(GuardrailNode):
+        metric_definition = "example_metric_definition"
+        metric_inputs = {}
+
+    # AND we know that the guardrail node will return a normalized score that is None
+    mock_metric_execution = MetricDefinitionExecution(
+        outputs=[
+            TestSuiteRunMetricNumberOutput(
+                name="score",
+                value=0.6,
+            ),
+            TestSuiteRunMetricNumberOutput(
+                name="normalized_score",
+                value=None,
+            ),
+        ],
+    )
+    vellum_client.metric_definitions.execute_metric_definition.return_value = mock_metric_execution
+
+    # WHEN we run the Guardrail Node
+    with pytest.raises(NodeException) as exc_info:
+        MyGuard().run()
+
+    # THEN we get an exception
+    assert exc_info.value.message == "Metric execution must have one output named 'normalized_score' with type 'float'"
+    assert exc_info.value.code == WorkflowErrorCode.INVALID_OUTPUTS


### PR DESCRIPTION
Context: While investigating metric node event translation, I would get this error about normalized_score being an unrecognized attribute