### PR TITLE
Support custom generic node inherited base classes

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import {
+  CodeResourceDefinition,
   PromptParameters,
   VellumVariable,
   VellumVariableType,
@@ -1462,6 +1463,7 @@ export function genericNodeFactory({
   nodeAttributes,
   nodeOutputs,
   adornments,
+  base,
 }: {
   id?: string;
   label?: string;
@@ -1470,13 +1472,14 @@ export function genericNodeFactory({
   nodeAttributes?: NodeAttribute[];
   nodeOutputs?: NodeOutput[];
   adornments?: AdornmentNode[];
+  base?: CodeResourceDefinition;
 } = {}): GenericNode {
   const label = _label ?? "MyCustomNode";
   const nodeData: GenericNode = {
     id: id ?? uuidv4(),
     label,
     type: WorkflowNodeType.GENERIC,
-    base: {
+    base: base ?? {
       module: ["vellum", "workflows", "nodes", "bases", "base"],
       name: "BaseNode",
     },

--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
@@ -80,6 +80,24 @@ class MyCustomNode(BaseNode):
 "
 `;
 
+exports[`GenericNode > basic with custom base > getNodeFile 1`] = `
+"from path.to.mock_networking_client import MockNetworkingClient
+
+from ..inputs import Inputs
+
+
+class MyCustomNode(MockNetworkingClient):
+    default_attribute = "default-value"
+    default_attribute_2 = Inputs.count
+
+    class NodeTrigger(MockNetworkingClient.Trigger):
+        merge_behavior = "AWAIT_ALL"
+
+    class Outputs(MockNetworkingClient.Outputs):
+        output = "default-value"
+"
+`;
+
 exports[`GenericNode > basic with default node trigger > getNodeFile 1`] = `
 "from vellum.workflows.nodes import BaseNode
 

--- a/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
@@ -378,4 +378,27 @@ describe("GenericNode", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });
+
+  describe("basic with custom base", () => {
+    it("getNodeFile", async () => {
+      const nodeData = genericNodeFactory({
+        base: {
+          name: "MockNetworkingClient",
+          module: ["path", "to", "mock_networking_client"],
+        },
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as GenericNodeContext;
+
+      node = new GenericNode({
+        workflowContext,
+        nodeContext,
+      });
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });

--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -51,10 +51,21 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
     this.nodeData = args.nodeData;
     this.importOrder = args.importOrder;
 
-    this.baseNodeClassModulePath =
-      args.nodeData.type === "GENERIC"
-        ? VELLUM_WORKFLOW_NODES_MODULE_PATH
-        : this.workflowContext.sdkModulePathNames.DISPLAYABLE_NODES_MODULE_PATH;
+    if (args.nodeData.type === "GENERIC") {
+      if (
+        args.nodeData.base &&
+        !args.nodeData.base.module
+          .join(".")
+          .startsWith(VELLUM_WORKFLOW_NODES_MODULE_PATH.join("."))
+      ) {
+        this.baseNodeClassModulePath = args.nodeData.base.module;
+      } else {
+        this.baseNodeClassModulePath = VELLUM_WORKFLOW_NODES_MODULE_PATH;
+      }
+    } else {
+      this.baseNodeClassModulePath =
+        this.workflowContext.sdkModulePathNames.DISPLAYABLE_NODES_MODULE_PATH;
+    }
     this.baseNodeDisplayClassModulePath =
       this.workflowContext.sdkModulePathNames.NODE_DISPLAY_MODULE_PATH;
 

--- a/ee/codegen/src/context/node-context/generic-node.ts
+++ b/ee/codegen/src/context/node-context/generic-node.ts
@@ -8,6 +8,13 @@ export class GenericNodeContext extends BaseNodeContext<GenericNodeType> {
   baseNodeClassName = "BaseNode";
   baseNodeDisplayClassName = "BaseNodeDisplay";
 
+  constructor(args: BaseNodeContext.Args<GenericNodeType>) {
+    super(args);
+
+    if (args.nodeData.base) {
+      this.baseNodeClassName = args.nodeData.base.name;
+    }
+  }
   getNodeOutputNamesById(): Record<string, string> {
     return Object.fromEntries(
       this.nodeData.outputs.map((output) => [output.id, output.name])


### PR DESCRIPTION
Discovered while working on the customer demo. Generic nodes were always assuming that they inherited from BaseNode, but with users wanting to create their own nodes, we need to be able to inherit from user provided Nodes