### PR TITLE
Make State snapshotting resilient to errors in state deepcopy

### DIFF
--- a/src/vellum/workflows/state/base.py
+++ b/src/vellum/workflows/state/base.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from copy import deepcopy
 from dataclasses import field
 from datetime import datetime
+import logging
 from queue import Queue
 from threading import Lock
 from uuid import UUID, uuid4
@@ -28,6 +29,8 @@ from vellum.workflows.types.utils import (
 
 if TYPE_CHECKING:
     from vellum.workflows.nodes.bases import BaseNode
+
+logger = logging.getLogger(__name__)
 
 
 class _Snapshottable:
@@ -377,7 +380,10 @@ class BaseState(metaclass=_BaseStateMeta):
         Snapshots the current state to the workflow emitter. The invoked callback is overridden by the
         workflow runner.
         """
-        self.__snapshot_callback__(deepcopy(self))
+        try:
+            self.__snapshot_callback__(deepcopy(self))
+        except Exception:
+            logger.exception("Failed to snapshot Workflow state.")
 
     @classmethod
     def __get_pydantic_core_schema__(


### PR DESCRIPTION
We had a customer workflow deployed on the SDK last night that kept running into connection dropping issues. I have >80% confidence that those connection drops are tied to this deepcopy error:

<img width="920" alt="Screenshot 2025-04-10 at 3 21 37 PM" src="https://github.com/user-attachments/assets/7a9567f3-48c4-4d6c-aeb8-ce51ca01d0ae" />

This state is being deepcopied across map node threads, making this particularly susceptible to failures. So this PR simply catches errors here so that a failure in state snapshotting doesn't tank the whole workflow execution.

Long term, I think we'll want to yank out deepcopy and have our own first class state copy approach. We already override some of it with `__deepcop__(self)`, but we likely want to extend that further.