### PR TITLE
remove deprecated args from get_workflow_display

### DIFF
--- a/ee/codegen_integration/test_code_to_display.py
+++ b/ee/codegen_integration/test_code_to_display.py
@@ -4,7 +4,6 @@ from typing import Any, Dict
 from deepdiff import DeepDiff
 
 from vellum.workflows.workflows.base import BaseWorkflow
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 
@@ -17,7 +16,7 @@ def test_code_to_display_data(code_to_display_fixture_paths, workspace_secret_cl
     module_path = ".".join(base_module_path + code_sub_path)
 
     workflow = BaseWorkflow.load_from_module(module_path)
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=workflow)
+    workflow_display = get_workflow_display(workflow_class=workflow)
     actual_serialized_workflow: dict = workflow_display.serialize()
 
     with open(expected_display_data_file_path) as file:

--- a/ee/vellum_cli/push.py
+++ b/ee/vellum_cli/push.py
@@ -17,7 +17,6 @@ from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_cli.config import DEFAULT_WORKSPACE_CONFIG, WorkflowConfig, WorkflowDeploymentConfig, load_vellum_cli_config
 from vellum_cli.logger import load_cli_logger
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
 def push_command(
@@ -105,7 +104,6 @@ def push_command(
     # https://app.shortcut.com/vellum/story/5585
     workflow = BaseWorkflow.load_from_module(workflow_config.module)
     workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
         workflow_class=workflow,
         dry_run=dry_run or False,
     )

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_code_execution_node.py
@@ -6,7 +6,6 @@ from vellum.workflows.nodes.displayable.code_execution_node.node import CodeExec
 from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.nodes.vellum.code_execution_node import BaseCodeExecutionNodeDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
 def _no_display_class(Node: Type[CodeExecutionNode]):
@@ -53,7 +52,7 @@ def test_serialize_node__code_node_inputs(GetDisplayClass, expected_input_id):
     GetDisplayClass(MyCodeExecutionNode)
 
     # WHEN the workflow is serialized
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=Workflow)
+    workflow_display = get_workflow_display(workflow_class=Workflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN the node should properly serialize the inputs

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_error_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_error_node.py
@@ -4,7 +4,6 @@ from vellum.client.types.vellum_error import VellumError
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.nodes.core.error_node.node import ErrorNode
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
 def test_error_node_display__serialize_with_vellum_error() -> None:
@@ -20,7 +19,7 @@ def test_error_node_display__serialize_with_vellum_error() -> None:
         graph = MyNode
 
     # WHEN we serialize the workflow
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=MyWorkflow)
+    workflow_display = get_workflow_display(workflow_class=MyWorkflow)
     serialized_workflow = cast(Dict[str, Any], workflow_display.serialize())
 
     # THEN the correct inputs should be serialized on the node

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_note_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_note_node.py
@@ -2,7 +2,6 @@ from vellum.workflows import BaseWorkflow
 from vellum.workflows.nodes.displayable.note_node.node import NoteNode
 from vellum_ee.workflows.display.nodes.vellum.note_node import BaseNoteNodeDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
 def test_serialize_node__note_node():
