### PR TITLE
Fix adornment null value in fixture

### DIFF
--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
@@ -162,13 +162,7 @@
               {
                 "id": "55821c68-5207-4a5b-8345-e89dee65f71a",
                 "name": "on_error_code",
-                "value": {
-                  "type": "CONSTANT_VALUE",
-                  "value": {
-                    "type": "JSON",
-                    "value": null
-                  }
-                }
+                "value": null
               }
             ]
           }


### PR DESCRIPTION
I think the value should be null only? according to what I pulled down