### PR TITLE
clean up default params to plain text block

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -248,13 +248,11 @@ class Prompt(InlinePromptNode):
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\\
 Summarize the following text: hello today is feb 7 bad weather
 
 \\
-""",
+"""
                         ),
                         VariablePromptBlock(input_variable="text"),
                     ]

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -63,13 +63,11 @@ class PromptNode(InlinePromptNode):
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\\
 Summarize the following text:
 
 \\
-""",
+"""
                         ),
                         VariablePromptBlock(input_variable="text"),
                     ]
@@ -157,13 +155,11 @@ class PromptNode(InlinePromptNode):
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\\
 Summarize the following text:
 
 \\
-""",
+"""
                         ),
                         VariablePromptBlock(input_variable="text"),
                     ]
@@ -260,13 +256,11 @@ class PromptNode(InlinePromptNode):
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\\
 Summarize the following text:
 
 \\
-""",
+"""
                         ),
                         VariablePromptBlock(input_variable="text"),
                     ]
@@ -783,13 +777,7 @@ from ..inputs import Inputs
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = [
-        RichTextPromptBlock(
-            blocks=[
-                PlainTextPromptBlock(
-                    state="ENABLED", cache_config=None, text="""Hello World!"""
-                )
-            ]
-        ),
+        RichTextPromptBlock(blocks=[PlainTextPromptBlock(text="""Hello World!""")]),
     ]
     prompt_inputs = {
         "text": Inputs.text,
@@ -859,13 +847,7 @@ from ..inputs import Inputs
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = [
-        RichTextPromptBlock(
-            blocks=[
-                PlainTextPromptBlock(
-                    state="ENABLED", cache_config=None, text="""Hello World!"""
-                )
-            ]
-        ),
+        RichTextPromptBlock(blocks=[PlainTextPromptBlock(text="""Hello World!""")]),
     ]
     prompt_inputs = {
         "text": Inputs.text,
@@ -944,13 +926,7 @@ from ..inputs import Inputs
 class PromptNode(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = [
-        RichTextPromptBlock(
-            blocks=[
-                PlainTextPromptBlock(
-                    state="ENABLED", cache_config=None, text="""Hello World!"""
-                )
-            ]
-        ),
+        RichTextPromptBlock(blocks=[PlainTextPromptBlock(text="""Hello World!""")]),
     ]
     prompt_inputs = {
         "text": Inputs.text,

--- a/ee/codegen/src/generators/base-prompt-block.ts
+++ b/ee/codegen/src/generators/base-prompt-block.ts
@@ -10,12 +10,12 @@ import { WorkflowContext } from "src/context/workflow-context";
 import {
   FunctionDefinitionPromptTemplateBlock,
   PromptTemplateBlock,
+  PlainTextPromptTemplateBlock,
 } from "src/types/vellum";
 
-export type PromptTemplateBlockExcludingFunctionDefinition = Exclude<
-  PromptTemplateBlock,
-  FunctionDefinitionPromptTemplateBlock
->;
+export type PromptTemplateBlockExcludingFunctionDefinition =
+  | Exclude<PromptTemplateBlock, FunctionDefinitionPromptTemplateBlock>
+  | PlainTextPromptTemplateBlock;
 
 export declare namespace BasePromptBlock {
   interface Args<T extends PromptTemplateBlockExcludingFunctionDefinition> {

--- a/ee/codegen/src/generators/nodes/inline-prompt-node.ts
+++ b/ee/codegen/src/generators/nodes/inline-prompt-node.ts
@@ -14,6 +14,7 @@ import {
   InlinePromptNode as InlinePromptNodeType,
   FunctionDefinitionPromptTemplateBlock,
   InlinePromptNodeData,
+  PlainTextPromptTemplateBlock,
 } from "src/types/vellum";
 
 const INPUTS_PREFIX = "prompt_inputs";
@@ -38,8 +39,12 @@ export class InlinePromptNode extends BaseSingleFileNode<
     const nodeData: InlinePromptNodeData = this.nodeData.data;
     const blocksExcludingFunctionDefinition =
       nodeData.execConfig.promptTemplateBlockData.blocks.filter(
-        (block): block is PromptTemplateBlockExcludingFunctionDefinition =>
-          block.blockType !== "FUNCTION_DEFINITION"
+        (
+          block
+        ): block is Exclude<
+          PromptTemplateBlockExcludingFunctionDefinition,
+          PlainTextPromptTemplateBlock
+        > => block.blockType !== "FUNCTION_DEFINITION"
       );
 
     const functionDefinitions =

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node.py
@@ -19,8 +19,6 @@ class PromptNode(InlinePromptNode):
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\
 You are an expert classifier. You will analyze the chat and output one of the following in JSON format: 
 
@@ -28,7 +26,7 @@ You are an expert classifier. You will analyze the chat and output one of the fo
 2. \"flight status\" if it is about which flights are currently in transit at a certain airport
 3. \"faa\" if the question is about any FAA related aviation policies
 4. \"other\" if the question is about anything else\
-""",
+"""
                         )
                     ]
                 )

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node_14.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node_14.py
@@ -19,9 +19,7 @@ class PromptNode14(InlinePromptNode):
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
-                            text="""Summarize the weather. Just use plain text, no special characters, no commas, no mathematical signs like + -""",
+                            text="""Summarize the weather. Just use plain text, no special characters, no commas, no mathematical signs like + -"""
                         )
                     ]
                 )

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node_16.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node_16.py
@@ -19,13 +19,11 @@ class PromptNode16(InlinePromptNode):
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\
 Respond with the IATA airport name this incoming message is about. For example, respond only with \"SJC\", \"SFO\", \"EWR\" or \"JFK\"
 
 \
-""",
+"""
                         ),
                         VariablePromptBlock(input_variable="most_recent_message"),
                     ]

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node_18.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node_18.py
@@ -19,13 +19,11 @@ class PromptNode18(InlinePromptNode):
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\
 Based on the below JSON response from an airline flight status tracker API, which flights are on the ground? And which airports are they going from and to? Where are they right now?
 
 \
-""",
+"""
                         ),
                         VariablePromptBlock(input_variable="text"),
                     ]
@@ -38,8 +36,6 @@ Based on the below JSON response from an airline flight status tracker API, whic
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\
  Respond in the following format
 
@@ -50,7 +46,7 @@ The flights that are on the ground are:
    - **Arrival Airport:** SJC (San Jose International Airport)
    - **Current Location:** Latitude 37.3664, Longitude -121.929 (San Jose International Airport)
 \
-""",
+"""
                         )
                     ]
                 )
@@ -60,13 +56,7 @@ The flights that are on the ground are:
             chat_role="USER",
             blocks=[
                 RichTextPromptBlock(
-                    blocks=[
-                        PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
-                            text=""" Just use plain text and no special characters""",
-                        )
-                    ]
+                    blocks=[PlainTextPromptBlock(text=""" Just use plain text and no special characters""")]
                 )
             ],
         ),

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node_19.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node_19.py
@@ -8,13 +8,7 @@ class PromptNode19(InlinePromptNode):
         ChatMessagePromptBlock(
             chat_role="SYSTEM",
             blocks=[
-                RichTextPromptBlock(
-                    blocks=[
-                        PlainTextPromptBlock(
-                            state="ENABLED", cache_config=None, text="""Respond with \"Sorry I don\'t know\""""
-                        )
-                    ]
-                )
+                RichTextPromptBlock(blocks=[PlainTextPromptBlock(text="""Respond with \"Sorry I don\'t know\"""")])
             ],
         ),
     ]

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node_9.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/nodes/prompt_node_9.py
@@ -20,25 +20,21 @@ class PromptNode9(InlinePromptNode):
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\
  Question:
 ---------------
 \