@@ -22,7 +21,7 @@ def test_serialize_node__note_node():
         graph = MyNoteNode
 
     # WHEN the workflow is serialized
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=Workflow)
+    workflow_display = get_workflow_display(workflow_class=Workflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN the node should properly serialize the inputs

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_node.py
@@ -8,7 +8,6 @@ from vellum.workflows.nodes.displayable.inline_prompt_node.node import InlinePro
 from vellum.workflows.references.lazy import LazyReference
 from vellum_ee.workflows.display.nodes.vellum.inline_prompt_node import BaseInlinePromptNodeDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
 def test_serialize_node__lazy_reference_in_prompt_inputs():
@@ -27,7 +26,7 @@ def test_serialize_node__lazy_reference_in_prompt_inputs():
         graph = LazyReferencePromptNode >> OtherNode
 
     # WHEN the workflow is serialized
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=Workflow)
+    workflow_display = get_workflow_display(workflow_class=Workflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN the node should properly serialize the attribute reference
@@ -103,7 +102,7 @@ def test_serialize_node__prompt_inputs(GetDisplayClass, expected_input_id):
     GetDisplayClass(MyPromptNode)
 
     # WHEN the workflow is serialized
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=Workflow)
+    workflow_display = get_workflow_display(workflow_class=Workflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN the node should properly serialize the inputs

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_retry_node.py
@@ -5,7 +5,6 @@ from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.retry_node.node import RetryNode
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
 def test_retry_node_parameters():
@@ -21,7 +20,7 @@ def test_retry_node_parameters():
         graph = MyRetryNode
 
     # WHEN we serialize the workflow
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=MyWorkflow)
+    workflow_display = get_workflow_display(workflow_class=MyWorkflow)
     serialized_workflow = cast(Dict[str, Any], workflow_display.serialize())
 
     # THEN the correct inputs should be serialized on the node

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_templating_node.py
@@ -6,7 +6,6 @@ from vellum.workflows import BaseWorkflow
 from vellum.workflows.nodes.core.templating_node.node import TemplatingNode
 from vellum_ee.workflows.display.nodes.vellum.templating_node import BaseTemplatingNodeDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
 def _no_display_class(Node: Type[TemplatingNode]):
@@ -53,7 +52,7 @@ def test_serialize_node__templating_node_inputs(GetDisplayClass, expected_input_
     GetDisplayClass(MyTemplatingNode)
 
     # WHEN the workflow is serialized
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=Workflow)
+    workflow_display = get_workflow_display(workflow_class=Workflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN the node should properly serialize the inputs

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_try_node.py
@@ -5,7 +5,6 @@ from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.templating_node.node import TemplatingNode
 from vellum.workflows.nodes.core.try_node.node import TryNode
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
 def test_try_node_display__serialize_with_error_output() -> None:
@@ -28,7 +27,7 @@ def test_try_node_display__serialize_with_error_output() -> None:
         graph = MyNode >> OtherNode
 
     # WHEN we serialize the workflow
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=MyWorkflow)
+    workflow_display = get_workflow_display(workflow_class=MyWorkflow)
     serialized_workflow = cast(Dict[str, Any], workflow_display.serialize())
 
     # THEN the correct inputs should be serialized on the node

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_utils.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_utils.py
@@ -22,7 +22,7 @@ from vellum_ee.workflows.display.utils.vellum import (
     NodeOutputPointer,
 )
 from vellum_ee.workflows.display.vellum import WorkflowInputsVellumDisplayOverrides, WorkflowMetaVellumDisplay
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows.base_workflow_display import BaseWorkflowDisplay
 
 
 class Inputs(BaseInputs):
