### PR TITLE
skip node_input_ids_by_name codegen if empty

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -67,7 +67,6 @@ from ...nodes.second_node import SecondNode
 
 
 class SecondNodeDisplay(BaseNodeDisplay[SecondNode]):
-    node_input_ids_by_name = {}
     display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None)
 "
 `;

--- a/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/error-node.test.ts.snap
@@ -49,7 +49,6 @@ class ErrorNodeDisplay(BaseErrorNodeDisplay[ErrorNode]):
     label = "Error Node"
     error_output_id = UUID("69250713-617d-42a4-9326-456c70d0ef20")
     target_handle_id = UUID("370d712d-3369-424e-bcf7-f4da1aef3928")
-    node_input_ids_by_name = {}
     display_data = NodeDisplayData(
         position=NodeDisplayPosition(x=0, y=0), width=None, height=None
     )

--- a/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
@@ -61,7 +61,6 @@ class FinalOutputNodeDisplay(BaseFinalOutputNodeDisplay[FinalOutputNode]):
     output_id = UUID("<output-id>")
     output_name = "final-output"
     node_input_id = UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
-    node_input_ids_by_name = {}
     output_display = {
         FinalOutputNode.Outputs.value: NodeOutputDisplay(
             id=UUID("<output-id>"), name="value"

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -33,7 +33,6 @@ class MyNodeDisplay(BaseInlineSubworkflowNodeDisplay[MyNode]):
     node_id = UUID("14fee4a0-ad25-402f-b942-104d3a5a0824")
     target_handle_id = UUID("3fe4b4a6-5ed2-4307-ac1c-02389337c4f2")
     workflow_input_ids_by_name = {}
-    node_input_ids_by_name = {}
     output_display = {
         MyNode.Outputs.final_output: NodeOutputDisplay(
             id=UUID("edd5cfd5-6ad8-437d-8775-4b9aeb62a5fb"), name="final-output"
@@ -63,7 +62,6 @@ class InlineSubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[InlineSubwor
     node_id = UUID("14fee4a0-ad25-402f-b942-104d3a5a0824")
     target_handle_id = UUID("3fe4b4a6-5ed2-4307-ac1c-02389337c4f2")
     workflow_input_ids_by_name = {}
-    node_input_ids_by_name = {}
     output_display = {
         InlineSubworkflowNode.Outputs.final_output: NodeOutputDisplay(
             id=UUID("edd5cfd5-6ad8-437d-8775-4b9aeb62a5fb"), name="final-output"
@@ -117,7 +115,6 @@ class MyNodeDisplay(BaseInlineSubworkflowNodeDisplay[MyNode]):
     node_id = UUID("14fee4a0-ad25-402f-b942-104d3a5a0824")
     target_handle_id = UUID("3fe4b4a6-5ed2-4307-ac1c-02389337c4f2")
     workflow_input_ids_by_name = {}
-    node_input_ids_by_name = {}
     output_display = {
         MyNode.Outputs.final_output: NodeOutputDisplay(
             id=UUID("edd5cfd5-6ad8-437d-8775-4b9aeb62a5fb"), name="final-output"

--- a/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/merge-node.test.ts.snap
@@ -14,7 +14,6 @@ class MergeNodeDisplay(BaseMergeNodeDisplay[MergeNode]):
     label = "Merge Node"
     node_id = UUID("merge-node-1")
     target_handle_ids = [UUID("target-handle-id-1"), UUID("target-handle-id-2")]
-    node_input_ids_by_name = {}
     port_displays = {
         MergeNode.Ports.default: PortDisplayOverrides(id=UUID("source-handle-id"))
     }

--- a/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/note-node.test.ts.snap
@@ -14,7 +14,6 @@ class NoteNodeDisplay(BaseNoteNodeDisplay[NoteNode]):
         "fontSize": 12,
         "fontWeight": "bold",
     }
-    node_input_ids_by_name = {}
     display_data = NodeDisplayData(
         position=NodeDisplayPosition(x=0, y=0), width=None, height=None
     )

--- a/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
@@ -19,7 +19,6 @@ class PromptDeploymentNodeDisplay(
     label = "Prompt Deployment Node"
     node_id = UUID("947cc337-9a53-4c12-9a38-4f65c04c6317")
     target_handle_id = UUID("e1f8a351-ab12-4167-93ee-d2dd72c8d15c")
-    node_input_ids_by_name = {}
     output_display = {
         PromptDeploymentNode.Outputs.text: NodeOutputDisplay(
             id=UUID("fa015382-7e5b-404e-b073-1c5f01832169"), name="text"
@@ -102,7 +101,6 @@ class PromptDeploymentNodeDisplay(
     label = "Prompt Deployment Node"
     node_id = UUID("947cc337-9a53-4c12-9a38-4f65c04c6317")
     target_handle_id = UUID("e1f8a351-ab12-4167-93ee-d2dd72c8d15c")
-    node_input_ids_by_name = {}
     output_display = {
         PromptDeploymentNode.Outputs.text: NodeOutputDisplay(
             id=UUID("fa015382-7e5b-404e-b073-1c5f01832169"), name="text"

--- a/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/subworkflow-deployment-node.test.ts.snap
@@ -17,7 +17,6 @@ class SubworkflowNodeDisplay(BaseSubworkflowDeploymentNodeDisplay[SubworkflowNod
     label = "Subworkflow Node"
     node_id = UUID("c8f2964c-09b8-44e0-a06d-606319fe5e2a")
     target_handle_id = UUID("f5e6bd33-527a-4ba6-8906-cd5e96a4321c")
-    node_input_ids_by_name = {}
     output_display = {
         SubworkflowNode.Outputs.output_1: NodeOutputDisplay(
             id=UUID("1"), name="output-1"
@@ -70,7 +69,6 @@ class SubworkflowNodeDisplay(BaseSubworkflowDeploymentNodeDisplay[SubworkflowNod
     label = "Subworkflow Node"
     node_id = UUID("c8f2964c-09b8-44e0-a06d-606319fe5e2a")
     target_handle_id = UUID("f5e6bd33-527a-4ba6-8906-cd5e96a4321c")
-    node_input_ids_by_name = {}
     output_display = {}
     port_displays = {
         SubworkflowNode.Ports.default: PortDisplayOverrides(

--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
@@ -8,7 +8,6 @@ from ...nodes.my_custom_node import MyCustomNode
 
 
 class MyCustomNodeDisplay(BaseNodeDisplay[MyCustomNode]):
-    node_input_ids_by_name = {}
     display_data = NodeDisplayData(
         position=NodeDisplayPosition(x=0, y=0), width=None, height=None
     )
@@ -51,7 +50,6 @@ from ...nodes.my_custom_node import MyCustomNode
 @BaseMapNodeDisplay.wrap(node_id=UUID("adornment-2"))
 @BaseRetryNodeDisplay.wrap(node_id=UUID("adornment-3"))
 class MyCustomNodeDisplay(BaseNodeDisplay[MyCustomNode]):
-    node_input_ids_by_name = {}
     display_data = NodeDisplayData(
         position=NodeDisplayPosition(x=0, y=0), width=None, height=None
     )
@@ -122,7 +120,6 @@ from ...nodes.my_custom_node import MyCustomNode
 
 
 class MyCustomNodeDisplay(BaseNodeDisplay[MyCustomNode]):
-    node_input_ids_by_name = {}
     display_data = NodeDisplayData(
         position=NodeDisplayPosition(x=0, y=0), width=None, height=None
     )

--- a/ee/codegen/src/generators/nodes/bases/base.ts
+++ b/ee/codegen/src/generators/nodes/bases/base.ts
@@ -484,24 +484,26 @@ export abstract class BaseNode<
       nodeClass.add(statement)
     );
 
-    const nodeInputIdsByNameField = python.field({
-      name: "node_input_ids_by_name",
-      initializer: python.TypeInstantiation.dict(
-        Array.from(this.nodeInputsByKey).map<{
-          key: AstNode;
-          value: AstNode;
-        }>(([key, nodeInput]) => {
-          const nodeAttributeName = this.nodeAttributeNameByNodeInputId.get(
-            nodeInput.nodeInputData.id
-          );
-          return {
-            key: python.TypeInstantiation.str(nodeAttributeName ?? key),
-            value: new UuidOrString(nodeInput.nodeInputData.id),
-          };
-        })
-      ),
-    });
-    nodeClass.add(nodeInputIdsByNameField);
+    if (this.nodeInputsByKey.size > 0) {
+      const nodeInputIdsByNameField = python.field({
+        name: "node_input_ids_by_name",
+        initializer: python.TypeInstantiation.dict(
+          Array.from(this.nodeInputsByKey).map<{
+            key: AstNode;
+            value: AstNode;
+          }>(([key, nodeInput]) => {
+            const nodeAttributeName = this.nodeAttributeNameByNodeInputId.get(
+              nodeInput.nodeInputData.id
+            );
+            return {
+              key: python.TypeInstantiation.str(nodeAttributeName ?? key),
+              value: new UuidOrString(nodeInput.nodeInputData.id),
+            };
+          })
+        ),
+      });
+      nodeClass.add(nodeInputIdsByNameField);
+    }
 
     try {
       const outputDisplay = this.getOutputDisplay();

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_19.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_19.py
@@ -13,7 +13,6 @@ class PromptNode19Display(BaseInlinePromptNodeDisplay[PromptNode19]):
     output_id = UUID("7b1ca9d1-d829-4329-b9f3-a864c3ce4230")
     array_output_id = UUID("17c0ef53-62bf-459f-8df8-2ff3f6b8852a")
     target_handle_id = UUID("35b77bfb-91d3-4e5b-8032-9786b9cc05c3")
-    node_input_ids_by_name = {}
     output_display = {
         PromptNode19.Outputs.text: NodeOutputDisplay(id=UUID("7b1ca9d1-d829-4329-b9f3-a864c3ce4230"), name="text"),
         PromptNode19.Outputs.results: NodeOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
@@ -16,7 +16,6 @@ class SubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[SubworkflowNode]):
     node_id = UUID("8c6d5fe5-e955-4598-9c35-0cd6f5eca47e")
     target_handle_id = UUID("67ee54dc-2505-4368-8e67-70d89ac2a9e5")
     workflow_input_ids_by_name = {}
-    node_input_ids_by_name = {}
     output_display = {
         SubworkflowNode.Outputs.final_output: NodeOutputDisplay(
             id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="final-output"

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/merge_node.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/merge_node.py
@@ -11,7 +11,6 @@ class MergeNodeDisplay(BaseMergeNodeDisplay[MergeNode]):
     label = "Merge Node"
     node_id = UUID("7426f273-a43d-4448-a2d2-76d0ee0d069c")
     target_handle_ids = [UUID("dee0633e-0221-40c7-b179-aae1cf67de87"), UUID("cf6974a6-1676-43ed-99a0-66bd3eac235f")]
-    node_input_ids_by_name = {}
     port_displays = {MergeNode.Ports.default: PortDisplayOverrides(id=UUID("e0e666c4-a90b-4a95-928e-144bab251356"))}
     display_data = NodeDisplayData(
         position=NodeDisplayPosition(x=2374.2549861495845, y=205.20096952908594), width=476, height=180


### PR DESCRIPTION
Noticed it while trying to codegen generic nodes [here](https://github.com/vellum-ai/workflows-as-code-runner-prototype/pull/659/files#diff-5155979fefcdff7cddfe87952a2e45c384ee2aedac120deaf231d68f2444f22cR8). This is a legacy field that will be replaced by `attribute_ids_by_name` in the future, so this PR cleans up.