### PR TITLE
Support optional workflow inputs in Run From Node state deserialization

### DIFF
--- a/src/vellum/workflows/types/generics.py
+++ b/src/vellum/workflows/types/generics.py
@@ -27,6 +27,21 @@ def _import_node_class() -> Type["BaseNode"]:
     return BaseNode
 
 
+def import_workflow_class() -> Type["BaseWorkflow"]:
+    """
+    Helper function to help avoid circular imports.
+    """
+
+    from vellum.workflows.workflows import BaseWorkflow
+
+    return BaseWorkflow
+
+
 def is_node_class(obj: Any) -> TypeGuard[Type["BaseNode"]]:
     base_node_class = _import_node_class()
     return isinstance(obj, type) and issubclass(obj, base_node_class)
+
+
+def is_workflow_class(obj: Any) -> TypeGuard[Type["BaseWorkflow"]]:
+    base_workflow_class = import_workflow_class()
+    return isinstance(obj, type) and issubclass(obj, base_workflow_class)

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -534,14 +534,13 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
     def deserialize_state(cls, state: dict, workflow_inputs: Optional[InputsType] = None) -> StateType:
         state_class = cls.get_state_class()
         if "meta" in state:
-            nodes = list(cls.get_nodes())
             state["meta"] = StateMeta.model_validate(
                 {
                     **state["meta"],
                     "workflow_inputs": workflow_inputs,
                 },
                 context={
-                    "nodes": nodes,
+                    "workflow_definition": cls,
                 },
             )
 

--- a/src/vellum/workflows/workflows/tests/test_base_workflow.py
+++ b/src/vellum/workflows/workflows/tests/test_base_workflow.py
@@ -378,3 +378,39 @@ def test_base_workflow__deserialize_state():
 
     # AND the node execution cache should deserialize
     assert state.meta.node_execution_cache
+
+
+def test_base_workflow__deserialize_state_with_optional_inputs():
+
+    # GIVEN a state definition
+    class State(BaseState):
+        bar: str
+
+    # AND an inputs definition with an optional field
+    class Inputs(BaseInputs):
+        baz: str = "My default baz"
+
+    # AND a node
+    class NodeA(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            foo: str
+
+    # AND a workflow that uses all three
+    class TestWorkflow(BaseWorkflow[Inputs, State]):
+        graph = NodeA
+
+    # WHEN we deserialize the state
+    state = TestWorkflow.deserialize_state(
+        {
+            "bar": "My state bar",
+            "meta": {
+                "node_outputs": {},
+                "parent": None,
+            },
+        },
+    )
+
+    # THEN the state should be correct
+    assert state.bar == "My state bar"
+    assert isinstance(state.meta.workflow_inputs, Inputs)
+    assert state.meta.workflow_inputs.baz == "My default baz"


### PR DESCRIPTION
Eventually working up to this PR: https://github.com/vellum-ai/vellum-python-sdks/pull/1385

This PR simply supports optional workflow inputs in our state deserialization