### PR TITLE
Simplify get_node_display_class utility

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
+++ b/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
@@ -1,30 +1,22 @@
 import types
 from uuid import UUID
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+from typing import TYPE_CHECKING, Any, Dict, Type
 
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.types.generics import NodeType
 from vellum.workflows.utils.uuids import uuid4_from_hash
+from vellum_ee.workflows.display.utils.registry import get_from_node_display_registry
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 
 
-def get_node_display_class(
-    base_class: Type["BaseNodeDisplay"], node_class: Type[NodeType], root_node_class: Optional[Type[NodeType]] = None
-) -> Type["BaseNodeDisplay"]:
-    node_display_class = base_class.get_from_node_display_registry(node_class)
+def get_node_display_class(node_class: Type[NodeType]) -> Type["BaseNodeDisplay"]:
+    node_display_class = get_from_node_display_registry(node_class)
     if node_display_class:
-        if not issubclass(node_display_class, base_class):
-            raise TypeError(
-                f"Expected to find a subclass of '{base_class.__name__}' for node class '{node_class.__name__}'"
-            )
-
         return node_display_class
 
-    base_node_display_class = get_node_display_class(
-        base_class, node_class.__bases__[0], node_class if root_node_class is None else root_node_class
-    )
+    base_node_display_class = get_node_display_class(node_class.__bases__[0])
 
     # `base_node_display_class` is always a Generic class, so it's safe to index into it
     NodeDisplayBaseClass = base_node_display_class[node_class]  # type: ignore[index]

--- a/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/base_adornment_node.py
@@ -14,6 +14,7 @@ from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeV
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
+from vellum_ee.workflows.display.utils.registry import register_node_display_class
 
 _BaseAdornmentNodeType = TypeVar("_BaseAdornmentNodeType", bound=BaseAdornmentNode)
 
