### PR TITLE
Fix codegen of node ports on legacy nodes

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1303,12 +1303,18 @@ export function apiNodeFactory({
 }
 
 export function codeExecutionNodeFactory({
+  id,
+  outputId,
+  label,
   codeInputValueRule,
   codeOutputValueType,
   runtimeInput,
   generateLogOutputId = true,
   code,
 }: {
+  id?: string;
+  outputId?: string;
+  label?: string;
   codeInputValueRule?: NodeInputValuePointerRule;
   codeOutputValueType?: VellumVariableType;
   runtimeInput?: NodeInput;
@@ -1334,12 +1340,12 @@ export function codeExecutionNodeFactory({
       },
     } as NodeInput);
   const nodeData: CodeExecutionNode = {
-    id: "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
+    id: id ?? "2cd960a3-cb8a-43ed-9e3f-f003fc480951",
     type: "CODE_EXECUTION",
     data: {
-      label: "Code Execution Node",
+      label: label ?? "Code Execution Node",
       codeInputId: "9bf086d4-feed-47ff-9736-a5a6aa3a11cc",
-      outputId: "81b270c0-4deb-4db3-aae5-138f79531b2b",
+      outputId: outputId ?? "81b270c0-4deb-4db3-aae5-138f79531b2b",
       outputType: codeOutputValueType ?? "STRING",
       logOutputId: generateLogOutputId
         ? "46abb839-400b-4766-997e-9c463b526139"

--- a/ee/codegen/src/__test__/helpers/node-data-factory-builder.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factory-builder.ts
@@ -1,6 +1,10 @@
-import { NodeAttribute, NodePort } from "src/types/vellum";
+import {
+  NodeAttribute,
+  NodePort,
+  WorkflowDataNode as WorkflowDataNodeType,
+} from "src/types/vellum";
 
-export class NodeDataFactoryBuilder<T> {
+export class NodeDataFactoryBuilder<T extends WorkflowDataNodeType> {
   public nodeData: T;
 
   constructor(nodeData: T) {

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -112,6 +112,51 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
 "
 `;
 
+exports[`CodeExecutionNode > basic with ports > with ports referencing current node output > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import (
+    CodeExecutionNode as BaseCodeExecutionNode,
+)
+from vellum.workflows.ports import Port
+from vellum.workflows.references import LazyReference
+from vellum.workflows.state import BaseState
+
+
+class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
+    filepath = "./script.py"
+    code_inputs = {}
+    runtime = "PYTHON_3_11_6"
+    packages = None
+
+    class Ports(BaseCodeExecutionNode.Ports):
+        if_port = Port.on_if(
+            LazyReference("CodeExecutionNode.Outputs.result").equals("Hello, World!")
+        )
+        else_port = Port.on_else()
+"
+`;
+
+exports[`CodeExecutionNode > basic with ports > with ports referencing upstream node output > getNodeFile 1`] = `
+"from vellum.workflows.nodes.displayable import (
+    CodeExecutionNode as BaseCodeExecutionNode,
+)
+from vellum.workflows.ports import Port
+from vellum.workflows.state import BaseState
+
+from .upstream_code_node import UpstreamCodeNode
+
+
+class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
+    filepath = "./script.py"
+    code_inputs = {}
+    runtime = "PYTHON_3_11_6"
+    packages = None
+
+    class Ports(BaseCodeExecutionNode.Ports):
+        if_port = Port.on_if(UpstreamCodeNode.Outputs.result.equals("Upstream node"))
+        else_port = Port.on_else()
+"
+`;
+
 exports[`CodeExecutionNode > code representation: Base case > should generate the correct node class 1`] = `
 "from vellum.workflows.nodes.displayable import CodeExecutionNode as BaseCodeExecutionNode
 from vellum.workflows.state import BaseState

--- a/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/code-execution-node.test.ts.snap
@@ -129,7 +129,9 @@ class CodeExecutionNode(BaseCodeExecutionNode[BaseState, str]):
 
     class Ports(BaseCodeExecutionNode.Ports):
         if_port = Port.on_if(
-            LazyReference("CodeExecutionNode.Outputs.result").equals("Hello, World!")
+            LazyReference(lambda: CodeExecutionNode.Outputs.result).equals(
+                "Hello, World!"
+            )
         )
         else_port = Port.on_else()
 "

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/node-output-workflow-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/node-output-workflow-reference.ts
@@ -41,11 +41,31 @@ export class NodeOutputWorkflowReference extends BaseNodeInputWorkflowReference<
           ],
         });
       }
-      return python.reference({
-        name: nodeContext.nodeClassName,
-        modulePath: nodeContext.nodeModulePath,
-        attribute: [OUTPUTS_CLASS_NAME, nodeOutputName],
-      });
+      if (this.nodeContext?.nodeClassName === nodeContext.nodeClassName) {
+        return python.instantiateClass({
+          classReference: python.reference({
+            name: "LazyReference",
+            modulePath: [
+              ...this.nodeContext.workflowContext.sdkModulePathNames
+                .WORKFLOWS_MODULE_PATH,
+              "references",
+            ],
+          }),
+          arguments_: [
+            python.methodArgument({
+              value: python.TypeInstantiation.str(
+                `${nodeContext.nodeClassName}.${OUTPUTS_CLASS_NAME}.${nodeOutputName}`
+              ),
+            }),
+          ],
+        });
+      } else {
+        return python.reference({
+          name: nodeContext.nodeClassName,
+          modulePath: nodeContext.nodeModulePath,
+          attribute: [OUTPUTS_CLASS_NAME, nodeOutputName],
+        });
+      }
     }
     return undefined;
   }

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/node-output-workflow-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/node-output-workflow-reference.ts
@@ -53,9 +53,18 @@ export class NodeOutputWorkflowReference extends BaseNodeInputWorkflowReference<
           }),
           arguments_: [
             python.methodArgument({
-              value: python.TypeInstantiation.str(
-                `${nodeContext.nodeClassName}.${OUTPUTS_CLASS_NAME}.${nodeOutputName}`
-              ),
+              value: python.lambda({
+                body: python.accessAttribute({
+                  lhs: python.reference({
+                    name: nodeContext.nodeClassName,
+                    modulePath: [],
+                  }),
+                  rhs: python.reference({
+                    name: `${OUTPUTS_CLASS_NAME}.${nodeOutputName}`,
+                    modulePath: [],
+                  }),
+                }),
+              }),
             }),
           ],
         });


### PR DESCRIPTION
We are codegening this currently (Notice how we are referencing the current node's output in the ports):
`@TryNode.wrap()
class CodeExecutionNode(BaseCodeExecutionNode[BaseState, Union[float, int]]):
    filepath = "./script.py"
    code_inputs = {}
    runtime = "PYTHON_3_11_6"
    packages = []

    class Ports(BaseCodeExecutionNode.Ports):
        port_5036eae0_fd01_4afc_9825_a029b4db0bf4 = Port.on_if(CodeExecutionNode.Outputs.result.equals(1))
        port_1a5d5ca5_7abb_4a06_9472_8e8b88d6d19b = Port.on_elif(CodeExecutionNode.Outputs.result.does_not_equal(0))
        ace58a77_2dcd_428e_8d44_4b7167e356c6 = Port.on_else()`