### PR TITLE
Fix bug surrounding BaseOutputs inheritance

### DIFF
--- a/src/vellum/workflows/nodes/bases/tests/test_base_node.py
+++ b/src/vellum/workflows/nodes/bases/tests/test_base_node.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from vellum.client.types.string_vellum_value_request import StringVellumValueRequest
 from vellum.core.pydantic_utilities import UniversalBaseModel
+from vellum.workflows.constants import undefined
 from vellum.workflows.descriptors.tests.test_utils import FixtureState
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes import FinalOutputNode
@@ -259,3 +260,23 @@ def test_resolve_value__for_falsy_values(falsy_value, expected_type):
 
     # THEN the output has the correct value
     assert falsy_output.value == falsy_value
+
+
+def test_node_outputs__inherits_instance():
+    # GIVEN a node with two outputs, one with and one without a default instance
+    class MyNode(BaseNode):
+        class Outputs:
+            foo: str
+            bar = "hello"
+
+    # AND a node that inherits from MyNode
+    class InheritedNode(MyNode):
+        pass
+
+    # WHEN we reference each output
+    foo_output = InheritedNode.Outputs.foo
+    bar_output = InheritedNode.Outputs.bar
+
+    # THEN the output reference instances are correct
+    assert foo_output.instance is undefined
+    assert bar_output.instance == "hello"

--- a/src/vellum/workflows/nodes/bases/tests/test_base_node.py
+++ b/src/vellum/workflows/nodes/bases/tests/test_base_node.py
@@ -10,6 +10,7 @@ from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes import FinalOutputNode
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.outputs.base import BaseOutputs
+from vellum.workflows.references.output import OutputReference
 from vellum.workflows.state.base import BaseState, StateMeta
 
 
@@ -278,5 +279,7 @@ def test_node_outputs__inherits_instance():
     bar_output = InheritedNode.Outputs.bar
 
     # THEN the output reference instances are correct
+    assert isinstance(foo_output, OutputReference)
     assert foo_output.instance is undefined
+    assert isinstance(bar_output, OutputReference)
     assert bar_output.instance == "hello"

--- a/src/vellum/workflows/nodes/core/try_node/node.py
+++ b/src/vellum/workflows/nodes/core/try_node/node.py
@@ -4,7 +4,6 @@ from vellum.workflows.context import execution_context, get_parent_context
 from vellum.workflows.errors.types import WorkflowError, WorkflowErrorCode
 from vellum.workflows.events.workflow import is_workflow_event
 from vellum.workflows.exceptions import NodeException
-from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.bases.base_adornment_node import BaseAdornmentNode
 from vellum.workflows.nodes.utils import create_adornment
 from vellum.workflows.outputs.base import BaseOutput, BaseOutputs
@@ -24,7 +23,7 @@ class TryNode(BaseAdornmentNode[StateType], Generic[StateType]):
 
     on_error_code: Optional[WorkflowErrorCode] = None
 
-    class Outputs(BaseNode.Outputs):
+    class Outputs(BaseAdornmentNode.Outputs):
         error: Optional[WorkflowError] = None
 
     def run(self) -> Iterator[BaseOutput]:

--- a/src/vellum/workflows/nodes/utils.py
+++ b/src/vellum/workflows/nodes/utils.py
@@ -57,9 +57,11 @@ def create_adornment(
         class Subworkflow(BaseWorkflow):
             graph = inner_cls
 
-            # mypy is wrong here, this works and is defined
-            class Outputs(inner_cls.Outputs):  # type: ignore[name-defined]
+            class Outputs(BaseWorkflow.Outputs):
                 pass
+
+        for output_reference in inner_cls.Outputs:
+            setattr(Subworkflow.Outputs, output_reference.name, output_reference)
 
         dynamic_module = f"{inner_cls.__module__}.{inner_cls.__name__}.{ADORNMENT_MODULE_NAME}"
         # This dynamic module allows calls to `type_hints` to work

--- a/src/vellum/workflows/outputs/base.py
+++ b/src/vellum/workflows/outputs/base.py
@@ -147,8 +147,9 @@ class _BaseOutputsMeta(type):
             instance = vars(cls).get(name, undefined)
             if instance is undefined:
                 for base in cls.__mro__[1:]:
-                    if hasattr(base, name):
-                        instance = getattr(base, name)
+                    inherited_output_reference = getattr(base, name, undefined)
+                    if isinstance(inherited_output_reference, OutputReference):
+                        instance = inherited_output_reference.instance
                         break
 
             types = infer_types(cls, name)

--- a/tests/workflows/basic_conditional_node/workflow_with_try_node.py
+++ b/tests/workflows/basic_conditional_node/workflow_with_try_node.py
@@ -32,7 +32,7 @@ class FinalNode(BaseNode):
 
 class TestConditionalNode(ConditionalNode):
     class Ports(ConditionalNode.Ports):
-        branch_1 = Port.on_if(Node.Outputs.error.contains("Provider Error"))
+        branch_1 = Port.on_if(Node.Outputs.error.is_not_nil())
         branch_2 = Port.on_else()
 
 

--- a/tests/workflows/basic_retry_node/workflow.py
+++ b/tests/workflows/basic_retry_node/workflow.py
@@ -20,15 +20,15 @@ class StartNode(BaseNode):
 class Subworkflow(BaseWorkflow[RetryNode.SubworkflowInputs, BaseState]):
     graph = StartNode
 
-    class Outputs(StartNode.Outputs):
-        pass
+    class Outputs(BaseWorkflow.Outputs):
+        execution_count = StartNode.Outputs.execution_count
 
 
 class RetryableNode(RetryNode):
     max_attempts = 3
     subworkflow = Subworkflow
 
-    class Outputs(Subworkflow.Outputs):
+    class Outputs(RetryNode.Outputs):
         pass
 
 

--- a/tests/workflows/basic_retry_node_delay/workflow.py
+++ b/tests/workflows/basic_retry_node_delay/workflow.py
@@ -20,8 +20,8 @@ class StartNode(BaseNode):
 class Subworkflow(BaseWorkflow[RetryNode.SubworkflowInputs, BaseState]):
     graph = StartNode
 
-    class Outputs(StartNode.Outputs):
-        pass
+    class Outputs(BaseWorkflow.Outputs):
+        execution_count = StartNode.Outputs.execution_count
 
 
 class RetryableNode(RetryNode):
@@ -29,7 +29,7 @@ class RetryableNode(RetryNode):
     delay = 0.1  # 0.1 second between retries
     subworkflow = Subworkflow
 
-    class Outputs(Subworkflow.Outputs):
+    class Outputs(RetryNode.Outputs):
         pass
 
 


### PR DESCRIPTION
This is a bug that was blocking me here: https://github.com/vellum-ai/vellum-python-sdks/pull/1414

Subworkflow nodes used to map all of the base outputs to the inherited outputs directly upon inheritance. This felt neat at the time I introduced it way back when, but breaks serialization logic, especially when one node inherits from an existing node. Instead this automapping should be the job of the workflow/node, and instead, inheriting just points outputs to the same default value.

This shouldn't affect live workflows, since we always codegen our outputs explicitly