### PR TITLE
Enforce attribute ordering based on class definition

### DIFF
--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -237,8 +237,12 @@ def test_serialize_node__stacked():
     exec_config = workflow_display.serialize()
 
     # THEN the workflow display is created successfully
+    assert isinstance(exec_config["workflow_raw_data"], dict)
+    assert isinstance(exec_config["workflow_raw_data"]["nodes"], list)
     inner_stacked_generic_node = [
-        node for node in exec_config["workflow_raw_data"]["nodes"] if node["type"] == "GENERIC"
+        node
+        for node in exec_config["workflow_raw_data"]["nodes"]
+        if isinstance(node, dict) and node["type"] == "GENERIC"
     ][0]
     assert not DeepDiff(
         {

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_adornments_serialization.py
@@ -237,124 +237,82 @@ def test_serialize_node__stacked():
     exec_config = workflow_display.serialize()
 
     # THEN the workflow display is created successfully
+    inner_stacked_generic_node = [
+        node for node in exec_config["workflow_raw_data"]["nodes"] if node["type"] == "GENERIC"
+    ][0]
     assert not DeepDiff(
         {
-            "workflow_raw_data": {
-                "nodes": [
-                    {
-                        "id": "c14c1c9b-a7a4-4d2c-84fb-c940cfb09525",
-                        "type": "ENTRYPOINT",
-                        "inputs": [],
-                        "data": {
-                            "label": "Entrypoint Node",
-                            "source_handle_id": "51a5eb25-af14-4bee-9ced-d2aa534ea8e9",
-                        },
-                        "display_data": {"position": {"x": 0.0, "y": 0.0}},
-                        "base": None,
-                        "definition": None,
-                    },
-                    {
-                        "id": "074833b0-e142-4bbc-8dec-209a35e178a3",
-                        "label": "test_serialize_node__stacked.<locals>.InnerStackedGenericNode",
-                        "type": "GENERIC",
-                        "display_data": {"position": {"x": 0.0, "y": 0.0}},
-                        "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
-                        "definition": {
-                            "name": "InnerStackedGenericNode",
-                            "module": [
-                                "vellum_ee",
-                                "workflows",
-                                "display",
-                                "tests",
-                                "workflow_serialization",
-                                "generic_nodes",
-                                "test_adornments_serialization",
-                            ],
-                        },
-                        "trigger": {
-                            "id": "6e4af17f-bbee-4777-b10d-af042cd6e16a",
-                            "merge_behavior": "AWAIT_ATTRIBUTES",
-                        },
-                        "ports": [{"id": "408cd5fb-3a3e-4eb2-9889-61111bd6a129", "name": "default", "type": "DEFAULT"}],
-                        "adornments": [
-                            {
-                                "id": "5be7d260-74f7-4734-b31b-a46a94539586",
-                                "label": "RetryNode",
-                                "base": {
-                                    "name": "RetryNode",
-                                    "module": ["vellum", "workflows", "nodes", "core", "retry_node", "node"],
-                                },
-                                "attributes": [
-                                    {
-                                        "id": "c91782e3-140f-4938-9c23-d2a7b85dcdd8",
-                                        "name": "retry_on_error_code",
-                                        "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
-                                    },
-                                    {
-                                        "id": "f388e93b-8c68-4f54-8577-bbd0c9091557",
-                                        "name": "max_attempts",
-                                        "value": {"type": "CONSTANT_VALUE", "value": {"type": "NUMBER", "value": 5}},
-                                    },
-                                    {
-                                        "id": "8a07dc58-3fed-41d4-8ca6-31ee0bb86c61",
-                                        "name": "delay",
-                                        "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
-                                    },
-                                    {
-                                        "id": "73a02e62-4535-4e1f-97b5-1264ca8b1d71",
-                                        "name": "retry_on_condition",
-                                        "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
-                                    },
-                                ],
-                            },
-                            {
-                                "id": "3344083c-a32c-4a32-920b-0fb5093448fa",
-                                "label": "TryNode",
-                                "base": {
-                                    "name": "TryNode",
-                                    "module": ["vellum", "workflows", "nodes", "core", "try_node", "node"],
-                                },
-                                "attributes": [
-                                    {
-                                        "id": "ab2fbab0-e2a0-419b-b1ef-ce11ecf11e90",
-                                        "name": "on_error_code",
-                                        "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
-                                    }
-                                ],
-                            },
-                        ],
-                        "attributes": [],
-                        "outputs": [],
-                    },
+            "id": "074833b0-e142-4bbc-8dec-209a35e178a3",
+            "label": "test_serialize_node__stacked.<locals>.InnerStackedGenericNode",
+            "type": "GENERIC",
+            "display_data": {"position": {"x": 0.0, "y": 0.0}},
+            "base": {"name": "BaseNode", "module": ["vellum", "workflows", "nodes", "bases", "base"]},
+            "definition": {
+                "name": "InnerStackedGenericNode",
+                "module": [
+                    "vellum_ee",
+                    "workflows",
+                    "display",
+                    "tests",
+                    "workflow_serialization",
+                    "generic_nodes",
+                    "test_adornments_serialization",
                 ],
-                "edges": [
-                    {
-                        "id": "e8bd50dd-37a0-49b0-8b7b-f1dd8eb478b9",
-                        "source_node_id": "c14c1c9b-a7a4-4d2c-84fb-c940cfb09525",
-                        "source_handle_id": "51a5eb25-af14-4bee-9ced-d2aa534ea8e9",
-                        "target_node_id": "074833b0-e142-4bbc-8dec-209a35e178a3",
-                        "target_handle_id": "6e4af17f-bbee-4777-b10d-af042cd6e16a",
-                        "type": "DEFAULT",
-                    }
-                ],
-                "display_data": {"viewport": {"x": 0.0, "y": 0.0, "zoom": 1.0}},
-                "definition": {
-                    "name": "StackedWorkflow",
-                    "module": [
-                        "vellum_ee",
-                        "workflows",
-                        "display",
-                        "tests",
-                        "workflow_serialization",
-                        "generic_nodes",
-                        "test_adornments_serialization",
+            },
+            "trigger": {
+                "id": "6e4af17f-bbee-4777-b10d-af042cd6e16a",
+                "merge_behavior": "AWAIT_ATTRIBUTES",
+            },
+            "ports": [{"id": "408cd5fb-3a3e-4eb2-9889-61111bd6a129", "name": "default", "type": "DEFAULT"}],
+            "adornments": [
+                {
+                    "id": "5be7d260-74f7-4734-b31b-a46a94539586",
+                    "label": "RetryNode",
+                    "base": {
+                        "name": "RetryNode",
+                        "module": ["vellum", "workflows", "nodes", "core", "retry_node", "node"],
+                    },
+                    "attributes": [
+                        {
+                            "id": "f388e93b-8c68-4f54-8577-bbd0c9091557",
+                            "name": "max_attempts",
+                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "NUMBER", "value": 5.0}},
+                        },
+                        {
+                            "id": "8a07dc58-3fed-41d4-8ca6-31ee0bb86c61",
+                            "name": "delay",
+                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                        },
+                        {
+                            "id": "c91782e3-140f-4938-9c23-d2a7b85dcdd8",
+                            "name": "retry_on_error_code",
+                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                        },
+                        {
+                            "id": "73a02e62-4535-4e1f-97b5-1264ca8b1d71",
+                            "name": "retry_on_condition",
+                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                        },
                     ],
                 },
-            },
-            "input_variables": [],
-            "state_variables": [],
-            "output_variables": [],
+                {
+                    "id": "3344083c-a32c-4a32-920b-0fb5093448fa",
+                    "label": "TryNode",
+                    "base": {
+                        "name": "TryNode",
+                        "module": ["vellum", "workflows", "nodes", "core", "try_node", "node"],
+                    },
+                    "attributes": [
+                        {
+                            "id": "ab2fbab0-e2a0-419b-b1ef-ce11ecf11e90",
+                            "name": "on_error_code",
+                            "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+                        }
+                    ],
+                },
+            ],
+            "attributes": [],
+            "outputs": [],
         },
-        exec_config,
-        ignore_order=True,
+        inner_stacked_generic_node,
     )

--- a/src/vellum/workflows/nodes/bases/tests/test_base_node.py
+++ b/src/vellum/workflows/nodes/bases/tests/test_base_node.py
@@ -283,3 +283,23 @@ def test_node_outputs__inherits_instance():
     assert foo_output.instance is undefined
     assert isinstance(bar_output, OutputReference)
     assert bar_output.instance == "hello"
+
+
+def test_base_node__iterate_over_attributes__preserves_order():
+    # GIVEN a node with two attributes
+    class MyNode(BaseNode):
+        foo = "foo"
+        bar = "bar"
+
+    # AND a node that inherits from MyNode
+    class InheritedNode(MyNode):
+        baz = "baz"
+        qux = "qux"
+        quux = "quux"
+
+    # WHEN we iterate over the attributes, multiple times
+    for i in range(10):
+        attribute_names = [attr.name for attr in InheritedNode]
+
+        # THEN the attributes are in the correct order
+        assert attribute_names == ["baz", "qux", "quux", "foo", "bar"], f"Iteration {i} failed"

--- a/src/vellum/workflows/types/tests/test_utils.py
+++ b/src/vellum/workflows/types/tests/test_utils.py
@@ -83,9 +83,9 @@ def test_infer_types(cls, attr_name, expected_type):
 @pytest.mark.parametrize(
     "cls, expected_attr_names",
     [
-        (ExampleClass, {"alpha", "beta", "gamma", "epsilon", "zeta", "eta", "kappa", "mu"}),
-        (ExampleGenericClass, {"delta"}),
-        (ExampleInheritedClass, {"alpha", "beta", "gamma", "epsilon", "zeta", "eta", "theta", "kappa", "mu"}),
+        (ExampleClass, ["beta", "epsilon", "alpha", "gamma", "zeta", "eta", "kappa", "mu"]),
+        (ExampleGenericClass, ["delta"]),
+        (ExampleInheritedClass, ["theta", "beta", "epsilon", "alpha", "gamma", "zeta", "eta", "kappa", "mu"]),
     ],
 )
 def test_class_attr_names(cls, expected_attr_names):


### PR DESCRIPTION
We want to enforce the ordering of attributes so that during serialization, we don't get false positives in changes. This improves our main helper for collecting class attributes to maintain order