### PR TITLE
Align the workflow output name with the terminal output name

### DIFF
--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_terminal_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_terminal_node_serialization.py
@@ -66,7 +66,7 @@ def test_serialize_workflow():
         "type": "TERMINAL",
         "data": {
             "label": "Basic Final Output Node",
-            "name": "basic-final-output-node",
+            "name": "value",
             "target_handle_id": "0173d3c6-11d1-44b7-b070-ca9ff5119046",
             "output_id": "aa63e3f6-fde3-4d19-84ef-29982d44d709",
             "output_type": "STRING",

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_complex_terminal_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_complex_terminal_node_serialization.py
@@ -90,7 +90,7 @@ def test_serialize_workflow__missing_final_output_node():
                 "type": "TERMINAL",
                 "data": {
                     "label": "First Final Output Node",
-                    "name": "first-final-output-node",
+                    "name": "alpha",
                     "target_handle_id": "a0c2eb7a-398e-4f28-b63d-f3bae9b563ee",
                     "output_id": "0cd02933-c5b9-47c9-aede-e97c5870e8aa",
                     "output_type": "STRING",


### PR DESCRIPTION
I noticed during the customer demo that we were serializing the wrong workflow output name. The full fix will require three PRs:
- This one, which edits terminal node name to be aligned with the workflow output name
- Next one, which will abstract out the BaseNodeDisplay.serialize_value() to its own util to be reused by workflows
- The last one, to start serializing workflow output values, which we have never done