### PR TITLE
Introduce node data factory builder for generic fields like ports and attributes

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -8,6 +8,7 @@ import {
 
 import { edgesFactory } from "./edge-data-factories";
 
+import { NodeDataFactoryBuilder } from "src/__test__/helpers/node-data-factory-builder";
 import { VellumValueLogicalExpressionSerializer } from "src/serializers/vellum";
 import {
   AdornmentNode,
@@ -1313,7 +1314,7 @@ export function codeExecutionNodeFactory({
   runtimeInput?: NodeInput;
   generateLogOutputId?: boolean;
   code?: string;
-} = {}): CodeExecutionNode {
+} = {}): NodeDataFactoryBuilder<CodeExecutionNode> {
   const runtime =
     runtimeInput ??
     ({
@@ -1377,7 +1378,8 @@ export function codeExecutionNodeFactory({
       },
     },
   };
-  return nodeData;
+
+  return new NodeDataFactoryBuilder<CodeExecutionNode>(nodeData);
 }
 
 export function errorNodeDataFactory({

--- a/ee/codegen/src/__test__/helpers/node-data-factory-builder.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factory-builder.ts
@@ -1,0 +1,29 @@
+import { NodeAttribute, NodePort } from "src/types/vellum";
+
+export class NodeDataFactoryBuilder<T> {
+  public nodeData: T;
+
+  constructor(nodeData: T) {
+    this.nodeData = nodeData;
+  }
+
+  withPorts(ports: NodePort[]): NodeDataFactoryBuilder<T> {
+    this.nodeData = {
+      ...this.nodeData,
+      ports: ports,
+    };
+    return this;
+  }
+
+  withAttributes(attributes: NodeAttribute[]): NodeDataFactoryBuilder<T> {
+    this.nodeData = {
+      ...this.nodeData,
+      attributes,
+    };
+    return this;
+  }
+
+  build(): T {
+    return this.nodeData;
+  }
+}


### PR DESCRIPTION
Context: This came up from initial QAing of node ports and I noticed an error there. That was done on a code exec node (I chose this randomly for testing) and am now getting slightly annoyed of having to introduce these fields that are meant to be generic in the future on all node types (ports, attributes, etc.). This in my opinion also eliminates the inconsistency with our factories and how some legacy node types have ports as an arg and how some don't (This is because we chose whatever one we are fixing a bug for). This PR just introduces a simple builder pattern wrapper on our node data factories and I included a test I purposely skipped that will be implemented in a follow up PR where I do the actual fix needed for Ports code generation