### PR TITLE
Handle escape characters

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
@@ -64,3 +64,24 @@ runner = WorkflowSandboxRunner(
 runner.run()
 "
 `;
+
+exports[`Workflow Sandbox > write > should properly handle special characters with escaped quotes 1`] = `
+"from vellum.workflows.sandbox import WorkflowSandboxRunner
+
+from .inputs import Inputs
+from .workflow import TestWorkflow
+
+if __name__ != "__main__":
+    raise Exception("This file is not meant to be imported")
+
+
+runner = WorkflowSandboxRunner(
+    workflow=TestWorkflow(),
+    inputs=[
+        Inputs(special_characters_input='"special characters"'),
+    ],
+)
+
+runner.run()
+"
+`;

--- a/ee/codegen/src/__test__/workflow-sandbox.test.ts
+++ b/ee/codegen/src/__test__/workflow-sandbox.test.ts
@@ -97,5 +97,42 @@ describe("Workflow Sandbox", () => {
       const sandboxFile = await generateSandboxFile(inputVariables, false);
       expect(sandboxFile).toMatchSnapshot();
     });
+
+    it("should properly handle special characters with escaped quotes", async () => {
+      const writer = new Writer();
+      const uniqueWorkflowContext = workflowContextFactory();
+      const inputVariable: VellumVariable = {
+        id: "1",
+        key: "special_characters_input",
+        type: "STRING",
+      };
+
+      uniqueWorkflowContext.addInputVariableContext(
+        inputVariableContextFactory({
+          inputVariableData: inputVariable,
+          workflowContext: uniqueWorkflowContext,
+        })
+      );
+
+      // Create sandbox input with a URL containing quotes that would normally be escaped
+      const sandboxInputs: WorkflowSandboxInputs[] = [
+        [
+          {
+            name: inputVariable.key,
+            type: "STRING",
+            value: '\\"special characters\\"',
+          },
+        ],
+      ];
+
+      const sandbox = codegen.workflowSandboxFile({
+        workflowContext: uniqueWorkflowContext,
+        sandboxInputs,
+      });
+
+      sandbox.write(writer);
+      const result = await writer.toStringFormatted();
+      expect(result).toMatchSnapshot();
+    });
   });
 });

--- a/ee/codegen/src/generators/vellum-variable-value.ts
+++ b/ee/codegen/src/generators/vellum-variable-value.ts
@@ -31,7 +31,7 @@ class StringVellumValue extends AstNode {
   }
 
   private generateAstNode(value: string): AstNode {
-    return python.TypeInstantiation.str(value);
+    return python.TypeInstantiation.str(removeEscapeCharacters(value));
   }
 
   public write(writer: Writer): void {


### PR DESCRIPTION
if the input contain some string like `\"`, during `pull` before this PR it will become `\\"` but python can't interpret this