### PR TITLE
Hoist up workflow inputs display from VellumWorkflowDisplay to BaseWorkflowDisplay

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/vellum-variable.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/vellum-variable.test.ts.snap
@@ -46,7 +46,7 @@ exports[`VellumVariableField > NumberVellumVariable snapshot 1`] = `
 `;
 
 exports[`VellumVariableField > OptionalVellumVariable defaultRequired=false snapshot 1`] = `
-"test: Optional[str]
+"test: Optional[str] = None
 "
 `;
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/inputs.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/inputs.py
@@ -5,4 +5,4 @@ from vellum.workflows.inputs import BaseInputs
 
 
 class Inputs(BaseInputs):
-    chat_history: Optional[List[ChatMessage]]
+    chat_history: Optional[List[ChatMessage]] = None

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/display_data/faa_q_and_a_bot.json
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/display_data/faa_q_and_a_bot.json
@@ -2241,7 +2241,7 @@
       "key": "chat_history",
       "type": "CHAT_HISTORY",
       "default": null,
-      "required": false,
+      "required": true,
       "extensions": {
         "color": null
       }

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/display_data/faa_q_and_a_bot.json
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/display_data/faa_q_and_a_bot.json
@@ -2241,7 +2241,7 @@
       "key": "chat_history",
       "type": "CHAT_HISTORY",
       "default": null,
-      "required": true,
+      "required": false,
       "extensions": {
         "color": null
       }

--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from uuid import UUID
-from typing import Optional, TypeVar
+from typing import Optional
 
 from pydantic import Field
 
@@ -36,17 +36,19 @@ class WorkflowMetaDisplayOverrides(WorkflowMetaDisplay):
 
 
 @dataclass
-class WorkflowInputsDisplayOverrides:
+class WorkflowInputsDisplay:
     id: UUID
+    name: Optional[str] = None
+    color: Optional[str] = None
 
 
 @dataclass
-class WorkflowInputsDisplay(WorkflowInputsDisplayOverrides):
+class WorkflowInputsDisplayOverrides(WorkflowInputsDisplay):
+    """
+    DEPRECATED: Use WorkflowInputsDisplay instead. Will be removed in 0.15.0
+    """
+
     pass
-
-
-WorkflowInputsDisplayType = TypeVar("WorkflowInputsDisplayType", bound=WorkflowInputsDisplay)
-WorkflowInputsDisplayOverridesType = TypeVar("WorkflowInputsDisplayOverridesType", bound=WorkflowInputsDisplayOverrides)
 
 
 @dataclass

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
@@ -1,11 +1,9 @@
 import pytest
 from uuid import uuid4
-from typing import Any, Dict, Type
+from typing import Any, Type
 
-from vellum.workflows.references.workflow_input import WorkflowInputReference
 from vellum.workflows.types.core import JsonObject
 from vellum.workflows.types.generics import NodeType
-from vellum_ee.workflows.display.base import WorkflowInputsDisplayType
 from vellum_ee.workflows.display.editor.types import NodeDisplayData
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
@@ -14,6 +12,7 @@ from vellum_ee.workflows.display.types import (
     NodeOutputDisplays,
     StateValueDisplays,
     WorkflowDisplayContext,
+    WorkflowInputsDisplays,
 )
 from vellum_ee.workflows.display.vellum import WorkflowMetaVellumDisplay
 from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
@@ -24,7 +23,7 @@ def serialize_node():
     def _serialize_node(
         node_class: Type[NodeType],
         base_class: type[BaseNodeDisplay[Any]] = BaseNodeDisplay,
-        global_workflow_input_displays: Dict[WorkflowInputReference, WorkflowInputsDisplayType] = {},
+        global_workflow_input_displays: WorkflowInputsDisplays = {},
         global_state_value_displays: StateValueDisplays = {},
         global_node_displays: NodeDisplays = {},
         global_node_output_displays: NodeOutputDisplays = {},

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_default_state_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_default_state_serialization.py
@@ -32,7 +32,7 @@ def test_serialize_workflow():
                 "key": "example",
                 "type": "STRING",
                 "default": {"type": "STRING", "value": "hello"},
-                "required": True,
+                "required": False,
                 "extensions": {"color": None},
             },
         ],

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, Generic, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Dict, Tuple, Type, TypeVar
 
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.events.workflow import WorkflowEventDisplayContext  # noqa: F401
@@ -10,7 +10,7 @@ from vellum_ee.workflows.display.base import (
     EdgeDisplay,
     EntrypointDisplay,
     StateValueDisplay,
-    WorkflowInputsDisplayType,
+    WorkflowInputsDisplay,
     WorkflowMetaDisplay,
     WorkflowOutputDisplay,
 )
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 WorkflowDisplayType = TypeVar("WorkflowDisplayType", bound="BaseWorkflowDisplay")
 