@@ -109,7 +109,7 @@ def test_create_node_input_value_pointer_rules(
     rules = create_node_input_value_pointer_rules(
         descriptor,
         WorkflowDisplayContext(
-            workflow_display_class=VellumWorkflowDisplay,
+            workflow_display_class=BaseWorkflowDisplay,
             workflow_display=WorkflowMetaVellumDisplay(
                 entrypoint_node_id=uuid4(),
                 entrypoint_node_source_handle_id=uuid4(),

--- a/ee/vellum_ee/workflows/display/tests/test_base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/tests/test_base_workflow_display.py
@@ -6,19 +6,16 @@ from vellum.workflows.nodes import BaseNode
 from vellum.workflows.state import BaseState
 from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.vellum import WorkflowInputsVellumDisplayOverrides
+from vellum_ee.workflows.display.workflows.base_workflow_display import BaseWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
-def test_vellum_workflow_display__serialize_empty_workflow():
+def test_base_workflow_display__serialize_empty_workflow():
     # GIVEN an empty workflow
     class ExampleWorkflow(BaseWorkflow):
         pass
 
-    display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=ExampleWorkflow,
-    )
+    display = get_workflow_display(workflow_class=ExampleWorkflow)
 
     # WHEN serializing the workflow
     exec_config = display.serialize()
@@ -30,18 +27,18 @@ def test_vellum_workflow_display__serialize_empty_workflow():
         "output_variables": [],
         "workflow_raw_data": {
             "definition": {
-                "module": ["vellum_ee", "workflows", "display", "tests", "test_vellum_workflow_display"],
+                "module": ["vellum_ee", "workflows", "display", "tests", "test_base_workflow_display"],
                 "name": "ExampleWorkflow",
             },
             "display_data": {"viewport": {"x": 0.0, "y": 0.0, "zoom": 1.0}},
             "edges": [],
             "nodes": [
                 {
-                    "data": {"label": "Entrypoint Node", "source_handle_id": "508b8b82-3517-4672-a155-18c9c7b9c545"},
+                    "data": {"label": "Entrypoint Node", "source_handle_id": "0af025a4-3b25-457d-a7ae-e3a7ba15c86c"},
                     "base": None,
                     "definition": None,
                     "display_data": {"position": {"x": 0.0, "y": 0.0}},
-                    "id": "9eef0c18-f322-4d56-aa89-f088d3e53f6a",
+                    "id": "3c41cdd9-999a-48b8-9088-f6dfa1369bfd",
                     "inputs": [],
                     "type": "ENTRYPOINT",
                 }
@@ -62,7 +59,7 @@ def test_vellum_workflow_display__serialize_input_variables_with_capitalized_var
     class ExampleWorkflow(BaseWorkflow[Inputs, BaseState]):
         graph = StartNode
 
-    class ExampleWorkflowDisplay(VellumWorkflowDisplay[ExampleWorkflow]):
+    class ExampleWorkflowDisplay(BaseWorkflowDisplay[ExampleWorkflow]):
         inputs_display = {
             Inputs.foo: WorkflowInputsVellumDisplayOverrides(
                 id=UUID("97b63d71-5413-417f-9cf5-49e1b4fd56e4"), name="Foo", required=True
@@ -108,10 +105,7 @@ def test_vellum_workflow_display_serialize_valid_handle_ids_for_base_nodes():
             final_value = EndNode.Outputs.hello
 
     # AND a display class for this workflow
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=Workflow,
-    )
+    workflow_display = get_workflow_display(workflow_class=Workflow)
 
     # WHEN we serialize the workflow
     exec_config = workflow_display.serialize()
@@ -169,10 +163,7 @@ def test_vellum_workflow_display__serialize_with_unused_nodes_and_edges():
             final = NodeA.Outputs.result
 
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=Workflow,
-    )
+    workflow_display = get_workflow_display(workflow_class=Workflow)
 
     # WHEN we serialize the workflow
     exec_config = workflow_display.serialize()
@@ -245,10 +236,7 @@ def test_vellum_workflow_display__serialize_with_parse_json_expression():
             final = JsonNode.Outputs.json_result
 
     # AND a display class for this workflow
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=Workflow,
-    )
+    workflow_display = get_workflow_display(workflow_class=Workflow)
 
     # WHEN we serialize the workflow
     exec_config = workflow_display.serialize()

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/conftest.py
@@ -14,7 +14,7 @@ from vellum_ee.workflows.display.types import (
     WorkflowInputsDisplays,
 )
 from vellum_ee.workflows.display.vellum import WorkflowMetaVellumDisplay
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows.base_workflow_display import BaseWorkflowDisplay
 
 
 @pytest.fixture()
@@ -30,7 +30,7 @@ def serialize_node():
         node_display = node_display_class()
 
         context: WorkflowDisplayContext = WorkflowDisplayContext(
-            workflow_display_class=VellumWorkflowDisplay,
+            workflow_display_class=BaseWorkflowDisplay,
             workflow_display=WorkflowMetaVellumDisplay(
                 entrypoint_node_id=uuid4(),
                 entrypoint_node_source_handle_id=uuid4(),

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -13,7 +13,6 @@ from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.retry_node import BaseRetryNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.try_node import BaseTryNodeDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
 class Inputs(BaseInputs):
@@ -123,10 +122,7 @@ def test_serialize_node__retry__no_display():
         graph = StartNode
 
     # WHEN we serialize the workflow
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=MyWorkflow,
-    )
+    workflow_display = get_workflow_display(workflow_class=MyWorkflow)
     exec_config = workflow_display.serialize()
 
     # THEN the workflow display is created successfully
@@ -218,10 +214,7 @@ def test_serialize_node__try__no_display():
         graph = StartNode
 
     # WHEN we serialize the workflow
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=MyWorkflow,
-    )
+    workflow_display = get_workflow_display(workflow_class=MyWorkflow)
 
     exec_config = workflow_display.serialize()
 
@@ -240,10 +233,7 @@ def test_serialize_node__stacked():
         graph = InnerStackedGenericNode
 
     # WHEN we serialize the workflow
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=StackedWorkflow,
-    )
+    workflow_display = get_workflow_display(workflow_class=StackedWorkflow)
     exec_config = workflow_display.serialize()
 
     # THEN the workflow display is created successfully

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py
@@ -16,7 +16,6 @@ from vellum_ee.workflows.display.base import WorkflowInputsDisplay
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
 
 
 class Inputs(BaseInputs):
@@ -169,7 +168,7 @@ def test_serialize_node__lazy_reference_with_string():
         graph = LazyReferenceGenericNode >> OtherNode
 
     # WHEN the workflow is serialized
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=Workflow)
+    workflow_display = get_workflow_display(workflow_class=Workflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN the node should properly serialize the attribute reference
@@ -257,10 +256,7 @@ def test_serialize_node__workflow_input_as_nested_chat_history():
         graph = GenericNode
 
     # WHEN the workflow is serialized
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=Workflow,
-    )
+    workflow_display = get_workflow_display(workflow_class=Workflow)
     with pytest.raises(Exception) as exc_info:
         workflow_display.serialize()
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_api_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_api_node_serialization.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 from deepdiff import DeepDiff
 
 from vellum import WorkspaceSecretRead
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_api_node.workflow import SimpleAPIWorkflow
@@ -24,7 +23,7 @@ def test_serialize_workflow(vellum_client):
     vellum_client.workspace_secrets.retrieve.return_value = workspace_secret
 
     # WHEN we serialize it
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=SimpleAPIWorkflow)
+    workflow_display = get_workflow_display(workflow_class=SimpleAPIWorkflow)
 
     serialized_workflow: dict = workflow_display.serialize()
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
@@ -1,7 +1,6 @@
 from deepdiff import DeepDiff
 
 from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_code_execution_node.try_workflow import TrySimpleCodeExecutionWorkflow
@@ -12,9 +11,7 @@ from tests.workflows.basic_code_execution_node.workflow_with_code import SimpleC
 def test_serialize_workflow_with_filepath():
     # GIVEN a Workflow with a code execution node
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=SimpleCodeExecutionWithFilepathWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=SimpleCodeExecutionWithFilepathWorkflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow
@@ -253,9 +250,7 @@ def test_serialize_workflow_with_filepath():
 def test_serialize_workflow_with_code():
     # GIVEN a Workflow with a code execution node
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=SimpleCodeExecutionWithCodeWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=SimpleCodeExecutionWithCodeWorkflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow
@@ -482,9 +477,7 @@ def test_serialize_workflow_with_code():
 def test_serialize_workflow__try_wrapped():
     # GIVEN a Workflow with a code execution node
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=TrySimpleCodeExecutionWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=TrySimpleCodeExecutionWorkflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_conditional_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_conditional_node_serialization.py
@@ -20,7 +20,6 @@ from vellum.workflows.expressions.less_than import LessThanExpression
 from vellum.workflows.expressions.less_than_or_equal_to import LessThanOrEqualToExpression
 from vellum.workflows.expressions.not_between import NotBetweenExpression
 from vellum.workflows.expressions.not_in import NotInExpression
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_conditional_node.workflow import CategoryWorkflow
@@ -30,7 +29,7 @@ from tests.workflows.basic_conditional_node.workflow_with_only_one_conditional_n
 def test_serialize_workflow():
     # GIVEN a Workflow that uses a ConditionalNode
     # WHEN we serialize it
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=CategoryWorkflow)
+    workflow_display = get_workflow_display(workflow_class=CategoryWorkflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow
@@ -779,7 +778,7 @@ def test_conditional_node_serialize_all_operators_with_lhs_and_rhs(descriptor, o
     # GIVEN a simple workflow with one conditional node
     workflow_cls = create_simple_workflow(descriptor)
 
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=workflow_cls)
+    workflow_display = get_workflow_display(workflow_class=workflow_cls)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow
@@ -885,7 +884,7 @@ def test_conditional_node_serialize_all_operators_with_expression(descriptor, op
     # GIVEN a simple workflow with one conditional node
     workflow_cls = create_simple_workflow(descriptor)
 
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=workflow_cls)
+    workflow_display = get_workflow_display(workflow_class=workflow_cls)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow
@@ -978,7 +977,7 @@ def test_conditional_node_serialize_all_operators_with_value_and_start_and_end(d
     # GIVEN a simple workflow with one conditional node
     workflow_cls = create_simple_workflow(descriptor)
 
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=workflow_cls)
+    workflow_display = get_workflow_display(workflow_class=workflow_cls)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_default_state_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_default_state_serialization.py
@@ -1,6 +1,5 @@
 from deepdiff import DeepDiff
 
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_default_state.workflow import BasicDefaultStateWorkflow
@@ -9,9 +8,7 @@ from tests.workflows.basic_default_state.workflow import BasicDefaultStateWorkfl
 def test_serialize_workflow():
     # GIVEN a Workflow that has a simple state definition
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=BasicDefaultStateWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=BasicDefaultStateWorkflow)
 
     serialized_workflow: dict = workflow_display.serialize()
     # THEN we should get a serialized representation of the Workflow

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_error_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_error_node_serialization.py
@@ -1,6 +1,5 @@
 from deepdiff import DeepDiff
 
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_error_node.workflow import BasicErrorNodeWorkflow
@@ -9,9 +8,7 @@ from tests.workflows.basic_error_node.workflow import BasicErrorNodeWorkflow
 def test_serialize_workflow():
     # GIVEN a Workflow with an error node
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=BasicErrorNodeWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=BasicErrorNodeWorkflow)
 
     serialized_workflow: dict = workflow_display.serialize()
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_generic_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_generic_node_serialization.py
@@ -1,17 +1,14 @@
 from deepdiff import DeepDiff
 
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_generic_node.workflow import BasicGenericNodeWorkflow
 
 
-def test_serialize_workflow(vellum_client):
+def test_serialize_workflow():
     # GIVEN a Workflow that uses a generic node
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=BasicGenericNodeWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=BasicGenericNodeWorkflow)
 
     serialized_workflow: dict = workflow_display.serialize()
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_guardrail_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_guardrail_node_serialization.py
@@ -1,6 +1,5 @@
 from deepdiff import DeepDiff
 
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_guardrail_node.workflow import BasicGuardrailNodeWorkflow
@@ -9,14 +8,17 @@ from tests.workflows.basic_guardrail_node.workflow import BasicGuardrailNodeWork
 def test_serialize_workflow():
     # GIVEN a workflow that uses a guardrail node
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=BasicGuardrailNodeWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=BasicGuardrailNodeWorkflow)
 
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the workflow
-    assert serialized_workflow.keys() == {"workflow_raw_data", "input_variables", "state_variables", "output_variables"}
+    assert serialized_workflow.keys() == {
+        "workflow_raw_data",
+        "input_variables",
+        "state_variables",
+        "output_variables",
+    }
 
     # AND its input variables should be what we expect
     input_variables = serialized_workflow["input_variables"]

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_inline_prompt_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_inline_prompt_node_serialization.py
@@ -1,4 +1,3 @@
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_inline_prompt_node_with_functions.workflow import BasicInlinePromptWithFunctionsWorkflow
@@ -6,9 +5,7 @@ from tests.workflows.basic_inline_prompt_node_with_functions.workflow import Bas
 
 def test_serialize_workflow():
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=BasicInlinePromptWithFunctionsWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=BasicInlinePromptWithFunctionsWorkflow)
     serialized_workflow: dict = workflow_display.serialize()
     assert (
         serialized_workflow["workflow_raw_data"]["nodes"][-2]["data"]["exec_config"]["prompt_template_block_data"][

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_inline_subworkflow_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_inline_subworkflow_serialization.py
@@ -1,6 +1,5 @@
 from deepdiff import DeepDiff
 
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_inline_subworkflow.workflow import BasicInlineSubworkflowWorkflow
@@ -9,9 +8,7 @@ from tests.workflows.basic_inline_subworkflow.workflow import BasicInlineSubwork
 def test_serialize_workflow():
     # GIVEN a Workflow
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=BasicInlineSubworkflowWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=BasicInlineSubworkflowWorkflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_map_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_map_node_serialization.py
@@ -1,6 +1,5 @@
 from deepdiff import DeepDiff
 
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_map_node.workflow import SimpleMapExample
@@ -9,7 +8,7 @@ from tests.workflows.basic_map_node.workflow import SimpleMapExample
 def test_serialize_workflow():
     # GIVEN a Workflow that uses a MapNode
     # WHEN we serialize it
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=SimpleMapExample)
+    workflow_display = get_workflow_display(workflow_class=SimpleMapExample)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_merge_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_merge_node_serialization.py
@@ -1,6 +1,5 @@
 from deepdiff import DeepDiff
 
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_merge_node.await_all_workflow import AwaitAllPassingWorkflow
@@ -9,9 +8,7 @@ from tests.workflows.basic_merge_node.await_all_workflow import AwaitAllPassingW
 def test_serialize_workflow__await_all():
     # GIVEN a Workflow that uses an await all merge node
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=AwaitAllPassingWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=AwaitAllPassingWorkflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_prompt_deployment_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_prompt_deployment_serialization.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 from deepdiff import DeepDiff
 
 from vellum import DeploymentRead
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_text_prompt_deployment.workflow import BasicTextPromptDeployment
@@ -25,9 +24,7 @@ def test_serialize_workflow(vellum_client):
     vellum_client.deployments.retrieve.return_value = deployment
 
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=BasicTextPromptDeployment
-    )
+    workflow_display = get_workflow_display(workflow_class=BasicTextPromptDeployment)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_search_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_search_node_serialization.py
@@ -1,4 +1,3 @@
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_search_node.workflow import BasicSearchWorkflow
@@ -8,14 +7,17 @@ def test_serialize_workflow():
     # GIVEN a Workflow with a search node
     # WHEN we serialize it
 
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=BasicSearchWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=BasicSearchWorkflow)
 
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the workflow
-    assert serialized_workflow.keys() == {"workflow_raw_data", "input_variables", "state_variables", "output_variables"}
+    assert serialized_workflow.keys() == {
+        "workflow_raw_data",
+        "input_variables",
+        "state_variables",
+        "output_variables",
+    }
 
     # AND its input variables should be what we expect
     input_variables = serialized_workflow["input_variables"]

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_subworkflow_deployment_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_subworkflow_deployment_serialization.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 from deepdiff import DeepDiff
 
 from vellum import WorkflowDeploymentRead
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_subworkflow_deployment.workflow import BasicSubworkflowDeploymentWorkflow
@@ -25,9 +24,7 @@ def test_serialize_workflow(vellum_client):
     vellum_client.workflow_deployments.retrieve.return_value = deployment
 
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=BasicSubworkflowDeploymentWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=BasicSubworkflowDeploymentWorkflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_templating_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_templating_node_serialization.py
@@ -1,6 +1,5 @@
 from deepdiff import DeepDiff
 
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_templating_node.workflow_with_json_input import BasicTemplatingNodeWorkflowWithJson
@@ -10,9 +9,7 @@ def test_serialize_workflow():
     # GIVEN a Workflow that uses a vellum templating node",
 
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=BasicTemplatingNodeWorkflowWithJson
-    )
+    workflow_display = get_workflow_display(workflow_class=BasicTemplatingNodeWorkflowWithJson)
 
     serialized_workflow: dict = workflow_display.serialize()
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_terminal_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_terminal_node_serialization.py
@@ -1,4 +1,3 @@
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_final_output_node.workflow import BasicFinalOutputNodeWorkflow
@@ -7,9 +6,7 @@ from tests.workflows.basic_final_output_node.workflow import BasicFinalOutputNod
 def test_serialize_workflow():
     # GIVEN a Workflow that uses a Final Output Node
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=BasicFinalOutputNodeWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=BasicFinalOutputNodeWorkflow)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_try_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_try_node_serialization.py
@@ -2,7 +2,6 @@ import pytest
 
 from deepdiff import DeepDiff
 
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.basic_try_node.workflow import SimpleTryExample, StandaloneTryExample
@@ -11,7 +10,7 @@ from tests.workflows.basic_try_node.workflow import SimpleTryExample, Standalone
 def test_serialize_workflow():
     # GIVEN a Workflow with a TryNode
     # WHEN we serialize it
