### PR TITLE
Add --workspace command to docker push

### DIFF
--- a/ee/vellum_cli/__init__.py
+++ b/ee/vellum_cli/__init__.py
@@ -354,9 +354,10 @@ def images() -> None:
     help="Tags the provided image inside of Vellum's repo. "
     "This field does not push multiple local tags of the passed in image.",
 )
-def image_push(image: str, tag: Optional[List[str]] = None) -> None:
+@click.option("--workspace", type=str, help="The specific Workspace config to use when pushing")
+def image_push(image: str, tag: Optional[List[str]] = None, workspace: Optional[str] = None) -> None:
     """Push Docker image to Vellum"""
-    image_push_command(image, tag)
+    image_push_command(image, tag, workspace)
 
 
 @workflows.command(name="init")

--- a/ee/vellum_cli/image_push.py
+++ b/ee/vellum_cli/image_push.py
@@ -10,7 +10,7 @@ from docker import DockerClient
 from dotenv import load_dotenv
 
 from vellum.workflows.vellum_client import create_vellum_client, create_vellum_environment
-from vellum_cli.config import load_vellum_cli_config
+from vellum_cli.config import DEFAULT_WORKSPACE_CONFIG, load_vellum_cli_config
 from vellum_cli.logger import load_cli_logger
 
 _SUPPORTED_ARCHITECTURE = "amd64"
@@ -20,9 +20,7 @@ def image_push_command(image: str, tags: Optional[List[str]] = None, workspace: 
     load_dotenv(dotenv_path=os.path.join(os.getcwd(), ".env"))
     logger = load_cli_logger()
     config = load_vellum_cli_config()
-    workspace_config = next((w for w in config.workspaces if w.name == workspace), None)
-    if not workspace_config:
-        raise ValueError(f"Workspace {workspace} not found")
+    workspace_config = next((w for w in config.workspaces if w.name == workspace), DEFAULT_WORKSPACE_CONFIG)
 
     api_key = os.getenv(workspace_config.api_key, None)
     if not api_key:

--- a/ee/vellum_cli/tests/test_image_push.py
+++ b/ee/vellum_cli/tests/test_image_push.py
@@ -31,6 +31,7 @@ def mock_temp_dir() -> Generator[str, None, None]:
 def test_image_push__self_hosted_happy_path(mock_docker_from_env, mock_run, vellum_client, monkeypatch):
     # GIVEN a self hosted vellum api URL env var
     monkeypatch.setenv("VELLUM_API_URL", "mycompany.api.com")
+    monkeypatch.setenv("VELLUM_API_KEY", "123456abcdef")
 
     # Mock Docker client
     mock_docker_client = MagicMock()

--- a/ee/vellum_cli/tests/test_image_push.py
+++ b/ee/vellum_cli/tests/test_image_push.py
@@ -1,9 +1,29 @@
+import pytest
+import json
+import os
+import shutil
 import subprocess
+import tempfile
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
+from typing import Generator
 
 from click.testing import CliRunner
+from httpx import Response
 
 from vellum_cli import main as cli_main
+
+
+@pytest.fixture
+def mock_temp_dir() -> Generator[str, None, None]:
+    current_dir = os.getcwd()
+    temp_dir = tempfile.mkdtemp()
+    os.chdir(temp_dir)
+
+    yield temp_dir
+
+    os.chdir(current_dir)
+    shutil.rmtree(temp_dir)
 
 
 @patch("subprocess.run")
@@ -33,6 +53,94 @@ def test_image_push__self_hosted_happy_path(mock_docker_from_env, mock_run, vell
 
     # AND gives the success message
     assert "Image successfully pushed" in result.output
+
+
+@patch("subprocess.run")
+@patch("docker.from_env")
+def test_image_push__self_hosted_happy_path__workspace_option(
+    mock_docker_from_env, mock_run, mock_httpx_transport, mock_temp_dir
+):
+    # GIVEN a workspace config with a new env for url
+    with open(os.path.join(mock_temp_dir, "vellum.lock.json"), "w") as f:
+        f.write(
+            json.dumps(
+                {
+                    "workspaces": [
+                        {
+                            "name": "my_workspace",
+                            "api_url": "MY_WORKSPACE_VELLUM_API_URL",
+                            "api_key": "MY_WORKSPACE_VELLUM_API_KEY",
+                        }
+                    ]
+                }
+            )
+        )
+
+    # AND a .env file with the workspace api key and url
+    with open(os.path.join(mock_temp_dir, ".env"), "w") as f:
+        f.write(
+            "VELLUM_API_KEY=123456abcdef\n"
+            "VELLUM_API_URL=https://api.vellum.ai\n"
+            "MY_WORKSPACE_VELLUM_API_KEY=789012ghijkl\n"
+            "MY_WORKSPACE_VELLUM_API_URL=https://api.vellum.mycompany.ai\n"
+        )
+
+    # AND the Docker client returns the correct response
+    mock_docker_client = MagicMock()
+    mock_docker_from_env.return_value = mock_docker_client
+
+    mock_run.side_effect = [
+        subprocess.CompletedProcess(
+            args="", returncode=0, stdout=b'{"manifests": [{"platform": {"architecture": "amd64"}}]}'
+        ),
+        subprocess.CompletedProcess(args="", returncode=0, stdout=b"sha256:hellosha"),
+    ]
+
+    # AND the vellum client returns the correct response for
+    mock_httpx_transport.handle_request.side_effect = [
+        # First call to get the docker service token
+        Response(
+            status_code=200,
+            text=json.dumps(
+                {
+                    "access_token": "345678mnopqr",
+                    "organization_id": str(uuid4()),
+                    "repository": "myrepo.net",
+                }
+            ),
+        ),
+        # Second call to push the image
+        Response(
+            status_code=200,
+            text=json.dumps(
+                {
+                    "id": str(uuid4()),
+                    "name": "myrepo.net/myimage",
+                    "visibility": "PRIVATE",
+                    "created": "2021-01-01T00:00:00Z",
+                    "modified": "2021-01-01T00:00:00Z",
+                    "repository": "myrepo.net",
+                    "sha": "sha256:hellosha",
+                    "tags": [],
+                }
+            ),
+        ),
+    ]
+
+    # WHEN the user runs the image push command
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["image", "push", "myrepo.net/myimage:latest", "--workspace", "my_workspace"])
+
+    # THEN the command exits successfully
+    assert result.exit_code == 0, (result.output, str(result.exception))
+
+    # AND gives the success message
+    assert "Image successfully pushed" in result.output
+
+    # AND the vellum client was called with the correct api key and url
+    request = mock_httpx_transport.handle_request.call_args[0][0]
+    assert request.headers["X-API-KEY"] == "789012ghijkl", result.stdout
+    assert str(request.url) == "https://api.vellum.mycompany.ai/v1/container-images/push"
 
 
 @patch("subprocess.run")


### PR DESCRIPTION
Allows the user to specify which `--workspace` they'd like to push a docker image to.