### PR TITLE
Add URL support to workspace push

### DIFF
--- a/ee/vellum_cli/config.py
+++ b/ee/vellum_cli/config.py
@@ -16,10 +16,15 @@ PYPROJECT_TOML_PATH = "pyproject.toml"
 
 class WorkspaceConfig(UniversalBaseModel):
     name: str
-    api_key: str
+    api_key: str = "VELLUM_API_KEY"
+    api_url: Optional[str] = None
 
     def merge(self, other: "WorkspaceConfig") -> "WorkspaceConfig":
-        return WorkspaceConfig(name=self.name or other.name, api_key=self.api_key or other.api_key)
+        return WorkspaceConfig(
+            name=self.name or other.name,
+            api_key=self.api_key or other.api_key,
+            api_url=self.api_url or other.api_url,
+        )
 
 
 DEFAULT_WORKSPACE_CONFIG = WorkspaceConfig(name="default", api_key="VELLUM_API_KEY")

--- a/ee/vellum_cli/push.py
+++ b/ee/vellum_cli/push.py
@@ -97,6 +97,7 @@ def push_command(
 
     client = create_vellum_client(
         api_key=api_key,
+        api_url=workspace_config.api_url,
     )
     sys.path.insert(0, os.getcwd())
 

--- a/src/vellum/workflows/vellum_client.py
+++ b/src/vellum/workflows/vellum_client.py
@@ -1,22 +1,34 @@
 import os
-from typing import Optional
+from typing import List, Optional
 
 from vellum import Vellum, VellumEnvironment
 
 
-def create_vellum_client(api_key: Optional[str] = None) -> Vellum:
+def create_vellum_client(api_key: Optional[str] = None, api_url: Optional[str] = None) -> Vellum:
     if api_key is None:
         api_key = os.getenv("VELLUM_API_KEY", default="")
 
     return Vellum(
         api_key=api_key,
-        environment=create_vellum_environment(),
+        environment=create_vellum_environment(api_url),
     )
 
 
-def create_vellum_environment() -> VellumEnvironment:
+def create_vellum_environment(api_url: Optional[str] = None) -> VellumEnvironment:
     return VellumEnvironment(
-        default=os.getenv("VELLUM_DEFAULT_API_URL", os.getenv("VELLUM_API_URL", "https://api.vellum.ai")),
-        documents=os.getenv("VELLUM_DOCUMENTS_API_URL", os.getenv("VELLUM_API_URL", "https://documents.vellum.ai")),
-        predict=os.getenv("VELLUM_PREDICT_API_URL", os.getenv("VELLUM_API_URL", "https://predict.vellum.ai")),
+        default=_resolve_env([api_url, "VELLUM_DEFAULT_API_URL", "VELLUM_API_URL"], "https://api.vellum.ai"),
+        documents=_resolve_env([api_url, "VELLUM_DOCUMENTS_API_URL", "VELLUM_API_URL"], "https://documents.vellum.ai"),
+        predict=_resolve_env([api_url, "VELLUM_PREDICT_API_URL", "VELLUM_API_URL"], "https://predict.vellum.ai"),
     )
+
+
+def _resolve_env(names: List[Optional[str]], default: Optional[str] = None) -> str:
+    for name in names:
+        if not name:
+            continue
+
+        value = os.getenv(name)
+        if value:
+            return value
+
+    return default

--- a/src/vellum/workflows/vellum_client.py
+++ b/src/vellum/workflows/vellum_client.py
@@ -22,7 +22,7 @@ def create_vellum_environment(api_url: Optional[str] = None) -> VellumEnvironmen
     )
 
 
-def _resolve_env(names: List[Optional[str]], default: Optional[str] = None) -> str:
+def _resolve_env(names: List[Optional[str]], default: str = "") -> str:
     for name in names:
         if not name:
             continue


### PR DESCRIPTION
Allows us to simply do `vellum workflows push my.workflow --workspace staging` for pushing to workspaces in other installations