### PR TITLE
Avoid Lazy Reference when second node references first in Loop

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -24,6 +24,8 @@ exports[`WorkflowProjectGenerator > LazyReference > should not generate LazyRefe
 "from vellum.workflows.nodes import BaseNode
 from vellum.workflows.ports import Port
 
+from .start_node import StartNode
+
 
 class RouterNode(BaseNode):
     class Ports(BaseNode.Ports):

--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -20,6 +20,18 @@ class APINode(BaseAPINode):
 "
 `;
 
+exports[`WorkflowProjectGenerator > LazyReference > should not generate LazyReference when there is a simple loop 1`] = `
+"from vellum.workflows.nodes import BaseNode
+from vellum.workflows.ports import Port
+
+
+class RouterNode(BaseNode):
+    class Ports(BaseNode.Ports):
+        top = Port.on_if(StartNode.Outputs.result.equals("top"))
+        bottom = Port.on_else()
+"
+`;
+
 exports[`WorkflowProjectGenerator > Nodes present but not in graph > should generate unused_graphs if final output is not used 1`] = `
 "from vellum.workflows import BaseWorkflow
 

--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`WorkflowProjectGenerator > LazyReference > should not generate LazyReference 1`] = `
+exports[`WorkflowProjectGenerator > LazyReference > should not generate LazyReference when there is a long branch 1`] = `
 "from vellum.workflows.constants import APIRequestMethod, AuthorizationType
 from vellum.workflows.nodes.displayable import APINode as BaseAPINode
 from vellum.workflows.references import VellumSecretReference

--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
@@ -172,21 +172,6 @@ class MyCustomNode(BaseNode):
 "
 `;
 
-exports[`GenericNode > basic without node outputs > getNodeFile 1`] = `
-"from vellum.workflows.nodes import BaseNode
-
-from ..inputs import Inputs
-
-
-class MyCustomNode(BaseNode):
-    default_attribute = "default-value"
-    default_attribute_2 = Inputs.count
-
-    class NodeTrigger(BaseNode.Trigger):
-        merge_behavior = "AWAIT_ALL"
-"
-`;
-
 exports[`GenericNode > basic without node outputs should skip node outputs class > getNodeFile 1`] = `
 "from vellum.workflows.nodes import BaseNode
 

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -434,6 +434,17 @@ ${errors.slice(0, 3).map((err) => {
     const visited = new Set<string>();
     const tempVisited = new Set<string>(); // Used to detect cycles
 
+    const processNode = (nodeId: string) => {
+      const node = nodesById[nodeId];
+      if (node && !visited.has(nodeId)) {
+        orderedNodes.push(node);
+      }
+
+      // Mark as fully processed
+      visited.add(nodeId);
+      tempVisited.delete(nodeId);
+    };
+
     // DFS function that ensures dependencies are processed first
     const visit = (nodeId: string) => {
       // Skip if already processed
@@ -442,7 +453,9 @@ ${errors.slice(0, 3).map((err) => {
       }
 
       // Return early if we've already visited this node in the current path (cycle)
+      // Make sure we add the node that started the cycle first
       if (tempVisited.has(nodeId)) {
+        processNode(nodeId);
         return;
       }
 
@@ -456,14 +469,7 @@ ${errors.slice(0, 3).map((err) => {
       }
 
       // All dependencies processed, now safe to add this node
-      const node = nodesById[nodeId];
-      if (node) {
-        orderedNodes.push(node);
-      }
-
-      // Mark as fully processed
-      visited.add(nodeId);
-      tempVisited.delete(nodeId);
+      processNode(nodeId);
     };
 
     // Visit each node to ensure all are processed


### PR DESCRIPTION
Noticed this in the demo we are preparing - in the case of a loop that goes 1 -> 2 -> 3 -> 4, we were ordering 2,3,4,1. This PR ensures that we now process 1 first.