### PR TITLE
Move serialize_value out of BaseNodeDisplay and into display utils

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/conditional_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/conditional_node.py
@@ -19,7 +19,7 @@ from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum_ee.workflows.display.utils.vellum import convert_descriptor_to_operator
+from vellum_ee.workflows.display.utils.expressions import convert_descriptor_to_operator
 from vellum_ee.workflows.display.vellum import NodeInput
 
 _ConditionalNodeType = TypeVar("_ConditionalNodeType", bound=ConditionalNode)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/final_output_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/final_output_node.py
@@ -8,6 +8,7 @@ from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.utils import to_kebab_case
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
+from vellum_ee.workflows.display.utils.expressions import serialize_value
 from vellum_ee.workflows.display.utils.vellum import infer_vellum_variable_type
 
 _FinalOutputNodeType = TypeVar("_FinalOutputNodeType", bound=FinalOutputNode)
@@ -52,7 +53,7 @@ class BaseFinalOutputNodeDisplay(BaseNodeDisplay[_FinalOutputNodeType], Generic[
                     "id": str(self._get_output_id()),
                     "name": node.Outputs.value.name,
                     "type": inferred_type,
-                    "value": self.serialize_value(display_context, node.Outputs.value.instance),
+                    "value": serialize_value(display_context, node.Outputs.value.instance),
                 }
             ],
         }

--- a/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/retry_node.py
@@ -1,7 +1,6 @@
 import inspect
-from typing import Any, Generic, Tuple, Type, TypeVar, cast
+from typing import Any, Generic, Tuple, Type, TypeVar
 
-from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.retry_node.node import RetryNode
 from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
@@ -13,6 +12,7 @@ from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_di
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.nodes.vellum.base_adornment_node import BaseAdornmentNodeDisplay
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
+from vellum_ee.workflows.display.utils.expressions import serialize_value
 
 _RetryNodeType = TypeVar("_RetryNodeType", bound=RetryNode)
 
