### PR TITLE
Silence warning from ruff with a new Writer()

### DIFF
--- a/ee/codegen/src/__test__/chat-message-content.test.ts
+++ b/ee/codegen/src/__test__/chat-message-content.test.ts
@@ -1,6 +1,5 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import { ChatMessageContent } from "src/generators/chat-message-content";
+import { Writer } from "src/generators/extensions";
 
 describe("ChatMessageContent", () => {
   let writer: Writer;

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { v4 as uuidv4 } from "uuid";
 
 import { workflowContextFactory } from "./helpers";
@@ -17,6 +16,7 @@ import {
 } from "./helpers/node-data-factories";
 
 import { createNodeContext } from "src/context";
+import { Writer } from "src/generators/extensions";
 import { GraphAttribute } from "src/generators/graph-attribute";
 
 describe("Workflow", () => {

--- a/ee/codegen/src/__test__/inputs.test.ts
+++ b/ee/codegen/src/__test__/inputs.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { Vellum } from "vellum-ai";
 import { VellumVariable } from "vellum-ai/api";
 import { VellumVariableType } from "vellum-ai/api/types";
@@ -8,6 +7,7 @@ import { inputVariableContextFactory } from "./helpers/input-variable-context-fa
 
 import * as codegen from "src/codegen";
 import { WorkflowContext } from "src/context";
+import { Writer } from "src/generators/extensions";
 
 describe("Inputs", () => {
   let workflowContext: WorkflowContext;

--- a/ee/codegen/src/__test__/json.test.ts
+++ b/ee/codegen/src/__test__/json.test.ts
@@ -1,5 +1,4 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
+import { Writer } from "src/generators/extensions";
 import { Json } from "src/generators/json";
 
 describe("Json", () => {

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/constant-value-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/constant-value-pointer.test.ts
@@ -1,7 +1,6 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import { nodeContextFactory } from "src/__test__/helpers";
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import { ConstantValuePointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/constant-value-pointer";
 import { ConstantValuePointer, WorkflowDataNode } from "src/types/vellum";
 

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/execution-counter-pointer.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { DocumentIndexRead } from "vellum-ai/api";
 import { DocumentIndexes as DocumentIndexesClient } from "vellum-ai/api/resources/documentIndexes/client/Client";
 import { vi } from "vitest";
@@ -9,6 +8,7 @@ import {
 } from "src/__test__/helpers";
 import { mockDocumentIndexFactory } from "src/__test__/helpers/document-index-factory";
 import { searchNodeDataFactory } from "src/__test__/helpers/node-data-factories";
+import { Writer } from "src/generators/extensions";
 import { ExecutionCounterPointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/execution-counter-pointer";
 
 describe("ExecutionCounterPointer", () => {

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/input-variable-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/input-variable-pointer.test.ts
@@ -1,10 +1,9 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import {
   nodeContextFactory,
   workflowContextFactory,
 } from "src/__test__/helpers";
 import { inputVariableContextFactory } from "src/__test__/helpers/input-variable-context-factory";
+import { Writer } from "src/generators/extensions";
 import { InputVariablePointerRule } from "src/generators/node-inputs";
 
 describe("InputVariablePointer", () => {

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.test.ts
@@ -1,5 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import {
   nodeContextFactory,
   workflowContextFactory,
@@ -8,6 +6,7 @@ import { inputVariableContextFactory } from "src/__test__/helpers/input-variable
 import { genericNodeFactory } from "src/__test__/helpers/node-data-factories";
 import { WorkflowContext, createNodeContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import { NodeInputValuePointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule";
 import {
   NodeInputValuePointerRule as NodeInputValuePointerRuleType,

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-output-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/node-output-pointer.test.ts
@@ -1,10 +1,9 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import {
   nodeContextFactory,
   workflowContextFactory,
 } from "src/__test__/helpers";
 import { genericNodeFactory } from "src/__test__/helpers/node-data-factories";
+import { Writer } from "src/generators/extensions";
 import { NodeOutputPointerRule } from "src/generators/node-inputs";
 
 describe("NodeOutputPointer", () => {

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer.test.ts
@@ -1,7 +1,6 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import { nodeContextFactory } from "src/__test__/helpers";
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import { WorkspaceSecretPointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer";
 import { WorkflowDataNode } from "src/types/vellum";
 

--- a/ee/codegen/src/__test__/node-inputs/node-input-value-pointer.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input-value-pointer.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { describe, it, expect, beforeEach } from "vitest";
 
 import {
@@ -8,6 +7,7 @@ import {
 import { genericNodeFactory } from "src/__test__/helpers/node-data-factories";
 import { WorkflowContext, createNodeContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import { NodeInputValuePointer } from "src/generators/node-inputs/node-input-value-pointer";
 import {
   NodeInputValuePointer as NodeInputValuePointerType,

--- a/ee/codegen/src/__test__/node-inputs/node-input.test.ts
+++ b/ee/codegen/src/__test__/node-inputs/node-input.test.ts
@@ -1,8 +1,7 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import { nodeContextFactory } from "src/__test__/helpers";
 import * as codegen from "src/codegen";
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import { NodeInput as NodeInputType, WorkflowDataNode } from "src/types/vellum";
 
 describe("NodeInput", () => {

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { v4 as uuidv4 } from "uuid";
 import { SecretTypeEnum, WorkspaceSecretRead } from "vellum-ai/api";
 import { WorkspaceSecrets } from "vellum-ai/api/resources/workspaceSecrets/client/Client";
@@ -15,6 +14,7 @@ import {
 import { createNodeContext, WorkflowContext } from "src/context";
 import { ApiNodeContext } from "src/context/node-context/api-node";
 import { EntityNotFoundError } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { ApiNode } from "src/generators/nodes/api-node";
 
 describe("ApiNode", () => {

--- a/ee/codegen/src/__test__/nodes/base-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/base-node.test.ts
@@ -1,5 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import { workflowContextFactory } from "src/__test__/helpers";
 import {
   genericNodeFactory,
@@ -12,6 +10,7 @@ import {
   NodeAttributeGenerationError,
   NodeDefinitionGenerationError,
 } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { GenericNode } from "src/generators/nodes/generic-node";
 import { TemplatingNode } from "src/generators/nodes/templating-node";
 

--- a/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/code-execution-node.test.ts
@@ -1,7 +1,6 @@
 import { mkdir, readFile } from "fs/promises";
 import { join } from "path";
 
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { v4 as uuid } from "uuid";
 import { SecretTypeEnum, WorkspaceSecretRead } from "vellum-ai/api";
 import { WorkspaceSecrets } from "vellum-ai/api/resources/workspaceSecrets/client/Client";
@@ -17,6 +16,7 @@ import { makeTempDir } from "src/__test__/helpers/temp-dir";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { CodeExecutionContext } from "src/context/node-context/code-execution-node";
 import { NodeAttributeGenerationError } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { CodeExecutionNode } from "src/generators/nodes/code-execution-node";
 import { NodeInput, NodeInputValuePointerRule } from "src/types/vellum";
 

--- a/ee/codegen/src/__test__/nodes/conditional-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/conditional-node.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { v4 as uuid4 } from "uuid";
 import { beforeEach, describe, it, expect } from "vitest";
 
@@ -15,6 +14,7 @@ import {
 import { createNodeContext, WorkflowContext } from "src/context";
 import { ConditionalNodeContext } from "src/context/node-context/conditional-node";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
+import { Writer } from "src/generators/extensions";
 import { ConditionalNode } from "src/generators/nodes/conditional-node";
 import {
   ConditionalNode as ConditionalNodeType,

--- a/ee/codegen/src/__test__/nodes/error-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/error-node.test.ts
@@ -1,10 +1,10 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { beforeEach } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
 import { errorNodeDataFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { ErrorNodeContext } from "src/context/node-context/error-node";
+import { Writer } from "src/generators/extensions";
 import { ErrorNode } from "src/generators/nodes/error-node";
 
 describe("ErrorNode", () => {

--- a/ee/codegen/src/__test__/nodes/final-output-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/final-output-node.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { beforeEach } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
@@ -6,6 +5,7 @@ import { finalOutputNodeFactory } from "src/__test__/helpers/node-data-factories
 import { createNodeContext, WorkflowContext } from "src/context";
 import { FinalOutputNodeContext } from "src/context/node-context/final-output-node";
 import { NodeAttributeGenerationError } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { FinalOutputNode } from "src/generators/nodes/final-output-node";
 
 describe("FinalOutputNode", () => {

--- a/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { v4 as uuidv4 } from "uuid";
 import { beforeEach } from "vitest";
 
@@ -11,6 +10,7 @@ import {
 } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { GenericNodeContext } from "src/context/node-context/generic-node";
+import { Writer } from "src/generators/extensions";
 import { GenericNode } from "src/generators/nodes/generic-node";
 import { AdornmentNode, NodeAttribute } from "src/types/vellum";
 

--- a/ee/codegen/src/__test__/nodes/generic-nodes/node-output.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/node-output.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
@@ -6,6 +5,7 @@ import { inputVariableContextFactory } from "src/__test__/helpers/input-variable
 import { genericNodeFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { GenericNodeContext } from "src/context/node-context/generic-node";
+import { Writer } from "src/generators/extensions";
 import { NodeOutputs } from "src/generators/node-outputs";
 import { NodeOutput as NodeOutputType } from "src/types/vellum";
 

--- a/ee/codegen/src/__test__/nodes/generic-nodes/node-ports.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/node-ports.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
@@ -9,6 +8,7 @@ import {
 } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { GenericNodeContext } from "src/context/node-context/generic-node";
+import { Writer } from "src/generators/extensions";
 import { NodePorts } from "src/generators/node-port";
 import { NodePort } from "src/types/vellum";
 

--- a/ee/codegen/src/__test__/nodes/generic-nodes/node-trigger.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/node-trigger.test.ts
@@ -1,10 +1,10 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
 import { genericNodeFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { GenericNodeContext } from "src/context/node-context/generic-node";
+import { Writer } from "src/generators/extensions";
 import { NodeTrigger } from "src/generators/node-trigger";
 import { NodeTrigger as NodeTriggerType } from "src/types/vellum";
 

--- a/ee/codegen/src/__test__/nodes/generic-nodes/workflow-value-descriptor.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/workflow-value-descriptor.test.ts
@@ -1,10 +1,10 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
 import { inputVariableContextFactory } from "src/__test__/helpers/input-variable-context-factory";
 import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import { WorkflowValueDescriptor } from "src/generators/workflow-value-descriptor";
 import {
   WorkflowDataNode,

--- a/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/guardrail-node.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { MetricDefinitionHistoryItem } from "vellum-ai/api";
 import { MetricDefinitions as MetricDefinitionsClient } from "vellum-ai/api/resources/metricDefinitions/client/Client";
 import { VellumError } from "vellum-ai/errors";
@@ -9,6 +8,7 @@ import { inputVariableContextFactory } from "src/__test__/helpers/input-variable
 import { guardrailNodeDataFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { GuardrailNodeContext } from "src/context/node-context/guardrail-node";
+import { Writer } from "src/generators/extensions";
 import { GuardrailNode } from "src/generators/nodes/guardrail-node";
 
 describe("GuardrailNode", () => {

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node-retry.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node-retry.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { v4 as uuidv4 } from "uuid";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -7,6 +6,7 @@ import { inputVariableContextFactory } from "src/__test__/helpers/input-variable
 import { inlinePromptNodeDataInlineVariantFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { InlinePromptNodeContext } from "src/context/node-context/inline-prompt-node";
+import { Writer } from "src/generators/extensions";
 import { InlinePromptNode } from "src/generators/nodes/inline-prompt-node";
 
 describe("InlinePromptRetryNode", () => {

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { v4 as uuidv4 } from "uuid";
 import { beforeEach } from "vitest";
 
@@ -10,6 +9,7 @@ import {
 } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { InlinePromptNodeContext } from "src/context/node-context/inline-prompt-node";
+import { Writer } from "src/generators/extensions";
 import { InlinePromptNode } from "src/generators/nodes/inline-prompt-node";
 import {
   NodeAttribute as NodeAttributeType,

--- a/ee/codegen/src/__test__/nodes/merge-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/merge-node.test.ts
@@ -1,10 +1,10 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { beforeEach } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
 import { mergeNodeDataFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { MergeNodeContext } from "src/context/node-context/merge-node";
+import { Writer } from "src/generators/extensions";
 import { MergeNode } from "src/generators/nodes/merge-node";
 
 describe("MergeNode", () => {

--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { v4 as uuidv4 } from "uuid";
 import { WorkflowDeploymentRelease } from "vellum-ai/api";
 import {
@@ -22,6 +21,7 @@ import { createNodeContext, WorkflowContext } from "src/context";
 import { ConditionalNodeContext } from "src/context/node-context/conditional-node";
 import { InlinePromptNodeContext } from "src/context/node-context/inline-prompt-node";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
+import { Writer } from "src/generators/extensions";
 import { ConditionalNode } from "src/generators/nodes/conditional-node";
 import { TemplatingNode } from "src/generators/nodes/templating-node";
 import { NodeOutput as NodeOutputType } from "src/types/vellum";

--- a/ee/codegen/src/__test__/nodes/note-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/note-node.test.ts
@@ -1,10 +1,10 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { beforeEach } from "vitest";
 
 import { workflowContextFactory } from "src/__test__/helpers";
 import { noteNodeDataFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { NoteNodeContext } from "src/context/node-context/note-node";
+import { Writer } from "src/generators/extensions";
 import { NoteNode } from "src/generators/nodes/note-node";
 
 describe("NoteNode", () => {

--- a/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/prompt-deployment-node.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { ReleaseReviews as PromptDeploymentReleaseClient } from "vellum-ai/api/resources/releaseReviews/client/Client";
 import { PromptDeploymentRelease } from "vellum-ai/api/types/PromptDeploymentRelease";
 import { VellumError } from "vellum-ai/errors";
@@ -8,6 +7,7 @@ import { workflowContextFactory } from "src/__test__/helpers";
 import { promptDeploymentNodeDataFactory } from "src/__test__/helpers/node-data-factories";
 import { createNodeContext, WorkflowContext } from "src/context";
 import { PromptDeploymentNodeContext } from "src/context/node-context/prompt-deployment-node";
+import { Writer } from "src/generators/extensions";
 import { PromptDeploymentNode } from "src/generators/nodes/prompt-deployment-node";
 import { NodeOutput as NodeOutputType } from "src/types/vellum";
 

--- a/ee/codegen/src/__test__/nodes/search-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/search-node.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { VellumError } from "vellum-ai";
 import { DocumentIndexRead } from "vellum-ai/api";
 import { DocumentIndexes as DocumentIndexesClient } from "vellum-ai/api/resources/documentIndexes/client/Client";
@@ -17,6 +16,7 @@ import {
   NodeAttributeGenerationError,
   ValueGenerationError,
 } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { SearchNode } from "src/generators/nodes/search-node";
 describe("TextSearchNode", () => {
   let workflowContext: WorkflowContext;

--- a/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { WorkflowDeploymentRelease } from "vellum-ai/api";
 import { ReleaseReviews as WorkflowReleaseClient } from "vellum-ai/api/resources/releaseReviews/client/Client";
 import { VellumError } from "vellum-ai/errors";
@@ -9,6 +8,7 @@ import { subworkflowDeploymentNodeDataFactory } from "src/__test__/helpers/node-
 import { createNodeContext, WorkflowContext } from "src/context";
 import { SubworkflowDeploymentNodeContext } from "src/context/node-context/subworkflow-deployment-node";
 import { NodeDefinitionGenerationError } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { SubworkflowDeploymentNode } from "src/generators/nodes/subworkflow-deployment-node";
 
 describe("SubworkflowDeploymentNode", () => {

--- a/ee/codegen/src/__test__/nodes/templating-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/templating-node.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { v4 as uuidv4 } from "uuid";
 import { VellumVariableType } from "vellum-ai/api/types";
 import { beforeEach } from "vitest";
@@ -12,6 +11,7 @@ import {
 import { createNodeContext, WorkflowContext } from "src/context";
 import { TemplatingNodeContext } from "src/context/node-context/templating-node";
 import { NodeNotFoundError } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { TemplatingNode } from "src/generators/nodes/templating-node";
 import {
   NodePort,

--- a/ee/codegen/src/__test__/prompt-block.test.ts
+++ b/ee/codegen/src/__test__/prompt-block.test.ts
@@ -1,8 +1,7 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import { workflowContextFactory } from "./helpers";
 
 import { WorkflowContext } from "src/context/workflow-context";
+import { Writer } from "src/generators/extensions";
 import { PromptBlock } from "src/generators/prompt-block";
 
 describe("PromptBlock", () => {

--- a/ee/codegen/src/__test__/unused-graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/unused-graph-attribute.test.ts
@@ -1,5 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import { workflowContextFactory } from "./helpers";
 import {
   EdgeFactoryNodePair,
@@ -12,6 +10,7 @@ import {
 
 import * as codegen from "src/codegen";
 import { createNodeContext } from "src/context";
+import { Writer } from "src/generators/extensions";
 
 describe("Workflow", () => {
   const entrypointNode = entrypointNodeDataFactory();

--- a/ee/codegen/src/__test__/vellum-variable-value.test.ts
+++ b/ee/codegen/src/__test__/vellum-variable-value.test.ts
@@ -1,6 +1,5 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import * as codegen from "src/codegen";
+import { Writer } from "src/generators/extensions";
 
 describe("VellumValue", () => {
   let writer: Writer;

--- a/ee/codegen/src/__test__/vellum-variable.test.ts
+++ b/ee/codegen/src/__test__/vellum-variable.test.ts
@@ -1,6 +1,5 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import * as codegen from "src/codegen";
+import { Writer } from "src/generators/extensions";
 
 describe("VellumVariableField", () => {
   let writer: Writer;

--- a/ee/codegen/src/__test__/workflow-sandbox.test.ts
+++ b/ee/codegen/src/__test__/workflow-sandbox.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { VellumVariable } from "vellum-ai/api";
 import { StringInput } from "vellum-ai/api/types";
 
@@ -6,6 +5,7 @@ import { workflowContextFactory } from "./helpers";
 import { inputVariableContextFactory } from "./helpers/input-variable-context-factory";
 
 import * as codegen from "src/codegen";
+import { Writer } from "src/generators/extensions";
 import { WorkflowSandboxInputs } from "src/types/vellum";
 
 describe("Workflow Sandbox", () => {

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/constant-value-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/constant-value-reference.test.ts
@@ -1,7 +1,6 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import { workflowContextFactory } from "src/__test__/helpers";
 import { WorkflowContext } from "src/context";
+import { Writer } from "src/generators/extensions";
 import { ConstantValueReference } from "src/generators/workflow-value-descriptor-reference/constant-value-reference";
 import { WorkflowValueDescriptorReference } from "src/types/vellum";
 

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/execution-counter-workflow-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/execution-counter-workflow-reference.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { DocumentIndexRead } from "vellum-ai/api";
 import { DocumentIndexes as DocumentIndexesClient } from "vellum-ai/api/resources/documentIndexes/client/Client";
 import { vi } from "vitest";
@@ -10,6 +9,7 @@ import {
 import { mockDocumentIndexFactory } from "src/__test__/helpers/document-index-factory";
 import { searchNodeDataFactory } from "src/__test__/helpers/node-data-factories";
 import { WorkflowContext } from "src/context";
+import { Writer } from "src/generators/extensions";
 import { ExecutionCounterWorkflowReference } from "src/generators/workflow-value-descriptor-reference/execution-counter-workflow-reference";
 import {
   WorkflowDataNode,

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/node-output-workflow-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/node-output-workflow-reference.test.ts
@@ -1,8 +1,7 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import { workflowContextFactory } from "src/__test__/helpers";
 import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import { NodeOutputWorkflowReference } from "src/generators/workflow-value-descriptor-reference/node-output-workflow-reference";
 import {
   WorkflowDataNode,

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/vellum-secret-workflow-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/vellum-secret-workflow-reference.test.ts
@@ -1,7 +1,6 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import { workflowContextFactory } from "src/__test__/helpers";
 import { WorkflowContext } from "src/context";
+import { Writer } from "src/generators/extensions";
 import { VellumSecretWorkflowReference } from "src/generators/workflow-value-descriptor-reference/vellum-secret-workflow-reference";
 import { WorkflowValueDescriptorReference } from "src/types/vellum";
 

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/workflow-input-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/workflow-input-reference.test.ts
@@ -1,8 +1,7 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
-
 import { workflowContextFactory } from "src/__test__/helpers";
 import { inputVariableContextFactory } from "src/__test__/helpers/input-variable-context-factory";
 import { WorkflowContext } from "src/context";
+import { Writer } from "src/generators/extensions";
 import { WorkflowInputReference } from "src/generators/workflow-value-descriptor-reference/workflow-input-reference";
 import { WorkflowValueDescriptorReference } from "src/types/vellum";
 

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/workflow-value-descriptor-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/workflow-value-descriptor-reference.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { DocumentIndexRead } from "vellum-ai/api";
 import { DocumentIndexes as DocumentIndexesClient } from "vellum-ai/api/resources/documentIndexes/client/Client";
 import { vi } from "vitest";
@@ -11,6 +10,7 @@ import { mockDocumentIndexFactory } from "src/__test__/helpers/document-index-fa
 import { searchNodeDataFactory } from "src/__test__/helpers/node-data-factories";
 import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import { WorkflowValueDescriptorReference } from "src/generators/workflow-value-descriptor-reference/workflow-value-descriptor-reference";
 import {
   WorkflowDataNode,

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -1,4 +1,3 @@
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { v4 as uuidv4 } from "uuid";
 import { DocumentIndexRead } from "vellum-ai/api";
 import { DocumentIndexes as DocumentIndexesClient } from "vellum-ai/api/resources/documentIndexes/client/Client";
@@ -23,6 +22,7 @@ import { createNodeContext, WorkflowContext } from "src/context";
 import { OutputVariableContext } from "src/context/output-variable-context";
 import { WorkflowOutputContext } from "src/context/workflow-output-context";
 import { WorkflowGenerationError } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { GraphAttribute } from "src/generators/graph-attribute";
 import { WorkflowEdge } from "src/types/vellum";
 

--- a/ee/codegen/src/generators/base-persisted-file.ts
+++ b/ee/codegen/src/generators/base-persisted-file.ts
@@ -5,12 +5,11 @@ import { Comment } from "@fern-api/python-ast/Comment";
 import { Reference } from "@fern-api/python-ast/Reference";
 import { StarImport } from "@fern-api/python-ast/StarImport";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { ModulePath } from "@fern-api/python-ast/core/types";
 
 import { INIT_FILE_NAME } from "src/constants";
 import { WorkflowContext } from "src/context";
-import { PythonFile } from "src/generators/extensions";
+import { PythonFile, Writer } from "src/generators/extensions";
 
 export declare namespace BasePersistedFile {
   interface Args {

--- a/ee/codegen/src/generators/base-prompt-block.ts
+++ b/ee/codegen/src/generators/base-prompt-block.ts
@@ -2,11 +2,11 @@ import { python } from "@fern-api/python-ast";
 import { ClassInstantiation } from "@fern-api/python-ast/ClassInstantiation";
 import { MethodArgument } from "@fern-api/python-ast/MethodArgument";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { isNil } from "lodash";
 
 import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
 import { WorkflowContext } from "src/context/workflow-context";
+import { Writer } from "src/generators/extensions";
 import {
   FunctionDefinitionPromptTemplateBlock,
   PromptTemplateBlock,

--- a/ee/codegen/src/generators/chat-message-content.ts
+++ b/ee/codegen/src/generators/chat-message-content.ts
@@ -1,7 +1,6 @@
 import { python } from "@fern-api/python-ast";
 import { MethodArgument } from "@fern-api/python-ast/MethodArgument";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { isNil } from "lodash";
 import {
   ChatMessageContentRequest as ChatMessageContentRequestType,
@@ -19,6 +18,7 @@ import {
 } from "vellum-ai/api";
 
 import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
+import { Writer } from "src/generators/extensions";
 import { Json } from "src/generators/json";
 import { removeEscapeCharacters } from "src/utils/casing";
 import { assertUnreachable } from "src/utils/typing";

--- a/ee/codegen/src/generators/conditional-node-port.ts
+++ b/ee/codegen/src/generators/conditional-node-port.ts
@@ -2,12 +2,11 @@ import { python } from "@fern-api/python-ast";
 import { MethodArgument } from "@fern-api/python-ast/MethodArgument";
 import { OperatorType } from "@fern-api/python-ast/OperatorType";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { isNil } from "lodash";
 import { VellumVariableType } from "vellum-ai/api";
 
 import { NodePortGenerationError, ValueGenerationError } from "./errors";
-import { PipeExpression } from "./extensions";
+import { PipeExpression, Writer } from "./extensions";
 
 import * as codegen from "src/codegen";
 import { PortContext } from "src/context/port-context";

--- a/ee/codegen/src/generators/expression.ts
+++ b/ee/codegen/src/generators/expression.ts
@@ -1,10 +1,10 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { VELLUM_WORKFLOW_CONSTANTS_PATH } from "src/constants";
 import { WorkflowContext } from "src/context";
 import { NodeAttributeGenerationError } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { WorkflowValueDescriptorReference } from "src/generators/workflow-value-descriptor-reference/workflow-value-descriptor-reference";
 
 export declare namespace Expression {

--- a/ee/codegen/src/generators/extensions/index.ts
+++ b/ee/codegen/src/generators/extensions/index.ts
@@ -12,3 +12,4 @@
  */
 
 export * from "./protected-python-file";
+export * from "./writer";

--- a/ee/codegen/src/generators/extensions/protected-python-file.ts
+++ b/ee/codegen/src/generators/extensions/protected-python-file.ts
@@ -9,9 +9,10 @@ import { Method } from "@fern-api/python-ast/Method";
 import { Reference } from "@fern-api/python-ast/Reference";
 import { StarImport } from "@fern-api/python-ast/StarImport";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { ImportedName, ModulePath } from "@fern-api/python-ast/core/types";
 import { createPythonClassName } from "@fern-api/python-ast/core/utils";
+
+import { Writer } from "src/generators/extensions";
 
 interface UniqueReferenceValue {
   modulePath: ModulePath;

--- a/ee/codegen/src/generators/extensions/writer.ts
+++ b/ee/codegen/src/generators/extensions/writer.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs/promises";
+
+import { Writer as FernWriter } from "@fern-api/python-ast/core/Writer";
+import { Config } from "@wasm-fmt/ruff_fmt";
+
+const wasm = new URL(
+  "../../../node_modules/@wasm-fmt/ruff_fmt/ruff_fmt_bg.wasm",
+  import.meta.url
+);
+
+const module_or_path = fs.readFile(wasm);
+
+export class Writer extends FernWriter {
+  async toStringFormatted(config?: Config) {
+    // This method copies the original method from the FernWriter class, but
+    // it passes a proper input to the `init` function from ruff to silence the
+    // deprecation warning from Ruff.
+    const { default: init, format } = await import("@wasm-fmt/ruff_fmt");
+    await init({ module_or_path });
+    return format(this.buffer, undefined, config);
+  }
+}

--- a/ee/codegen/src/generators/function-definition.ts
+++ b/ee/codegen/src/generators/function-definition.ts
@@ -1,10 +1,10 @@
 import { python } from "@fern-api/python-ast";
 import { MethodArgument } from "@fern-api/python-ast/MethodArgument";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { AstNode } from "@fern-api/python-ast/python";
 import { isNil } from "lodash";
 
 import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
+import { Writer } from "src/generators/extensions";
 import { Json } from "src/generators/json";
 import { FunctionDefinitionPromptTemplateBlock } from "src/types/vellum";
 

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -1,7 +1,6 @@
 import { python } from "@fern-api/python-ast";
 import { OperatorType } from "@fern-api/python-ast/OperatorType";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import {
   PORTS_CLASS_NAME,
@@ -11,6 +10,7 @@ import {
   NodeDefinitionGenerationError,
   NodeNotFoundError,
 } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { WorkflowDataNode, WorkflowEdge } from "src/types/vellum";
 
 import type { WorkflowContext } from "src/context";

--- a/ee/codegen/src/generators/json.ts
+++ b/ee/codegen/src/generators/json.ts
@@ -1,8 +1,9 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { ValueGenerationError } from "./errors";
+
+import { Writer } from "src/generators/extensions";
 
 export class Json extends AstNode {
   private readonly astNode: python.AstNode;

--- a/ee/codegen/src/generators/node-display-data.ts
+++ b/ee/codegen/src/generators/node-display-data.ts
@@ -1,9 +1,9 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { VELLUM_WORKFLOW_EDITOR_TYPES_PATH } from "src/constants";
 import { WorkflowContext } from "src/context";
+import { Writer } from "src/generators/extensions";
 import { NodeDisplayData as NodeDisplayDataType } from "src/types/vellum";
 import { isNilOrEmpty } from "src/utils/typing";
 

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/base.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/base.ts
@@ -1,8 +1,8 @@
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import {
   IterableConfig,
   NodeInputValuePointerRule as NodeInputValuePointerRuleType,

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/node-input-value-pointer-rule.ts
@@ -1,5 +1,4 @@
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { BaseNodeInputValuePointerRule } from "./base";
 import { ConstantValuePointerRule } from "./constant-value-pointer";
@@ -7,6 +6,7 @@ import { InputVariablePointerRule } from "./input-variable-pointer";
 import { NodeOutputPointerRule } from "./node-output-pointer";
 
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import { ExecutionCounterPointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/execution-counter-pointer";
 import { WorkspaceSecretPointerRule } from "src/generators/node-inputs/node-input-value-pointer-rules/workspace-secret-pointer";
 import {

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer.ts
@@ -1,12 +1,12 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { isNil } from "lodash";
 
 import { NodeInputValuePointerRule } from "./node-input-value-pointer-rules/node-input-value-pointer-rule";
 
 import { BaseNodeContext } from "src/context/node-context/base";
 import { BaseCodegenError } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import {
   NodeInputValuePointer as NodeInputValuePointerType,
   WorkflowDataNode,

--- a/ee/codegen/src/generators/node-inputs/node-input.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input.ts
@@ -1,9 +1,9 @@
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { NodeInputValuePointer } from "./node-input-value-pointer";
 
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import { NodeInput as NodeInputType, WorkflowDataNode } from "src/types/vellum";
 
 export declare namespace NodeInput {

--- a/ee/codegen/src/generators/node-outputs.ts
+++ b/ee/codegen/src/generators/node-outputs.ts
@@ -1,10 +1,10 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { OUTPUTS_CLASS_NAME } from "src/constants";
 import { WorkflowContext } from "src/context";
 import { GenericNodeContext } from "src/context/node-context/generic-node";
+import { Writer } from "src/generators/extensions";
 import { WorkflowValueDescriptor } from "src/generators/workflow-value-descriptor";
 import { NodeOutput as NodeOutputType } from "src/types/vellum";
 import { getVellumVariablePrimitiveType } from "src/utils/vellum-variables";

--- a/ee/codegen/src/generators/node-port.ts
+++ b/ee/codegen/src/generators/node-port.ts
@@ -1,9 +1,9 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import { WorkflowValueDescriptor } from "src/generators/workflow-value-descriptor";
 import {
   NodePort as NodePortType,

--- a/ee/codegen/src/generators/node-trigger.ts
+++ b/ee/codegen/src/generators/node-trigger.ts
@@ -1,8 +1,8 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { GenericNodeContext } from "src/context/node-context/generic-node";
+import { Writer } from "src/generators/extensions";
 import { NodeTrigger as NodeTriggerType } from "src/types/vellum";
 
 export declare namespace NodeTrigger {

--- a/ee/codegen/src/generators/nodes/search-node.ts
+++ b/ee/codegen/src/generators/nodes/search-node.ts
@@ -1,7 +1,6 @@
 import { python } from "@fern-api/python-ast";
 import { ClassInstantiation } from "@fern-api/python-ast/ClassInstantiation";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import {
   OUTPUTS_CLASS_NAME,
@@ -14,6 +13,7 @@ import {
   NodeAttributeGenerationError,
   ValueGenerationError,
 } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base";
 import { VellumValueLogicalExpressionSerializer } from "src/serializers/vellum";
 import {

--- a/ee/codegen/src/generators/prompt-parameters-request.ts
+++ b/ee/codegen/src/generators/prompt-parameters-request.ts
@@ -1,11 +1,11 @@
 import { python } from "@fern-api/python-ast";
 import { MethodArgument } from "@fern-api/python-ast/MethodArgument";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { isNil } from "lodash";
 import { PromptParameters as PromptParametersType } from "vellum-ai/api";
 
 import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
+import { Writer } from "src/generators/extensions";
 import { Json } from "src/generators/json";
 
 export declare namespace PromptParameters {

--- a/ee/codegen/src/generators/uuid-or-string.ts
+++ b/ee/codegen/src/generators/uuid-or-string.ts
@@ -1,7 +1,8 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { validate as uuidValidate } from "uuid";
+
+import { Writer } from "src/generators/extensions";
 
 export class UuidOrString extends AstNode {
   private id: string;

--- a/ee/codegen/src/generators/vellum-variable-value.ts
+++ b/ee/codegen/src/generators/vellum-variable-value.ts
@@ -1,6 +1,5 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { isNil } from "lodash";
 import {
   ChatMessageRequest,
@@ -17,6 +16,7 @@ import { ChatMessageContent } from "./chat-message-content";
 import { ValueGenerationError } from "./errors";
 
 import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
+import { Writer } from "src/generators/extensions";
 import { Json } from "src/generators/json";
 import { IterableConfig } from "src/types/vellum";
 import { removeEscapeCharacters } from "src/utils/casing";

--- a/ee/codegen/src/generators/vellum-variable.ts
+++ b/ee/codegen/src/generators/vellum-variable.ts
@@ -1,10 +1,10 @@
 import { python } from "@fern-api/python-ast";
 import { Type } from "@fern-api/python-ast/Type";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { isNil } from "lodash";
 import { VellumValue as VellumValueType } from "vellum-ai/api/types";
 
+import { Writer } from "src/generators/extensions";
 import { VellumValue } from "src/generators/vellum-variable-value";
 import { getVellumVariablePrimitiveType } from "src/utils/vellum-variables";
 

--- a/ee/codegen/src/generators/workflow-output.ts
+++ b/ee/codegen/src/generators/workflow-output.ts
@@ -1,12 +1,12 @@
 import { python } from "@fern-api/python-ast";
 import { Field } from "@fern-api/python-ast/Field";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { WorkflowValueDescriptor } from "./workflow-value-descriptor";
 
 import { WorkflowContext } from "src/context";
 import { WorkflowOutputContext } from "src/context/workflow-output-context";
+import { Writer } from "src/generators/extensions";
 
 export declare namespace WorkflowOutput {
   export interface Args {

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/BaseNodeInputWorkflowReference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/BaseNodeInputWorkflowReference.ts
@@ -1,8 +1,8 @@
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
+import { Writer } from "src/generators/extensions";
 import {
   IterableConfig,
   WorkflowDataNode,

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-value-descriptor-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-value-descriptor-reference.ts
@@ -1,9 +1,9 @@
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 
 import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
 import { ValueGenerationError } from "src/generators/errors";
+import { Writer } from "src/generators/extensions";
 import { BaseNodeInputWorkflowReference } from "src/generators/workflow-value-descriptor-reference/BaseNodeInputWorkflowReference";
 import { ConstantValueReference } from "src/generators/workflow-value-descriptor-reference/constant-value-reference";
 import { ExecutionCounterWorkflowReference } from "src/generators/workflow-value-descriptor-reference/execution-counter-workflow-reference";

--- a/ee/codegen/src/generators/workflow-value-descriptor.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor.ts
@@ -1,11 +1,11 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
-import { Writer } from "@fern-api/python-ast/core/Writer";
 import { isNil } from "lodash";
 
 import { WorkflowContext } from "src/context";
 import { BaseNodeContext } from "src/context/node-context/base";
 import { Expression } from "src/generators/expression";
+import { Writer } from "src/generators/extensions";
 import { WorkflowValueDescriptorReference } from "src/generators/workflow-value-descriptor-reference/workflow-value-descriptor-reference";
 import {
   IterableConfig,


### PR DESCRIPTION
We keep seeing these guys locally

<img width="688" alt="Screenshot 2025-04-20 at 4 42 31 PM" src="https://github.com/user-attachments/assets/a3253970-6eca-40a2-a1a8-bc6aa7d50fc4" />

Figured out how to silence them by sporting an extension of our Writer class. Gonna check in with Fern to see if they'd be willing to main line this since there's no rush from us to implement this