### PR TITLE
build resilience against empty templates

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -1194,6 +1194,35 @@ class PromptNode(InlinePromptNode):
 "
 `;
 
+exports[`InlinePromptNode > basic with undefined template > should generate node file 1`] = `
+"from vellum import JinjaPromptBlock, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
+from ..inputs import Inputs
+
+
+class PromptNode(InlinePromptNode):
+    ml_model = "gpt-4o-mini"
+    blocks = [
+        JinjaPromptBlock(state="DISABLED", template=""),
+    ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
+    parameters = PromptParameters(
+        stop=[],
+        temperature=0,
+        max_tokens=1000,
+        top_p=1,
+        top_k=0,
+        frequency_penalty=0,
+        presence_penalty=0,
+        logit_bias={},
+        custom_parameters={},
+    )
+"
+`;
+
 exports[`InlinePromptNode > should generate cache config correctly 1`] = `
 "from vellum import EphemeralPromptCacheConfig, JinjaPromptBlock, PromptParameters
 from vellum.workflows.nodes.displayable import InlinePromptNode

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -300,4 +300,31 @@ describe("InlinePromptNode", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });
+
+  describe("basic with undefined template", () => {
+    it("should generate node file", async () => {
+      const nodeData = inlinePromptNodeDataInlineVariantFactory({
+        defaultBlock: {
+          blockType: "JINJA",
+          properties: {
+            template: "",
+          },
+          id: uuidv4(),
+          state: "DISABLED",
+        },
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as InlinePromptNodeContext;
+
+      const node = new InlinePromptNode({
+        workflowContext,
+        nodeContext,
+      });
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });

--- a/ee/codegen/src/generators/prompt-block.ts
+++ b/ee/codegen/src/generators/prompt-block.ts
@@ -81,6 +81,13 @@ export class PromptBlock extends BasePromptBlock<PromptTemplateBlockExcludingFun
           }),
         })
       );
+    } else {
+      classArgs.push(
+        new MethodArgument({
+          name: "template",
+          value: python.TypeInstantiation.str(""),
+        })
+      );
     }
 
     const jinjaBlock = python.instantiateClass({


### PR DESCRIPTION
User had an empty Jinja block in a workflow that wouldn't initialize bc of the bug fixed by this PR

https://files.slack.com/files-pri/T04CD0JKF3K-F08PUEV2ZFY/image.png