### PR TITLE
Consolidate CodeResourceDefinition classes

### DIFF
--- a/ee/vellum_ee/workflows/display/vellum.py
+++ b/ee/vellum_ee/workflows/display/vellum.py
@@ -19,11 +19,6 @@ from vellum_ee.workflows.display.editor.types import NodeDisplayPosition  # noqa
 from vellum_ee.workflows.display.utils.vellum import NodeInputValuePointerRule
 
 
-class CodeResourceDefinition(UniversalBaseModel):
-    name: str
-    module: List[str]
-
-
 @dataclass
 class WorkflowMetaVellumDisplayOverrides(WorkflowMetaDisplayOverrides):
     """

--- a/src/vellum/workflows/events/node.py
+++ b/src/vellum/workflows/events/node.py
@@ -8,9 +8,10 @@ from vellum.workflows.expressions.accessor import AccessorExpression
 from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.ports.port import Port
 from vellum.workflows.references.node import NodeReference
+from vellum.workflows.types.definition import serialize_type_encoder_with_id
 from vellum.workflows.types.generics import OutputsType
 
-from .types import BaseEvent, default_serializer, serialize_type_encoder_with_id
+from .types import BaseEvent, default_serializer
 
 if TYPE_CHECKING:
     from vellum.workflows.nodes.bases import BaseNode

--- a/src/vellum/workflows/events/workflow.py
+++ b/src/vellum/workflows/events/workflow.py
@@ -8,6 +8,7 @@ from vellum.core.pydantic_utilities import UniversalBaseModel
 from vellum.workflows.errors import WorkflowError
 from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.references import ExternalInputReference
+from vellum.workflows.types.definition import serialize_type_encoder_with_id
 from vellum.workflows.types.generics import InputsType, OutputsType, StateType
 
 from .node import (
@@ -18,7 +19,7 @@ from .node import (
     NodeExecutionResumedEvent,
     NodeExecutionStreamingEvent,
 )
-from .types import BaseEvent, default_serializer, serialize_type_encoder_with_id
+from .types import BaseEvent, default_serializer
 
 if TYPE_CHECKING:
     from vellum.workflows.workflows.base import BaseWorkflow

--- a/src/vellum/workflows/nodes/displayable/conftest.py
+++ b/src/vellum/workflows/nodes/displayable/conftest.py
@@ -1,12 +1,8 @@
 import pytest
 from uuid import UUID
 
-from vellum.workflows.events.types import (
-    CodeResourceDefinition,
-    NodeParentContext,
-    WorkflowDeploymentParentContext,
-    WorkflowParentContext,
-)
+from vellum.workflows.events.types import NodeParentContext, WorkflowDeploymentParentContext, WorkflowParentContext
+from vellum.workflows.types.definition import CodeResourceDefinition
 
 
 @pytest.fixture

--- a/src/vellum/workflows/types/definition.py
+++ b/src/vellum/workflows/types/definition.py
@@ -1,0 +1,39 @@
+from uuid import UUID
+from typing import Annotated, Any, Dict, Union
+
+from pydantic import BeforeValidator
+
+from vellum.client.types.code_resource_definition import CodeResourceDefinition as ClientCodeResourceDefinition
+
+
+def serialize_type_encoder(obj: type) -> Dict[str, Any]:
+    return {
+        "name": obj.__name__,
+        "module": obj.__module__.split("."),
+    }
+
+
+def serialize_type_encoder_with_id(obj: Union[type, "CodeResourceDefinition"]) -> Dict[str, Any]:
+    if hasattr(obj, "__id__") and isinstance(obj, type):
+        return {
+            "id": getattr(obj, "__id__"),
+            **serialize_type_encoder(obj),
+        }
+    elif isinstance(obj, CodeResourceDefinition):
+        return obj.model_dump(mode="json")
+
+    raise AttributeError(f"The object of type '{type(obj).__name__}' must have an '__id__' attribute.")
+
+
+class CodeResourceDefinition(ClientCodeResourceDefinition):
+    id: UUID
+
+    @staticmethod
+    def encode(obj: type) -> "CodeResourceDefinition":
+        return CodeResourceDefinition(**serialize_type_encoder_with_id(obj))
+
+
+VellumCodeResourceDefinition = Annotated[
+    CodeResourceDefinition,
+    BeforeValidator(lambda d: (d if type(d) is dict else serialize_type_encoder_with_id(d))),
+]

--- a/tests/workflows/basic_parent_context/tests/test_basic_parent_context_workflow_runner.py
+++ b/tests/workflows/basic_parent_context/tests/test_basic_parent_context_workflow_runner.py
@@ -1,7 +1,8 @@
 from uuid import uuid4
 
 from vellum.workflows.context import execution_context
-from vellum.workflows.events.types import CodeResourceDefinition, NodeParentContext
+from vellum.workflows.events.types import NodeParentContext
+from vellum.workflows.types.definition import CodeResourceDefinition
 from vellum.workflows.workflows.event_filters import root_workflow_event_filter
 
 from tests.workflows.basic_parent_context.basic_workflow import TrivialWorkflow

--- a/tests/workflows/stream_retry_node_annotation/tests/test_workflow.py
+++ b/tests/workflows/stream_retry_node_annotation/tests/test_workflow.py
@@ -1,5 +1,5 @@
-from vellum.workflows.events.types import CodeResourceDefinition, VellumCodeResourceDefinition
 from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
+from vellum.workflows.types.definition import CodeResourceDefinition, VellumCodeResourceDefinition
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum.workflows.workflows.event_filters import all_workflow_event_filter
 

--- a/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
+++ b/tests/workflows/stream_try_node_annotation/tests/test_workflow.py
@@ -1,5 +1,5 @@
-from vellum.workflows.events.types import CodeResourceDefinition, VellumCodeResourceDefinition
 from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
+from vellum.workflows.types.definition import CodeResourceDefinition, VellumCodeResourceDefinition
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum.workflows.workflows.event_filters import all_workflow_event_filter
 


### PR DESCRIPTION
Eventually working towards this Nested State Deserialization PR: https://github.com/vellum-ai/vellum-python-sdks/pull/1385

This PR splits out our CodeResourceDefinition classes into its own file to help avoid circular deps issues. We also consolidate the other two places that we call `CodeResourceDefinition`s