### PR TITLE
Serialize function definition

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from functools import cached_property
 import inspect
 from uuid import UUID
@@ -493,14 +492,14 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
         if (
             isinstance(value, list)
             and len(value) > 0
-            and all(isinstance(function, (FunctionDefinition, Callable)) for function in value)
+            and all(isinstance(function, FunctionDefinition) or callable(function) for function in value)
         ):
             normalized_functions = [
                 function if isinstance(function, FunctionDefinition) else compile_function_definition(function)
                 for function in value
             ]
 
-            functions = [
+            functions: JsonArray = [
                 {
                     "id": str(uuid4_from_hash(f"{str(self.node_id)}-FUNCTION_DEFINITION-{i}")),
                     "block_type": "FUNCTION_DEFINITION",


### PR DESCRIPTION
Initial serialization for function definitions, will add test serialization for the whole tool calling workflow

will get
`{'id': '78324739-ff89-47a5-902b-10da0cb95c6d', 'name': 'functions', 'value': {'type': 'FUNCTION_DEFINITIONS', 'functions': [{'id': '0328f399-1d74-4375-8e65-62ec31b7db57', 'block_type': 'FUNCTION_DEFINITION', 'properties': {'function_name': 'get_current_weather', 'function_description': None, 'function_parameters': {'type': 'object', 'properties': {'location': {'type': 'string'}, 'unit': {'type': 'string'}}, 'required': ['location', 'unit']}, 'function_forced': None, 'function_strict': None}}]}}`