### PR TITLE
Simplify get_workflow_display

### DIFF
--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Dict, Tuple, Type
 
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.events.workflow import WorkflowEventDisplayContext  # noqa: F401
@@ -20,7 +20,6 @@ from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDispl
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
-WorkflowDisplayType = TypeVar("WorkflowDisplayType", bound="BaseWorkflowDisplay")
 
 WorkflowInputsDisplays = Dict[WorkflowInputReference, WorkflowInputsDisplay]
 StateValueDisplays = Dict[StateValueReference, StateValueDisplay]

--- a/ee/vellum_ee/workflows/display/utils/registry.py
+++ b/ee/vellum_ee/workflows/display/utils/registry.py
@@ -1,13 +1,28 @@
 from typing import TYPE_CHECKING, Dict, Optional, Type
 
 from vellum.workflows.nodes import BaseNode
+from vellum.workflows.workflows.base import BaseWorkflow
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
+    from vellum_ee.workflows.display.workflows.base_workflow_display import BaseWorkflowDisplay
 
+
+# Used to store the mapping between workflows and their display classes
+_workflow_display_registry: Dict[Type[BaseWorkflow], Type["BaseWorkflowDisplay"]] = {}
 
 # Used to store the mapping between node types and their display classes
 _node_display_registry: Dict[Type[BaseNode], Type["BaseNodeDisplay"]] = {}
+
+
+def get_from_workflow_display_registry(workflow_class: Type[BaseWorkflow]) -> Optional[Type["BaseWorkflowDisplay"]]:
+    return _workflow_display_registry.get(workflow_class)
+
+
+def register_workflow_display_class(
+    workflow_class: Type[BaseWorkflow], workflow_display_class: Type["BaseWorkflowDisplay"]
+) -> None:
+    _workflow_display_registry[workflow_class] = workflow_display_class
 
 
 def get_from_node_display_registry(node_class: Type[BaseNode]) -> Optional[Type["BaseNodeDisplay"]]:


### PR DESCRIPTION
Continuing with display simplification.

This PR deprecates two params to `get_workflow_display`, which are essentially the same two params we removed from `get_node_display_class`: https://github.com/vellum-ai/vellum-python-sdks/pull/1409

We have to deprecate for now instead of remove bc this is a user facing method that's used by vembda and the cli. Will start removing consumers on the next PR