### PR TITLE
Thread parent display context through to node input serialization

### DIFF
--- a/ee/vellum_cli/push.py
+++ b/ee/vellum_cli/push.py
@@ -106,6 +106,7 @@ def push_command(
     workflow = BaseWorkflow.load_from_module(workflow_config.module)
     workflow_display = get_workflow_display(
         workflow_class=workflow,
+        client=client,
         dry_run=dry_run or False,
     )
     exec_config = workflow_display.serialize()

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, Tuple, Type
 
+from vellum.client import Vellum as VellumClient
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.events.workflow import WorkflowEventDisplayContext  # noqa: F401
 from vellum.workflows.nodes import BaseNode
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference, StateValueReference, WorkflowInputReference
+from vellum.workflows.vellum_client import create_vellum_client
 from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
@@ -35,6 +37,7 @@ PortDisplays = Dict[Port, PortDisplay]
 
 @dataclass
 class WorkflowDisplayContext:
+    client: VellumClient = field(default_factory=create_vellum_client)
     workflow_display_class: Type["BaseWorkflowDisplay"] = field(default_factory=get_default_workflow_display_class)
     workflow_display: WorkflowMetaDisplay = field(default_factory=lambda: WorkflowMetaDisplay.get_default(BaseWorkflow))
     workflow_input_displays: WorkflowInputsDisplays = field(default_factory=dict)

--- a/ee/vellum_ee/workflows/display/utils/vellum.py
+++ b/ee/vellum_ee/workflows/display/utils/vellum.py
@@ -13,7 +13,6 @@ from vellum.workflows.references.lazy import LazyReference
 from vellum.workflows.references.node import NodeReference
 from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
-from vellum.workflows.vellum_client import create_vellum_client
 from vellum_ee.workflows.display.utils.exceptions import UnsupportedSerializationException
 from vellum_ee.workflows.display.utils.expressions import get_child_descriptor
 
@@ -118,8 +117,7 @@ def create_node_input_value_pointer_rule(
         workflow_input_display = display_context.global_workflow_input_displays[value]
         return InputVariablePointer(data=InputVariableData(input_variable_id=str(workflow_input_display.id)))
     if isinstance(value, VellumSecretReference):
-        vellum_client = create_vellum_client()
-        workspace_secret = vellum_client.workspace_secrets.retrieve(
+        workspace_secret = display_context.client.workspace_secrets.retrieve(
             id=value.name,
         )
         return WorkspaceSecretPointer(

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -22,6 +22,7 @@ from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.types.utils import get_original_base
 from vellum.workflows.utils.uuids import uuid4_from_hash
+from vellum.workflows.vellum_client import create_vellum_client
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
     EntrypointDisplay,
@@ -89,13 +90,14 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
         dry_run: bool = False,
     ):
         self._parent_display_context = parent_display_context
-        self._client = client
+        self._client = client or (
+            # propagate the client from the parent display context if it is not provided
+            self._parent_display_context.client
+            if self._parent_display_context
+            else create_vellum_client()
+        )
         self._errors: List[Exception] = []
         self._dry_run = dry_run
-
-        # propagate the client from the parent display context if it is not provided
-        if self._parent_display_context and not self._client:
-            self._client = self._parent_display_context.client
 
     def serialize(self) -> JsonObject:
         input_variables: JsonArray = []

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -6,6 +6,7 @@ import logging
 from uuid import UUID
 from typing import Any, Dict, ForwardRef, Generic, Iterator, List, Optional, Tuple, Type, TypeVar, Union, cast, get_args
 
+from vellum.client import Vellum as VellumClient
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.constants import undefined
 from vellum.workflows.descriptors.base import BaseDescriptor
@@ -84,11 +85,17 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
         self,
         *,
         parent_display_context: Optional[WorkflowDisplayContext] = None,
+        client: Optional[VellumClient] = None,
         dry_run: bool = False,
     ):
         self._parent_display_context = parent_display_context
+        self._client = client
         self._errors: List[Exception] = []
         self._dry_run = dry_run
+
+        # propagate the client from the parent display context if it is not provided
+        if self._parent_display_context and not self._client:
+            self._client = self._parent_display_context.client
 
     def serialize(self) -> JsonObject:
         input_variables: JsonArray = []
@@ -494,6 +501,7 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
             )
 
         return WorkflowDisplayContext(
+            client=self._client,
             workflow_display=workflow_meta_display,
             workflow_input_displays=workflow_input_displays,
             global_workflow_input_displays=global_workflow_input_displays,

--- a/ee/vellum_ee/workflows/display/workflows/get_vellum_workflow_display_class.py
+++ b/ee/vellum_ee/workflows/display/workflows/get_vellum_workflow_display_class.py
@@ -1,6 +1,7 @@
 import types
 from typing import TYPE_CHECKING, Generic, Optional, Type, TypeVar
 
+from vellum.client import Vellum as VellumClient
 from vellum.workflows.types.generics import WorkflowType
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
 from vellum_ee.workflows.display.utils.registry import get_from_workflow_display_registry
@@ -35,6 +36,7 @@ def get_workflow_display(
     *,
     workflow_class: Type[WorkflowType],
     parent_display_context: Optional[WorkflowDisplayContext] = None,
+    client: Optional[VellumClient] = None,
     dry_run: bool = False,
     # DEPRECATED: The following arguments will be removed in 0.15.0
     root_workflow_class: Optional[Type[WorkflowType]] = None,
@@ -42,5 +44,6 @@ def get_workflow_display(
 ) -> "BaseWorkflowDisplay":
     return _get_workflow_display_class(workflow_class=workflow_class)(
         parent_display_context=parent_display_context,
+        client=client,
         dry_run=dry_run,
     )


### PR DESCRIPTION
Discovered this issue trying to push a workflow to a VPC environment. The client that we reinitialize during serialization is not the same as the one that we use to invoke the push API.

This PR focuses on just one use case, workspace secret serialization in legacy node inputs. The next PR will apply the same sort of threading to our other vellum client use cases