-    workflow_display = get_workflow_display(base_display_class=VellumWorkflowDisplay, workflow_class=SimpleTryExample)
+    workflow_display = get_workflow_display(workflow_class=SimpleTryExample)
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN we should get a serialized representation of the Workflow
@@ -77,9 +76,7 @@ def test_serialize_workflow__standalone():
     # GIVEN a Workflow with a standalone TryNode
     # WHEN we serialize it
     with pytest.raises(NotImplementedError) as exc:
-        workflow_display = get_workflow_display(
-            base_display_class=VellumWorkflowDisplay, workflow_class=StandaloneTryExample
-        )
+        workflow_display = get_workflow_display(workflow_class=StandaloneTryExample)
         workflow_display.serialize()
 
     # THEN we should get an error

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_complex_terminal_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_complex_terminal_node_serialization.py
@@ -2,7 +2,6 @@ import pytest
 
 from deepdiff import DeepDiff
 
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 from tests.workflows.complex_final_output_node.missing_final_output_node import MissingFinalOutputNodeWorkflow
@@ -11,9 +10,7 @@ from tests.workflows.complex_final_output_node.missing_workflow_output import Mi
 
 def test_serialize_workflow__missing_final_output_node():
     # GIVEN a Workflow that is missing a Terminal Node
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=MissingFinalOutputNodeWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=MissingFinalOutputNodeWorkflow)
 
     # WHEN we serialize it
     serialized_workflow: dict = workflow_display.serialize()
