### PR TITLE
Serialize node ids in the node execution cache instead of node module paths

### DIFF
--- a/src/vellum/workflows/types/stack.py
+++ b/src/vellum/workflows/types/stack.py
@@ -37,3 +37,14 @@ class Stack(Generic[_T]):
 
     def dump(self) -> List[_T]:
         return [item for item in self._items][::-1]
+
+    @classmethod
+    def from_list(cls, items: List[_T]) -> "Stack[_T]":
+        stack = cls()
+        stack.extend(items)
+        return stack
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Stack):
+            return False
+        return self._items == other._items

--- a/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
+++ b/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
@@ -37,6 +37,8 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
             execution_context=ExecutionContext(trace_id=trace_id),
         ),
     )
+    serialized_start_node_id = str(StartNode.__id__)
+    serialized_next_node_id = str(NextNode.__id__)
 
     # WHEN the workflow is run
     frozen_datetime = datetime(2024, 1, 1, 12, 0, 0)
@@ -47,7 +49,6 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
     time.sleep(0.01)
 
     # THEN the emitter should have emitted all of the expected events
-    base_module = ".".join(__name__.split(".")[:-2])
     events = list(emitter.events)
 
     assert events[0].name == "workflow.execution.initiated"
@@ -72,8 +73,8 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
             "node_outputs": {"StartNode.Outputs.final_value": "Hello, World!"},
             "parent": None,
             "node_execution_cache": {
-                "node_executions_fulfilled": {f"{base_module}.workflow.StartNode": [str(start_node_span_id)]},
-                "node_executions_initiated": {f"{base_module}.workflow.StartNode": [str(start_node_span_id)]},
+                "node_executions_fulfilled": {serialized_start_node_id: [str(start_node_span_id)]},
+                "node_executions_initiated": {serialized_start_node_id: [str(start_node_span_id)]},
                 "node_executions_queued": {},
                 "dependencies_invoked": {},
             },
@@ -109,17 +110,17 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
             "parent": None,
             "node_execution_cache": {
                 "node_executions_fulfilled": {
-                    f"{base_module}.workflow.StartNode": [str(start_node_span_id)],
+                    serialized_start_node_id: [str(start_node_span_id)],
                 },
                 "node_executions_initiated": {
-                    f"{base_module}.workflow.StartNode": [str(start_node_span_id)],
-                    f"{base_module}.workflow.NextNode": [str(next_node_span_id)],
+                    serialized_start_node_id: [str(start_node_span_id)],
+                    serialized_next_node_id: [str(next_node_span_id)],
                 },
                 "node_executions_queued": {
-                    f"{base_module}.workflow.NextNode": [],
+                    serialized_next_node_id: [],
                 },
                 "dependencies_invoked": {
-                    str(next_node_span_id): [f"{base_module}.workflow.StartNode"],
+                    str(next_node_span_id): [serialized_start_node_id],
                 },
             },
             "workflow_definition": {
@@ -145,18 +146,18 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
             },
             "node_execution_cache": {
                 "node_executions_fulfilled": {
-                    f"{base_module}.workflow.StartNode": [str(start_node_span_id)],
-                    f"{base_module}.workflow.NextNode": [str(next_node_span_id)],
+                    serialized_start_node_id: [str(start_node_span_id)],
+                    serialized_next_node_id: [str(next_node_span_id)],
                 },
                 "node_executions_initiated": {
-                    f"{base_module}.workflow.StartNode": [str(start_node_span_id)],
-                    f"{base_module}.workflow.NextNode": [str(next_node_span_id)],
+                    serialized_start_node_id: [str(start_node_span_id)],
+                    serialized_next_node_id: [str(next_node_span_id)],
                 },
                 "node_executions_queued": {
-                    f"{base_module}.workflow.NextNode": [],
+                    serialized_next_node_id: [],
                 },
                 "dependencies_invoked": {
-                    str(next_node_span_id): [f"{base_module}.workflow.StartNode"],
+                    str(next_node_span_id): [serialized_start_node_id],
                 },
             },
             "parent": None,


### PR DESCRIPTION
Hopefully the last piece I need from the SDK for run from node.

In order to show which previous nodes we are rendering results from the previous execution, we need the node execution cache to return the relevant data in terms of node id's instead of node module paths. This will allow the UI, which is node id driven, to do easy lookups.

Will need to followup to do the same for the output ids