### PR TITLE
Serialize constant error inputs

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -9,6 +9,7 @@ from typing import (
     ForwardRef,
     Generic,
     Optional,
+    Set,
     Tuple,
     Type,
     TypeVar,
@@ -24,6 +25,7 @@ from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.utils import get_unadorned_node, get_wrapped_node
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference
+from vellum.workflows.references.node import NodeReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.types.generics import NodeType
 from vellum.workflows.types.utils import get_original_base
@@ -98,12 +100,18 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
     # Default values set by the metaclass
     output_display: Dict[OutputReference, NodeOutputDisplay]
     port_displays: Dict[Port, PortDisplayOverrides] = {}
-    node_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
     attribute_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
+    # START: Attributes for backwards compatible serialization
     # Used to explicitly set the target handle id for a node
     # Once all nodes are Generic Nodes, we may replace this with a trigger_id or trigger attribute
     target_handle_id: ClassVar[Optional[UUID]] = None
+    # Used to explicitly set the input ids for each node input
+    node_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
+    # Used by each class extending BaseNodeDisplay to specify which attributes are meant to be serialized
+    # as the former `"inputs"` field
+    __serializable_inputs__: Set[NodeReference] = set()
+    # END: Attributes for backwards compatible serialization
 
     def serialize(self, display_context: "WorkflowDisplayContext", **kwargs: Any) -> JsonObject:
         node = self._node

--- a/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
+++ b/ee/vellum_ee/workflows/display/nodes/get_node_display_class.py
@@ -2,7 +2,6 @@ import types
 from uuid import UUID
 from typing import TYPE_CHECKING, Any, Dict, Generic, Type, TypeVar
 
-from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.types.generics import NodeType
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.utils.registry import get_from_node_display_registry
@@ -30,14 +29,14 @@ def get_node_display_class(node_class: Type[NodeType]) -> Type["BaseNodeDisplay"
                 node_input_ids_by_name.update(_get_node_input_ids_by_ref(f"{path}.{key}", value))
             return node_input_ids_by_name
 
-        if isinstance(inst, BaseDescriptor):
-            return {path: uuid4_from_hash(f"{node_class.__id__}|{path}")}
-
-        return {}
+        return {path: uuid4_from_hash(f"{node_class.__id__}|{path}")}
 
     def exec_body(ns: Dict):
         node_input_ids_by_name: Dict[str, UUID] = {}
         for ref in node_class:
+            if ref not in base_node_display_class.__serializable_inputs__:
+                continue
+
             node_input_ids_by_name.update(_get_node_input_ids_by_ref(ref.name, ref.instance))
 
         if node_input_ids_by_name:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
@@ -20,6 +20,17 @@ class BaseAPINodeDisplay(BaseNodeDisplay[_APINodeType], Generic[_APINodeType]):
     # A mapping between node input keys and their ids for inputs representing additional header values
     additional_header_value_input_ids: ClassVar[Optional[Dict[str, UUID]]] = None
 
+    __serializable_inputs__ = {
+        APINode.url,
+        APINode.method,
+        APINode.json,
+        APINode.headers,
+        APINode.api_key_header_key,
+        APINode.api_key_header_value,
+        APINode.bearer_token_value,
+        APINode.authorization_type,
+    }
+
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs: Any
     ) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
@@ -18,6 +18,11 @@ class BaseCodeExecutionNodeDisplay(BaseNodeDisplay[_CodeExecutionNodeType], Gene
     output_id: ClassVar[Optional[UUID]] = None
     log_output_id: ClassVar[Optional[UUID]] = None
 
+    __serializable_inputs__ = {
+        CodeExecutionNode.code,
+        CodeExecutionNode.code_inputs,
+    }
+
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
     ) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/guardrail_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/guardrail_node.py
@@ -12,6 +12,8 @@ _GuardrailNodeType = TypeVar("_GuardrailNodeType", bound=GuardrailNode)
 
 
 class BaseGuardrailNodeDisplay(BaseNodeDisplay[_GuardrailNodeType], Generic[_GuardrailNodeType]):
+    __serializable_inputs__ = {GuardrailNode.metric_inputs}
+
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
     ) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
