### PR TITLE
Skip serialization of legacy node inputs pointing to unsupported reference types

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/utils.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/utils.py
@@ -8,6 +8,7 @@ from vellum.workflows.references import NodeReference
 from vellum.workflows.references.lazy import LazyReference
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
+from vellum_ee.workflows.display.utils.exceptions import UnsupportedSerializationException
 from vellum_ee.workflows.display.utils.expressions import get_child_descriptor
 from vellum_ee.workflows.display.utils.vellum import (
     ConstantValuePointer,
@@ -76,7 +77,12 @@ def create_node_input_value_pointer_rules(
                 node_input_value_pointer_rules.extend(rhs_rules)
         else:
             # Non-CoalesceExpression case
-            node_input_value_pointer_rules.append(create_node_input_value_pointer_rule(value, display_context))
+            try:
+                rule = create_node_input_value_pointer_rule(value, display_context)
+            except UnsupportedSerializationException:
+                return node_input_value_pointer_rules
+
+            node_input_value_pointer_rules.append(rule)
     else:
         pointer = create_pointer(value, pointer_type)
         node_input_value_pointer_rules.append(pointer)

--- a/ee/vellum_ee/workflows/display/utils/exceptions.py
+++ b/ee/vellum_ee/workflows/display/utils/exceptions.py
@@ -1,0 +1,7 @@
+class UserFacingException(Exception):
+    def to_message(self) -> str:
+        return str(self)
+
+
+class UnsupportedSerializationException(UserFacingException):
+    pass

--- a/ee/vellum_ee/workflows/display/utils/vellum.py
+++ b/ee/vellum_ee/workflows/display/utils/vellum.py
@@ -41,6 +41,7 @@ from vellum.workflows.references.node import NodeReference
 from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
 from vellum.workflows.vellum_client import create_vellum_client
+from vellum_ee.workflows.display.utils.exceptions import UnsupportedSerializationException
 from vellum_ee.workflows.display.utils.expressions import get_child_descriptor
 
 if TYPE_CHECKING:
@@ -164,7 +165,7 @@ def create_node_input_value_pointer_rule(
         vellum_value = primitive_to_vellum_value(value)
         return ConstantValuePointer(type="CONSTANT_VALUE", data=vellum_value)
 
-    raise ValueError(f"Unsupported descriptor type: {value.__class__.__name__}")
+    raise UnsupportedSerializationException(f"Unsupported descriptor type: {value.__class__.__name__}")
 
 
 def convert_descriptor_to_operator(descriptor: BaseDescriptor) -> LogicalOperator:


### PR DESCRIPTION
The customer workflow I'm trying to push to Vellum has legacy node inputs referencing State. This PR unblocks the failure that occurs during serialization