### PR TITLE
Pass through none during deserialize state

### DIFF
--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -533,7 +533,12 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
         return most_recent_state_snapshot
 
     @classmethod
-    def deserialize_state(cls, state: dict, workflow_inputs: Optional[InputsType] = None) -> StateType:
+    def deserialize_state(
+        cls, state: Optional[dict], workflow_inputs: Optional[InputsType] = None
+    ) -> Optional[StateType]:
+        if state is None:
+            return None
+
         state_class = cls.get_state_class()
         if "meta" in state:
             state["meta"] = StateMeta.model_validate(

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -22,6 +22,7 @@ from typing import (
     Union,
     cast,
     get_args,
+    overload,
 )
 
 from vellum.workflows.edges import Edge
@@ -531,6 +532,14 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
             return self.get_default_state()
 
         return most_recent_state_snapshot
+
+    @overload
+    @classmethod
+    def deserialize_state(cls, state: dict, workflow_inputs: Optional[InputsType] = None) -> StateType: ...
+
+    @overload
+    @classmethod
+    def deserialize_state(cls, state: None, workflow_inputs: Optional[InputsType] = None) -> None: ...
 
     @classmethod
     def deserialize_state(

--- a/src/vellum/workflows/workflows/tests/test_base_workflow.py
+++ b/src/vellum/workflows/workflows/tests/test_base_workflow.py
@@ -483,3 +483,29 @@ def test_base_workflow__deserialize_nested_state():
     assert state.meta.parent.foo == "My outer state foo"
     assert state.meta.parent.meta.node_outputs == {OuterNode.Outputs.qux: "My outer node output qux"}
     assert state.meta.parent.meta.workflow_definition == TestWorkflow
+
+
+def test_base_workflow__deserialize_state_with_none():
+
+    # GIVEN a state definition
+    class State(BaseState):
+        bar: str
+
+    # AND an inputs definition
+    class Inputs(BaseInputs):
+        baz: str
+
+    # AND a node
+    class NodeA(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            foo: str
+
+    # AND a workflow that uses all three
+    class TestWorkflow(BaseWorkflow[Inputs, State]):
+        graph = NodeA
+
+    # WHEN we deserialize None
+    state = TestWorkflow.deserialize_state(None)
+
+    # THEN we should get back None
+    assert state is None


### PR DESCRIPTION
We pass through `None` to clean up this line from our workflow server:

```python
    workflow_state = (
        workflow.deserialize_state(
            executor_context.state,
            workflow_inputs=workflow_inputs,
        )
        if executor_context.state
        else None
    )
```

to

```python
    workflow_state =workflow.deserialize_state(executor_context.state, workflow_inputs=workflow_inputs)
```