### PR TITLE
Remove the inputs AST arg from the Workflo AST

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -434,7 +434,6 @@ class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
         entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None),
         display_data=WorkflowDisplayData(viewport=WorkflowDisplayDataViewport(x=0, y=0, zoom=0)),
     )
-    inputs_display = {}
     entrypoint_displays = {
         TemplatingNode: EntrypointDisplay(id=UUID("entry"), edge_display=EdgeDisplay(id=UUID("edge_1")))
     }

--- a/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow.test.ts.snap
@@ -2,9 +2,12 @@
 
 exports[`Workflow > write > should generate correct code when there are input variables 1`] = `
 "from vellum.workflows import BaseWorkflow
+from vellum.workflows.state import BaseState
+
+from .inputs import Inputs
 
 
-class TestWorkflow(BaseWorkflow):
+class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
     pass
 "
 `;

--- a/ee/codegen/src/__test__/unused-graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/unused-graph-attribute.test.ts
@@ -51,10 +51,8 @@ describe("Workflow", () => {
         })
       );
 
-      const inputs = codegen.inputs({ workflowContext });
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowFile().write(writer);

--- a/ee/codegen/src/__test__/workflow.test.ts
+++ b/ee/codegen/src/__test__/workflow.test.ts
@@ -53,10 +53,19 @@ describe("Workflow", () => {
 
   describe("write", () => {
     it("should generate correct code when there are input variables", async () => {
-      const inputs = codegen.inputs({ workflowContext });
+      const workflowContext = workflowContextFactory();
+      workflowContext.addInputVariableContext(
+        inputVariableContextFactory({
+          inputVariableData: {
+            id: "input-variable-id",
+            key: "query",
+            type: "STRING",
+          },
+          workflowContext,
+        })
+      );
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -64,10 +73,8 @@ describe("Workflow", () => {
     });
 
     it("should generate correct code when there are no input variables", async () => {
-      const inputs = codegen.inputs({ workflowContext });
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -86,8 +93,6 @@ describe("Workflow", () => {
         })
       );
 
-      const inputs = codegen.inputs({ workflowContext });
-
       workflowContext.addOutputVariableContext(
         new OutputVariableContext({
           outputVariableData: {
@@ -104,7 +109,6 @@ describe("Workflow", () => {
 
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -150,8 +154,6 @@ describe("Workflow", () => {
         })
       );
 
-      const inputs = codegen.inputs({ workflowContext });
-
       await createNodeContext({
         workflowContext: workflowContext,
         nodeData: searchNodeData,
@@ -159,7 +161,6 @@ describe("Workflow", () => {
 
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -216,10 +217,8 @@ describe("Workflow", () => {
         nodeData: templatingNodeData2,
       });
 
-      const inputs = codegen.inputs({ workflowContext });
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -264,10 +263,8 @@ describe("Workflow", () => {
         nodeData: templatingNodeData1,
       });
 
-      const inputs = codegen.inputs({ workflowContext });
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -335,10 +332,8 @@ describe("Workflow", () => {
         nodeData: topNode,
       });
 
-      const inputs = codegen.inputs({ workflowContext });
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -356,8 +351,6 @@ describe("Workflow", () => {
           workflowContext,
         })
       );
-
-      const inputs = codegen.inputs({ workflowContext });
 
       workflowContext.addOutputVariableContext(
         new OutputVariableContext({
@@ -385,7 +378,6 @@ describe("Workflow", () => {
 
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -410,10 +402,8 @@ describe("Workflow", () => {
           workflowContext,
         })
       );
-      const inputs = codegen.inputs({ workflowContext });
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowDisplayFile().write(writer);
@@ -432,8 +422,6 @@ describe("Workflow", () => {
           workflowContext,
         })
       );
-
-      const inputs = codegen.inputs({ workflowContext });
 
       workflowContext.addOutputVariableContext(
         new OutputVariableContext({
@@ -462,7 +450,6 @@ describe("Workflow", () => {
 
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowFile().write(writer);
@@ -485,7 +472,6 @@ describe("Workflow", () => {
           edges: [],
         },
       });
-      const inputs = codegen.inputs({ workflowContext });
       await createNodeContext({
         workflowContext,
         nodeData: terminalNode,
@@ -518,7 +504,6 @@ describe("Workflow", () => {
 
       const workflow = codegen.workflow({
         workflowContext,
-        inputs,
       });
 
       workflow.getWorkflowFile().write(writer);

--- a/ee/codegen/src/context/input-variable-context.ts
+++ b/ee/codegen/src/context/input-variable-context.ts
@@ -1,5 +1,5 @@
 import { isEmpty, isNil } from "lodash";
-import { VellumVariable } from "vellum-ai/api/types";
+import { CodeResourceDefinition, VellumVariable } from "vellum-ai/api/types";
 
 import { WorkflowContext } from "src/context/workflow-context";
 import {
@@ -18,7 +18,7 @@ export declare namespace InputVariableContext {
 export class InputVariableContext {
   private readonly workflowContext: WorkflowContext;
   private readonly inputVariableData: VellumVariable;
-  public readonly modulePath: string[];
+  public readonly definition: CodeResourceDefinition;
 
   public readonly name: string;
 
@@ -28,7 +28,10 @@ export class InputVariableContext {
   }: InputVariableContext.Args) {
     this.workflowContext = workflowContext;
     this.inputVariableData = inputVariableData;
-    this.modulePath = getGeneratedInputsModulePath(workflowContext);
+    this.definition = {
+      name: "Inputs",
+      module: getGeneratedInputsModulePath(workflowContext),
+    };
 
     this.name = this.generateSanitizedInputVariableName();
   }

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 
 import { VellumEnvironmentUrls } from "vellum-ai";
-import { WorkspaceSecretRead } from "vellum-ai/api";
+import { CodeResourceDefinition, WorkspaceSecretRead } from "vellum-ai/api";
 import { MlModels } from "vellum-ai/api/resources/mlModels/client/Client";
 import { WorkspaceSecrets as WorkspaceSecretsClient } from "vellum-ai/api/resources/workspaceSecrets/client/Client";
 
@@ -60,6 +60,7 @@ export declare namespace WorkflowContext {
     vellumApiKey: string;
     vellumApiEnvironment?: VellumEnvironmentUrls;
     workflowRawData: WorkflowRawData;
+    inputsClassDefinition?: CodeResourceDefinition;
     strict: boolean;
     disableFormatting: boolean;
     classNames?: Set<string>;

--- a/ee/codegen/src/generators/inputs.ts
+++ b/ee/codegen/src/generators/inputs.ts
@@ -53,7 +53,7 @@ export class Inputs extends BasePersistedFile {
     const inputVariables = Array.from(
       [...inputVariableContextsById.values()].filter((inputVariableContext) => {
         return isEqual(
-          inputVariableContext.modulePath.slice(0, -1),
+          inputVariableContext.definition.module.slice(0, -1),
           this.workflowContext.modulePath.slice(0, -1)
         );
       })

--- a/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/input-variable-pointer.ts
+++ b/ee/codegen/src/generators/node-inputs/node-input-value-pointer-rules/input-variable-pointer.ts
@@ -25,8 +25,8 @@ export class InputVariablePointerRule extends BaseNodeInputValuePointerRule<Inpu
     }
 
     return python.reference({
-      name: "Inputs",
-      modulePath: inputVariableContext.modulePath,
+      name: inputVariableContext.definition.name,
+      modulePath: inputVariableContext.definition.module,
       attribute: [inputVariableContext.name],
     });
   }

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-input-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-input-reference.ts
@@ -23,8 +23,8 @@ export class WorkflowInputReference extends BaseNodeInputWorkflowReference<Workf
       return python.TypeInstantiation.none();
     }
     return python.reference({
-      name: "Inputs",
-      modulePath: inputVariableContext.modulePath,
+      name: inputVariableContext.definition.name,
+      modulePath: inputVariableContext.definition.module,
       attribute: [inputVariableContext.name],
     });
   }

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -426,7 +426,6 @@ ${errors.slice(0, 3).map((err) => {
 
     const workflow = codegen.workflow({
       workflowContext: this.workflowContext,
-      inputs,
       displayData: this.workflowVersionExecConfig.workflowRawData.displayData,
     });
 

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/workflow.py
@@ -19,7 +19,6 @@ class SubworkflowNodeWorkflowDisplay(BaseWorkflowDisplay[SubworkflowNodeWorkflow
             viewport=WorkflowDisplayDataViewport(x=-1196.2209238684252, y=58.34576651524276, zoom=0.8182365497236056)
         ),
     )
-    inputs_display = {}
     entrypoint_displays = {
         SearchNode: EntrypointDisplay(
             id=UUID("c48f318d-4d87-44da-be54-0ecf537608f6"),

--- a/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_merge_node/code/display/workflow.py
@@ -22,7 +22,6 @@ class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
             viewport=WorkflowDisplayDataViewport(x=-799.056805115941, y=229.9501405115533, zoom=0.5596719538849867)
         ),
     )
-    inputs_display = {}
     entrypoint_displays = {
         TemplatingNode2: EntrypointDisplay(
             id=UUID("b8b9eb69-4af1-4953-b576-aa59eb138696"),

--- a/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/simple_templating_node/code/display/workflow.py
@@ -19,7 +19,6 @@ class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
             viewport=WorkflowDisplayDataViewport(x=-992.7774269608426, y=-82.38774859214823, zoom=0.6534253694599966)
         ),
     )
-    inputs_display = {}
     entrypoint_displays = {
         TemplatingNode: EntrypointDisplay(
             id=UUID("6b52893a-e649-434d-aedd-e8ad73d78dce"),


### PR DESCRIPTION
Before adding support for Generics and Display for Workflow State, I wanted to first clean up how we thread through the workflow input AST. This allows us to not complicate the interface of a Workflow AST further when we introduce support for `State`