### PR TITLE
support pushing workflows that have lazy references from nested nodes

### DIFF
--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -107,7 +107,7 @@ def get_child_descriptor(value: LazyReference, display_context: "WorkflowDisplay
             )
 
         node_class_name = ".".join(reference_parts[:-2])
-        for node in display_context.node_displays.keys():
+        for node in display_context.global_node_displays.keys():
             if node.__name__ == node_class_name:
                 return getattr(node.Outputs, output_name)
 

--- a/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/tests/test_workflow_display.py
@@ -378,7 +378,7 @@ def test_serialize_workflow__terminal_node_mismatches_workflow_output_name():
 def test_serialize_workflow__nested_lazy_reference():
     # GIVEN an inner node that references the output of an outer node
     class InnerNode(BaseNode):
-        foo = LazyReference("OuterNode.Outputs.bar")
+        foo = LazyReference[str]("OuterNode.Outputs.bar")
 
         class Outputs(BaseNode.Outputs):
             foo = "foo"
@@ -408,7 +408,7 @@ def test_serialize_workflow__nested_lazy_reference():
 
     # WHEN we serialize it
     workflow_display = get_workflow_display(workflow_class=MyWorkflow)
-    data = workflow_display.serialize()
+    data: dict = workflow_display.serialize()
 
     # THEN it should have properly serialized the lazy reference
     subworkflow_node = next(


### PR DESCRIPTION
Discovered while trying to push the function call example to VPC