### PR TITLE
Support serialization of Inherited workflows

### DIFF
--- a/ee/vellum_ee/workflows/display/workflows/get_vellum_workflow_display_class.py
+++ b/ee/vellum_ee/workflows/display/workflows/get_vellum_workflow_display_class.py
@@ -1,5 +1,5 @@
 import types
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Generic, Optional, Type, TypeVar
 
 from vellum.workflows.types.generics import WorkflowType
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
@@ -18,12 +18,14 @@ def _get_workflow_display_class(*, workflow_class: Type[WorkflowType]) -> Type["
         workflow_class=workflow_class.__bases__[0],
     )
 
+    # mypy gets upset at dynamic TypeVar's, but it's technically allowed by python
+    _WorkflowClassType = TypeVar(f"_{workflow_class.__name__}Type", bound=workflow_class)  # type: ignore[misc]
     # `base_workflow_display_class` is always a Generic class, so it's safe to index into it
-    WorkflowDisplayBaseClass = base_workflow_display_class[workflow_class]  # type: ignore[index]
+    WorkflowDisplayBaseClass = base_workflow_display_class[_WorkflowClassType]  # type: ignore[index]
 
     WorkflowDisplayClass = types.new_class(
         f"{workflow_class.__name__}Display",
-        bases=(WorkflowDisplayBaseClass,),
+        bases=(WorkflowDisplayBaseClass, Generic[_WorkflowClassType]),
     )
 
     return WorkflowDisplayClass

--- a/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
@@ -304,3 +304,26 @@ def test_serialize_workflow__inherited_node_display_class_not_registered():
 
     # THEN it should should succeed
     assert data is not None
+
+
+def test_serialize_workflow__inherited_workflow_display_class_not_registered():
+    # GIVEN a node
+    class StartNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            result: str
+
+    # AND a workflow that uses the node
+    class MyWorkflow(BaseWorkflow):
+        graph = StartNode
+
+    # AND a workflow that inherits from it
+    class InheritedWorkflow(MyWorkflow):
+        class Outputs(MyWorkflow.Outputs):
+            answer = StartNode.Outputs.result
+
+    # WHEN we serialize it
+    workflow_display = get_workflow_display(workflow_class=InheritedWorkflow)
+    data = workflow_display.serialize()
+
+    # THEN it should should succeed
+    assert data is not None

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -80,6 +80,11 @@ class _BaseWorkflowMeta(type):
     def __new__(mcs, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
         if "graph" not in dct:
             dct["graph"] = set()
+            for base in bases:
+                base_graph = getattr(base, "graph", None)
+                if base_graph:
+                    dct["graph"] = base_graph
+                    break
 
         if "Outputs" in dct:
             outputs_class = dct["Outputs"]


### PR DESCRIPTION
The workflow display version of https://github.com/vellum-ai/vellum-python-sdks/pull/1414/files

Admittedly, workflow inheritance will be a super advanced feature, but I wanted to keep the to `get_[node|workflow]_display_class` utilities in sync in the meantime