### PR TITLE
Add test for Run From Node inputs

### DIFF
--- a/tests/workflows/run_from_node/tests/test_workflow.py
+++ b/tests/workflows/run_from_node/tests/test_workflow.py
@@ -1,4 +1,5 @@
 from vellum.workflows.state.base import BaseState, StateMeta
+from vellum.workflows.workflows.event_filters import all_workflow_event_filter
 
 from tests.workflows.run_from_node.workflow import NextNode, RunFromNodeWorkflow, StartNode
 
@@ -24,3 +25,30 @@ def test_run_workflow__happy_path():
 
     # AND the final value should be dependent on the intermediate State value
     assert terminal_event.outputs == {"final_value": 43}
+
+
+def test_stream_workflow__node_inputs():
+    # GIVEN a workflow that we expect to run from the middle of
+    workflow = RunFromNodeWorkflow()
+
+    # WHEN the workflow is run
+    stream = workflow.stream(
+        entrypoint_nodes=[NextNode],
+        state=BaseState(
+            meta=StateMeta(
+                node_outputs={
+                    StartNode.Outputs.next_value: 42,
+                },
+            )
+        ),
+        event_filter=all_workflow_event_filter,
+    )
+    events = list(stream)
+
+    # THEN the workflow should be fulfilled
+    assert events[-1].name == "workflow.execution.fulfilled"
+
+    # AND the node initiated events should have the correct inputs
+    node_initiated_event = events[1]
+    assert node_initiated_event.name == "node.execution.initiated"
+    assert node_initiated_event.inputs == {NextNode.next_value: 42}


### PR DESCRIPTION
I'm debugging this run from node inputs issue:

<img width="500" alt="Screenshot 2025-04-11 at 10 30 20 AM" src="https://github.com/user-attachments/assets/008c759d-7935-4f74-8fad-ca65120fead3" />

This test rules out the problem being on the SDK side. Problem likely lies with Vembda