### PR TITLE
Change codegen from VellumWorkflowDisplay to BaseWorkflowDisplay

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -81,15 +81,13 @@ from vellum_ee.workflows.display.vellum import (
     WorkflowDisplayData,
     WorkflowDisplayDataViewport,
 )
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import (
-    VellumWorkflowDisplay,
-)
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..workflow import TestWorkflow
 
 
-class TestWorkflowDisplay(VellumWorkflowDisplay[TestWorkflow]):
+class TestWorkflowDisplay(BaseWorkflowDisplay[TestWorkflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("entrypoint"),
         entrypoint_node_source_handle_id=UUID("<source_handle_id>"),

--- a/ee/codegen/src/constants.ts
+++ b/ee/codegen/src/constants.ts
@@ -36,6 +36,12 @@ export const VELLUM_WORKFLOW_EDITOR_TYPES_PATH = [
   "display",
   "editor",
 ] as const;
+export const VELLUM_WORKFLOWS_DISPLAY_MODULE_PATH = [
+  "vellum_ee",
+  "workflows",
+  "display",
+  "workflows",
+] as const;
 /* Class names */
 export const OUTPUTS_CLASS_NAME = "Outputs";
 export const PORTS_CLASS_NAME = "Ports";

--- a/ee/codegen/src/context/workflow-context/sdk-module-paths.ts
+++ b/ee/codegen/src/context/workflow-context/sdk-module-paths.ts
@@ -7,13 +7,6 @@ export function generateSdkModulePaths(
 
   return {
     WORKFLOWS_MODULE_PATH: workflowsSdkModulePath,
-    WORKFLOWS_DISPLAY_MODULE_PATH: [
-      "vellum_ee",
-      "workflows",
-      "display",
-      "workflows",
-      "vellum_workflow_display",
-    ] as const,
     CORE_NODES_MODULE_PATH: [...nodesModulePath, "core"] as const,
     DISPLAYABLE_NODES_MODULE_PATH: [...nodesModulePath, "displayable"] as const,
     INPUTS_MODULE_PATH: [...workflowsSdkModulePath, "inputs"] as const,

--- a/ee/codegen/src/context/workflow-context/types.ts
+++ b/ee/codegen/src/context/workflow-context/types.ts
@@ -1,6 +1,5 @@
 export interface SDK_MODULE_PATHS {
   WORKFLOWS_MODULE_PATH: readonly string[];
-  WORKFLOWS_DISPLAY_MODULE_PATH: readonly string[];
   CORE_NODES_MODULE_PATH: readonly string[];
   DISPLAYABLE_NODES_MODULE_PATH: readonly string[];
   INPUTS_MODULE_PATH: readonly string[];

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -11,6 +11,7 @@ import {
   OUTPUTS_CLASS_NAME,
   PORTS_CLASS_NAME,
   VELLUM_WORKFLOWS_DISPLAY_BASE_PATH,
+  VELLUM_WORKFLOWS_DISPLAY_MODULE_PATH,
 } from "src/constants";
 import { WorkflowContext } from "src/context";
 import { BasePersistedFile } from "src/generators/base-persisted-file";
@@ -153,10 +154,8 @@ export class Workflow {
       name: workflowDisplayClassName,
       extends_: [
         python.reference({
-          name: "VellumWorkflowDisplay",
-          modulePath:
-            this.workflowContext.sdkModulePathNames
-              .WORKFLOWS_DISPLAY_MODULE_PATH,
+          name: "BaseWorkflowDisplay",
+          modulePath: VELLUM_WORKFLOWS_DISPLAY_MODULE_PATH,
           genericTypes: [workflowClassRef],
         }),
       ],

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.api_node import APINode
@@ -30,7 +30,7 @@ from ..nodes.templating_node_15 import TemplatingNode15
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("81ec43d2-49ec-47ce-b953-faaec3a22c63"),
         entrypoint_node_source_handle_id=UUID("6888c8eb-9dba-42b4-94d4-52900edcfeea"),

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.api_node import ApiNode
@@ -17,7 +17,7 @@ from ..nodes.final_output import FinalOutput
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("c4ef480d-635a-49c8-900f-6583c4b79fb5"),
         entrypoint_node_source_handle_id=UUID("0465edea-e797-4558-aabb-65bce040e095"),

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.code_execution_node import CodeExecutionNode
@@ -17,7 +17,7 @@ from ..nodes.final_output import FinalOutput
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("d49107fe-1424-42ba-9413-9ab5ce398077"),
         entrypoint_node_source_handle_id=UUID("08d78489-ce80-4743-a22d-2d5f62b575ac"),

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.conditional_node import ConditionalNode
@@ -17,7 +17,7 @@ from ..nodes.final_output import FinalOutput
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("6dbd327c-3b96-4da4-9063-5b36dab7f6d0"),
         entrypoint_node_source_handle_id=UUID("498eed8e-38d5-48b8-bbc4-f45411100502"),

--- a/ee/codegen_integration/fixtures/simple_error_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_error_node/code/display/workflow.py
@@ -3,14 +3,14 @@ from uuid import UUID
 from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowInputsDisplay, WorkflowMetaDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.error_node import ErrorNode
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("27a1723c-e892-4303-bbf0-c1a0428af295"),
         entrypoint_node_source_handle_id=UUID("6cbf47ee-84ef-42cb-b1df-7b9e0fee2bee"),

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.final_output import FinalOutput
@@ -17,7 +17,7 @@ from ..nodes.guardrail_node import GuardrailNode
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("872c757c-9544-4ad6-ada5-5ee574f1fe5e"),
         entrypoint_node_source_handle_id=UUID("5751330f-60a8-4d6a-88aa-a35b968db364"),

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -3,14 +3,14 @@ from uuid import UUID
 from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ....nodes.subworkflow_node.nodes.final_output import FinalOutput
 from ....nodes.subworkflow_node.nodes.search_node import SearchNode
 from ....nodes.subworkflow_node.workflow import SubworkflowNodeWorkflow
 
 
-class SubworkflowNodeWorkflowDisplay(VellumWorkflowDisplay[SubworkflowNodeWorkflow]):
+class SubworkflowNodeWorkflowDisplay(BaseWorkflowDisplay[SubworkflowNodeWorkflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("c48f318d-4d87-44da-be54-0ecf537608f6"),
         entrypoint_node_source_handle_id=UUID("cfec8bf4-d335-4681-a5c6-cbd53ffbd0d1"),

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.final_output import FinalOutput
@@ -17,7 +17,7 @@ from ..nodes.subworkflow_node import SubworkflowNode
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("48134634-f654-4a45-9f00-4e9378ab1f32"),
         entrypoint_node_source_handle_id=UUID("c1eca197-d299-4feb-906b-a9f4647e759c"),

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ....nodes.map_node.inputs import Inputs
 from ....nodes.map_node.nodes.final_output import FinalOutput
@@ -18,7 +18,7 @@ from ....nodes.map_node.nodes.templating_node import TemplatingNode
 from ....nodes.map_node.workflow import MapNodeWorkflow
 
 
-class MapNodeWorkflowDisplay(VellumWorkflowDisplay[MapNodeWorkflow]):
+class MapNodeWorkflowDisplay(BaseWorkflowDisplay[MapNodeWorkflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("79145e96-23c3-4763-ad7e-f3c6529fe535"),
         entrypoint_node_source_handle_id=UUID("b4b974ea-716d-4187-a5fb-808284272fe2"),

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.code_execution_node import CodeExecutionNode
@@ -18,7 +18,7 @@ from ..nodes.map_node import MapNode
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("77325e35-b73e-4596-bfb0-3cf3ddf11a2e"),
         entrypoint_node_source_handle_id=UUID("f342d075-e79a-46ea-8de9-e40ed8152070"),

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..nodes.final_output import FinalOutput
 from ..nodes.merge_node import MergeNode
@@ -13,7 +13,7 @@ from ..nodes.templating_node_3 import TemplatingNode3
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("b8b9eb69-4af1-4953-b576-aa59eb138696"),
         entrypoint_node_source_handle_id=UUID("1095ae85-1e2f-4433-aacf-fac30fe12ff3"),

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.final_output import FinalOutput
@@ -17,7 +17,7 @@ from ..nodes.prompt_node import PromptNode
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("1c05df03-f699-42e4-9816-9b1b3757c10e"),
         entrypoint_node_source_handle_id=UUID("4ee49c3a-68ef-4134-b73d-c1754abaac44"),

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.final_output import FinalOutput
@@ -17,7 +17,7 @@ from ..nodes.prompt_node import PromptNode
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("fedbe8f4-aa63-405b-aefa-0e40e65d547e"),
         entrypoint_node_source_handle_id=UUID("4d6a6de9-d3d6-4b8f-9a71-caf53c2f31c3"),

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.final_output import FinalOutput
@@ -17,7 +17,7 @@ from ..nodes.search_node import SearchNode
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("27a1723c-e892-4303-bbf0-c1a0428af295"),
         entrypoint_node_source_handle_id=UUID("6cbf47ee-84ef-42cb-b1df-7b9e0fee2bee"),

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.final_output import FinalOutput
@@ -17,7 +17,7 @@ from ..nodes.subworkflow_deployment import SubworkflowDeployment
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("39a5155a-d137-4a56-be36-d525802df463"),
         entrypoint_node_source_handle_id=UUID("beddfefc-dc34-483d-b313-f6a2a2e0737e"),

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -3,14 +3,14 @@ from uuid import UUID
 from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..nodes.final_output import FinalOutput
 from ..nodes.templating_node import TemplatingNode
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("6b52893a-e649-434d-aedd-e8ad73d78dce"),
         entrypoint_node_source_handle_id=UUID("b4f25dad-17c6-464d-b347-9945065f17e4"),

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/workflow.py
@@ -9,7 +9,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
 from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
-from vellum_ee.workflows.display.workflows.vellum_workflow_display import VellumWorkflowDisplay
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs
 from ..nodes.final_output import FinalOutput
@@ -17,7 +17,7 @@ from ..nodes.templating_node import TemplatingNode
 from ..workflow import Workflow
 
 
-class WorkflowDisplay(VellumWorkflowDisplay[Workflow]):
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
     workflow_display = WorkflowMetaDisplay(
         entrypoint_node_id=UUID("39a5155a-d137-4a56-be36-d525802df463"),
         entrypoint_node_source_handle_id=UUID("beddfefc-dc34-483d-b313-f6a2a2e0737e"),


### PR DESCRIPTION
This removes the last reference to `VellumWorkflowDisplay` from the SDK repo. On the next release, will do the same to vembda and prototype repo