### PR TITLE
Serialize State.meta.node_output keys as id's for the UI

### DIFF
--- a/src/vellum/workflows/references/output.py
+++ b/src/vellum/workflows/references/output.py
@@ -1,4 +1,6 @@
+from functools import cached_property
 from queue import Queue
+from uuid import UUID, uuid4
 from typing import TYPE_CHECKING, Any, Generator, Generic, Optional, Tuple, Type, TypeVar, cast
 
 from pydantic import GetCoreSchemaHandler
@@ -30,6 +32,24 @@ class OutputReference(BaseDescriptor[_OutputType], Generic[_OutputType]):
     @property
     def outputs_class(self) -> Type["BaseOutputs"]:
         return self._outputs_class
+
+    @cached_property
+    def id(self) -> UUID:
+        self._outputs_class = self._outputs_class
+
+        node_class = getattr(self._outputs_class, "_node_class", None)
+        if not node_class:
+            return uuid4()
+
+        output_ids = getattr(node_class, "__output_ids__", {})
+        if not isinstance(output_ids, dict):
+            return uuid4()
+
+        output_id = output_ids.get(self.name)
+        if not isinstance(output_id, UUID):
+            return uuid4()
+
+        return output_id
 
     def resolve(self, state: "BaseState") -> _OutputType:
         node_output = state.meta.node_outputs.get(self, undefined)

--- a/src/vellum/workflows/state/tests/test_state.py
+++ b/src/vellum/workflows/state/tests/test_state.py
@@ -47,6 +47,9 @@ class MockNode(BaseNode):
         baz: str
 
 
+MOCK_NODE_OUTPUT_ID = "e4dc3136-0c27-4bda-b3ab-ea355d5219d6"
+
+
 def test_state_snapshot__node_attribute_edit():
     # GIVEN an initial state instance
     state = MockState(foo="bar")
@@ -144,7 +147,7 @@ def test_state_json_serialization__with_node_output_updates():
     json_state = json.loads(json.dumps(state, cls=DefaultStateEncoder))
 
     # THEN the state is serialized correctly
-    assert json_state["meta"]["node_outputs"] == {"MockNode.Outputs.baz": "hello"}
+    assert json_state["meta"]["node_outputs"] == {MOCK_NODE_OUTPUT_ID: "hello"}
 
 
 def test_state_deepcopy__with_external_input_updates():
@@ -185,7 +188,7 @@ def test_state_json_serialization__with_queue():
     json_state = json.loads(json.dumps(state, cls=DefaultStateEncoder))
 
     # THEN the state is serialized correctly with the queue turned into a list
-    assert json_state["meta"]["node_outputs"] == {"MockNode.Outputs.baz": ["test1", "test2"]}
+    assert json_state["meta"]["node_outputs"] == {MOCK_NODE_OUTPUT_ID: ["test1", "test2"]}
 
 
 def test_state_snapshot__deepcopy_fails__logs_error(mock_deepcopy, mock_logger):

--- a/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
+++ b/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
@@ -37,8 +37,12 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
             execution_context=ExecutionContext(trace_id=trace_id),
         ),
     )
+
+    # AND we have known serialized ids for the nodes and outputs
     serialized_start_node_id = str(StartNode.__id__)
     serialized_next_node_id = str(NextNode.__id__)
+    serialized_start_node_output_id = str(StartNode.__output_ids__["final_value"])
+    serialized_next_node_output_id = str(NextNode.__output_ids__["final_value"])
 
     # WHEN the workflow is run
     frozen_datetime = datetime(2024, 1, 1, 12, 0, 0)
@@ -70,7 +74,7 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
             "updated_ts": "2024-01-01T12:00:00",
             "workflow_inputs": {},
             "external_inputs": {},
-            "node_outputs": {"StartNode.Outputs.final_value": "Hello, World!"},
+            "node_outputs": {serialized_start_node_output_id: "Hello, World!"},
             "parent": None,
             "node_execution_cache": {
                 "node_executions_fulfilled": {serialized_start_node_id: [str(start_node_span_id)]},
@@ -105,7 +109,7 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
             "workflow_inputs": {},
             "external_inputs": {},
             "node_outputs": {
-                "StartNode.Outputs.final_value": "Hello, World!",
+                serialized_start_node_output_id: "Hello, World!",
             },
             "parent": None,
             "node_execution_cache": {
@@ -141,8 +145,8 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
             "workflow_inputs": {},
             "external_inputs": {},
             "node_outputs": {
-                "StartNode.Outputs.final_value": "Hello, World!",
-                "NextNode.Outputs.final_value": "Score: 13",
+                serialized_start_node_output_id: "Hello, World!",
+                serialized_next_node_output_id: "Score: 13",
             },
             "node_execution_cache": {
                 "node_executions_fulfilled": {


### PR DESCRIPTION
A continuation of this PR: https://github.com/vellum-ai/vellum-python-sdks/pull/1420, but for node outputs. Ok now we're ready to implement Run from Node B from Node C!