### PR TITLE
Serialize null adornment value

### DIFF
--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
@@ -162,13 +162,7 @@
               {
                 "id": "55821c68-5207-4a5b-8345-e89dee65f71a",
                 "name": "on_error_code",
-                "value": {
-                  "type": "CONSTANT_VALUE",
-                  "value": {
-                    "type": "JSON",
-                    "value": null
-                  }
-                }
+                "value": null
               }
             ]
           }

--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -157,7 +157,9 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
                     {
                         "id": id,
                         "name": attribute.name,
-                        "value": self.serialize_value(display_context, attribute.instance),
+                        "value": (
+                            self.serialize_value(display_context, attribute.instance) if attribute.instance else None
+                        ),
                     }
                 )
             except ValueError as e:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
@@ -33,7 +33,11 @@ class BaseRetryNodeDisplay(BaseAdornmentNodeDisplay[_RetryNodeType], Generic[_Re
                 {
                     "id": id,
                     "name": attribute.name,
-                    "value": self.serialize_value(display_context, cast(BaseDescriptor, attribute.instance)),
+                    "value": (
+                        self.serialize_value(display_context, cast(BaseDescriptor, attribute.instance))
+                        if attribute.instance
+                        else None
+                    ),
                 }
             )
 

--- a/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
@@ -37,7 +37,11 @@ class BaseTryNodeDisplay(BaseAdornmentNodeDisplay[_TryNodeType], Generic[_TryNod
                 {
                     "id": id,
                     "name": attribute.name,
-                    "value": self.serialize_value(display_context, cast(BaseDescriptor, attribute.instance)),
+                    "value": (
+                        self.serialize_value(display_context, cast(BaseDescriptor, attribute.instance))
+                        if attribute.instance
+                        else None
+                    ),
                 }
             )
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -76,7 +76,7 @@ def test_serialize_node__retry(serialize_node):
                         {
                             "id": "8a07dc58-3fed-41d4-8ca6-31ee0bb86c61",
                             "name": "delay",
-                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                            "value": None,
                         },
                         {
                             "id": "f388e93b-8c68-4f54-8577-bbd0c9091557",
@@ -86,12 +86,12 @@ def test_serialize_node__retry(serialize_node):
                         {
                             "id": "73a02e62-4535-4e1f-97b5-1264ca8b1d71",
                             "name": "retry_on_condition",
-                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                            "value": None,
                         },
                         {
                             "id": "c91782e3-140f-4938-9c23-d2a7b85dcdd8",
                             "name": "retry_on_error_code",
-                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                            "value": None,
                         },
                     ],
                 }
@@ -183,7 +183,7 @@ def test_serialize_node__try(serialize_node):
                         {
                             "id": "ab2fbab0-e2a0-419b-b1ef-ce11ecf11e90",
                             "name": "on_error_code",
-                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                            "value": None,
                         }
                     ],
                 }
@@ -288,7 +288,7 @@ def test_serialize_node__stacked():
                                     {
                                         "id": "c91782e3-140f-4938-9c23-d2a7b85dcdd8",
                                         "name": "retry_on_error_code",
-                                        "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                                        "value": None,
                                     },
                                     {
                                         "id": "f388e93b-8c68-4f54-8577-bbd0c9091557",
@@ -298,12 +298,12 @@ def test_serialize_node__stacked():
                                     {
                                         "id": "8a07dc58-3fed-41d4-8ca6-31ee0bb86c61",
                                         "name": "delay",
-                                        "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                                        "value": None,
                                     },
                                     {
                                         "id": "73a02e62-4535-4e1f-97b5-1264ca8b1d71",
                                         "name": "retry_on_condition",
-                                        "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                                        "value": None,
                                     },
                                 ],
                             },
@@ -318,7 +318,7 @@ def test_serialize_node__stacked():
                                     {
                                         "id": "ab2fbab0-e2a0-419b-b1ef-ce11ecf11e90",
                                         "name": "on_error_code",
-                                        "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                                        "value": None,
                                     }
                                 ],
                             },

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_code_execution_node_serialization.py
@@ -600,7 +600,7 @@ def test_serialize_workflow__try_wrapped():
                     {
                         "id": "ab2fbab0-e2a0-419b-b1ef-ce11ecf11e90",
                         "name": "on_error_code",
-                        "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                        "value": None,
                     }
                 ],
             }


### PR DESCRIPTION
What I am pulling down for null adornment value is

```
'attributes': [{'id': 'b1bcf28e-a8d8-4746-9736-f96f7de73c73',
 'name': 'on_error_code',
 'value': None}]},
```

not sure if this would break something