@@ -179,9 +176,7 @@ def test_serialize_workflow__missing_final_output_node():
 
 def test_serialize_workflow__missing_workflow_output():
     # GIVEN a Workflow that contains a terminal node that is unreferenced by the Workflow's Outputs
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay, workflow_class=MissingWorkflowOutputWorkflow
-    )
+    workflow_display = get_workflow_display(workflow_class=MissingWorkflowOutputWorkflow)
 
     # WHEN we serialize it, it should throw an error
     with pytest.raises(ValueError) as exc_info:

--- a/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
@@ -11,7 +11,6 @@ from vellum_ee.workflows.display.editor.types import NodeDisplayData, NodeDispla
 from vellum_ee.workflows.display.nodes import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.retry_node import BaseRetryNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.try_node import BaseTryNodeDisplay
-from vellum_ee.workflows.display.workflows import VellumWorkflowDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 
@@ -32,10 +31,7 @@ def test_serialize_workflow__node_referenced_in_workflow_outputs_not_in_graph():
             final = OutNode.Outputs.foo
 
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=Workflow,
-    )
+    workflow_display = get_workflow_display(workflow_class=Workflow)
 
     # THEN it should raise an error
     with pytest.raises(ValueError) as exc_info:
@@ -57,10 +53,7 @@ def test_serialize_workflow__workflow_outputs_reference_non_node_outputs():
             final = FirstWorkflow.Outputs.foo
 
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=Workflow,
-    )
+    workflow_display = get_workflow_display(workflow_class=Workflow)
 
     # THEN it should raise an error
     with pytest.raises(ValueError) as exc_info:
@@ -91,10 +84,7 @@ def test_serialize_workflow__node_display_class_not_registered():
             answer = StartNode.Outputs.result
 
     # WHEN we serialize it
-    workflow_display = get_workflow_display(
-        base_display_class=VellumWorkflowDisplay,
-        workflow_class=MyWorkflow,
-    )
+    workflow_display = get_workflow_display(workflow_class=MyWorkflow)
     data = workflow_display.serialize()
 
     # THEN it should should succeed
@@ -111,7 +101,7 @@ def test_get_event_display_context__node_display_filled_without_base_display():
         graph = StartNode
 
     # WHEN we gather the event display context
-    display_context = VellumWorkflowDisplay(MyWorkflow).get_event_display_context()
+    display_context = get_workflow_display(workflow_class=MyWorkflow).get_event_display_context()
 
     # THEN the node display should be included
     assert StartNode.__id__ in display_context.node_displays
@@ -134,7 +124,7 @@ def test_get_event_display_context__node_display_filled_without_output_display()
         pass
 
     # WHEN we gather the event display context
-    display_context = VellumWorkflowDisplay(MyWorkflow).get_event_display_context()
+    display_context = get_workflow_display(workflow_class=MyWorkflow).get_event_display_context()
 
     # THEN the node display should be included
     assert StartNode.__id__ in display_context.node_displays
