### PR TITLE
Support node comments on generic nodes

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_vellum_display.py
@@ -1,36 +1,14 @@
 from uuid import UUID
-from typing import ClassVar, Dict, Optional
+from typing import Dict
 
 from vellum.workflows.nodes.utils import get_unadorned_node
 from vellum.workflows.ports import Port
 from vellum.workflows.types.generics import NodeType
-from vellum_ee.workflows.display.editor.types import NodeDisplayComment, NodeDisplayData
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.types import PortDisplay
 
 
 class BaseNodeVellumDisplay(BaseNodeDisplay[NodeType]):
-    # Used to explicitly set display data for a node
-    display_data: ClassVar[Optional[NodeDisplayData]] = None
-
-    def get_display_data(self) -> NodeDisplayData:
-        explicit_value = self._get_explicit_node_display_attr("display_data", NodeDisplayData)
-        docstring = self._node.__doc__
-
-        if explicit_value and explicit_value.comment and docstring:
-            comment = (
-                NodeDisplayComment(value=docstring, expanded=explicit_value.comment.expanded)
-                if explicit_value.comment.expanded
-                else NodeDisplayComment(value=docstring)
-            )
-            return NodeDisplayData(
-                position=explicit_value.position,
-                width=explicit_value.width,
-                height=explicit_value.height,
-                comment=comment,
-            )
-
-        return explicit_value if explicit_value else NodeDisplayData()
 
     def get_source_handle_id(self, port_displays: Dict[Port, PortDisplay]) -> UUID:
         unadorned_node = get_unadorned_node(self._node)

--- a/ee/vellum_ee/workflows/display/nodes/tests/test_base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/tests/test_base_node_display.py
@@ -82,3 +82,21 @@ def test_serialize_condition__accessor_expression():
             },
         }
     ]
+
+
+def test_serialize_display_data():
+    # GIVEN a node with an accessor expression in a Port
+    class MyNode(BaseNode):
+        """I hope this works"""
+
+        pass
+
+    # WHEN we serialize the node
+    node_display_class = get_node_display_class(MyNode)
+    data = node_display_class().serialize(WorkflowDisplayContext())
+
+    # THEN the condition should be serialized correctly
+    assert data["display_data"] == {
+        "position": {"x": 0.0, "y": 0.0},
+        "comment": {"value": "I hope this works"},
+    }


### PR DESCRIPTION
Discovered while setting up the customer demo. This also furthers another side plot of getting rid of `BaseNodeVellumDisplay`, which we'll do on the next PR.