@@ -33,7 +33,7 @@ class BaseRetryNodeDisplay(BaseAdornmentNodeDisplay[_RetryNodeType], Generic[_Re
                 {
                     "id": id,
                     "name": attribute.name,
-                    "value": self.serialize_value(display_context, cast(BaseDescriptor, attribute.instance)),
+                    "value": serialize_value(display_context, attribute.instance),
                 }
             )
 

--- a/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/try_node.py
@@ -1,8 +1,7 @@
 import inspect
 from uuid import UUID
-from typing import Any, ClassVar, Generic, Optional, Tuple, Type, TypeVar, cast
+from typing import Any, ClassVar, Generic, Optional, Tuple, Type, TypeVar
 
-from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.core.try_node.node import TryNode
 from vellum.workflows.nodes.utils import ADORNMENT_MODULE_NAME
@@ -14,6 +13,7 @@ from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_di
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 from vellum_ee.workflows.display.nodes.vellum.base_adornment_node import BaseAdornmentNodeDisplay
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
+from vellum_ee.workflows.display.utils.expressions import serialize_value
 
 _TryNodeType = TypeVar("_TryNodeType", bound=TryNode)
 
@@ -37,7 +37,7 @@ class BaseTryNodeDisplay(BaseAdornmentNodeDisplay[_TryNodeType], Generic[_TryNod
                 {
                     "id": id,
                     "name": attribute.name,
-                    "value": self.serialize_value(display_context, cast(BaseDescriptor, attribute.instance)),
+                    "value": serialize_value(display_context, attribute.instance),
                 }
             )
 

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -1,7 +1,44 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.expressions.accessor import AccessorExpression
+from vellum.workflows.expressions.and_ import AndExpression
+from vellum.workflows.expressions.begins_with import BeginsWithExpression
+from vellum.workflows.expressions.between import BetweenExpression
+from vellum.workflows.expressions.coalesce_expression import CoalesceExpression
+from vellum.workflows.expressions.contains import ContainsExpression
+from vellum.workflows.expressions.does_not_begin_with import DoesNotBeginWithExpression
+from vellum.workflows.expressions.does_not_contain import DoesNotContainExpression
+from vellum.workflows.expressions.does_not_end_with import DoesNotEndWithExpression
+from vellum.workflows.expressions.does_not_equal import DoesNotEqualExpression
+from vellum.workflows.expressions.ends_with import EndsWithExpression
+from vellum.workflows.expressions.equals import EqualsExpression
+from vellum.workflows.expressions.greater_than import GreaterThanExpression
+from vellum.workflows.expressions.greater_than_or_equal_to import GreaterThanOrEqualToExpression
+from vellum.workflows.expressions.in_ import InExpression
+from vellum.workflows.expressions.is_nil import IsNilExpression
+from vellum.workflows.expressions.is_not_nil import IsNotNilExpression
+from vellum.workflows.expressions.is_not_null import IsNotNullExpression
+from vellum.workflows.expressions.is_not_undefined import IsNotUndefinedExpression
+from vellum.workflows.expressions.is_null import IsNullExpression
+from vellum.workflows.expressions.is_undefined import IsUndefinedExpression
+from vellum.workflows.expressions.less_than import LessThanExpression
+from vellum.workflows.expressions.less_than_or_equal_to import LessThanOrEqualToExpression
+from vellum.workflows.expressions.not_between import NotBetweenExpression
+from vellum.workflows.expressions.not_in import NotInExpression
+from vellum.workflows.expressions.or_ import OrExpression
+from vellum.workflows.expressions.parse_json import ParseJsonExpression
+from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
+from vellum.workflows.references.constant import ConstantValueReference
+from vellum.workflows.references.execution_count import ExecutionCountReference
 from vellum.workflows.references.lazy import LazyReference
+from vellum.workflows.references.output import OutputReference
+from vellum.workflows.references.state_value import StateValueReference
+from vellum.workflows.references.vellum_secret import VellumSecretReference
+from vellum.workflows.references.workflow_input import WorkflowInputReference
+from vellum.workflows.types.core import JsonObject
+from vellum_ee.workflows.display.utils.exceptions import UnsupportedSerializationException
+from vellum_ee.workflows.display.utils.vellum import convert_descriptor_to_operator
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.types import WorkflowDisplayContext
@@ -28,3 +65,137 @@ def get_child_descriptor(value: LazyReference, display_context: "WorkflowDisplay
         raise Exception(f"Failed to parse lazy reference: {value._get}")
 
     return value._get()
+
+
+def serialize_condition(display_context: "WorkflowDisplayContext", condition: BaseDescriptor) -> JsonObject:
+    if isinstance(
+        condition,
+        (
+            IsNullExpression,
+            IsNotNullExpression,
+            IsNilExpression,
+            IsNotNilExpression,
+            IsUndefinedExpression,
+            IsNotUndefinedExpression,
+            ParseJsonExpression,
+        ),
+    ):
+        lhs = serialize_value(display_context, condition._expression)
+        return {
+            "type": "UNARY_EXPRESSION",
+            "lhs": lhs,
+            "operator": convert_descriptor_to_operator(condition),
+        }
+    elif isinstance(condition, (BetweenExpression, NotBetweenExpression)):
+        base = serialize_value(display_context, condition._value)
+        lhs = serialize_value(display_context, condition._start)
+        rhs = serialize_value(display_context, condition._end)
+
+        return {
+            "type": "TERNARY_EXPRESSION",
+            "base": base,
+            "operator": convert_descriptor_to_operator(condition),
+            "lhs": lhs,
+            "rhs": rhs,
+        }
+    elif isinstance(
+        condition,
+        (
+            AndExpression,
+            BeginsWithExpression,
+            CoalesceExpression,
+            ContainsExpression,
+            DoesNotBeginWithExpression,
+            DoesNotContainExpression,
+            DoesNotEndWithExpression,
+            DoesNotEqualExpression,
+            EndsWithExpression,
+            EqualsExpression,
+            GreaterThanExpression,
+            GreaterThanOrEqualToExpression,
+            InExpression,
+            LessThanExpression,
+            LessThanOrEqualToExpression,
+            NotInExpression,
+            OrExpression,
+        ),
+    ):
+        lhs = serialize_value(display_context, condition._lhs)
+        rhs = serialize_value(display_context, condition._rhs)
+
+        return {
+            "type": "BINARY_EXPRESSION",
+            "lhs": lhs,
+            "operator": convert_descriptor_to_operator(condition),
+            "rhs": rhs,
+        }
+    elif isinstance(condition, AccessorExpression):
+        return {
+            "type": "BINARY_EXPRESSION",
+            "lhs": serialize_value(display_context, condition._base),
+            "operator": "accessField",
+            "rhs": serialize_value(display_context, condition._field),
+        }
+
+    raise UnsupportedSerializationException(f"Unsupported condition type: {condition.__class__.__name__}")
+
+
+def serialize_value(display_context: "WorkflowDisplayContext", value: Any) -> JsonObject:
+    if isinstance(value, ConstantValueReference):
+        return serialize_value(display_context, value._value)
+
+    if isinstance(value, LazyReference):
+        child_descriptor = get_child_descriptor(value, display_context)
+        return serialize_value(display_context, child_descriptor)
+
+    if isinstance(value, WorkflowInputReference):
+        workflow_input_display = display_context.global_workflow_input_displays[value]
+        return {
+            "type": "WORKFLOW_INPUT",
+            "input_variable_id": str(workflow_input_display.id),
+        }
+
+    if isinstance(value, StateValueReference):
+        state_value_display = display_context.global_state_value_displays[value]
+        return {
+            "type": "STATE_VALUE",
+            "state_variable_id": str(state_value_display.id),
+        }
+
+    if isinstance(value, OutputReference):
+        upstream_node, output_display = display_context.global_node_output_displays[value]
+        upstream_node_display = display_context.global_node_displays[upstream_node]
+
+        return {
+            "type": "NODE_OUTPUT",
+            "node_id": str(upstream_node_display.node_id),
+            "node_output_id": str(output_display.id),
+        }
+
+    if isinstance(value, VellumSecretReference):
+        return {
+            "type": "VELLUM_SECRET",
+            "vellum_secret_name": value.name,
+        }
+
+    if isinstance(value, ExecutionCountReference):
+        node_class_display = display_context.global_node_displays[value.node_class]
+
+        return {
+            "type": "EXECUTION_COUNTER",
+            "node_id": str(node_class_display.node_id),
+        }
+
+    if isinstance(value, dict) and any(isinstance(v, BaseDescriptor) for v in value.values()):
+        raise ValueError("Nested references are not supported.")
+
+    if not isinstance(value, BaseDescriptor):
+        vellum_value = primitive_to_vellum_value(value)
+        return {
+            "type": "CONSTANT_VALUE",
+            "value": vellum_value.dict(),
+        }
+
+    # If it's not any of the references we know about,
+    # then try to serialize it as a nested value
+    return serialize_condition(display_context, value)

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
+from vellum.client.types.logical_operator import LogicalOperator
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.expressions.accessor import AccessorExpression
 from vellum.workflows.expressions.and_ import AndExpression
@@ -38,10 +39,58 @@ from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.references.workflow_input import WorkflowInputReference
 from vellum.workflows.types.core import JsonObject
 from vellum_ee.workflows.display.utils.exceptions import UnsupportedSerializationException
-from vellum_ee.workflows.display.utils.vellum import convert_descriptor_to_operator
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.types import WorkflowDisplayContext
+
+
+def convert_descriptor_to_operator(descriptor: BaseDescriptor) -> LogicalOperator:
+    if isinstance(descriptor, EqualsExpression):
+        return "="
+    elif isinstance(descriptor, DoesNotEqualExpression):
+        return "!="
+    elif isinstance(descriptor, LessThanExpression):
+        return "<"
+    elif isinstance(descriptor, GreaterThanExpression):
+        return ">"
+    elif isinstance(descriptor, LessThanOrEqualToExpression):
+        return "<="
+    elif isinstance(descriptor, GreaterThanOrEqualToExpression):
+        return ">="
+    elif isinstance(descriptor, ContainsExpression):
+        return "contains"
+    elif isinstance(descriptor, BeginsWithExpression):
+        return "beginsWith"
+    elif isinstance(descriptor, EndsWithExpression):
+        return "endsWith"
+    elif isinstance(descriptor, DoesNotContainExpression):
+        return "doesNotContain"
+    elif isinstance(descriptor, DoesNotBeginWithExpression):
+        return "doesNotBeginWith"
+    elif isinstance(descriptor, DoesNotEndWithExpression):
+        return "doesNotEndWith"
+    elif isinstance(descriptor, (IsNullExpression, IsNilExpression, IsUndefinedExpression)):
+        return "null"
+    elif isinstance(descriptor, (IsNotNullExpression, IsNotNilExpression, IsNotUndefinedExpression)):
+        return "notNull"
+    elif isinstance(descriptor, InExpression):
+        return "in"
+    elif isinstance(descriptor, NotInExpression):
+        return "notIn"
+    elif isinstance(descriptor, BetweenExpression):
+        return "between"
+    elif isinstance(descriptor, NotBetweenExpression):
+        return "notBetween"
+    elif isinstance(descriptor, AndExpression):
+        return "and"
+    elif isinstance(descriptor, OrExpression):
+        return "or"
+    elif isinstance(descriptor, CoalesceExpression):
+        return "coalesce"
+    elif isinstance(descriptor, ParseJsonExpression):
+        return "parseJson"
+    else:
+        raise ValueError(f"Unsupported descriptor type: {descriptor}")
 
 
 def get_child_descriptor(value: LazyReference, display_context: "WorkflowDisplayContext") -> BaseDescriptor:

--- a/ee/vellum_ee/workflows/display/utils/vellum.py
+++ b/ee/vellum_ee/workflows/display/utils/vellum.py
@@ -2,36 +2,9 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
 from vellum.client.types.array_vellum_value import ArrayVellumValue
-from vellum.client.types.logical_operator import LogicalOperator
 from vellum.client.types.vellum_value import VellumValue
 from vellum.client.types.vellum_variable_type import VellumVariableType
 from vellum.workflows.descriptors.base import BaseDescriptor
-from vellum.workflows.expressions.and_ import AndExpression
-from vellum.workflows.expressions.begins_with import BeginsWithExpression
-from vellum.workflows.expressions.between import BetweenExpression
-from vellum.workflows.expressions.coalesce_expression import CoalesceExpression
-from vellum.workflows.expressions.contains import ContainsExpression
-from vellum.workflows.expressions.does_not_begin_with import DoesNotBeginWithExpression
-from vellum.workflows.expressions.does_not_contain import DoesNotContainExpression
-from vellum.workflows.expressions.does_not_end_with import DoesNotEndWithExpression
-from vellum.workflows.expressions.does_not_equal import DoesNotEqualExpression
-from vellum.workflows.expressions.ends_with import EndsWithExpression
-from vellum.workflows.expressions.equals import EqualsExpression
-from vellum.workflows.expressions.greater_than import GreaterThanExpression
-from vellum.workflows.expressions.greater_than_or_equal_to import GreaterThanOrEqualToExpression
-from vellum.workflows.expressions.in_ import InExpression
-from vellum.workflows.expressions.is_nil import IsNilExpression
-from vellum.workflows.expressions.is_not_nil import IsNotNilExpression
-from vellum.workflows.expressions.is_not_null import IsNotNullExpression
-from vellum.workflows.expressions.is_not_undefined import IsNotUndefinedExpression
-from vellum.workflows.expressions.is_null import IsNullExpression
-from vellum.workflows.expressions.is_undefined import IsUndefinedExpression
-from vellum.workflows.expressions.less_than import LessThanExpression
-from vellum.workflows.expressions.less_than_or_equal_to import LessThanOrEqualToExpression
-from vellum.workflows.expressions.not_between import NotBetweenExpression
-from vellum.workflows.expressions.not_in import NotInExpression
-from vellum.workflows.expressions.or_ import OrExpression
-from vellum.workflows.expressions.parse_json import ParseJsonExpression
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
 from vellum.workflows.references import OutputReference, WorkflowInputReference
@@ -166,52 +139,3 @@ def create_node_input_value_pointer_rule(
         return ConstantValuePointer(type="CONSTANT_VALUE", data=vellum_value)
 
     raise UnsupportedSerializationException(f"Unsupported descriptor type: {value.__class__.__name__}")
-
-
-def convert_descriptor_to_operator(descriptor: BaseDescriptor) -> LogicalOperator:
-    if isinstance(descriptor, EqualsExpression):
-        return "="
-    elif isinstance(descriptor, DoesNotEqualExpression):
-        return "!="
-    elif isinstance(descriptor, LessThanExpression):
-        return "<"
-    elif isinstance(descriptor, GreaterThanExpression):
-        return ">"
-    elif isinstance(descriptor, LessThanOrEqualToExpression):
-        return "<="
-    elif isinstance(descriptor, GreaterThanOrEqualToExpression):
-        return ">="
-    elif isinstance(descriptor, ContainsExpression):
-        return "contains"
-    elif isinstance(descriptor, BeginsWithExpression):
-        return "beginsWith"
-    elif isinstance(descriptor, EndsWithExpression):
-        return "endsWith"
-    elif isinstance(descriptor, DoesNotContainExpression):
-        return "doesNotContain"
-    elif isinstance(descriptor, DoesNotBeginWithExpression):
-        return "doesNotBeginWith"
-    elif isinstance(descriptor, DoesNotEndWithExpression):
-        return "doesNotEndWith"
-    elif isinstance(descriptor, (IsNullExpression, IsNilExpression, IsUndefinedExpression)):
-        return "null"
-    elif isinstance(descriptor, (IsNotNullExpression, IsNotNilExpression, IsNotUndefinedExpression)):
-        return "notNull"
-    elif isinstance(descriptor, InExpression):
-        return "in"
-    elif isinstance(descriptor, NotInExpression):
-        return "notIn"
-    elif isinstance(descriptor, BetweenExpression):
-        return "between"
-    elif isinstance(descriptor, NotBetweenExpression):
-        return "notBetween"
-    elif isinstance(descriptor, AndExpression):
-        return "and"
-    elif isinstance(descriptor, OrExpression):
-        return "or"
-    elif isinstance(descriptor, CoalesceExpression):
-        return "coalesce"
-    elif isinstance(descriptor, ParseJsonExpression):
-        return "parseJson"
-    else:
-        raise ValueError(f"Unsupported descriptor type: {descriptor}")


### PR DESCRIPTION
This PR simply moves the serialize methods out of BaseNodeDisplay and into the utils directory so that we could reuse it in the future for workflow outputs