@@ -18,6 +18,8 @@ _InlinePromptNodeType = TypeVar("_InlinePromptNodeType", bound=InlinePromptNode)
 
 
 class BaseInlinePromptNodeDisplay(BaseNodeDisplay[_InlinePromptNodeType], Generic[_InlinePromptNodeType]):
+    __serializable_inputs__ = {InlinePromptNode.prompt_inputs}
+
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
     ) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_subworkflow_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_subworkflow_node.py
@@ -21,6 +21,8 @@ class BaseInlineSubworkflowNodeDisplay(
 ):
     workflow_input_ids_by_name: ClassVar[Dict[str, UUID]] = {}
 
+    __serializable_inputs__ = {InlineSubworkflowNode.subworkflow_inputs}
+
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
     ) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
@@ -13,6 +13,8 @@ _MapNodeType = TypeVar("_MapNodeType", bound=MapNode)
 
 
 class BaseMapNodeDisplay(BaseAdornmentNodeDisplay[_MapNodeType], Generic[_MapNodeType]):
+    __serializable_inputs__ = {MapNode.items}  # type: ignore[misc]
+
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
     ) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/prompt_deployment_node.py
@@ -13,6 +13,8 @@ _PromptDeploymentNodeType = TypeVar("_PromptDeploymentNodeType", bound=PromptDep
 
 
 class BasePromptDeploymentNodeDisplay(BaseNodeDisplay[_PromptDeploymentNodeType], Generic[_PromptDeploymentNodeType]):
+    __serializable_inputs__ = {PromptDeploymentNode.prompt_inputs}
+
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
     ) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/search_node.py
