### PR TITLE
Remove tests and mypy from pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,38 +58,9 @@ repos:
 
   - repo: local
     hooks:
-      - id: mypy
-        name: mypy
-        entry: poetry run mypy .
-        language: system
-        exclude: ".*"
-        always_run: true
-        stages: [push]
-
-  - repo: local
-    hooks:
-      - id: pytest
-        name: pytest
-        entry: make test
-        language: system
-        exclude: ".*"
-        always_run: true
-        stages: [push]
-
-  - repo: local
-    hooks:
       - id: tsc
         name: tsc
         entry: bash -c 'cd ee/codegen && npm run types'
-        language: system
-        pass_filenames: false
-        stages: [push]
-
-  - repo: local
-    hooks:
-      - id: vitest
-        name: vitest
-        entry: bash -c 'cd ee/codegen && npm run test'
         language: system
         pass_filenames: false
         stages: [push]


### PR DESCRIPTION
Talked about removing this earlier and I'm waiting around for a vembda test to finish. This removes notoriously flakey mypy and the slow/flakey tests from hooks.