### PR TITLE
Support serialization of legacy nodes when they have custom ports

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -260,10 +260,15 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
 
     def get_source_handle_id(self, port_displays: Dict[Port, PortDisplay]) -> UUID:
         unadorned_node = get_unadorned_node(self._node)
-        default_port = unadorned_node.Ports.default
+        default_port = next((port for port in unadorned_node.Ports if port.default), None)
+        if default_port in port_displays:
+            return port_displays[default_port].id
 
-        default_port_display = port_displays[default_port]
-        return default_port_display.id
+        first_port = next((port for port in unadorned_node.Ports), None)
+        if not first_port:
+            raise ValueError(f"Node {self._node.__name__} must have at least one port.")
+
+        return port_displays[first_port].id
 
     def get_trigger_id(self) -> UUID:
         return self.get_target_handle_id()

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
@@ -32,7 +32,7 @@ class BaseInlinePromptNodeDisplay(BaseNodeDisplay[_InlinePromptNodeType], Generi
         output_display = self.output_display[node.Outputs.text]
         array_display = self.output_display[node.Outputs.results]
         json_display = self.output_display[node.Outputs.json]
-        node_blocks = raise_if_descriptor(node.blocks)
+        node_blocks = raise_if_descriptor(node.blocks) or []
         function_definitions = raise_if_descriptor(node.functions)
 
         ml_model = str(raise_if_descriptor(node.ml_model))

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_node.py
@@ -234,53 +234,15 @@ def test_serialize_node__port_groups():
     serialized_workflow: dict = workflow_display.serialize()
 
     # THEN the node should have the ports serialized
-    assert serialized_workflow["workflow_raw_data"]["nodes"][1]["ports"] == [
-        {
-            "id": "149d97a4-3da3-44a9-95f7-ea7b8d38b877",
-            "name": "apple",
-            "type": "IF",
-            "expression": {
-                "type": "BINARY_EXPRESSION",
-                "operator": "=",
-                "lhs": {
-                    "type": "NODE_OUTPUT",
-                    "node_id": "f76670b8-afd5-40a8-b484-893966482d6d",
-                    "node_output_id": "9d1d1db6-8874-49d5-8829-042ebd507e9e",
-                },
-                "rhs": {
-                    "type": "CONSTANT_VALUE",
-                    "value": {
-                        "type": "STRING",
-                        "value": "apple",
-                    },
-                },
-            },
-        },
-        {
-            "id": "71f2d2b3-194f-4492-bc1c-a5ca1f60fb0a",
-            "name": "banana",
-            "type": "IF",
-            "expression": {
-                "type": "BINARY_EXPRESSION",
-                "operator": "=",
-                "lhs": {
-                    "type": "NODE_OUTPUT",
-                    "node_id": "f76670b8-afd5-40a8-b484-893966482d6d",
-                    "node_output_id": "9d1d1db6-8874-49d5-8829-042ebd507e9e",
-                },
-                "rhs": {
-                    "type": "CONSTANT_VALUE",
-                    "value": {
-                        "type": "STRING",
-                        "value": "banana",
-                    },
-                },
-            },
-        },
-    ]
+    my_prompt_node = next(
+        node for node in serialized_workflow["workflow_raw_data"]["nodes"] if node["id"] == str(MyPromptNode.__id__)
+    )
+    ports = my_prompt_node["ports"]
+    assert len(ports) == 2
+    assert ports[0]["id"] == "149d97a4-3da3-44a9-95f7-ea7b8d38b877"
+    assert ports[1]["id"] == "71f2d2b3-194f-4492-bc1c-a5ca1f60fb0a"
+    assert ports[0]["name"] == "apple"
+    assert ports[1]["name"] == "banana"
 
     # AND the legacy source_handle_id should be the default port
-    assert (
-        serialized_workflow["workflow_raw_data"]["nodes"][1]["data"]["source_handle_id"]
-        == "149d97a4-3da3-44a9-95f7-ea7b8d38b877"
-    )
+    assert my_prompt_node["data"]["source_handle_id"] == "149d97a4-3da3-44a9-95f7-ea7b8d38b877"

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_prompt_node.py
@@ -6,6 +6,7 @@ from vellum.client.types.variable_prompt_block import VariablePromptBlock
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.nodes import BaseNode
 from vellum.workflows.nodes.displayable.inline_prompt_node.node import InlinePromptNode
+from vellum.workflows.ports.port import Port
 from vellum.workflows.references.lazy import LazyReference
 from vellum.workflows.state.base import BaseState
 from vellum_ee.workflows.display.nodes.vellum.inline_prompt_node import BaseInlinePromptNodeDisplay
@@ -215,3 +216,71 @@ def test_serialize_node__unreferenced_variable_block__still_serializes():
     # warnings = list(workflow_display.errors)
     # assert len(warnings) == 1
     # assert "Missing input variable 'foo' for prompt block 0" in str(warnings[0])
+
+
+def test_serialize_node__port_groups():
+    # GIVEN a prompt node with ports
+    class MyPromptNode(InlinePromptNode):
+        class Ports(InlinePromptNode.Ports):
+            apple = Port.on_if(LazyReference(lambda: MyPromptNode.Outputs.text).equals("apple"))
+            banana = Port.on_if(LazyReference(lambda: MyPromptNode.Outputs.text).equals("banana"))
+
+    # AND a workflow with the prompt node
+    class MyWorkflow(BaseWorkflow):
+        graph = MyPromptNode
+
+    # WHEN the prompt node is serialized
+    workflow_display = get_workflow_display(workflow_class=MyWorkflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    # THEN the node should have the ports serialized
+    assert serialized_workflow["workflow_raw_data"]["nodes"][1]["ports"] == [
+        {
+            "id": "149d97a4-3da3-44a9-95f7-ea7b8d38b877",
+            "name": "apple",
+            "type": "IF",
+            "expression": {
+                "type": "BINARY_EXPRESSION",
+                "operator": "=",
+                "lhs": {
+                    "type": "NODE_OUTPUT",
+                    "node_id": "f76670b8-afd5-40a8-b484-893966482d6d",
+                    "node_output_id": "9d1d1db6-8874-49d5-8829-042ebd507e9e",
+                },
+                "rhs": {
+                    "type": "CONSTANT_VALUE",
+                    "value": {
+                        "type": "STRING",
+                        "value": "apple",
+                    },
+                },
+            },
+        },
+        {
+            "id": "71f2d2b3-194f-4492-bc1c-a5ca1f60fb0a",
+            "name": "banana",
+            "type": "IF",
+            "expression": {
+                "type": "BINARY_EXPRESSION",
+                "operator": "=",
+                "lhs": {
+                    "type": "NODE_OUTPUT",
+                    "node_id": "f76670b8-afd5-40a8-b484-893966482d6d",
+                    "node_output_id": "9d1d1db6-8874-49d5-8829-042ebd507e9e",
+                },
+                "rhs": {
+                    "type": "CONSTANT_VALUE",
+                    "value": {
+                        "type": "STRING",
+                        "value": "banana",
+                    },
+                },
+            },
+        },
+    ]
+
+    # AND the legacy source_handle_id should be the default port
+    assert (
+        serialized_workflow["workflow_raw_data"]["nodes"][1]["data"]["source_handle_id"]
+        == "149d97a4-3da3-44a9-95f7-ea7b8d38b877"
+    )


### PR DESCRIPTION
the source handle id helper was failing whenever we tried to push a legacy nodes with Ports attached. This PR addresses