+WorkflowInputsDisplays = Dict[WorkflowInputReference, WorkflowInputsDisplay]
 StateValueDisplays = Dict[StateValueReference, StateValueDisplay]
 NodeDisplays = Dict[Type[BaseNode], BaseNodeDisplay]
 NodeOutputDisplays = Dict[OutputReference, Tuple[Type[BaseNode], NodeOutputDisplay]]
@@ -32,13 +33,11 @@ PortDisplays = Dict[Port, PortDisplay]
 
 
 @dataclass
-class WorkflowDisplayContext(Generic[WorkflowInputsDisplayType,]):
+class WorkflowDisplayContext:
     workflow_display_class: Type["BaseWorkflowDisplay"]
     workflow_display: WorkflowMetaDisplay
-    workflow_input_displays: Dict[WorkflowInputReference, WorkflowInputsDisplayType] = field(default_factory=dict)
-    global_workflow_input_displays: Dict[WorkflowInputReference, WorkflowInputsDisplayType] = field(
-        default_factory=dict
-    )
+    workflow_input_displays: WorkflowInputsDisplays = field(default_factory=dict)
+    global_workflow_input_displays: WorkflowInputsDisplays = field(default_factory=dict)
     state_value_displays: StateValueDisplays = field(default_factory=dict)
     global_state_value_displays: StateValueDisplays = field(default_factory=dict)
     node_displays: NodeDisplays = field(default_factory=dict)

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -8,7 +8,6 @@ from vellum_ee.workflows.display.base import (
     EntrypointDisplayOverrides,
     StateValueDisplayOverrides,
     WorkflowInputsDisplay,
-    WorkflowInputsDisplayOverrides,
     WorkflowMetaDisplayOverrides,
     WorkflowOutputDisplayOverrides,
 )
@@ -44,10 +43,13 @@ class WorkflowMetaVellumDisplay(WorkflowMetaVellumDisplayOverrides):
 
 
 @dataclass
-class WorkflowInputsVellumDisplayOverrides(WorkflowInputsDisplay, WorkflowInputsDisplayOverrides):
+class WorkflowInputsVellumDisplayOverrides(WorkflowInputsDisplay):
+    """
+    DEPRECATED: Use WorkflowInputsDisplay instead. Will be removed in 0.15.0
+    """
+
     name: Optional[str] = None
     required: Optional[bool] = None
-    color: Optional[str] = None
 
 
 @dataclass

