### PR TITLE
Emit the initiated state with the workflow initiated event

### DIFF
--- a/src/vellum/workflows/events/tests/test_event.py
+++ b/src/vellum/workflows/events/tests/test_event.py
@@ -89,6 +89,7 @@ mock_node_uuid = str(uuid4_from_hash(MockNode.__qualname__))
                         "foo": "bar",
                     },
                     "display_context": None,
+                    "initial_state": None,
                 },
                 "parent": None,
             },

--- a/src/vellum/workflows/events/workflow.py
+++ b/src/vellum/workflows/events/workflow.py
@@ -54,8 +54,10 @@ class WorkflowEventDisplayContext(UniversalBaseModel):
     workflow_outputs: Dict[str, UUID]
 
 
-class WorkflowExecutionInitiatedBody(_BaseWorkflowExecutionBody, Generic[InputsType]):
+class WorkflowExecutionInitiatedBody(_BaseWorkflowExecutionBody, Generic[InputsType, StateType]):
     inputs: InputsType
+    initial_state: Optional[StateType] = None
+
     # It is still the responsibility of the workflow server to populate this context. The SDK's
     # Workflow Runner will always leave this field None.
     #
@@ -67,14 +69,22 @@ class WorkflowExecutionInitiatedBody(_BaseWorkflowExecutionBody, Generic[InputsT
     def serialize_inputs(self, inputs: InputsType, _info: Any) -> Dict[str, Any]:
         return default_serializer(inputs)
 
+    @field_serializer("initial_state")
+    def serialize_initial_state(self, initial_state: Optional[StateType], _info: Any) -> Optional[Dict[str, Any]]:
+        return default_serializer(initial_state)
 
-class WorkflowExecutionInitiatedEvent(_BaseWorkflowEvent, Generic[InputsType]):
+
+class WorkflowExecutionInitiatedEvent(_BaseWorkflowEvent, Generic[InputsType, StateType]):
     name: Literal["workflow.execution.initiated"] = "workflow.execution.initiated"
-    body: WorkflowExecutionInitiatedBody[InputsType]
+    body: WorkflowExecutionInitiatedBody[InputsType, StateType]
 
     @property
     def inputs(self) -> InputsType:
         return self.body.inputs
+
+    @property
+    def initial_state(self) -> Optional[StateType]:
+        return self.body.initial_state
 
 
 class WorkflowExecutionStreamingBody(_BaseWorkflowExecutionBody):

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -146,7 +146,7 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
 
     WorkflowEvent = Union[  # type: ignore
         GenericWorkflowEvent,
-        WorkflowExecutionInitiatedEvent[InputsType],  # type: ignore[valid-type]
+        WorkflowExecutionInitiatedEvent[InputsType, StateType],  # type: ignore[valid-type]
         WorkflowExecutionFulfilledEvent[Outputs],
         WorkflowExecutionSnapshottedEvent[StateType],  # type: ignore[valid-type]
     ]

--- a/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
+++ b/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
@@ -54,6 +54,7 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
     assert events[0].trace_id == trace_id
     assert events[0].span_id == workflow_span_id
     assert events[0].timestamp == frozen_datetime
+    assert events[0].initial_state is None
 
     assert events[1].name == "node.execution.initiated"
     assert events[1].node_definition == StartNode

--- a/tests/workflows/run_from_external/tests/test_workflow.py
+++ b/tests/workflows/run_from_external/tests/test_workflow.py
@@ -2,7 +2,7 @@ import pytest
 
 from pytest_mock import MockerFixture
 
-from tests.workflows.run_from_external.workflow import NextNode, RunFromExternalWorkflow
+from tests.workflows.run_from_external.workflow import NextNode, RunFromExternalWorkflow, StartNode
 
 
 @pytest.fixture
@@ -27,7 +27,7 @@ def test_run_workflow__happy_path(mock_random_int):
     terminal_event = workflow.run()
     assert terminal_event.name == "workflow.execution.rejected"
 
-    # WHEN the workflow is resumed from the node that failed
+    # WHEN the workflow is restarted from the node that failed
     terminal_event = workflow.run(entrypoint_nodes=[NextNode])
 
     # THEN the workflow should be fulfilled
@@ -38,3 +38,41 @@ def test_run_workflow__happy_path(mock_random_int):
 
     # AND the workflow execution should have the same span id
     assert terminal_event.span_id == terminal_event.span_id
+
+
+def test_stream_workflow__happy_path(mock_random_int):
+    """
+    Runs a workflow that has access to an external emitter and resolver. The test runs
+    the workflow twice, with the second run resuming from the first run as a stream, to
+    make assertions about initiated events.
+    """
+
+    # GIVEN a node that fails non-deterministically the first time, but succeeds the second
+    mock_random_int.side_effect = iter([99, 42])
+
+    # AND a workflow with external emitters and resolvers that runs this node
+    workflow = RunFromExternalWorkflow()
+
+    # AND we run it once the first time with a failure
+    terminal_event = workflow.run()
+    assert terminal_event.name == "workflow.execution.rejected"
+
+    # WHEN the workflow is restarted from the node that failed
+    stream = workflow.stream(entrypoint_nodes=[NextNode])
+    events = list(stream)
+
+    # THEN the workflow should be fulfilled
+    assert events[-1].name == "workflow.execution.fulfilled"
+
+    # AND the final value should be as expected
+    assert events[-1].outputs == {"final_value": 47}
+
+    # AND the workflow execution should have the same span id
+    assert events[-1].span_id == events[-1].span_id
+
+    # AND the workflow execution's initiated event should have the initial state
+    initiated_event = events[0]
+    assert initiated_event.name == "workflow.execution.initiated"
+    assert initiated_event.initial_state is not None
+    assert initiated_event.initial_state.meta.span_id == events[-1].span_id
+    assert initiated_event.initial_state.meta.node_outputs == {StartNode.Outputs.next_value: 5}

--- a/tests/workflows/run_from_node/tests/test_workflow.py
+++ b/tests/workflows/run_from_node/tests/test_workflow.py
@@ -30,7 +30,7 @@ def test_run_workflow__happy_path():
     assert terminal_event.span_id != previous_state.meta.span_id
 
 
-def test_stream_workflow__node_inputs():
+def test_stream_workflow__happy_path():
     # GIVEN a workflow that we expect to run from the middle of
     workflow = RunFromNodeWorkflow()
 
@@ -55,3 +55,10 @@ def test_stream_workflow__node_inputs():
     node_initiated_event = events[1]
     assert node_initiated_event.name == "node.execution.initiated"
     assert node_initiated_event.inputs == {NextNode.next_value: 42}
+
+    # AND the workflow initiated event should have the correct initial state
+    workflow_initiated_event = events[0]
+    assert workflow_initiated_event.name == "workflow.execution.initiated"
+    assert workflow_initiated_event.initial_state
+    assert workflow_initiated_event.initial_state.meta.node_outputs == {StartNode.Outputs.next_value: 42}
+    assert workflow_initiated_event.initial_state.meta.span_id == workflow_initiated_event.span_id

--- a/tests/workflows/run_from_workflow/tests/test_workflow.py
+++ b/tests/workflows/run_from_workflow/tests/test_workflow.py
@@ -2,7 +2,7 @@ import pytest
 
 from pytest_mock import MockerFixture
 
-from tests.workflows.run_from_workflow.workflow import NextNode, RunFromPreviousWorkflow
+from tests.workflows.run_from_workflow.workflow import NextNode, RunFromPreviousWorkflow, StartNode
 
 
 @pytest.fixture
@@ -30,3 +30,41 @@ def test_run_workflow__happy_path(mock_random_int):
 
     # AND the final value should be as expected
     assert terminal_event.outputs == {"final_value": 47}
+
+
+def test_stream_workflow__happy_path(mock_random_int):
+    """
+    Runs a workflow that has access to an external emitter and resolver. The test runs
+    the workflow twice, with the second run resuming from the first run as a stream, to
+    make assertions about initiated events.
+    """
+
+    # GIVEN a node that fails non-deterministically the first time, but succeeds the second
+    mock_random_int.side_effect = iter([99, 42])
+
+    # AND a workflow with external emitters and resolvers that runs this node
+    workflow = RunFromPreviousWorkflow()
+
+    # AND we run it once the first time with a failure
+    terminal_event = workflow.run()
+    assert terminal_event.name == "workflow.execution.rejected"
+
+    # WHEN the workflow is restarted from the node that failed
+    stream = workflow.stream(entrypoint_nodes=[NextNode])
+    events = list(stream)
+
+    # THEN the workflow should be fulfilled
+    assert events[-1].name == "workflow.execution.fulfilled"
+
+    # AND the final value should be as expected
+    assert events[-1].outputs == {"final_value": 47}
+
+    # AND the workflow execution should have the same span id
+    assert events[-1].span_id == events[-1].span_id
+
+    # AND the workflow execution's initiated event should have the initial state
+    initiated_event = events[0]
+    assert initiated_event.name == "workflow.execution.initiated"
+    assert initiated_event.initial_state is not None
+    assert initiated_event.initial_state.meta.span_id == events[-1].span_id
+    assert initiated_event.initial_state.meta.node_outputs == {StartNode.Outputs.next_value: 5}


### PR DESCRIPTION
Run from node currently is missing node outputs from previous nodes, making it unable to run from _previous_ nodes. Problem is depicted here:

![Screenshot 2025-04-16 at 12 57 41 PM](https://github.com/user-attachments/assets/9baaa592-f7ae-4937-999c-2a2177193cbe)

We are going to use the initiated event to return the state that was captured at the beginning of the workflow. From there, UI/django will be able to infer what where the synthetic looking events.