### PR TITLE
Handle custom files from within the same module used in the base node

### DIFF
--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
@@ -112,6 +112,19 @@ class MyCustomNode(MockNetworkingClient):
 "
 `;
 
+exports[`GenericNode > basic with custom, same module, base > getNodeFile 1`] = `
+"from .mock_networking_client import MockNetworkingClient
+
+
+class MyCustomNode(MockNetworkingClient):
+    class NodeTrigger(MockNetworkingClient.Trigger):
+        merge_behavior = "AWAIT_ALL"
+
+    class Outputs(MockNetworkingClient.Outputs):
+        output = "default-value"
+"
+`;
+
 exports[`GenericNode > basic with default node trigger > getNodeFile 1`] = `
 "from vellum.workflows.nodes import BaseNode
 

--- a/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
@@ -431,8 +431,9 @@ describe("GenericNode", () => {
       const nodeData = genericNodeFactory({
         base: {
           name: "MockNetworkingClient",
-          module: ["path", "to", "mock_networking_client"],
+          module: ["my", "custom", "path", "nodes", "mock_networking_client"],
         },
+        nodeAttributes: [],
       });
 
       const nodeContext = (await createNodeContext({

--- a/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
@@ -421,4 +421,31 @@ describe("GenericNode", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });
+
+  describe("basic with custom, same module, base", () => {
+    it("getNodeFile", async () => {
+      workflowContext = workflowContextFactory({
+        moduleName: "my.custom.path",
+      });
+
+      const nodeData = genericNodeFactory({
+        base: {
+          name: "MockNetworkingClient",
+          module: ["path", "to", "mock_networking_client"],
+        },
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as GenericNodeContext;
+
+      node = new GenericNode({
+        workflowContext,
+        nodeContext,
+      });
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -158,7 +158,7 @@ export class WorkflowContext {
           ...parentNode.nodeContext.nodeModulePath,
           GENERATED_WORKFLOW_MODULE_NAME,
         ]
-      : [this.moduleName, GENERATED_WORKFLOW_MODULE_NAME];
+      : [...this.moduleName.split("."), GENERATED_WORKFLOW_MODULE_NAME];
     this.workflowClassName = workflowClassName;
     this.vellumApiKey = vellumApiKey;
     this.vellumApiEnvironment = vellumApiEnvironment;

--- a/ee/codegen/src/utils/paths.ts
+++ b/ee/codegen/src/utils/paths.ts
@@ -33,7 +33,10 @@ export function getGeneratedNodesModulePath(
       GENERATED_NODES_MODULE_NAME,
     ];
   } else {
-    modulePath = [workflowContext.moduleName, GENERATED_NODES_MODULE_NAME];
+    modulePath = [
+      ...workflowContext.modulePath.slice(0, -1),
+      GENERATED_NODES_MODULE_NAME,
+    ];
   }
 
   return modulePath;


### PR DESCRIPTION
If a node inherits from a custom node within the project, we want the relative imports to work accrodingly