--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -48,7 +48,6 @@ class WorkflowInputsVellumDisplayOverrides(WorkflowInputsDisplay):
     DEPRECATED: Use WorkflowInputsDisplay instead. Will be removed in 0.15.0
     """
 
-    name: Optional[str] = None
     required: Optional[bool] = None
 
 

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -2,6 +2,7 @@ import logging
 from uuid import UUID
 from typing import Optional, cast
 
+from vellum.workflows.constants import undefined
 from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
 from vellum.workflows.nodes.displayable.final_output_node import FinalOutputNode
 from vellum.workflows.nodes.utils import get_unadorned_node, get_unadorned_port
@@ -36,7 +37,7 @@ class VellumWorkflowDisplay(BaseWorkflowDisplay[WorkflowType]):
                     "key": workflow_input_display.name or workflow_input_reference.name,
                     "type": infer_vellum_variable_type(workflow_input_reference),
                     "default": default.dict() if default else None,
-                    "required": workflow_input_reference.instance is None,
+                    "required": workflow_input_reference.instance is undefined,
                     "extensions": {"color": workflow_input_display.color},
                 }
             )
@@ -52,7 +53,7 @@ class VellumWorkflowDisplay(BaseWorkflowDisplay[WorkflowType]):
                     "key": state_value_display.name or state_value_reference.name,
                     "type": infer_vellum_variable_type(state_value_reference),
                     "default": default.dict() if default else None,
-                    "required": state_value_reference.instance is None,
+                    "required": state_value_reference.instance is undefined,
                     "extensions": {"color": state_value_display.color},
                 }
             )

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -5,7 +5,6 @@ from typing import Optional, cast
 from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
 from vellum.workflows.nodes.displayable.final_output_node import FinalOutputNode
 from vellum.workflows.nodes.utils import get_unadorned_node, get_unadorned_port
-from vellum.workflows.references import WorkflowInputReference
 from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
@@ -15,38 +14,29 @@ from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.utils.vellum import infer_vellum_variable_type
-from vellum_ee.workflows.display.vellum import WorkflowInputsVellumDisplay, WorkflowInputsVellumDisplayOverrides
 from vellum_ee.workflows.display.workflows.base_workflow_display import BaseWorkflowDisplay
 
 logger = logging.getLogger(__name__)
 
 
-class VellumWorkflowDisplay(
-    BaseWorkflowDisplay[
-        WorkflowType,
-        WorkflowInputsVellumDisplay,
-        WorkflowInputsVellumDisplayOverrides,
-    ]
-):
+class VellumWorkflowDisplay(BaseWorkflowDisplay[WorkflowType]):
     node_display_base_class = BaseNodeDisplay
 
     def serialize(self) -> JsonObject:
         input_variables: JsonArray = []
-        for workflow_input, workflow_input_display in self.display_context.workflow_input_displays.items():
-            default = primitive_to_vellum_value(workflow_input.instance) if workflow_input.instance else None
-            required = (
-                workflow_input_display.required
-                if workflow_input_display.required is not None
-                else type(None) not in workflow_input.types
+        for workflow_input_reference, workflow_input_display in self.display_context.workflow_input_displays.items():
+            default = (
+                primitive_to_vellum_value(workflow_input_reference.instance)
+                if workflow_input_reference.instance
+                else None
             )
-
             input_variables.append(
                 {
                     "id": str(workflow_input_display.id),
-                    "key": workflow_input_display.name or workflow_input.name,
-                    "type": infer_vellum_variable_type(workflow_input),
+                    "key": workflow_input_display.name or workflow_input_reference.name,
+                    "type": infer_vellum_variable_type(workflow_input_reference),
                     "default": default.dict() if default else None,
-                    "required": required,
+                    "required": workflow_input_reference.instance is None,
                     "extensions": {"color": workflow_input_display.color},
                 }
             )
@@ -269,20 +259,3 @@ class VellumWorkflowDisplay(
             "state_variables": state_variables,
             "output_variables": output_variables,
         }
-
-    def _generate_workflow_input_display(
-        self, workflow_input: WorkflowInputReference, overrides: Optional[WorkflowInputsVellumDisplayOverrides] = None
-    ) -> WorkflowInputsVellumDisplay:
-        workflow_input_id: UUID
-        name = None
-        required = None
-        color = None
-        if overrides:
-            workflow_input_id = overrides.id
-            name = overrides.name
-            required = overrides.required
-            color = overrides.color
-        else:
-            workflow_input_id = uuid4_from_hash(f"{self.workflow_id}|inputs|id|{workflow_input.name}")
-
-        return WorkflowInputsVellumDisplay(id=workflow_input_id, name=name, required=required, color=color)

--- a/src/vellum/workflows/inputs/base.py
+++ b/src/vellum/workflows/inputs/base.py
@@ -4,6 +4,7 @@ from typing_extensions import dataclass_transform
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
 
+from vellum.workflows.constants import undefined
 from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import WorkflowInitializationException
 from vellum.workflows.references import ExternalInputReference, WorkflowInputReference
@@ -15,7 +16,7 @@ from vellum.workflows.types.utils import get_class_attr_names, infer_types
 class _BaseInputsMeta(type):
     def __getattribute__(cls, name: str) -> Any:
         if not name.startswith("_") and name in cls.__annotations__ and issubclass(cls, BaseInputs):
-            instance = vars(cls).get(name)
+            instance = vars(cls).get(name, undefined)
             types = infer_types(cls, name)
 
             if getattr(cls, "__descriptor_class__", None) is ExternalInputReference:

--- a/src/vellum/workflows/state/base.py
+++ b/src/vellum/workflows/state/base.py
@@ -50,7 +50,7 @@ class _Snapshottable:
 class _BaseStateMeta(type):
     def __getattribute__(cls, name: str) -> Any:
         if not name.startswith("_"):
-            instance = vars(cls).get(name)
+            instance = vars(cls).get(name, undefined)
             types = infer_types(cls, name)
             return StateValueReference(name=name, types=types, instance=instance)
 


### PR DESCRIPTION
The last generic to clean up from our VellumWorkflowDisplay before we could start to deprecate and remove the class outright. This PR just hoists up and consolidates our workflow input display classes