### PR TITLE
Inherit references during node outputs codegen

### DIFF
--- a/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/__snapshots__/generic-node.test.ts.snap
@@ -40,6 +40,18 @@ class MyCustomNode(BaseNode):
 "
 `;
 
+exports[`GenericNode > basic with a JSON output > getNodeFile 1`] = `
+"from typing import Any
+
+from vellum.workflows.nodes import BaseNode
+
+
+class MyCustomNode(BaseNode):
+    class Outputs(BaseNode.Outputs):
+        output: Any
+"
+`;
+
 exports[`GenericNode > basic with adornments > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 

--- a/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-nodes/generic-node.test.ts
@@ -474,4 +474,36 @@ describe("GenericNode", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });
+
+  describe("basic with a JSON output", () => {
+    it("getNodeFile", async () => {
+      const nodeData = genericNodeFactory({
+        nodeAttributes: [],
+        nodeOutputs: [
+          {
+            id: uuidv4(),
+            name: "output",
+            type: "JSON",
+            value: undefined,
+          },
+        ],
+        nodeTrigger: {
+          id: uuidv4(),
+          mergeBehavior: "AWAIT_ATTRIBUTES",
+        },
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as GenericNodeContext;
+
+      node = new GenericNode({
+        workflowContext,
+        nodeContext,
+      });
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });

--- a/ee/codegen/src/generators/node-outputs.ts
+++ b/ee/codegen/src/generators/node-outputs.ts
@@ -70,6 +70,7 @@ export class NodeOutputs extends AstNode {
       clazz.addField(field);
     });
 
+    this.inheritReferences(clazz);
     return clazz;
   }
 


### PR DESCRIPTION
Without this inherit references, workflows failed to initialize due to python reference error