### PR TITLE
Support the serialization of access field expressions and clean up node display testing

### DIFF
--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass, field
 from uuid import UUID
-from typing import Optional
+from typing import Optional, Type
 
 from pydantic import Field
 
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
+from vellum.workflows.utils.uuids import uuid4_from_hash
+from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.editor.types import NodeDisplayData
 
 
@@ -24,6 +26,17 @@ class WorkflowMetaDisplay:
     entrypoint_node_source_handle_id: UUID
     entrypoint_node_display: NodeDisplayData = Field(default_factory=NodeDisplayData)
     display_data: WorkflowDisplayData = field(default_factory=WorkflowDisplayData)
+
+    @classmethod
+    def get_default(cls, workflow: Type[BaseWorkflow]) -> "WorkflowMetaDisplay":
+        entrypoint_node_id = uuid4_from_hash(f"{workflow.__id__}|entrypoint_node_id")
+        entrypoint_node_source_handle_id = uuid4_from_hash(f"{workflow.__id__}|entrypoint_node_source_handle_id")
+
+        return WorkflowMetaDisplay(
+            entrypoint_node_id=entrypoint_node_id,
+            entrypoint_node_source_handle_id=entrypoint_node_source_handle_id,
+            entrypoint_node_display=NodeDisplayData(),
+        )
 
 
 @dataclass

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -6,6 +6,7 @@ from vellum.workflows.events.workflow import WorkflowEventDisplayContext  # noqa
 from vellum.workflows.nodes import BaseNode
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference, StateValueReference, WorkflowInputReference
+from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
     EntrypointDisplay,
@@ -16,6 +17,7 @@ from vellum_ee.workflows.display.base import (
 )
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplay
+from vellum_ee.workflows.display.utils.registry import get_default_workflow_display_class
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
@@ -33,8 +35,8 @@ PortDisplays = Dict[Port, PortDisplay]
 
 @dataclass
 class WorkflowDisplayContext:
-    workflow_display_class: Type["BaseWorkflowDisplay"]
-    workflow_display: WorkflowMetaDisplay
+    workflow_display_class: Type["BaseWorkflowDisplay"] = field(default_factory=get_default_workflow_display_class)
+    workflow_display: WorkflowMetaDisplay = field(default_factory=lambda: WorkflowMetaDisplay.get_default(BaseWorkflow))
     workflow_input_displays: WorkflowInputsDisplays = field(default_factory=dict)
     global_workflow_input_displays: WorkflowInputsDisplays = field(default_factory=dict)
     state_value_displays: StateValueDisplays = field(default_factory=dict)

--- a/ee/vellum_ee/workflows/display/utils/registry.py
+++ b/ee/vellum_ee/workflows/display/utils/registry.py
@@ -25,6 +25,10 @@ def register_workflow_display_class(
     _workflow_display_registry[workflow_class] = workflow_display_class
 
 
+def get_default_workflow_display_class() -> Type["BaseWorkflowDisplay"]:
+    return _workflow_display_registry[BaseWorkflow]
+
+
 def get_from_node_display_registry(node_class: Type[BaseNode]) -> Optional[Type["BaseNodeDisplay"]]:
     return _node_display_registry.get(node_class)
 

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -331,7 +331,7 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
     @cached_property
     def workflow_id(self) -> UUID:
         """Can be overridden as a class attribute to specify a custom workflow id."""
-        return uuid4_from_hash(self._workflow.__qualname__)
+        return self._workflow.__id__
 
     def add_error(self, error: Exception) -> None:
         if self._dry_run:
@@ -513,14 +513,7 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
                 display_data=overrides.display_data,
             )
 
-        entrypoint_node_id = uuid4_from_hash(f"{self.workflow_id}|entrypoint_node_id")
-        entrypoint_node_source_handle_id = uuid4_from_hash(f"{self.workflow_id}|entrypoint_node_source_handle_id")
-
-        return WorkflowMetaDisplay(
-            entrypoint_node_id=entrypoint_node_id,
-            entrypoint_node_source_handle_id=entrypoint_node_source_handle_id,
-            entrypoint_node_display=NodeDisplayData(),
-        )
+        return WorkflowMetaDisplay.get_default(self._workflow)
 
     def _generate_workflow_input_display(
         self, workflow_input: WorkflowInputReference, overrides: Optional[WorkflowInputsDisplay] = None


### PR DESCRIPTION
Ran into this error trying to push a customer's workflow that used accessor expressions in ports:

![Screenshot 2025-04-17 at 10 01 33 AM](https://github.com/user-attachments/assets/0c9d1eca-35cb-4efc-af80-55b3f2a184be)

I also implemented some defaulting logic to make the testing of node displays a bit more approachable