@@ -31,7 +32,7 @@ def _recursively_replace_wrapped_node(node_class: Type[BaseNode], wrapped_node_d
     # 1. The node display class' parameterized type
     original_base_node_display = get_original_base(wrapped_node_display_class)
     original_base_node_display.__args__ = (wrapped_node_class,)
-    wrapped_node_display_class._node_display_registry[wrapped_node_class] = wrapped_node_display_class
+    register_node_display_class(node_class=wrapped_node_class, node_display_class=wrapped_node_display_class)
     wrapped_node_display_class.__annotate_node__()
 
     # 2. The node display class' output displays
@@ -89,7 +90,7 @@ class BaseAdornmentNodeDisplay(BaseNodeVellumDisplay[_BaseAdornmentNodeType], Ge
                 "Unable to serialize standalone adornment nodes. Please use adornment nodes as a decorator."
             )
 
-        wrapped_node_display_class = get_node_display_class(BaseNodeDisplay, wrapped_node)
+        wrapped_node_display_class = get_node_display_class(wrapped_node)
         wrapped_node_display = wrapped_node_display_class()
         additional_kwargs = get_additional_kwargs(wrapped_node_display.node_id) if get_additional_kwargs else {}
         serialized_wrapped_node = wrapped_node_display.serialize(display_context, **kwargs, **additional_kwargs)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
@@ -9,7 +9,6 @@ from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum.workflows.workflows.base import BaseWorkflow
-from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.nodes.vellum.base_adornment_node import BaseAdornmentNodeDisplay
@@ -72,7 +71,7 @@ class BaseRetryNodeDisplay(BaseAdornmentNodeDisplay[_RetryNodeType], Generic[_Re
         if not inner_node:
             return super().get_node_output_display(output)
 
-        node_display_class = get_node_display_class(BaseNodeDisplay, inner_node)
+        node_display_class = get_node_display_class(inner_node)
         node_display = node_display_class()
 
         inner_output = getattr(inner_node.Outputs, output.name)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
@@ -10,7 +10,6 @@ from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum.workflows.workflows.base import BaseWorkflow
-from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.nodes.vellum.base_adornment_node import BaseAdornmentNodeDisplay
@@ -82,7 +81,7 @@ class BaseTryNodeDisplay(BaseAdornmentNodeDisplay[_TryNodeType], Generic[_TryNod
         if not inner_node:
             return super().get_node_output_display(output)
 
-        node_display_class = get_node_display_class(BaseNodeDisplay, inner_node)
+        node_display_class = get_node_display_class(inner_node)
         node_display = node_display_class()
         if output.name == "error":
             return inner_node, NodeOutputDisplay(

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
@@ -1,11 +1,10 @@
 import pytest
 from uuid import uuid4
-from typing import Any, Type
+from typing import Type
 
 from vellum.workflows.types.core import JsonObject
 from vellum.workflows.types.generics import NodeType
 from vellum_ee.workflows.display.editor.types import NodeDisplayData
-from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.types import (
     NodeDisplays,
@@ -22,13 +21,12 @@ from vellum_ee.workflows.display.workflows.vellum_workflow_display import Vellum
 def serialize_node():
     def _serialize_node(
         node_class: Type[NodeType],
-        base_class: type[BaseNodeDisplay[Any]] = BaseNodeDisplay,
         global_workflow_input_displays: WorkflowInputsDisplays = {},
         global_state_value_displays: StateValueDisplays = {},
         global_node_displays: NodeDisplays = {},
         global_node_output_displays: NodeOutputDisplays = {},
     ) -> JsonObject:
-        node_display_class = get_node_display_class(base_class, node_class)
+        node_display_class = get_node_display_class(node_class)
         node_display = node_display_class()
 
         context: WorkflowDisplayContext = WorkflowDisplayContext(

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -10,7 +10,6 @@ from vellum.workflows.outputs.base import BaseOutputs
 from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.base import WorkflowInputsDisplay
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
-from vellum_ee.workflows.display.nodes.base_node_vellum_display import BaseNodeVellumDisplay
 from vellum_ee.workflows.display.nodes.vellum.retry_node import BaseRetryNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.try_node import BaseTryNodeDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
@@ -148,7 +147,6 @@ def test_serialize_node__try(serialize_node):
 
     input_id = uuid4()
     serialized_node = serialize_node(
-        base_class=BaseNodeVellumDisplay,
         node_class=InnerTryGenericNode,
         global_workflow_input_displays={Inputs.input: WorkflowInputsDisplay(id=input_id)},
         global_node_displays={
@@ -283,7 +281,10 @@ def test_serialize_node__stacked():
                                 "test_adornments_serialization",
                             ],
                         },
-                        "trigger": {"id": "6e4af17f-bbee-4777-b10d-af042cd6e16a", "merge_behavior": "AWAIT_ATTRIBUTES"},
+                        "trigger": {
+                            "id": "6e4af17f-bbee-4777-b10d-af042cd6e16a",
+                            "merge_behavior": "AWAIT_ATTRIBUTES",
+                        },
                         "ports": [{"id": "408cd5fb-3a3e-4eb2-9889-61111bd6a129", "name": "default", "type": "DEFAULT"}],
                         "adornments": [
                             {

--- a/ee/vellum_ee/workflows/display/utils/registry.py
+++ b/ee/vellum_ee/workflows/display/utils/registry.py
@@ -1,0 +1,18 @@
+from typing import TYPE_CHECKING, Dict, Optional, Type
+
+from vellum.workflows.nodes import BaseNode
+
+if TYPE_CHECKING:
+    from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
+
+
+# Used to store the mapping between node types and their display classes
+_node_display_registry: Dict[Type[BaseNode], Type["BaseNodeDisplay"]] = {}
+
+
+def get_from_node_display_registry(node_class: Type[BaseNode]) -> Optional[Type["BaseNodeDisplay"]]:
+    return _node_display_registry.get(node_class)
+
+
+def register_node_display_class(node_class: Type[BaseNode], node_display_class: Type["BaseNodeDisplay"]) -> None:
+    _node_display_registry[node_class] = node_display_class

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -104,11 +104,6 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
         """Can be overridden as a class attribute to specify a custom workflow id."""
         return uuid4_from_hash(self._workflow.__qualname__)
 
-    @property
-    @abstractmethod
-    def node_display_base_class(self) -> Type[BaseNodeDisplay]:
-        pass
-
     def add_error(self, error: Exception) -> None:
         if self._dry_run:
             self._errors.append(error)
@@ -159,13 +154,8 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
             port_displays[port] = node_display.get_node_port_display(port)
 
     def _get_node_display(self, node: Type[BaseNode]) -> BaseNodeDisplay:
-        node_display_class = get_node_display_class(self.node_display_base_class, node)
-        node_display = node_display_class()
-
-        if not isinstance(node_display, self.node_display_base_class):
-            raise ValueError(f"{node.__name__} must be a subclass of {self.node_display_base_class.__name__}")
-
-        return node_display
+        node_display_class = get_node_display_class(node)
+        return node_display_class()
 
     @cached_property
     def display_context(self) -> WorkflowDisplayContext:

--- a/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/vellum_workflow_display.py
@@ -21,8 +21,6 @@ logger = logging.getLogger(__name__)
 
 
 class VellumWorkflowDisplay(BaseWorkflowDisplay[WorkflowType]):
-    node_display_base_class = BaseNodeDisplay
-
     def serialize(self) -> JsonObject:
         input_variables: JsonArray = []
         for workflow_input_reference, workflow_input_display in self.display_context.workflow_input_displays.items():


### PR DESCRIPTION
I was working on pushing a customer workflow to Vellum that utilizes a subclass of a generic node before I ran into:

```
  File "/Users/dvargas/vellum-ai/workflows-as-code-runner-prototype/venv/lib/python3.11/site-packages/vellum_ee/workflows/display/nodes/get_node_display_class.py", line 30, in get_node_display_class
    NodeDisplayBaseClass = base_node_display_class[node_class]  # type: ignore[index]
                           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/typing.py", line 351, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/typing.py", line 1826, in __class_getitem__
    _check_generic(cls, params, len(cls.__parameters__))
  File "/Users/dvargas/vellum-ai/workflows-as-code-runner-prototype/venv/lib/python3.11/site-packages/typing_extensions.py", line 2922, in _check_generic
    raise TypeError(f"{cls} is not a generic class")
TypeError: <class 'vellum_ee.workflows.display.nodes.base_node_display.MockNetworkingClientDisplay'> is not a generic class
```

So before I get started on tackling this issue, I wanted to continue some display cleanup work I've been doing by simplifying our `get_node_display_class` utility. We can remove two of the three args on the assumption that all displays will eventually inherit from `BaseNodeDisplay`. This also forces us to move the registry from `BaseNodeDisplay`, which was dangerous bc it allowed users to subclass and mess with that internal state.