### PR TITLE
Clean up unused terminal node display attributes

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/final-output-node.test.ts.snap
@@ -14,9 +14,7 @@ class FinalOutputNodeDisplay(BaseFinalOutputNodeDisplay[FinalOutputNode]):
     label = "Final Output Node"
     node_id = UUID("48e0d88b-a544-4a14-b49f-38aca82e0e13")
     target_handle_id = UUID("<target-handle-id>")
-    output_id = UUID("<output-id>")
     output_name = "final-output"
-    node_input_id = UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
     node_input_ids_by_name = {
         "node_input": UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
     }
@@ -58,9 +56,7 @@ class FinalOutputNodeDisplay(BaseFinalOutputNodeDisplay[FinalOutputNode]):
     label = "Final Output Node"
     node_id = UUID("48e0d88b-a544-4a14-b49f-38aca82e0e13")
     target_handle_id = UUID("<target-handle-id>")
-    output_id = UUID("<output-id>")
     output_name = "final-output"
-    node_input_id = UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc")
     output_display = {
         FinalOutputNode.Outputs.value: NodeOutputDisplay(
             id=UUID("<output-id>"), name="value"

--- a/ee/codegen/src/generators/nodes/final-output-node.ts
+++ b/ee/codegen/src/generators/nodes/final-output-node.ts
@@ -103,24 +103,8 @@ export class FinalOutputNode extends BaseSingleFileNode<
 
     statements.push(
       python.field({
-        name: "output_id",
-        initializer: python.TypeInstantiation.uuid(this.nodeData.data.outputId),
-      })
-    );
-
-    statements.push(
-      python.field({
         name: "output_name",
         initializer: python.TypeInstantiation.str(this.nodeData.data.name),
-      })
-    );
-
-    statements.push(
-      python.field({
-        name: "node_input_id",
-        initializer: python.TypeInstantiation.uuid(
-          this.nodeData.data.nodeInputId
-        ),
       })
     );
 

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/final_output_2.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/final_output_2.py
@@ -11,9 +11,7 @@ class FinalOutput2Display(BaseFinalOutputNodeDisplay[FinalOutput2]):
     label = "Final Output 2"
     node_id = UUID("f9c5254c-b86d-420d-811a-a1674df273cd")
     target_handle_id = UUID("87d73dc6-cafd-4f8b-b2fd-8367baba5d61")
-    output_id = UUID("8c6e5464-8916-4039-b911-cf707855d372")
     output_name = "answer"
-    node_input_id = UUID("4a999b21-0555-404c-a4f4-c613cd108450")
     node_input_ids_by_name = {"node_input": UUID("4a999b21-0555-404c-a4f4-c613cd108450")}
     output_display = {
         FinalOutput2.Outputs.value: NodeOutputDisplay(id=UUID("8c6e5464-8916-4039-b911-cf707855d372"), name="value")

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("dad01b99-c0b4-4904-a75e-066fa947d256")
     target_handle_id = UUID("2d005e2b-e8bb-404a-9702-8faf10c2213d")
-    output_id = UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62")
     output_name = "final-output"
-    node_input_id = UUID("bc3e4cad-e6b6-4f3d-b0d8-ee7099fe6352")
     node_input_ids_by_name = {"node_input": UUID("bc3e4cad-e6b6-4f3d-b0d8-ee7099fe6352")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("e53bdfb1-f74d-43f0-a3fc-24c7a5162a62"), name="value")

--- a/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_code_execution_node/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("5bb10d67-efc7-4bd4-9452-4ec2ffbc031d")
     target_handle_id = UUID("ab9dd41a-5c7b-484a-bcd5-d55658ea849c")
-    output_id = UUID("87760362-25b9-4dcb-8034-b49dc9e033ab")
     output_name = "final-output"
-    node_input_id = UUID("d3b9060a-40b5-492c-a628-f2d3c912cf44")
     node_input_ids_by_name = {"node_input": UUID("d3b9060a-40b5-492c-a628-f2d3c912cf44")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("87760362-25b9-4dcb-8034-b49dc9e033ab"), name="value")

--- a/ee/codegen_integration/fixtures/simple_conditional_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_conditional_node/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("b0d2bd58-fa00-4eea-98fb-bc09ee1427dd")
     target_handle_id = UUID("ddb7fe0e-0500-4862-8d0d-b05645283c28")
-    output_id = UUID("d8381526-1225-4843-8c22-eec7747445e4")
     output_name = "final-output"
-    node_input_id = UUID("8a2dbefa-0722-4989-8cb7-f2eb526b3247")
     node_input_ids_by_name = {"node_input": UUID("8a2dbefa-0722-4989-8cb7-f2eb526b3247")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("d8381526-1225-4843-8c22-eec7747445e4"), name="value")

--- a/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_guardrail_node/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("a9455dc7-85f5-43a9-8be7-f131bc5f08e2")
     target_handle_id = UUID("0ef13a41-8905-45ad-9aee-09c201368981")
-    output_id = UUID("493cfa4b-5235-4b71-99ef-270955f35fcb")
     output_name = "final-output"
-    node_input_id = UUID("ff856e07-ed9a-47fa-8cec-76ebd8795cdb")
     node_input_ids_by_name = {"node_input": UUID("ff856e07-ed9a-47fa-8cec-76ebd8795cdb")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("493cfa4b-5235-4b71-99ef-270955f35fcb"), name="value")

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("075932b7-c6ba-4c3a-8c8f-d6b043f8fe48")
     target_handle_id = UUID("abf4fec7-4053-417c-bf17-21819155d4d1")
-    output_id = UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6")
     output_name = "final-output"
-    node_input_id = UUID("e4585fda-2016-40fb-8ceb-6553a73f0311")
     node_input_ids_by_name = {"node_input": UUID("e4585fda-2016-40fb-8ceb-6553a73f0311")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("b38e08c7-904d-4f49-b8fb-56e1eff254d6"), name="value")

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("f3fe1e6e-5a4a-42d8-9cfe-9ecbcb935f72")
     target_handle_id = UUID("20aa0107-742b-4662-941f-4f146b3c5565")
-    output_id = UUID("6ab3665f-881d-488b-9124-a6da40136c68")
     output_name = "final-output"
-    node_input_id = UUID("8e8c6182-4898-47de-be8f-769edad990ed")
     node_input_ids_by_name = {"node_input": UUID("8e8c6182-4898-47de-be8f-769edad990ed")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("6ab3665f-881d-488b-9124-a6da40136c68"), name="value")

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("fa0d5829-f259-4db8-a11a-b12fd7237ea5")
     target_handle_id = UUID("8e19172a-4f87-4c21-8c91-ccdfb3e74c16")
-    output_id = UUID("d9269719-a7a2-4388-9b85-73e329a78d16")
     output_name = "final-output"
-    node_input_id = UUID("ca8f8a34-24d3-4941-893f-73c5e3bbb66c")
     node_input_ids_by_name = {"node_input": UUID("ca8f8a34-24d3-4941-893f-73c5e3bbb66c")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("d9269719-a7a2-4388-9b85-73e329a78d16"), name="value")

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("d9d29911-dd45-45d5-9ac8-1a06bb596c2f")
     target_handle_id = UUID("8ff89a09-6ff0-4b02-bba7-eb8456a9c865")
-    output_id = UUID("bffc4749-00b8-44db-90ee-db655cbc7e62")
     output_name = "final-output"
-    node_input_id = UUID("18dddbce-025b-461c-aa7a-ab2561739521")
     node_input_ids_by_name = {"node_input": UUID("18dddbce-025b-461c-aa7a-ab2561739521")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("bffc4749-00b8-44db-90ee-db655cbc7e62"), name="value")

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("7ea2c9ed-efb3-4d20-bf3d-7fafdaf6d842")
     target_handle_id = UUID("8a2df326-df6a-4a5e-81a3-12da082e468c")
-    output_id = UUID("8988fa40-5083-4635-a647-bcbbf42c1652")
     output_name = "final-output"
-    node_input_id = UUID("1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c")
     node_input_ids_by_name = {"node_input": UUID("1cd60ba7-1bce-4ce0-b8b0-f2ab6bf9fc5c")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("8988fa40-5083-4635-a647-bcbbf42c1652"), name="value")

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("54803ff7-9afd-4eb1-bff3-242345d3443d")
     target_handle_id = UUID("6bf50c29-d2f5-4a4f-a63b-907c9053833d")
-    output_id = UUID("f1eca494-a7dc-41c0-9c74-9658a64955e6")
     output_name = "final-output"
-    node_input_id = UUID("960ac634-0081-4e20-9ab8-c98b826fbfc6")
     node_input_ids_by_name = {"node_input": UUID("960ac634-0081-4e20-9ab8-c98b826fbfc6")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("f1eca494-a7dc-41c0-9c74-9658a64955e6"), name="value")

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("e39c8f13-d59b-49fc-8c59-03ee7997b9b6")
     target_handle_id = UUID("77ab6d0c-7fea-441e-8e22-7afc62b3555b")
-    output_id = UUID("aed7279d-59cd-4c15-b82c-21de48129ba3")
     output_name = "final-output"
-    node_input_id = UUID("cfed56e1-bdf8-4e17-a0f9-ff1bb8ca4221")
     node_input_ids_by_name = {"node_input": UUID("cfed56e1-bdf8-4e17-a0f9-ff1bb8ca4221")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("aed7279d-59cd-4c15-b82c-21de48129ba3"), name="value")

--- a/ee/codegen_integration/fixtures/simple_search_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_search_node/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("ed688426-1976-4d0c-9f3a-2a0b0fae161a")
     target_handle_id = UUID("b28439f6-0c1e-44c0-87b1-b7fa3c7408b2")
-    output_id = UUID("43e128f4-24fe-4484-9d08-948a4a390707")
     output_name = "final-output"
-    node_input_id = UUID("097798e5-9330-46a4-b8ec-e93532668d37")
     node_input_ids_by_name = {"node_input": UUID("097798e5-9330-46a4-b8ec-e93532668d37")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("43e128f4-24fe-4484-9d08-948a4a390707"), name="value")

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("eb72f89e-f831-4fc1-a54f-dec7f429fff9")
     target_handle_id = UUID("52b9ff71-e090-4c68-a713-fd72d194b992")
-    output_id = UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585")
     output_name = "final-output"
-    node_input_id = UUID("0d184119-05b8-4551-a01c-418d3b983880")
     node_input_ids_by_name = {"node_input": UUID("0d184119-05b8-4551-a01c-418d3b983880")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"), name="value")

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("f0347fdc-1611-446c-b1da-408511d4181b")
     target_handle_id = UUID("f3ad283c-d092-4973-91e0-996e5859002a")
-    output_id = UUID("b0961a8d-f702-4922-b410-2aecf7d34b68")
     output_name = "final-output"
-    node_input_id = UUID("bb465fa1-defb-493c-8284-7156cd680fb3")
     node_input_ids_by_name = {"node_input": UUID("bb465fa1-defb-493c-8284-7156cd680fb3")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("b0961a8d-f702-4922-b410-2aecf7d34b68"), name="value")

--- a/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/nodes/final_output.py
+++ b/ee/codegen_integration/fixtures/simple_workflow_node_with_output_values/code/display/nodes/final_output.py
@@ -11,9 +11,7 @@ class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
     label = "Final Output"
     node_id = UUID("eb72f89e-f831-4fc1-a54f-dec7f429fff9")
     target_handle_id = UUID("52b9ff71-e090-4c68-a713-fd72d194b992")
-    output_id = UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585")
     output_name = "final-output"
-    node_input_id = UUID("0d184119-05b8-4551-a01c-418d3b983880")
     node_input_ids_by_name = {"node_input": UUID("0d184119-05b8-4551-a01c-418d3b983880")}
     output_display = {
         FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("4dc6e13e-92ba-436e-aa35-87e258f2f585"), name="value")

--- a/ee/vellum_ee/workflows/display/nodes/vellum/final_output_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/final_output_node.py
@@ -14,9 +14,7 @@ _FinalOutputNodeType = TypeVar("_FinalOutputNodeType", bound=FinalOutputNode)
 
 
 class BaseFinalOutputNodeDisplay(BaseNodeDisplay[_FinalOutputNodeType], Generic[_FinalOutputNodeType]):
-    output_id: ClassVar[Optional[UUID]] = None
     output_name: ClassVar[Optional[str]] = None
-    node_input_id: ClassVar[Optional[UUID]] = None
 
     def serialize(self, display_context: WorkflowDisplayContext, **kwargs: Any) -> JsonObject:
         node = self._node

--- a/ee/vellum_ee/workflows/display/nodes/vellum/final_output_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/final_output_node.py
@@ -12,6 +12,8 @@ from vellum_ee.workflows.display.utils.vellum import infer_vellum_variable_type
 
 _FinalOutputNodeType = TypeVar("_FinalOutputNodeType", bound=FinalOutputNode)
 
+NODE_INPUT_KEY = "node_input"
+
 
 class BaseFinalOutputNodeDisplay(BaseNodeDisplay[_FinalOutputNodeType], Generic[_FinalOutputNodeType]):
     output_name: ClassVar[Optional[str]] = None
@@ -22,7 +24,7 @@ class BaseFinalOutputNodeDisplay(BaseNodeDisplay[_FinalOutputNodeType], Generic[
 
         node_input = create_node_input(
             node_id,
-            "node_input",
+            NODE_INPUT_KEY,
             # Get the pointer that the Terminal Node's output is referencing
             node.Outputs.value.instance,
             display_context,
@@ -56,13 +58,13 @@ class BaseFinalOutputNodeDisplay(BaseNodeDisplay[_FinalOutputNodeType], Generic[
         }
 
     def _get_output_id(self) -> UUID:
-        explicit_value = self._get_explicit_node_display_attr("output_id", UUID)
-        return explicit_value if explicit_value else uuid4_from_hash(f"{self.node_id}|output_id")
+        explicit_value = self.output_display.get(self._node.Outputs.value)
+        return explicit_value.id if explicit_value else uuid4_from_hash(f"{self.node_id}|output_id")
 
     def _get_output_name(self) -> str:
         explicit_value = self._get_explicit_node_display_attr("output_name", str)
         return explicit_value if explicit_value else to_kebab_case(self._node.__name__)
 
     def _get_node_input_id(self) -> UUID:
-        explicit_value = self._get_explicit_node_display_attr("node_input_id", UUID)
+        explicit_value = self.node_input_ids_by_name.get(NODE_INPUT_KEY)
         return explicit_value if explicit_value else uuid4_from_hash(f"{self.node_id}|node_input_id")

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_terminal_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_terminal_node_serialization.py
@@ -68,7 +68,7 @@ def test_serialize_workflow():
             "label": "Basic Final Output Node",
             "name": "basic-final-output-node",
             "target_handle_id": "0173d3c6-11d1-44b7-b070-ca9ff5119046",
-            "output_id": "97349956-d228-4b51-a64b-1331f788373f",
+            "output_id": "aa63e3f6-fde3-4d19-84ef-29982d44d709",
             "output_type": "STRING",
             "node_input_id": "5322567a-f40c-400a-96b3-c3b054db543e",
         },
@@ -98,7 +98,7 @@ def test_serialize_workflow():
         },
         "outputs": [
             {
-                "id": "97349956-d228-4b51-a64b-1331f788373f",
+                "id": "aa63e3f6-fde3-4d19-84ef-29982d44d709",
                 "name": "value",
                 "type": "STRING",
                 "value": {"type": "WORKFLOW_INPUT", "input_variable_id": "e39a7b63-de15-490a-ae9b-8112c767aea0"},

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_complex_terminal_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_complex_terminal_node_serialization.py
@@ -92,7 +92,7 @@ def test_serialize_workflow__missing_final_output_node():
                     "label": "First Final Output Node",
                     "name": "first-final-output-node",
                     "target_handle_id": "a0c2eb7a-398e-4f28-b63d-f3bae9b563ee",
-                    "output_id": "5517e50d-7f40-4f7c-acb2-e329d79a25bf",
+                    "output_id": "0cd02933-c5b9-47c9-aede-e97c5870e8aa",
                     "output_type": "STRING",
                     "node_input_id": "16363762-c14a-4162-8fab-525079d3cffe",
                 },
@@ -122,7 +122,7 @@ def test_serialize_workflow__missing_final_output_node():
                 },
                 "outputs": [
                     {
-                        "id": "5517e50d-7f40-4f7c-acb2-e329d79a25bf",
+                        "id": "0cd02933-c5b9-47c9-aede-e97c5870e8aa",
                         "name": "value",
                         "type": "STRING",
                         "value": {


### PR DESCRIPTION
Discovered while preparing the customer demo. These two attributes on FinalOutputNodeDisplay are unused, so we should stop codegenning them