### PR TITLE
Fix nested map node item reference

### DIFF
--- a/src/vellum/workflows/inputs/base.py
+++ b/src/vellum/workflows/inputs/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterator, Tuple, Type, Union, get_args, get_origin
+from typing import Any, Dict, Iterator, Set, Tuple, Type, Union, get_args, get_origin
 from typing_extensions import dataclass_transform
 
 from pydantic import GetCoreSchemaHandler
@@ -14,6 +14,10 @@ from vellum.workflows.types.utils import get_class_attr_names, infer_types
 
 @dataclass_transform(kw_only_default=True)
 class _BaseInputsMeta(type):
+    def __new__(cls, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
+        dct["__parent_class__"] = type(None)
+        return super().__new__(cls, name, bases, dct)
+
     def __getattribute__(cls, name: str) -> Any:
         if name.startswith("_") or not issubclass(cls, BaseInputs):
             return super().__getattribute__(name)
@@ -42,14 +46,20 @@ class _BaseInputsMeta(type):
     def __iter__(cls) -> Iterator[InputReference]:
         # We iterate through the inheritance hierarchy to find all the WorkflowInputReference attached to this
         # Inputs class. __mro__ is the method resolution order, which is the order in which base classes are resolved.
+        yielded_attr_names: Set[str] = set()
+
         for resolved_cls in cls.__mro__:
             attr_names = get_class_attr_names(resolved_cls)
             for attr_name in attr_names:
+                if attr_name in yielded_attr_names:
+                    continue
+
                 attr_value = getattr(resolved_cls, attr_name)
                 if not isinstance(attr_value, (WorkflowInputReference, ExternalInputReference)):
                     continue
 
                 yield attr_value
+                yielded_attr_names.add(attr_name)
 
 
 class BaseInputs(metaclass=_BaseInputsMeta):

--- a/src/vellum/workflows/inputs/tests/test_inputs.py
+++ b/src/vellum/workflows/inputs/tests/test_inputs.py
@@ -61,3 +61,4 @@ def test_base_inputs__supports_inherited_inputs():
     # THEN both references should be available
     assert BottomInputs.first.name == "first"
     assert BottomInputs.second.name == "second"
+    assert len([ref for ref in BottomInputs]) == 2

--- a/src/vellum/workflows/nodes/bases/base_adornment_node.py
+++ b/src/vellum/workflows/nodes/bases/base_adornment_node.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Dict, Generic, Optional, Tuple, Type
 
+from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode, BaseNodeMeta
 from vellum.workflows.outputs.base import BaseOutputs
 from vellum.workflows.references.output import OutputReference
@@ -12,6 +13,14 @@ if TYPE_CHECKING:
 class _BaseAdornmentNodeMeta(BaseNodeMeta):
     def __new__(cls, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
         node_class = super().__new__(cls, name, bases, dct)
+
+        SubworkflowInputs = dct.get("SubworkflowInputs")
+        if (
+            isinstance(SubworkflowInputs, type)
+            and issubclass(SubworkflowInputs, BaseInputs)
+            and SubworkflowInputs.__parent_class__ is type(None)
+        ):
+            SubworkflowInputs.__parent_class__ = node_class
 
         subworkflow_attribute = dct.get("subworkflow")
         if not subworkflow_attribute:

--- a/src/vellum/workflows/nodes/core/map_node/node.py
+++ b/src/vellum/workflows/nodes/core/map_node/node.py
@@ -176,8 +176,9 @@ class MapNode(BaseAdornmentNode[StateType], Generic[StateType, MapNodeItemType])
             parent_state=self.state,
             context=context,
         )
+        SubworkflowInputsClass = self.subworkflow.get_inputs_class()
         events = subworkflow.stream(
-            inputs=self.SubworkflowInputs(index=index, item=item, all_items=self.items),
+            inputs=SubworkflowInputsClass(index=index, item=item, all_items=self.items),
             node_output_mocks=self._context._get_all_node_output_mocks(),
             event_filter=all_workflow_event_filter,
         )

--- a/src/vellum/workflows/nodes/core/retry_node/node.py
+++ b/src/vellum/workflows/nodes/core/retry_node/node.py
@@ -47,8 +47,9 @@ class RetryNode(BaseAdornmentNode[StateType], Generic[StateType]):
                     parent_state=self.state,
                     context=WorkflowContext.create_from(self._context),
                 )
+                inputs_class = subworkflow.get_inputs_class()
                 subworkflow_stream = subworkflow.stream(
-                    inputs=self.SubworkflowInputs(attempt_number=attempt_number),
+                    inputs=inputs_class(attempt_number=attempt_number),
                     event_filter=all_workflow_event_filter,
                     node_output_mocks=self._context._get_all_node_output_mocks(),
                 )

--- a/src/vellum/workflows/references/workflow_input.py
+++ b/src/vellum/workflows/references/workflow_input.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Generic, Optional, Tuple, Type, TypeVar, cast
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
+from vellum.workflows.types.generics import import_workflow_class
 
 if TYPE_CHECKING:
     from vellum.workflows.inputs.base import BaseInputs
@@ -29,7 +30,10 @@ class WorkflowInputReference(BaseDescriptor[_InputType], Generic[_InputType]):
         return self._inputs_class
 
     def resolve(self, state: "BaseState") -> _InputType:
-        if hasattr(state.meta.workflow_inputs, self._name):
+        if hasattr(state.meta.workflow_inputs, self._name) and (
+            state.meta.workflow_definition == self._inputs_class.__parent_class__
+            or not issubclass(self._inputs_class.__parent_class__, import_workflow_class())
+        ):
             return cast(_InputType, getattr(state.meta.workflow_inputs, self._name))
 
         if state.meta.parent:

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -101,6 +101,7 @@ class WorkflowRunner(Generic[StateType]):
             if state:
                 self._initial_state = deepcopy(state)
                 self._initial_state.meta.span_id = uuid4()
+                self._initial_state.meta.workflow_definition = self.workflow.__class__
             else:
                 self._initial_state = self.workflow.get_state_at_node(node)
             self._entrypoints = entrypoint_nodes
@@ -126,6 +127,7 @@ class WorkflowRunner(Generic[StateType]):
                 self._initial_state = deepcopy(state)
                 self._initial_state.meta.workflow_inputs = normalized_inputs
                 self._initial_state.meta.span_id = uuid4()
+                self._initial_state.meta.workflow_definition = self.workflow.__class__
             else:
                 self._initial_state = self.workflow.get_default_state(normalized_inputs)
                 # We don't want to emit the initial state on the base case of Workflow Runs, since

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -133,6 +133,11 @@ class _BaseWorkflowMeta(type):
         cls = super().__new__(mcs, name, bases, dct)
         workflow_class = cast(Type["BaseWorkflow"], cls)
         workflow_class.__id__ = uuid4_from_hash(workflow_class.__qualname__)
+
+        inputs_class = workflow_class.get_inputs_class()
+        if inputs_class is not BaseInputs and inputs_class.__parent_class__ is type(None):
+            inputs_class.__parent_class__ = workflow_class
+
         return workflow_class
 
 

--- a/tests/workflows/stream_subworkflow_node/tests/test_subworkflow_node.py
+++ b/tests/workflows/stream_subworkflow_node/tests/test_subworkflow_node.py
@@ -4,7 +4,7 @@ from vellum.workflows.workflows.event_filters import all_workflow_event_filter
 from tests.workflows.stream_subworkflow_node.workflow import (
     InnerNode,
     InnerWorkflow,
-    Inputs,
+    OuterInputs,
     StreamingInlineSubworkflowExample,
     SubworkflowNode,
 )
@@ -20,12 +20,15 @@ def test_workflow_stream__happy_path():
 
     # WHEN we stream the events of the Workflow
     stream = workflow.stream(
-        inputs=Inputs(items=["apple", "banana", "cherry"]),
+        inputs=OuterInputs(items=["apple", "banana", "cherry"]),
         event_filter=all_workflow_event_filter,
     )
     events = list(stream)
 
-    # THEN we see the expected events in the correct relative order
+    # THEN the subworkflow fulfilled
+    assert events[-1].name == "workflow.execution.fulfilled", events[-1]
+
+    # AND we see the expected events in the correct relative order
     workflow_initiated_events = [e for e in events if e.name.startswith("workflow.execution.initiated")]
     node_initiated_events = [e for e in events if e.name.startswith("node.execution.initiated")]
 

--- a/tests/workflows/stream_subworkflow_node/workflow.py
+++ b/tests/workflows/stream_subworkflow_node/workflow.py
@@ -8,12 +8,12 @@ from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.state import BaseState
 
 
-class Inputs(BaseInputs):
+class InnerInputs(BaseInputs):
     items: List[str]
 
 
 class InnerNode(BaseNode):
-    items = Inputs.items
+    items = InnerInputs.items
 
     class Outputs(BaseNode.Outputs):
         processed: List[str]
@@ -28,22 +28,26 @@ class InnerNode(BaseNode):
         yield BaseOutput(value=processed_fruits, name="processed")
 
 
-class InnerWorkflow(BaseWorkflow[Inputs, BaseState]):
+class InnerWorkflow(BaseWorkflow[InnerInputs, BaseState]):
     graph = InnerNode
 
     class Outputs(BaseWorkflow.Outputs):
         processed = InnerNode.Outputs.processed
 
 
-class SubworkflowNode(InlineSubworkflowNode[BaseState, Inputs, BaseState]):
-    subworkflow_inputs = {"items": Inputs.items}  # type: ignore[dict-item]
+class OuterInputs(BaseInputs):
+    items: List[str]
+
+
+class SubworkflowNode(InlineSubworkflowNode[BaseState, InnerInputs, BaseState]):
+    subworkflow_inputs = {"items": OuterInputs.items}  # type: ignore[dict-item]
     subworkflow = InnerWorkflow
 
     class Outputs(InlineSubworkflowNode.Outputs):
         processed = InnerWorkflow.Outputs.processed
 
 
-class StreamingInlineSubworkflowExample(BaseWorkflow[Inputs, BaseState]):
+class StreamingInlineSubworkflowExample(BaseWorkflow[OuterInputs, BaseState]):
     """
     This Workflow ensures that we support streaming within the context of an InlineSubworkflowNode.
     """


### PR DESCRIPTION
Discovered this pretty gnarly bug during FF. Essentially, the `item` input always resolved to the innermost map node's `item` value. So this PR adds handling that says that not just the names need to match, but the parent class does too. This essentially matches the UI which is matching by id.