### PR TITLE
Allow workflows to push a workflow even if not in lockfile or in pyproject toml

### DIFF
--- a/ee/vellum_cli/push.py
+++ b/ee/vellum_cli/push.py
@@ -36,9 +36,6 @@ def push_command(
     logger = load_cli_logger()
     config = load_vellum_cli_config()
 
-    if not config.workflows:
-        raise ValueError("No Workflows found in project to push.")
-
     workflow_configs = (
         [
             w
@@ -61,6 +58,8 @@ def push_command(
             )
             config.workflows.append(new_config)
             workflow_configs = [new_config]
+        elif not module:
+            raise ValueError("No Workflows found in project to push.")
         else:
             raise ValueError(f"No workflow config for '{module}' found in project to push.")
 


### PR DESCRIPTION
I want to be able to start a workflow from scratch locally, then just do `vellum workflows push path.to.that.workflow`