@@ -160,7 +150,7 @@ def test_get_event_display_context__node_display_to_include_subworkflow_display(
         graph = SubworkflowNode
 
     # WHEN we gather the event display context
-    display_context = VellumWorkflowDisplay(MyWorkflow).get_event_display_context()
+    display_context = get_workflow_display(workflow_class=MyWorkflow).get_event_display_context()
 
     # THEN the subworkflow display should be included
     assert SubworkflowNode.__id__ in display_context.node_displays
@@ -201,7 +191,7 @@ def test_get_event_display_context__node_display_for_adornment_nodes(
         node_id = inner_node_id
 
     # WHEN we gather the event display context
-    display_context = VellumWorkflowDisplay(MyWorkflow).get_event_display_context()
+    display_context = get_workflow_display(workflow_class=MyWorkflow).get_event_display_context()
 
     # THEN the subworkflow display should be included
     assert adornment_node_id in display_context.node_displays
@@ -228,7 +218,7 @@ def test_get_event_display_context__templating_node_input_display():
         graph = DataNode >> MyNode
 
     # WHEN we gather the event display context
-    display_context = VellumWorkflowDisplay(MyWorkflow).get_event_display_context()
+    display_context = get_workflow_display(workflow_class=MyWorkflow).get_event_display_context()
 
     # THEN the subworkflow display should be included
     assert MyNode.__id__ in display_context.node_displays
@@ -259,7 +249,7 @@ def test_get_event_display_context__node_display_for_mutiple_adornments():
         node_id = innermost_node_id
 
     # WHEN we gather the event display context
-    display_context = VellumWorkflowDisplay(MyWorkflow).get_event_display_context()
+    display_context = get_workflow_display(workflow_class=MyWorkflow).get_event_display_context()
 
     # THEN the subworkflow display should be included
     assert node_id in display_context.node_displays
@@ -285,7 +275,7 @@ def test_get_event_display_context__workflow_output_display_with_none():
             bar = "baz"
 
     # WHEN we gather the event display context
-    display_context = VellumWorkflowDisplay(MyWorkflow).get_event_display_context()
+    display_context = get_workflow_display(workflow_class=MyWorkflow).get_event_display_context()
 
     # THEN the workflow output display should be included
     assert display_context.workflow_outputs.keys() == {"foo", "bar"}

--- a/ee/vellum_ee/workflows/tests/local_workflow/display/workflow.py
+++ b/ee/vellum_ee/workflows/tests/local_workflow/display/workflow.py
@@ -11,7 +11,7 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowMetaVellumDisplayOverrides,
     WorkflowOutputVellumDisplayOverrides,
 )
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.final_output import FinalOutput
@@ -19,7 +19,7 @@ from ..nodes.templating_node import TemplatingNode
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaVellumDisplayOverrides(
         entrypoint_node_id=UUID("0bf86989-13f2-438c-ab9c-d172e5771d31"),
         entrypoint_node_source_handle_id=UUID("23448f09-81ad-4378-abbd-1cccff350627"),


### PR DESCRIPTION
This PR removes all consumers in the SDK repo using these deprecated args: https://github.com/vellum-ai/vellum-python-sdks/pull/1411

We are close to having no more reads of `VellumWorkflowDisplay`. Just need to update codegen to round it out