### PR TITLE
Fix codegen for access fields

### DIFF
--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
@@ -143,6 +143,35 @@ class MyCustomNode(BaseNode):
 "
 `;
 
+exports[`GenericNode > basic with with access field in ports > getNodeFile 1`] = `
+"from vellum.workflows.nodes import BaseNode
+from vellum.workflows.ports import Port
+from vellum.workflows.references.constant import ConstantValueReference
+
+from ..inputs import Inputs
+
+
+class MyCustomNode(BaseNode):
+    default_attribute = "default-value"
+    default_attribute_2 = Inputs.count
+
+    class NodeTrigger(BaseNode.Trigger):
+        merge_behavior = "AWAIT_ALL"
+
+    class Outputs(BaseNode.Outputs):
+        output = "default-value"
+
+    class Ports(BaseNode.Ports):
+        access = Port.on_if(
+            ConstantValueReference(
+                {
+                    "foo": "bar",
+                }
+            )["foo"]
+        )
+"
+`;
+
 exports[`GenericNode > basic without node outputs > getNodeFile 1`] = `
 "from vellum.workflows.nodes import BaseNode
 

--- a/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
@@ -332,4 +332,50 @@ describe("GenericNode", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });
+
+  describe("basic with with access field in ports", () => {
+    it("getNodeFile", async () => {
+      const nodeData = genericNodeFactory({
+        nodePorts: [
+          {
+            id: "port-1",
+            name: "access",
+            type: "IF",
+            expression: {
+              type: "BINARY_EXPRESSION",
+              operator: "accessField",
+              lhs: {
+                type: "CONSTANT_VALUE",
+                value: {
+                  type: "JSON",
+                  value: {
+                    foo: "bar",
+                  },
+                },
+              },
+              rhs: {
+                type: "CONSTANT_VALUE",
+                value: {
+                  type: "STRING",
+                  value: "foo",
+                },
+              },
+            },
+          },
+        ],
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as GenericNodeContext;
+
+      node = new GenericNode({
+        workflowContext,
+        nodeContext,
+      });
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });

--- a/ee/codegen/src/generators/conditional-node-port.ts
+++ b/ee/codegen/src/generators/conditional-node-port.ts
@@ -210,6 +210,7 @@ export class ConditionalNodePort extends AstNode {
       lhs: lhs,
       operator: operator,
       rhs: rhs,
+      workflowContext: this.portContext.workflowContext,
     });
   }
 

--- a/ee/codegen/src/generators/workflow-value-descriptor.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor.ts
@@ -84,6 +84,7 @@ export class WorkflowValueDescriptor extends AstNode {
         return new Expression({
           lhs,
           operator: operator,
+          workflowContext: this.workflowContext,
         });
       }
       case "BINARY_EXPRESSION": {
@@ -94,6 +95,7 @@ export class WorkflowValueDescriptor extends AstNode {
           lhs,
           operator: operator,
           rhs,
+          workflowContext: this.workflowContext,
         });
       }
       case "TERNARY_EXPRESSION": {
@@ -106,6 +108,7 @@ export class WorkflowValueDescriptor extends AstNode {
           operator: operator,
           rhs: rhs,
           base: base,
+          workflowContext: this.workflowContext,
         });
       }
       default:

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -845,7 +845,8 @@ export type OperatorMapping =
   | "between"
   | "not_between"
   | "parse_json"
-  | "coalesce";
+  | "coalesce"
+  | "access_field";
 
 export interface IterableConfig {
   endWithComma?: boolean;

--- a/ee/codegen/src/utils/workflow-value-descriptor.ts
+++ b/ee/codegen/src/utils/workflow-value-descriptor.ts
@@ -38,6 +38,7 @@ export function convertOperatorType(
     notBetween: "not_between",
     parseJson: "parse_json",
     coalesce: "coalesce",
+    accessField: "access_field",
   };
 
   return operatorMappings[operator] || "equals"; // return default operator if not found


### PR DESCRIPTION
We were previously codegenning `.equals()` expressions for access fields, which appear to be our default. This PR gives us actual access field codegen support