### PR TITLE
Fixing Subworkflow Deployment Inputs

### DIFF
--- a/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
@@ -7,10 +7,16 @@ import { NodeDefinitionGenerationError } from "src/generators/errors";
 import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base";
 import { DeploymentPromptNodeData, PromptNode } from "src/types/vellum";
 
+const INPUTS_PREFIX = "prompt_inputs";
+
 export class PromptDeploymentNode extends BaseSingleFileNode<
   PromptNode,
   PromptDeploymentNodeContext
 > {
+  protected getNodeAttributeNameByNodeInputKey(nodeInputKey: string): string {
+    return `${INPUTS_PREFIX}.${nodeInputKey}`;
+  }
+
   protected getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 
@@ -66,7 +72,7 @@ export class PromptDeploymentNode extends BaseSingleFileNode<
 
     statements.push(
       python.field({
-        name: "prompt_inputs",
+        name: INPUTS_PREFIX,
         initializer: python.TypeInstantiation.dict(
           Array.from(this.nodeInputsByKey.entries()).map(([key, value]) => ({
             key: python.TypeInstantiation.str(key),

--- a/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/subworkflow-deployment-node.ts
@@ -11,10 +11,16 @@ import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base"
 import { codegen } from "src/index";
 import { SubworkflowNode as SubworkflowNodeType } from "src/types/vellum";
 
+const INPUTS_PREFIX = "subworkflow_inputs";
+
 export class SubworkflowDeploymentNode extends BaseSingleFileNode<
   SubworkflowNodeType,
   SubworkflowDeploymentNodeContext
 > {
+  protected getNodeAttributeNameByNodeInputKey(nodeInputKey: string): string {
+    return `${INPUTS_PREFIX}.${nodeInputKey}`;
+  }
+
   getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 
@@ -52,7 +58,7 @@ export class SubworkflowDeploymentNode extends BaseSingleFileNode<
 
     statements.push(
       python.field({
-        name: "subworkflow_inputs",
+        name: INPUTS_PREFIX,
         initializer: python.TypeInstantiation.dict(
           Array.from(this.nodeInputsByKey.entries()).map(([key, value]) => ({
             key: python.TypeInstantiation.str(key),

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/subworkflow_node.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/subworkflow_node.py
@@ -11,7 +11,7 @@ class SubworkflowNodeDisplay(BaseSubworkflowDeploymentNodeDisplay[SubworkflowNod
     label = "Subworkflow Node"
     node_id = UUID("ddb58eb1-f089-4bb0-b4b9-f630411c0acf")
     target_handle_id = UUID("d96bb2c2-1c6f-4e7d-9163-c6b16a67e1f2")
-    node_input_ids_by_name = {"chat_history": UUID("76519b3c-285d-425d-ba7a-ce7300e4ed9c")}
+    node_input_ids_by_name = {"subworkflow_inputs.chat_history": UUID("76519b3c-285d-425d-ba7a-ce7300e4ed9c")}
     output_display = {
         SubworkflowNode.Outputs.chat_history: NodeOutputDisplay(
             id=UUID("53970e88-0bf6-4364-86b3-840d78a2afe5"), name="chat_history"

--- a/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/subworkflow_deployment.py
+++ b/ee/codegen_integration/fixtures/simple_subworkflow_deployment_node/code/display/nodes/subworkflow_deployment.py
@@ -11,7 +11,7 @@ class SubworkflowDeploymentDisplay(BaseSubworkflowDeploymentNodeDisplay[Subworkf
     label = "Subworkflow Deployment"
     node_id = UUID("07d76e33-f3df-4235-8493-07e341208bf5")
     target_handle_id = UUID("30771282-5c0a-4a98-a3a8-4c7eeda30d23")
-    node_input_ids_by_name = {"test": UUID("97b63d71-5413-417f-9cf5-49e1b4fd56e4")}
+    node_input_ids_by_name = {"subworkflow_inputs.test": UUID("97b63d71-5413-417f-9cf5-49e1b4fd56e4")}
     output_display = {
         SubworkflowDeployment.Outputs.chat_history: NodeOutputDisplay(
             id=UUID("53970e88-0bf6-4364-86b3-840d78a2afe5"), name="chat_history"

--- a/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
@@ -28,7 +28,10 @@ class BasePromptDeploymentNodeDisplay(BaseNodeDisplay[_PromptDeploymentNodeType]
                     input_name=variable_name,
                     value=variable_value,
                     display_context=display_context,
-                    input_id=self.node_input_ids_by_name.get(variable_name),
+                    input_id=self.node_input_ids_by_name.get(
+                        f"{PromptDeploymentNode.prompt_inputs.name}.{variable_name}"
+                    )
+                    or self.node_input_ids_by_name.get(variable_name),
                 )
                 for variable_name, variable_value in prompt_inputs.items()
             ]

--- a/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
@@ -29,7 +29,8 @@ class BaseSubworkflowDeploymentNodeDisplay(
                 input_name=variable_name,
                 value=variable_value,
                 display_context=display_context,
-                input_id=self.node_input_ids_by_name.get(variable_name),
+                input_id=self.node_input_ids_by_name.get(f"subworkflow_inputs.{variable_name}")
+                or self.node_input_ids_by_name.get(variable_name),
             )
             for variable_name, variable_value in subworkflow_inputs.items()
         ]

--- a/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
@@ -29,7 +29,9 @@ class BaseSubworkflowDeploymentNodeDisplay(
                 input_name=variable_name,
                 value=variable_value,
                 display_context=display_context,
-                input_id=self.node_input_ids_by_name.get(f"subworkflow_inputs.{variable_name}")
+                input_id=self.node_input_ids_by_name.get(
+                    f"{SubworkflowDeploymentNode.subworkflow_inputs.name}.{variable_name}"
+                )
                 or self.node_input_ids_by_name.get(variable_name),
             )
             for variable_name, variable_value in subworkflow_inputs.items()

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_deployment_node.py
@@ -1,0 +1,106 @@
+import pytest
+from datetime import datetime
+from uuid import UUID, uuid4
+from typing import Type
+
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes import PromptDeploymentNode
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+
+def _no_display_class(Node: Type[PromptDeploymentNode]):  # type: ignore
+    return None
+
+
+def _display_class_with_node_input_ids_by_name(Node: Type[PromptDeploymentNode]):
+    class PromptDeploymentNodeDisplay(PromptDeploymentNode[Node]):  # type: ignore[valid-type]
+        node_input_ids_by_name = {"foo": UUID("6037747a-1d35-4094-b363-4369fc92c5d4")}
+
+    return PromptDeploymentNodeDisplay
+
+
+def _display_class_with_node_input_ids_by_name_with_inputs_prefix(Node: Type[PromptDeploymentNode]):
+    class PromptDeploymentNodeDisplay(PromptDeploymentNode[Node]):  # type: ignore[valid-type]
+        node_input_ids_by_name = {"prompt_inputs.foo": UUID("6037747a-1d35-4094-b363-4369fc92c5d4")}
+
+    return PromptDeploymentNodeDisplay
+
+
+@pytest.fixture
+def mock_fetch_deployment(mocker):
+    # Create a mock deployment response
+    mock_deployment = mocker.Mock(
+        id="test-id",
+        name="test-deployment",
+        label="Test Deployment",
+        status="ACTIVE",
+        environment="DEVELOPMENT",
+        created=datetime.now(),
+        last_deployed_on=datetime.now(),
+        last_deployed_history_item_id=str(uuid4()),
+        input_variables=[],
+        output_variables=[],
+        description="Test deployment description",
+    )
+
+    # Patch the create_vellum_client function to return our mock client
+    mocker.patch("vellum.client.resources.deployments.client.DeploymentsClient.retrieve", return_value=mock_deployment)
+    return mock_deployment
+
+
+@pytest.mark.parametrize(
+    ["GetDisplayClass", "expected_input_id"],
+    [
+        (_no_display_class, "6037747a-1d35-4094-b363-4369fc92c5d4"),
+        (_display_class_with_node_input_ids_by_name, "6037747a-1d35-4094-b363-4369fc92c5d4"),
+        (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "6037747a-1d35-4094-b363-4369fc92c5d4"),
+    ],
+    ids=[
+        "no_display_class",
+        "display_class_with_node_input_ids_by_name",
+        "display_class_with_node_input_ids_by_name_with_inputs_prefix",
+    ],
+)
+def test_serialize_node__prompt_inputs(GetDisplayClass, expected_input_id, mock_fetch_deployment):
+    # GIVEN a prompt node with inputs
+    class MyPromptDeploymentNode(PromptDeploymentNode):
+        deployment = "DEPLOYMENT"
+        prompt_inputs = {"foo": "bar"}
+        ml_model_fallbacks = None
+
+    # AND a workflow with the prompt node
+    class Workflow(BaseWorkflow):
+        graph = MyPromptDeploymentNode
+
+    # AND a display class
+    GetDisplayClass(MyPromptDeploymentNode)
+
+    # WHEN the workflow is serialized
+    workflow_display = get_workflow_display(workflow_class=Workflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    # THEN the node should properly serialize the inputs
+    my_prompt_node = next(
+        node
+        for node in serialized_workflow["workflow_raw_data"]["nodes"]
+        if node["id"] == str(MyPromptDeploymentNode.__id__)
+    )
+
+    assert my_prompt_node["inputs"] == [
+        {
+            "id": expected_input_id,
+            "key": "foo",
+            "value": {
+                "rules": [
+                    {
+                        "type": "CONSTANT_VALUE",
+                        "data": {
+                            "type": "STRING",
+                            "value": "bar",
+                        },
+                    }
+                ],
+                "combinator": "OR",
+            },
+        }
+    ]

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_subworkflow_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_subworkflow_deployment_node.py
@@ -14,14 +14,14 @@ def _no_display_class(Node: Type[SubworkflowDeploymentNode]):  # type: ignore
 
 def _display_class_with_node_input_ids_by_name(Node: Type[SubworkflowDeploymentNode]):
     class SubworkflowNodeDisplay(SubworkflowDeploymentNode[Node]):  # type: ignore[valid-type]
-        node_input_ids_by_name = {"foo": UUID("74996e96-b7e5-4936-98e3-b88415782944")}
+        node_input_ids_by_name = {"foo": UUID("aff4f838-577e-44b9-ac5c-6d8213abbb9c")}
 
     return SubworkflowNodeDisplay
 
 
 def _display_class_with_node_input_ids_by_name_with_inputs_prefix(Node: Type[SubworkflowDeploymentNode]):
     class SubworkflowNodeDisplay(SubworkflowDeploymentNode[Node]):  # type: ignore[valid-type]
-        node_input_ids_by_name = {"subworkflow_inputs.foo": UUID("74996e96-b7e5-4936-98e3-b88415782944")}
+        node_input_ids_by_name = {"subworkflow_inputs.foo": UUID("aff4f838-577e-44b9-ac5c-6d8213abbb9c")}
 
     return SubworkflowNodeDisplay
 
@@ -55,9 +55,9 @@ def mock_fetch_deployment(mocker):
 @pytest.mark.parametrize(
     ["GetDisplayClass", "expected_input_id"],
     [
-        (_no_display_class, "74996e96-b7e5-4936-98e3-b88415782944"),
-        (_display_class_with_node_input_ids_by_name, "74996e96-b7e5-4936-98e3-b88415782944"),
-        (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "74996e96-b7e5-4936-98e3-b88415782944"),
+        (_no_display_class, "aff4f838-577e-44b9-ac5c-6d8213abbb9c"),
+        (_display_class_with_node_input_ids_by_name, "aff4f838-577e-44b9-ac5c-6d8213abbb9c"),
+        (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "aff4f838-577e-44b9-ac5c-6d8213abbb9c"),
     ],
     ids=[
         "no_display_class",

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_subworkflow_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_subworkflow_deployment_node.py
@@ -1,0 +1,109 @@
+import pytest
+from datetime import datetime
+from uuid import UUID, uuid4
+from typing import Type
+
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes import SubworkflowDeploymentNode
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+
+def _no_display_class(Node: Type[SubworkflowDeploymentNode]):  # type: ignore
+    return None
+
+
+def _display_class_with_node_input_ids_by_name(Node: Type[SubworkflowDeploymentNode]):
+    class SubworkflowNodeDisplay(SubworkflowDeploymentNode[Node]):  # type: ignore[valid-type]
+        node_input_ids_by_name = {"foo": UUID("74996e96-b7e5-4936-98e3-b88415782944")}
+
+    return SubworkflowNodeDisplay
+
+
+def _display_class_with_node_input_ids_by_name_with_inputs_prefix(Node: Type[SubworkflowDeploymentNode]):
+    class SubworkflowNodeDisplay(SubworkflowDeploymentNode[Node]):  # type: ignore[valid-type]
+        node_input_ids_by_name = {"subworkflow_inputs.foo": UUID("74996e96-b7e5-4936-98e3-b88415782944")}
+
+    return SubworkflowNodeDisplay
+
+
+@pytest.fixture
+def mock_fetch_deployment(mocker):
+    # Create a mock deployment response
+    mock_deployment = mocker.Mock(
+        id="test-id",
+        name="test-deployment",
+        label="Test Deployment",
+        status="ACTIVE",
+        environment="DEVELOPMENT",
+        created=datetime.now(),
+        last_deployed_on=datetime.now(),
+        last_deployed_history_item_id=str(uuid4()),
+        input_variables=[],
+        output_variables=[],
+        description="Test deployment description",
+    )
+
+    # Patch the create_vellum_client function to return our mock client
+    mocker.patch(
+        "vellum.client.resources.workflow_deployments.client.WorkflowDeploymentsClient.retrieve",
+        return_value=mock_deployment,
+    )
+
+    return mock_deployment
+
+
+@pytest.mark.parametrize(
+    ["GetDisplayClass", "expected_input_id"],
+    [
+        (_no_display_class, "74996e96-b7e5-4936-98e3-b88415782944"),
+        (_display_class_with_node_input_ids_by_name, "74996e96-b7e5-4936-98e3-b88415782944"),
+        (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "74996e96-b7e5-4936-98e3-b88415782944"),
+    ],
+    ids=[
+        "no_display_class",
+        "display_class_with_node_input_ids_by_name",
+        "display_class_with_node_input_ids_by_name_with_inputs_prefix",
+    ],
+)
+def test_serialize_node__subworkflow_inputs(GetDisplayClass, expected_input_id, mock_fetch_deployment):
+    # GIVEN a deployment subworkflow node with inputs
+    class MySubworkflowDeploymentNode(SubworkflowDeploymentNode):
+        deployment = "DEPLOYMENT"
+        subworkflow_inputs = {"foo": "bar"}
+
+    # AND a workflow with the subworkflow node
+    class Workflow(BaseWorkflow):
+        graph = MySubworkflowDeploymentNode
+
+    # AND a display class
+    GetDisplayClass(MySubworkflowDeploymentNode)
+
+    # WHEN the workflow is serialized
+    workflow_display = get_workflow_display(workflow_class=Workflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    # THEN the node should properly serialize the inputs
+    my_subworkflow_node = next(
+        node
+        for node in serialized_workflow["workflow_raw_data"]["nodes"]
+        if node["id"] == str(MySubworkflowDeploymentNode.__id__)
+    )
+
+    assert my_subworkflow_node["inputs"] == [
+        {
+            "id": expected_input_id,
+            "key": "foo",
+            "value": {
+                "rules": [
+                    {
+                        "type": "CONSTANT_VALUE",
+                        "data": {
+                            "type": "STRING",
+                            "value": "bar",
+                        },
+                    }
+                ],
+                "combinator": "OR",
+            },
+        }
+    ]

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_prompt_deployment_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_prompt_deployment_serialization.py
@@ -101,7 +101,7 @@ def test_serialize_workflow(vellum_client):
         "type": "PROMPT",
         "inputs": [
             {
-                "id": "509cf3d4-db72-483e-897a-0f7f20e70d03",
+                "id": "947d7ead-0fad-4e5f-aa3a-d06029ac94bc",
                 "key": "city",
                 "value": {
                     "combinator": "OR",
@@ -116,7 +116,7 @@ def test_serialize_workflow(vellum_client):
                 },
             },
             {
-                "id": "7d6ec5ac-c582-4153-bd8a-b8794c367420",
+                "id": "3deebdd7-2900-4d8c-93f2-e5b90649ac42",
                 "key": "date",
                 "value": {
                     "combinator": "OR",

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_subworkflow_deployment_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_subworkflow_deployment_serialization.py
@@ -110,7 +110,7 @@ def test_serialize_workflow(vellum_client):
         "type": "SUBWORKFLOW",
         "inputs": [
             {
-                "id": "dade23b9-dab6-4760-9247-da189f1019d2",
+                "id": "be426336-0844-4ebd-8cfe-efef60305b92",
                 "key": "city",
                 "value": {
                     "rules": [
@@ -123,7 +123,7 @@ def test_serialize_workflow(vellum_client):
                 },
             },
             {
-                "id": "8d73270e-2cf9-4146-b053-4780b99857a6",
+                "id": "8a7495b1-a7fc-405f-8ef6-ba05dd3f9e5c",
                 "key": "date",
                 "value": {
                     "rules": [


### PR DESCRIPTION
** related to https://linear.app/vellum/issue/APO-426/customer-workflow-from-evals-are-missing-input-events

adds in the prefix that is needed for lookup