@@ -32,6 +32,14 @@ class BaseSearchNodeDisplay(BaseNodeDisplay[_SearchNodeType], Generic[_SearchNod
     # A mapping between the id of the operand (e.g. "lhs_variable_id" or "rhs_variable_id") and the id of the node input
     # that the operand is pointing to.
     metadata_filter_input_id_by_operand_id: Dict[UUID, UUID] = {}
+    __serializable_inputs__ = {
+        SearchNode.query,
+        SearchNode.document_index,
+        SearchNode.weights,
+        SearchNode.chunk_separator,
+        SearchNode.limit,
+        SearchNode.result_merging,
+    }
 
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs

--- a/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/subworkflow_deployment_node.py
@@ -14,6 +14,7 @@ _SubworkflowDeploymentNodeType = TypeVar("_SubworkflowDeploymentNodeType", bound
 class BaseSubworkflowDeploymentNodeDisplay(
     BaseNodeDisplay[_SubworkflowDeploymentNodeType], Generic[_SubworkflowDeploymentNodeType]
 ):
+    __serializable_inputs__ = {SubworkflowDeploymentNode.subworkflow_inputs}
 
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs

--- a/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/templating_node.py
@@ -15,6 +15,8 @@ TEMPLATE_INPUT_NAME = TemplatingNode.template.name
 
 
 class BaseTemplatingNodeDisplay(BaseNodeDisplay[_TemplatingNodeType], Generic[_TemplatingNodeType]):
+    __serializable_inputs__ = {TemplatingNode.inputs}
+
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **kwargs
     ) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_code_execution_node.py
@@ -29,7 +29,7 @@ def _display_class_with_node_input_ids_by_name_with_inputs_prefix(Node: Type[Cod
 @pytest.mark.parametrize(
     ["GetDisplayClass", "expected_input_id"],
     [
-        (_no_display_class, "e3cdb222-324e-4ad1-abb2-bdd7881b3a0e"),
+        (_no_display_class, "a5dbe403-0b00-4df6-b8f7-ed5f7794b003"),
         (_display_class_with_node_input_ids_by_name, "fba6a4d5-835a-4e99-afb7-f6a4aed15110"),
         (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "fba6a4d5-835a-4e99-afb7-f6a4aed15110"),
     ],

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_deployment_node.py
@@ -5,6 +5,7 @@ from typing import Type
 
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.nodes import PromptDeploymentNode
+from vellum_ee.workflows.display.nodes.vellum.prompt_deployment_node import BasePromptDeploymentNodeDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 
@@ -13,14 +14,14 @@ def _no_display_class(Node: Type[PromptDeploymentNode]):  # type: ignore
 
 
 def _display_class_with_node_input_ids_by_name(Node: Type[PromptDeploymentNode]):
-    class PromptDeploymentNodeDisplay(PromptDeploymentNode[Node]):  # type: ignore[valid-type]
+    class PromptDeploymentNodeDisplay(BasePromptDeploymentNodeDisplay[Node]):  # type: ignore[valid-type]
         node_input_ids_by_name = {"foo": UUID("6037747a-1d35-4094-b363-4369fc92c5d4")}
 
     return PromptDeploymentNodeDisplay
 
 
 def _display_class_with_node_input_ids_by_name_with_inputs_prefix(Node: Type[PromptDeploymentNode]):
-    class PromptDeploymentNodeDisplay(PromptDeploymentNode[Node]):  # type: ignore[valid-type]
+    class PromptDeploymentNodeDisplay(BasePromptDeploymentNodeDisplay[Node]):  # type: ignore[valid-type]
         node_input_ids_by_name = {"prompt_inputs.foo": UUID("6037747a-1d35-4094-b363-4369fc92c5d4")}
 
     return PromptDeploymentNodeDisplay
@@ -51,7 +52,7 @@ def mock_fetch_deployment(mocker):
 @pytest.mark.parametrize(
     ["GetDisplayClass", "expected_input_id"],
     [
-        (_no_display_class, "6037747a-1d35-4094-b363-4369fc92c5d4"),
+        (_no_display_class, "016187d6-2830-4256-a61d-e52f9bf6355e"),
         (_display_class_with_node_input_ids_by_name, "6037747a-1d35-4094-b363-4369fc92c5d4"),
         (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "6037747a-1d35-4094-b363-4369fc92c5d4"),
     ],

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_node.py
@@ -78,7 +78,7 @@ def _display_class_with_node_input_ids_by_name_with_inputs_prefix(Node: Type[Inl
 @pytest.mark.parametrize(
     ["GetDisplayClass", "expected_input_id"],
     [
-        (_no_display_class, "8aa4ce7f-5eb8-41b7-abd0-ea2b40c8fb88"),
+        (_no_display_class, "9b036991-67ff-4cd0-a4d7-b4ed581e8b6d"),
         (_display_class_with_node_input_ids_by_name, "fba6a4d5-835a-4e99-afb7-f6a4aed15110"),
         (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "fba6a4d5-835a-4e99-afb7-f6a4aed15110"),
     ],
@@ -165,7 +165,7 @@ def test_serialize_node__prompt_inputs__state_reference():
             },
         },
         {
-            "id": "3750feb9-5d5c-4150-b62d-a9924f466888",
+            "id": "b83c40f7-0159-442f-af03-e80870363c52",
             "key": "bar",
             "value": {
                 "rules": [

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_subworkflow_deployment_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_subworkflow_deployment_node.py
@@ -4,7 +4,8 @@ from uuid import UUID, uuid4
 from typing import Type
 
 from vellum.workflows import BaseWorkflow
-from vellum.workflows.nodes import SubworkflowDeploymentNode
+from vellum.workflows.nodes.displayable.subworkflow_deployment_node.node import SubworkflowDeploymentNode
+from vellum_ee.workflows.display.nodes.vellum.subworkflow_deployment_node import BaseSubworkflowDeploymentNodeDisplay
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 
@@ -13,14 +14,14 @@ def _no_display_class(Node: Type[SubworkflowDeploymentNode]):  # type: ignore
 
 
 def _display_class_with_node_input_ids_by_name(Node: Type[SubworkflowDeploymentNode]):
-    class SubworkflowNodeDisplay(SubworkflowDeploymentNode[Node]):  # type: ignore[valid-type]
+    class SubworkflowNodeDisplay(BaseSubworkflowDeploymentNodeDisplay[Node]):  # type: ignore[valid-type]
         node_input_ids_by_name = {"foo": UUID("aff4f838-577e-44b9-ac5c-6d8213abbb9c")}
 
     return SubworkflowNodeDisplay
 
 
 def _display_class_with_node_input_ids_by_name_with_inputs_prefix(Node: Type[SubworkflowDeploymentNode]):
-    class SubworkflowNodeDisplay(SubworkflowDeploymentNode[Node]):  # type: ignore[valid-type]
+    class SubworkflowNodeDisplay(BaseSubworkflowDeploymentNodeDisplay[Node]):  # type: ignore[valid-type]
         node_input_ids_by_name = {"subworkflow_inputs.foo": UUID("aff4f838-577e-44b9-ac5c-6d8213abbb9c")}
 
     return SubworkflowNodeDisplay
@@ -55,7 +56,7 @@ def mock_fetch_deployment(mocker):
 @pytest.mark.parametrize(
     ["GetDisplayClass", "expected_input_id"],
     [
-        (_no_display_class, "aff4f838-577e-44b9-ac5c-6d8213abbb9c"),
+        (_no_display_class, "394132c2-1817-455e-9f3f-b7073eb63a2b"),
         (_display_class_with_node_input_ids_by_name, "aff4f838-577e-44b9-ac5c-6d8213abbb9c"),
         (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "aff4f838-577e-44b9-ac5c-6d8213abbb9c"),
     ],

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_templating_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_templating_node.py
@@ -29,7 +29,7 @@ def _display_class_with_node_input_ids_by_name_with_inputs_prefix(Node: Type[Tem
 @pytest.mark.parametrize(
     ["GetDisplayClass", "expected_input_id"],
     [
-        (_no_display_class, "d3519cec-590c-416d-8eb1-96051aed5ddd"),
+        (_no_display_class, "91d982a9-6c41-42ac-aff9-7b623c450a55"),
         (_display_class_with_node_input_ids_by_name, "fba6a4d5-835a-4e99-afb7-f6a4aed15110"),
         (_display_class_with_node_input_ids_by_name_with_inputs_prefix, "fba6a4d5-835a-4e99-afb7-f6a4aed15110"),
     ],

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_error_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_error_node_serialization.py
@@ -87,7 +87,7 @@ def test_serialize_workflow():
             "type": "ERROR",
             "inputs": [
                 {
-                    "id": "690d825f-6ffd-493e-8141-c86d384e6150",
+                    "id": "8e4c8d76-2e02-4d7e-a7bf-d71af392dc49",
                     "key": "error_source_input_id",
                     "value": {
                         "rules": [
@@ -103,7 +103,7 @@ def test_serialize_workflow():
             "data": {
                 "label": "Fail Node",
                 "target_handle_id": "70c19f1c-309c-4a5d-ba65-664c0bb2fedf",
-                "error_source_input_id": "None",
+                "error_source_input_id": "8e4c8d76-2e02-4d7e-a7bf-d71af392dc49",
             },
             "display_data": {"position": {"x": 0.0, "y": 0.0}},
             "base": {

--- a/src/vellum/workflows/nodes/core/error_node/node.py
+++ b/src/vellum/workflows/nodes/core/error_node/node.py
@@ -13,7 +13,7 @@ class ErrorNode(BaseNode):
     error: Union[str, VellumError] - The error to raise.
     """
 
-    error: ClassVar[Union[str, WorkflowError, VellumError]] = ""
+    error: ClassVar[Union[str, WorkflowError, VellumError]]
 
     def run(self) -> BaseNode.Outputs:
         if isinstance(self.error, str):

--- a/src/vellum/workflows/nodes/core/error_node/node.py
+++ b/src/vellum/workflows/nodes/core/error_node/node.py
@@ -13,7 +13,7 @@ class ErrorNode(BaseNode):
     error: Union[str, VellumError] - The error to raise.
     """
 
-    error: ClassVar[Union[str, WorkflowError, VellumError]]
+    error: ClassVar[Union[str, WorkflowError, VellumError]] = ""
 
     def run(self) -> BaseNode.Outputs:
         if isinstance(self.error, str):


### PR DESCRIPTION
This PR started as a resolution to a serialization problem I saw during the customer demo. The error node had a constant string value, but after running `vellum push`, it was missing. This revealed an issue with inferred node input serialization of constants in general.

This PR introduces `__serializable_inputs__` on BaseNodeDisplay. The goal is not just to solve this issue, but to allow us to continue generalizing all of our node input displays in the future