### PR TITLE
Fix serialization for Note Nodes

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/note_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/note_node.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, ClassVar, Dict, Generic, TypeVar, Union
 
 from vellum.workflows.nodes import NoteNode
@@ -23,7 +22,7 @@ class BaseNoteNodeDisplay(BaseNodeVellumDisplay[_NoteNodeType], Generic[_NoteNod
             "data": {
                 "label": self.label,
                 "text": self.text,
-                "style": json.dumps(self.style) if self.style else None,
+                "style": self.style,
             },
             "display_data": self.get_display_data().dict(),
             "base": self.get_base().dict(),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_note_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_note_node.py
@@ -1,0 +1,33 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes.displayable.note_node.node import NoteNode
+from vellum_ee.workflows.display.nodes.vellum.note_node import BaseNoteNodeDisplay
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+
+
+def test_serialize_node__note_node():
+    # GIVEN a note node
+    class MyNoteNode(NoteNode):
+        pass
+
+    # AND a display class for the note node
+    class MyNoteNodeDisplay(BaseNoteNodeDisplay[MyNoteNode]):
+        text = "This makes sense"
+        style = {
+            "fontSize": 24,
+        }
+
+    # AND a workflow with the code node
+    class Workflow(BaseWorkflow):
+        graph = MyNoteNode
+
+    # WHEN the workflow is serialized
+    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=Workflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    # THEN the node should properly serialize the inputs
+    my_note_node = next(node for node in serialized_workflow["workflow_raw_data"]["nodes"] if node["type"] == "NOTE")
+
+    assert my_note_node["inputs"] == []
+    assert my_note_node["data"]["text"] == "This makes sense"
+    assert my_note_node["data"]["style"] == {"fontSize": 24}


### PR DESCRIPTION
Was working on a high priority bug for a VPC customer and was trying to push their workflow into one of our workspaces, when I ran into this serialization bug:

<img width="1446" alt="Screenshot 2025-04-11 at 12 17 21 AM" src="https://github.com/user-attachments/assets/fe018291-f57c-4cfe-81fe-ef186a40e239" />
