### PR TITLE
Make deprecated error node data fields optional throughout codegen/serialization

### DIFF
--- a/ee/codegen/src/context/node-context/error-node.ts
+++ b/ee/codegen/src/context/node-context/error-node.ts
@@ -11,15 +11,11 @@ export class ErrorNodeContext extends BaseNodeContext<ErrorNode> {
   isCore = true;
 
   getNodeOutputNamesById(): Record<string, string> {
-    return {
-      [this.nodeData.data.errorOutputId]: "error",
-    };
+    return {};
   }
 
   getNodeOutputTypesById(): Record<string, VellumVariableType> {
-    return {
-      [this.nodeData.data.errorOutputId]: "ERROR",
-    };
+    return {};
   }
 
   createPortContexts(): PortContext[] {

--- a/ee/codegen/src/generators/nodes/error-node.ts
+++ b/ee/codegen/src/generators/nodes/error-node.ts
@@ -29,12 +29,15 @@ export class ErrorNode extends BaseSingleFileNode<
   getNodeDisplayClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 
-    statements.push(
-      python.field({
-        name: "name",
-        initializer: python.TypeInstantiation.str(this.nodeData.data.name),
-      })
-    );
+    if (this.nodeData.data.name) {
+      // DEPRECATED: To be removed in the 0.15.0 release
+      statements.push(
+        python.field({
+          name: "name",
+          initializer: python.TypeInstantiation.str(this.nodeData.data.name),
+        })
+      );
+    }
 
     statements.push(
       python.field({
@@ -49,14 +52,17 @@ export class ErrorNode extends BaseSingleFileNode<
       })
     );
 
-    statements.push(
-      python.field({
-        name: "error_output_id",
-        initializer: python.TypeInstantiation.uuid(
-          this.nodeData.data.errorOutputId
-        ),
-      })
-    );
+    if (this.nodeData.data.errorOutputId) {
+      // DEPRECATED: To be removed in the 0.15.0 release
+      statements.push(
+        python.field({
+          name: "error_output_id",
+          initializer: python.TypeInstantiation.uuid(
+            this.nodeData.data.errorOutputId
+          ),
+        })
+      );
+    }
 
     statements.push(
       python.field({

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -1928,10 +1928,10 @@ export const ErrorNodeSerializer: ObjectSchema<
   id: stringSchema(),
   data: objectSchema({
     label: stringSchema(),
-    name: stringSchema(),
+    name: stringSchema().optional(),
     targetHandleId: propertySchema("target_handle_id", stringSchema()),
     errorSourceInputId: propertySchema("error_source_input_id", stringSchema()),
-    errorOutputId: propertySchema("error_output_id", stringSchema()),
+    errorOutputId: propertySchema("error_output_id", stringSchema().optional()),
   }),
   inputs: listSchema(NodeInputSerializer),
   displayData: propertySchema(
@@ -1948,10 +1948,10 @@ export declare namespace ErrorNodeSerializer {
   interface Raw extends BaseDisplayableWorkflowNodeSerializer.Raw {
     data: {
       label: string;
-      name: string;
+      name?: string | null;
       target_handle_id: string;
       error_source_input_id: string;
-      error_output_id: string;
+      error_output_id?: string | null;
     };
   }
 }

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -640,10 +640,10 @@ export interface NoteNode extends BaseDisplayableWorkflowNode {
 
 export interface ErrorNodeData {
   label: string;
-  name: string;
+  name?: string;
   targetHandleId: string;
   errorSourceInputId: string;
-  errorOutputId: string;
+  errorOutputId?: string;
 }
 
 export interface ErrorNode extends BaseDisplayableWorkflowNode {

--- a/ee/codegen_integration/fixtures/simple_error_node/code/display/nodes/error_node.py
+++ b/ee/codegen_integration/fixtures/simple_error_node/code/display/nodes/error_node.py
@@ -7,10 +7,8 @@ from ...nodes.error_node import ErrorNode
 
 
 class ErrorNodeDisplay(BaseErrorNodeDisplay[ErrorNode]):
-    name = "error-node"
     node_id = UUID("e5ff9360-a29c-437b-a9c1-05fc52df2834")
     label = "Error Node"
-    error_output_id = UUID("77839b3c-fe1c-4dcb-9c61-2fac827f729b")
     target_handle_id = UUID("370d712d-3369-424e-bcf7-f4da1aef3928")
     node_input_ids_by_name = {"error_source_input_id": UUID("f3a0d8b9-7772-4db6-8e28-f49f8c4d9e2a")}
     display_data = NodeDisplayData(

--- a/ee/codegen_integration/fixtures/simple_error_node/display_data/simple_error_node.json
+++ b/ee/codegen_integration/fixtures/simple_error_node/display_data/simple_error_node.json
@@ -24,11 +24,9 @@
         "id": "e5ff9360-a29c-437b-a9c1-05fc52df2834",
         "type": "ERROR",
         "data": {
-          "name": "error-node",
           "label": "Error Node",
           "target_handle_id": "370d712d-3369-424e-bcf7-f4da1aef3928",
-          "error_source_input_id": "f3a0d8b9-7772-4db6-8e28-f49f8c4d9e2a",
-          "error_output_id": "77839b3c-fe1c-4dcb-9c61-2fac827f729b"
+          "error_source_input_id": "f3a0d8b9-7772-4db6-8e28-f49f8c4d9e2a"
         },
         "inputs": [
           {

--- a/ee/vellum_ee/workflows/display/nodes/vellum/error_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/error_node.py
@@ -1,9 +1,8 @@
 from uuid import UUID
-from typing import ClassVar, Generic, Optional, TypeVar
+from typing import Any, ClassVar, Generic, Optional, TypeVar
 
 from vellum.workflows.nodes import ErrorNode
 from vellum.workflows.types.core import JsonObject
-from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
@@ -16,7 +15,7 @@ class BaseErrorNodeDisplay(BaseNodeDisplay[_ErrorNodeType], Generic[_ErrorNodeTy
     # DEPRECATED: Remove in 0.15.0 once removed from the vellum-side
     error_output_id: ClassVar[Optional[UUID]] = None
     # DEPRECATED: Remove in 0.15.0 once removed from the vellum-side
-    name: ClassVar[str] = "error-node"
+    name: ClassVar[Optional[str]] = None
 
     def serialize(self, display_context: WorkflowDisplayContext, **kwargs) -> JsonObject:
         node_id = self.node_id
@@ -38,22 +37,24 @@ class BaseErrorNodeDisplay(BaseNodeDisplay[_ErrorNodeType], Generic[_ErrorNodeTy
             for variable_name, variable_value in input_values_by_name.items()
         ]
 
-        return {
+        node_data: dict[str, Any] = {
             "id": str(node_id),
             "type": "ERROR",
             "inputs": [node_input.dict() for node_input in node_inputs],
             "data": {
-                "name": self.name,
                 "label": self.label,
                 "target_handle_id": str(self.get_target_handle_id()),
                 "error_source_input_id": str(error_source_input_id),
-                "error_output_id": (
-                    str(self.error_output_id)
-                    if self.error_output_id
-                    else str(uuid4_from_hash(f"{node_id}|error_output_id"))
-                ),
             },
             "display_data": self.get_display_data().dict(),
             "base": self.get_base().dict(),
             "definition": self.get_definition().dict(),
         }
+
+        if self.name:
+            node_data["data"]["name"] = self.name
+
+        if self.error_output_id:
+            node_data["data"]["error_output_id"] = str(self.error_output_id)
+
+        return node_data

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_error_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_error_node.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, cast
 
 from vellum.client.types.vellum_error import VellumError
-from vellum.utils.uuid import is_valid_uuid
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.nodes.core.error_node.node import ErrorNode
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
@@ -44,5 +43,5 @@ def test_error_node_display__serialize_with_vellum_error() -> None:
     }
 
     # AND we serialize the DEPRECATED fields
-    assert is_valid_uuid(serialized_node["data"]["error_output_id"])
-    assert serialized_node["data"]["name"] == "error-node"
+    assert "error_output_id" not in serialized_node["data"]
+    assert "name" not in serialized_node["data"]

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_error_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_error_node_serialization.py
@@ -101,11 +101,9 @@ def test_serialize_workflow():
                 }
             ],
             "data": {
-                "name": "error-node",
                 "label": "Fail Node",
                 "target_handle_id": "70c19f1c-309c-4a5d-ba65-664c0bb2fedf",
                 "error_source_input_id": "None",
-                "error_output_id": "d3dbe464-d63e-40fb-ba9c-eb28410105f2",
             },
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {


### PR DESCRIPTION
Now that we're making this fields on the Vellum side optional, we could do so here before we eventually remove altogether