### PR TITLE
Generate new span ids for Run From Node state's

### DIFF
--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import logging
 from queue import Empty, Queue
 from threading import Event as ThreadingEvent, Thread
-from uuid import UUID
+from uuid import UUID, uuid4
 from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, Iterator, Optional, Sequence, Set, Tuple, Type, Union
 
 from vellum.workflows.constants import undefined
@@ -98,7 +98,8 @@ class WorkflowRunner(Generic[StateType]):
             # https://app.shortcut.com/vellum/story/4408
             node = next(iter(entrypoint_nodes))
             if state:
-                self._initial_state = state
+                self._initial_state = deepcopy(state)
+                self._initial_state.meta.span_id = uuid4()
             else:
                 self._initial_state = self.workflow.get_state_at_node(node)
             self._entrypoints = entrypoint_nodes
@@ -123,6 +124,7 @@ class WorkflowRunner(Generic[StateType]):
             if state:
                 self._initial_state = deepcopy(state)
                 self._initial_state.meta.workflow_inputs = normalized_inputs
+                self._initial_state.meta.span_id = uuid4()
             else:
                 self._initial_state = self.workflow.get_default_state(normalized_inputs)
             self._entrypoints = self.workflow.get_entrypoints()

--- a/tests/workflows/basic_external_input/tests/test_workflow.py
+++ b/tests/workflows/basic_external_input/tests/test_workflow.py
@@ -37,6 +37,9 @@ def test_workflow__happy_path_multi_stop():
     assert final_terminal_event.name == "workflow.execution.fulfilled"
     assert final_terminal_event.outputs.final_value == "sunny"
 
+    # AND the workflow execution should have the same span id
+    assert final_terminal_event.span_id == terminal_event.span_id
+
 
 def test_workflow__happy_path_multi_stop_invalid_external_input():
     """

--- a/tests/workflows/basic_input_node/tests/test_workflow.py
+++ b/tests/workflows/basic_input_node/tests/test_workflow.py
@@ -32,6 +32,9 @@ def test_workflow__happy_path():
     assert final_terminal_event.name == "workflow.execution.fulfilled"
     assert final_terminal_event.outputs.final_value == "hello sunny world"
 
+    # AND the workflow execution should have the same span id
+    assert final_terminal_event.span_id == terminal_event.span_id
+
 
 def test_workflow__happy_path_stream():
     """
@@ -68,3 +71,7 @@ def test_workflow__happy_path_stream():
     final_event = events[-1]
     assert final_event.name == "workflow.execution.fulfilled"
     assert final_event.outputs.final_value == "hello sunny world"
+
+    # AND the workflow execution should have the same span id
+    assert events[0].span_id == terminal_event.span_id
+    assert final_event.span_id == terminal_event.span_id

--- a/tests/workflows/run_from_external/tests/test_workflow.py
+++ b/tests/workflows/run_from_external/tests/test_workflow.py
@@ -35,3 +35,6 @@ def test_run_workflow__happy_path(mock_random_int):
 
     # AND the final value should be as expected
     assert terminal_event.outputs == {"final_value": 47}
+
+    # AND the workflow execution should have the same span id
+    assert terminal_event.span_id == terminal_event.span_id

--- a/tests/workflows/run_from_node/tests/test_workflow.py
+++ b/tests/workflows/run_from_node/tests/test_workflow.py
@@ -8,23 +8,26 @@ def test_run_workflow__happy_path():
     # GIVEN a workflow that we expect to run from the middle of
     workflow = RunFromNodeWorkflow()
 
-    # WHEN the workflow is run
-    terminal_event = workflow.run(
-        entrypoint_nodes=[NextNode],
-        state=BaseState(
-            meta=StateMeta(
-                node_outputs={
-                    StartNode.Outputs.next_value: 42,
-                },
-            )
-        ),
+    # AND a state from a previous workflow execution
+    previous_state = BaseState(
+        meta=StateMeta(
+            node_outputs={
+                StartNode.Outputs.next_value: 42,
+            },
+        )
     )
+
+    # WHEN the workflow is run
+    terminal_event = workflow.run(entrypoint_nodes=[NextNode], state=previous_state)
 
     # THEN the workflow should be fulfilled
     assert terminal_event.name == "workflow.execution.fulfilled"
 
     # AND the final value should be dependent on the intermediate State value
     assert terminal_event.outputs == {"final_value": 43}
+
+    # AND the workflow execution should have a new span id
+    assert terminal_event.span_id != previous_state.meta.span_id
 
 
 def test_stream_workflow__node_inputs():


### PR DESCRIPTION
Each workflow execution should be its own span id. However, bc Run From Node stored the span id, we were seeing the same span id across runs. This PR fixes that so workflows executed by the Run From Node flow have their own span id's