### PR TITLE
Support deserialization of nested Workflow State's

### DIFF
--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -488,11 +488,13 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
                     parent=self._parent_state,
                     workflow_inputs=workflow_inputs or self.get_default_inputs(),
                     trace_id=execution_context.trace_id,
+                    workflow_definition=self.__class__,
                 )
                 if execution_context and int(execution_context.trace_id)
                 else StateMeta(
                     parent=self._parent_state,
                     workflow_inputs=workflow_inputs or self.get_default_inputs(),
+                    workflow_definition=self.__class__,
                 )
             )
         )
@@ -600,3 +602,5 @@ NodeExecutionRejectedEvent.model_rebuild()
 NodeExecutionPausedEvent.model_rebuild()
 NodeExecutionResumedEvent.model_rebuild()
 NodeExecutionStreamingEvent.model_rebuild()
+
+StateMeta.model_rebuild()

--- a/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
+++ b/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
@@ -67,6 +67,11 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
                 "node_executions_queued": {},
                 "dependencies_invoked": {},
             },
+            "workflow_definition": {
+                "name": "BasicEmitterWorkflow",
+                "id": str(BasicEmitterWorkflow.__id__),
+                "module": ["tests", "workflows", "basic_emitter_workflow", "workflow"],
+            },
         },
         "score": 0,
     }
@@ -106,6 +111,11 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
                     str(next_node_span_id): [f"{base_module}.workflow.StartNode"],
                 },
             },
+            "workflow_definition": {
+                "name": "BasicEmitterWorkflow",
+                "id": str(BasicEmitterWorkflow.__id__),
+                "module": ["tests", "workflows", "basic_emitter_workflow", "workflow"],
+            },
         },
         "score": 13,
     }
@@ -140,6 +150,11 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
                 },
             },
             "parent": None,
+            "workflow_definition": {
+                "name": "BasicEmitterWorkflow",
+                "id": str(BasicEmitterWorkflow.__id__),
+                "module": ["tests", "workflows", "basic_emitter_workflow", "workflow"],
+            },
         },
         "score": 13,
     }


### PR DESCRIPTION
This ended up being way trickier than I thought and involves adding a new field to workflow state. Before I do so, going to start splitting out easier chunks from this PR and resolve some other cases that are higher pri in Run From Node deserialization.

EDIT: Ok just finished merging though the two related PRs, this one is now ready for review. This PR supports deserializing the parent state. In order to do so, we needed to introduce a reference of _which_ workflow definition the state was a part of. This allows us to maintain a decoupling of State and Workflow, allowing the same state class to be used in any workflow, since how it gets deserialized is fully encoded.