### PR TITLE
Fixing Prompt Deployment Inputs

### DIFF
--- a/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
@@ -7,10 +7,16 @@ import { NodeDefinitionGenerationError } from "src/generators/errors";
 import { BaseSingleFileNode } from "src/generators/nodes/bases/single-file-base";
 import { DeploymentPromptNodeData, PromptNode } from "src/types/vellum";
 
+const INPUTS_PREFIX = "prompt_inputs";
+
 export class PromptDeploymentNode extends BaseSingleFileNode<
   PromptNode,
   PromptDeploymentNodeContext
 > {
+  protected getNodeAttributeNameByNodeInputKey(nodeInputKey: string): string {
+    return `${INPUTS_PREFIX}.${nodeInputKey}`;
+  }
+
   protected getNodeClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 
@@ -66,7 +72,7 @@ export class PromptDeploymentNode extends BaseSingleFileNode<
 
     statements.push(
       python.field({
-        name: "prompt_inputs",
+        name: INPUTS_PREFIX,
         initializer: python.TypeInstantiation.dict(
           Array.from(this.nodeInputsByKey.entries()).map(([key, value]) => ({
             key: python.TypeInstantiation.str(key),

--- a/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
@@ -28,7 +28,9 @@ class BasePromptDeploymentNodeDisplay(BaseNodeDisplay[_PromptDeploymentNodeType]
                     input_name=variable_name,
                     value=variable_value,
                     display_context=display_context,
-                    input_id=self.node_input_ids_by_name.get(f"prompt_inputs.{variable_name}")
+                    input_id=self.node_input_ids_by_name.get(
+                        f"{PromptDeploymentNode.prompt_inputs.name}.{variable_name}"
+                    )
                     or self.node_input_ids_by_name.get(variable_name),
                 )
                 for variable_name, variable_value in prompt_inputs.items()

--- a/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
@@ -28,7 +28,8 @@ class BasePromptDeploymentNodeDisplay(BaseNodeDisplay[_PromptDeploymentNodeType]
                     input_name=variable_name,
                     value=variable_value,
                     display_context=display_context,
-                    input_id=self.node_input_ids_by_name.get(variable_name),
+                    input_id=self.node_input_ids_by_name.get(f"prompt_inputs.{variable_name}")
+                    or self.node_input_ids_by_name.get(variable_name),
                 )
                 for variable_name, variable_value in prompt_inputs.items()
             ]

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_deployment_node.py
@@ -1,0 +1,106 @@
+import pytest
+from datetime import datetime
+from uuid import UUID, uuid4
+from typing import Type
+
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.nodes import PromptDeploymentNode
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+
+def _no_display_class(Node: Type[PromptDeploymentNode]):  # type: ignore
+    return None
+
+
+def _display_class_with_node_input_ids_by_name(Node: Type[PromptDeploymentNode]):
+    class PromptDeploymentNodeDisplay(PromptDeploymentNode[Node]):  # type: ignore[valid-type]
+        node_input_ids_by_name = {"foo": UUID("6037747a-1d35-4094-b363-4369fc92c5d4")}
+
+    return PromptDeploymentNodeDisplay
+
+
+def _display_class_with_node_input_ids_by_name_with_inputs_prefix(Node: Type[PromptDeploymentNode]):
+    class PromptDeploymentNodeDisplay(PromptDeploymentNode[Node]):  # type: ignore[valid-type]
+        node_input_ids_by_name = {"prompt_inputs.foo": UUID("6037747a-1d35-4094-b363-4369fc92c5d4")}
+
+    return PromptDeploymentNodeDisplay
+
+
+@pytest.fixture
+def mock_fetch_deployment(mocker):
+    # Create a mock deployment response
+    mock_deployment = mocker.Mock(
+        id="test-id",
+        name="test-deployment",
+        label="Test Deployment",
+        status="ACTIVE",
+        environment="DEVELOPMENT",
+        created=datetime.now(),
+        last_deployed_on=datetime.now(),
+        last_deployed_history_item_id=str(uuid4()),
+        input_variables=[],
+        output_variables=[],
+        description="Test deployment description",
+    )
+
+    # Patch the create_vellum_client function to return our mock client
+    mocker.patch("vellum.client.resources.deployments.client.DeploymentsClient.retrieve", return_value=mock_deployment)
+    return mock_deployment
+
+
+@pytest.mark.parametrize(
+    ["GetDisplayClass", "expected_input_id"],
+    [
+        (_no_display_class, "6037747a-1d35-4094-b363-4369fc92c5d4"),
+        (_display_class_with_node_input_ids_by_name, "6037747a-1d35-4094-b363-4369fc92c5d4"),
+        (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "6037747a-1d35-4094-b363-4369fc92c5d4"),
+    ],
+    ids=[
+        "no_display_class",
+        "display_class_with_node_input_ids_by_name",
+        "display_class_with_node_input_ids_by_name_with_inputs_prefix",
+    ],
+)
+def test_serialize_node__prompt_inputs(GetDisplayClass, expected_input_id, mock_fetch_deployment):
+    # GIVEN a prompt node with inputs
+    class MyPromptDeploymentNode(PromptDeploymentNode):
+        deployment = "DEPLOYMENT"
+        prompt_inputs = {"foo": "bar"}
+        ml_model_fallbacks = None
+
+    # AND a workflow with the prompt node
+    class Workflow(BaseWorkflow):
+        graph = MyPromptDeploymentNode
+
+    # AND a display class
+    GetDisplayClass(MyPromptDeploymentNode)
+
+    # WHEN the workflow is serialized
+    workflow_display = get_workflow_display(workflow_class=Workflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    # THEN the node should properly serialize the inputs
+    my_prompt_node = next(
+        node
+        for node in serialized_workflow["workflow_raw_data"]["nodes"]
+        if node["id"] == str(MyPromptDeploymentNode.__id__)
+    )
+
+    assert my_prompt_node["inputs"] == [
+        {
+            "id": expected_input_id,
+            "key": "foo",
+            "value": {
+                "rules": [
+                    {
+                        "type": "CONSTANT_VALUE",
+                        "data": {
+                            "type": "STRING",
+                            "value": "bar",
+                        },
+                    }
+                ],
+                "combinator": "OR",
+            },
+        }
+    ]

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_prompt_deployment_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_prompt_deployment_serialization.py
@@ -101,7 +101,7 @@ def test_serialize_workflow(vellum_client):
         "type": "PROMPT",
         "inputs": [
             {
-                "id": "509cf3d4-db72-483e-897a-0f7f20e70d03",
+                "id": "947d7ead-0fad-4e5f-aa3a-d06029ac94bc",
                 "key": "city",
                 "value": {
                     "combinator": "OR",
@@ -116,7 +116,7 @@ def test_serialize_workflow(vellum_client):
                 },
             },
             {
-                "id": "7d6ec5ac-c582-4153-bd8a-b8794c367420",
+                "id": "3deebdd7-2900-4d8c-93f2-e5b90649ac42",
                 "key": "date",
                 "value": {
                     "combinator": "OR",


### PR DESCRIPTION
** related to https://linear.app/vellum/issue/APO-426/customer-workflow-from-evals-are-missing-input-events

adding in the required prefix for prompt - inputs