-""",
+"""
                         ),
                         VariablePromptBlock(input_variable="question"),
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\
 
 
 Policy Quotes:
 -----------------------
 \
-""",
+"""
                         ),
                         VariablePromptBlock(input_variable="context"),
                     ]
@@ -46,13 +42,11 @@ Policy Quotes:
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\
 You are an expert on FAA rules, guidelines, and safety. Answer the above question given the context. Provide citation of the policy you got it from at the end of the response. If you don\'t know the answer, say \"Sorry, I don\'t know\"
 
 Limit your response to 250 words. Just use plain text, no special characters, no commas, no mathematical signs like + -\
-""",
+"""
                         )
                     ]
                 ),

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/nodes/prompt_node.py
@@ -19,13 +19,11 @@ class PromptNode(InlinePromptNode):
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\
 What is the origin of the following phrase
 
 \
-""",
+"""
                         ),
                         VariablePromptBlock(input_variable="text"),
                     ]

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/nodes/prompt_node.py
@@ -19,13 +19,11 @@ class PromptNode(InlinePromptNode):
                 RichTextPromptBlock(
                     blocks=[
                         PlainTextPromptBlock(
-                            state="ENABLED",
-                            cache_config=None,
                             text="""\
 Summarize the following text:
 
 \
-""",
+"""
                         ),
                         VariablePromptBlock(input_variable="text"),
                     ]


### PR DESCRIPTION
Discovered while setting up a demo. We don't need to codegen these defaults, and now plain text prompt block works like the rest of them