### PR TITLE
Add some resilience to trying to deserialize workflow definition in State

### DIFF
--- a/src/vellum/workflows/state/base.py
+++ b/src/vellum/workflows/state/base.py
@@ -268,9 +268,16 @@ class StateMeta(UniversalBaseModel):
     @classmethod
     def deserialize_workflow_definition(cls, workflow_definition: Any, info: ValidationInfo):
         if isinstance(workflow_definition, dict):
-            return CodeResourceDefinition.model_validate(workflow_definition).decode()
+            deserialized_workflow_definition = CodeResourceDefinition.model_validate(workflow_definition).decode()
+            if not is_workflow_class(deserialized_workflow_definition):
+                return import_workflow_class()
 
-        return workflow_definition
+            return deserialized_workflow_definition
+
+        if is_workflow_class(workflow_definition):
+            return workflow_definition
+
+        return import_workflow_class()
 
     @field_serializer("node_outputs")
     def serialize_node_outputs(self, node_outputs: Dict[OutputReference, Any], _info: Any) -> Dict[str, Any]:

--- a/src/vellum/workflows/types/definition.py
+++ b/src/vellum/workflows/types/definition.py
@@ -42,8 +42,12 @@ class CodeResourceDefinition(ClientCodeResourceDefinition):
             frame = inspect.currentframe()
             return self._resolve_local(frame)
 
-        imported_module = importlib.import_module(".".join(self.module))
-        return getattr(imported_module, self.name)
+        try:
+            imported_module = importlib.import_module(".".join(self.module))
+        except ImportError:
+            return None
+
+        return getattr(imported_module, self.name, None)
 
     def _resolve_local(self, frame: Optional[FrameType]) -> Any:
         if not frame:


### PR DESCRIPTION
This will be the last of the State deserialization PRs before release. This new Code Resource Definition decoding is a bit risky, so adding some resilience so that things could run smoothly in case we receive data we are not expecting