### PR TITLE
pipe vellum client through to deployment node serialization

### DIFF
--- a/ee/vellum_cli/tests/test_push.py
+++ b/ee/vellum_cli/tests/test_push.py
@@ -554,8 +554,43 @@ class ExampleWorkflow(BaseWorkflow):
     graph = StartNode
 """,
         },
+        {
+            "nodes/start_node.py": """\
+from vellum.workflows.nodes import PromptDeploymentNode
+
+class StartNode(PromptDeploymentNode):
+    deployment = "my-deployment"
+""",
+            "workflow.py": """\
+from vellum.workflows import BaseWorkflow
+from .nodes.start_node import StartNode
+
+class ExampleWorkflow(BaseWorkflow):
+    graph = StartNode
+""",
+        },
+        {
+            "nodes/start_node.py": """\
+from vellum.workflows.nodes import SubworkflowDeploymentNode
+
+class StartNode(SubworkflowDeploymentNode):
+    deployment = "my-deployment"
+""",
+            "workflow.py": """\
+from vellum.workflows import BaseWorkflow
+from .nodes.start_node import StartNode
+
+class ExampleWorkflow(BaseWorkflow):
+    graph = StartNode
+""",
+        },
     ],
-    ids=["base_case", "with_secret_reference"],
+    ids=[
+        "base_case",
+        "with_secret_reference",
+        "with_prompt_deployment",
+        "with_subworkflow_deployment",
+    ],
 )
 def test_push__workspace_option__uses_different_api_key(mock_module, vellum_client_class, file_data):
     # GIVEN a single workflow configured

--- a/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
@@ -4,7 +4,6 @@ from typing import Generic, Optional, TypeVar, cast
 from vellum.workflows.nodes.displayable.prompt_deployment_node import PromptDeploymentNode
 from vellum.workflows.references import OutputReference
 from vellum.workflows.types.core import JsonObject
-from vellum.workflows.vellum_client import create_vellum_client
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
@@ -42,10 +41,7 @@ class BasePromptDeploymentNodeDisplay(BaseNodeDisplay[_PromptDeploymentNodeType]
         _, output_display = display_context.global_node_output_displays[cast(OutputReference, node.Outputs.text)]
         _, array_display = display_context.global_node_output_displays[cast(OutputReference, node.Outputs.results)]
 
-        # TODO: Pass through the name instead of retrieving the ID
-        # https://app.shortcut.com/vellum/story/4702
-        vellum_client = create_vellum_client()
-        deployment = vellum_client.deployments.retrieve(
+        deployment = display_context.client.deployments.retrieve(
             id=str(raise_if_descriptor(node.deployment)),
         )
         ml_model_fallbacks = raise_if_descriptor(node.ml_model_fallbacks)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
@@ -3,7 +3,6 @@ from typing import Generic, Optional, TypeVar
 
 from vellum.workflows.nodes import SubworkflowDeploymentNode
 from vellum.workflows.types.core import JsonObject
-from vellum.workflows.vellum_client import create_vellum_client
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
@@ -37,10 +36,7 @@ class BaseSubworkflowDeploymentNodeDisplay(
             for variable_name, variable_value in subworkflow_inputs.items()
         ]
 
-        # TODO: Pass through the name instead of retrieving the ID
-        # https://app.shortcut.com/vellum/story/4702
-        vellum_client = create_vellum_client()
-        deployment = vellum_client.workflow_deployments.retrieve(
+        deployment = display_context.client.workflow_deployments.retrieve(
             id=str(raise_if_descriptor(node.deployment)),
         )
 

--- a/src/vellum/workflows/nodes/displayable/tests/test_text_prompt_deployment_node.py
+++ b/src/vellum/workflows/nodes/displayable/tests/test_text_prompt_deployment_node.py
@@ -9,7 +9,6 @@ from vellum import (
     PromptOutput,
     StringVellumValue,
 )
-from vellum.workflows.constants import OMIT
 from vellum.workflows.inputs import BaseInputs
 from vellum.workflows.nodes import PromptDeploymentNode
 from vellum.workflows.state import BaseState
@@ -66,14 +65,14 @@ def test_text_prompt_deployment_node__basic(vellum_client):
 
     # AND we should have made the expected call to stream the prompt execution
     vellum_client.execute_prompt_stream.assert_called_once_with(
-        expand_meta=OMIT,
-        expand_raw=OMIT,
-        external_id=OMIT,
+        expand_meta=None,
+        expand_raw=None,
+        external_id=None,
         inputs=[],
-        metadata=OMIT,
+        metadata=None,
         prompt_deployment_id=None,
         prompt_deployment_name="my-deployment",
-        raw_overrides=OMIT,
+        raw_overrides=None,
         release_tag="LATEST",
         request_options={
             "additional_body_parameters": {"execution_context": {"parent_context": None, "trace_id": mock.ANY}}

--- a/tests/workflows/basic_prompt_deployment/tests/test_workflow.py
+++ b/tests/workflows/basic_prompt_deployment/tests/test_workflow.py
@@ -14,7 +14,7 @@ from vellum import (
     StringVellumValue,
 )
 from vellum.client.core.api_error import ApiError
-from vellum.workflows.constants import LATEST_RELEASE_TAG, OMIT
+from vellum.workflows.constants import LATEST_RELEASE_TAG
 from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.events.types import VellumCodeResourceDefinition, WorkflowParentContext
 from vellum.workflows.workflows.event_filters import root_workflow_event_filter
@@ -74,11 +74,11 @@ def test_run_workflow__happy_path(vellum_client):
         prompt_deployment_id=None,
         prompt_deployment_name="example_prompt_deployment",
         release_tag=LATEST_RELEASE_TAG,
-        external_id=OMIT,
-        expand_meta=OMIT,
-        raw_overrides=OMIT,
-        expand_raw=OMIT,
-        metadata=OMIT,
+        external_id=None,
+        expand_meta=None,
+        raw_overrides=None,
+        expand_raw=None,
+        metadata=None,
         request_options=ANY,
     )
 
@@ -140,11 +140,11 @@ def test_run_workflow_return_only_function_call__happy_path(vellum_client):
         prompt_deployment_id=None,
         prompt_deployment_name="example_prompt_deployment",
         release_tag=LATEST_RELEASE_TAG,
-        external_id=OMIT,
-        expand_meta=OMIT,
-        raw_overrides=OMIT,
-        expand_raw=OMIT,
-        metadata=OMIT,
+        external_id=None,
+        expand_meta=None,
+        raw_overrides=None,
+        expand_raw=None,
+        metadata=None,
         request_options=ANY,
     )
 

--- a/tests/workflows/basic_text_prompt_deployment/tests/test_workflow.py
+++ b/tests/workflows/basic_text_prompt_deployment/tests/test_workflow.py
@@ -13,7 +13,7 @@ from vellum import (
     StringInputRequest,
     StringVellumValue,
 )
-from vellum.workflows.constants import LATEST_RELEASE_TAG, OMIT
+from vellum.workflows.constants import LATEST_RELEASE_TAG
 from vellum.workflows.events.types import VellumCodeResourceDefinition
 
 from tests.workflows.basic_text_prompt_deployment.workflow import (
@@ -71,11 +71,11 @@ def test_run_workflow__happy_path(vellum_client):
         prompt_deployment_id=None,
         prompt_deployment_name="example_prompt_deployment",
         release_tag=LATEST_RELEASE_TAG,
-        external_id=OMIT,
-        expand_meta=OMIT,
-        raw_overrides=OMIT,
-        expand_raw=OMIT,
-        metadata=OMIT,
+        external_id=None,
+        expand_meta=None,
+        raw_overrides=None,
+        expand_raw=None,
+        metadata=None,
         request_options=ANY,
     )
 


### PR DESCRIPTION
Same PR as this [one](https://github.com/vellum-ai/vellum-python-sdks/pull/1499), but for prompt/subworkflow deployment nodes