### PR TITLE
Migrate custom prompt node into SDK examples

### DIFF
--- a/examples/workflows/custom_prompt_node/inputs.py
+++ b/examples/workflows/custom_prompt_node/inputs.py
@@ -1,0 +1,5 @@
+from vellum.workflows.inputs import BaseInputs
+
+
+class Inputs(BaseInputs):
+    message: str

--- a/examples/workflows/custom_prompt_node/nodes/be_happy.py
+++ b/examples/workflows/custom_prompt_node/nodes/be_happy.py
@@ -1,0 +1,41 @@
+from vellum import ChatMessagePromptBlock, PlainTextPromptBlock, RichTextPromptBlock, VariablePromptBlock
+
+from ..inputs import Inputs
+from .local_bedrock_node import LocalBedrockNode
+
+
+class BeHappyPrompt(LocalBedrockNode):
+    ml_model = "aws-bedrock//anthropic/claude-3-5-sonnet-20240620-v1:0/us-west-2"
+
+    blocks = [
+        ChatMessagePromptBlock(
+            chat_role="SYSTEM",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        PlainTextPromptBlock(
+                            text="""\
+You will be given a message from the user that is already categorized as happy.
+
+Partake in the user's happiness with some happiness of your own.
+"""
+                        )
+                    ]
+                )
+            ],
+        ),
+        ChatMessagePromptBlock(
+            chat_role="USER",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        VariablePromptBlock(input_variable="message"),
+                    ]
+                )
+            ],
+        ),
+    ]
+
+    prompt_inputs = {
+        "message": Inputs.message,
+    }

--- a/examples/workflows/custom_prompt_node/nodes/bot_response.py
+++ b/examples/workflows/custom_prompt_node/nodes/bot_response.py
@@ -1,0 +1,10 @@
+from classifier.nodes.be_happy import BeHappyPrompt
+from classifier.nodes.cheer_up import CheerUpPrompt
+from classifier.nodes.settle_down import SettleDownPrompt
+
+from vellum.workflows.nodes.displayable import FinalOutputNode
+
+
+class BotResponse(FinalOutputNode):
+    class Outputs(FinalOutputNode.Outputs):
+        value = BeHappyPrompt.Outputs.text.coalesce(CheerUpPrompt.Outputs.text).coalesce(SettleDownPrompt.Outputs.text)

--- a/examples/workflows/custom_prompt_node/nodes/cheer_up.py
+++ b/examples/workflows/custom_prompt_node/nodes/cheer_up.py
@@ -1,0 +1,41 @@
+from vellum import ChatMessagePromptBlock, PlainTextPromptBlock, RichTextPromptBlock, VariablePromptBlock
+
+from ..inputs import Inputs
+from .local_bedrock_node import LocalBedrockNode
+
+
+class CheerUpPrompt(LocalBedrockNode):
+    ml_model = "aws-bedrock//anthropic/claude-3-5-sonnet-20240620-v1:0/us-west-2"
+
+    blocks = [
+        ChatMessagePromptBlock(
+            chat_role="SYSTEM",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        PlainTextPromptBlock(
+                            text="""\
+You will be given a message from the user that is already categorized as sad.
+
+Offer some words of encouragement and support.
+"""
+                        )
+                    ]
+                )
+            ],
+        ),
+        ChatMessagePromptBlock(
+            chat_role="USER",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        VariablePromptBlock(input_variable="message"),
+                    ]
+                )
+            ],
+        ),
+    ]
+
+    prompt_inputs = {
+        "message": Inputs.message,
+    }

--- a/examples/workflows/custom_prompt_node/nodes/detect_tone_prompt.py
+++ b/examples/workflows/custom_prompt_node/nodes/detect_tone_prompt.py
@@ -1,0 +1,54 @@
+from vellum import ChatMessagePromptBlock, PlainTextPromptBlock, RichTextPromptBlock, VariablePromptBlock
+from vellum.workflows.ports import Port
+from vellum.workflows.references import LazyReference
+
+from ..inputs import Inputs
+from .local_bedrock_node import LocalBedrockNode
+
+
+class DetectTonePrompt(LocalBedrockNode):
+    ml_model = "aws-bedrock//anthropic/claude-3-5-sonnet-20240620-v1:0/us-west-2"
+
+    blocks = [
+        ChatMessagePromptBlock(
+            chat_role="SYSTEM",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        PlainTextPromptBlock(
+                            text="""\
+You will be given a message and you need to detect the tone of the message.
+
+The tone can be one of the following:
+- happy
+- sad
+- angry
+
+
+Only respond with one of those three tones and nothing more.
+"""
+                        )
+                    ]
+                )
+            ],
+        ),
+        ChatMessagePromptBlock(
+            chat_role="USER",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        VariablePromptBlock(input_variable="message"),
+                    ]
+                )
+            ],
+        ),
+    ]
+
+    prompt_inputs = {
+        "message": Inputs.message,
+    }
+
+    class Ports(LocalBedrockNode.Ports):
+        happy = Port.on_if(LazyReference(lambda: DetectTonePrompt.Outputs.text.equals("happy")))
+        sad = Port.on_elif(LazyReference(lambda: DetectTonePrompt.Outputs.text.equals("sad")))
+        angry = Port.on_elif(LazyReference(lambda: DetectTonePrompt.Outputs.text.equals("angry")))

--- a/examples/workflows/custom_prompt_node/nodes/local_bedrock_node.py
+++ b/examples/workflows/custom_prompt_node/nodes/local_bedrock_node.py
@@ -1,0 +1,106 @@
+import json
+from uuid import uuid4
+from typing import Any, Iterator
+
+import boto3
+
+from vellum import (
+    AdHocExecutePromptEvent,
+    FulfilledAdHocExecutePromptEvent,
+    InitiatedAdHocExecutePromptEvent,
+    PromptOutput,
+    StringVellumValue,
+)
+from vellum.prompts.blocks.compilation import compile_prompt_blocks
+from vellum.workflows.exceptions import NodeException
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
+
+class LocalBedrockNode(InlinePromptNode):
+    """
+    Used to execute a Prompt against the AWS Bedrock API directly instead of growing through Vellum.
+    """
+
+    # Override
+    def _get_prompt_event_stream(self) -> Iterator[AdHocExecutePromptEvent]:
+        """
+        This is the main method that needs to be overridden to execute the prompt against the Bedrock API directly.
+        """
+
+        client = self._get_client()
+
+        execution_id = str(uuid4())
+
+        yield InitiatedAdHocExecutePromptEvent(
+            execution_id=execution_id,
+        )
+
+        response = client.invoke_model(
+            modelId=".".join(self.ml_model.replace("aws-bedrock//", "").split("/")[0:-1]),
+            body=json.dumps(self._get_body()),
+        )
+        response_body = json.loads(response["body"].read())
+
+        content = response_body.get("content")
+        outputs: list[PromptOutput] = []
+        for part in content:
+            if part.get("type") == "text":
+                outputs.append(StringVellumValue(value=part["text"]))
+
+        yield FulfilledAdHocExecutePromptEvent(
+            outputs=outputs,
+            execution_id=execution_id,
+        )
+
+    def _get_client(self) -> Any:
+        return boto3.client("bedrock-runtime", region_name="us-west-2")
+
+    def _get_body(self) -> dict:
+        input_variables, input_values = self._compile_prompt_inputs()
+        compiled_blocks = compile_prompt_blocks(
+            blocks=self.blocks, inputs=input_values, input_variables=input_variables
+        )
+
+        system_blocks: list[dict] = []
+        messages: list[dict] = []
+
+        for block in compiled_blocks:
+            if block.block_type != "CHAT_MESSAGE":
+                continue
+
+            contents: list[dict[str, Any]] = []
+            for child_block in block.blocks:
+                if child_block.content.type == "STRING":
+                    text = child_block.content.value
+                    if text.strip():
+                        contents.append({"type": "text", "text": text})
+                elif child_block.content.type == "JSON":
+                    contents.append(
+                        {
+                            "type": "text",
+                            "text": json.dumps(child_block.content.value),
+                        }
+                    )
+                else:
+                    raise NodeException(f"Unsupported child block type: {child_block.content.type}")
+
+            if block.role == "SYSTEM":
+                system_blocks = contents
+
+            elif block.role == "USER":
+                messages.append({"role": "user", "content": contents})
+
+            elif block.role == "ASSISTANT":
+                messages.append({"role": "assistant", "content": contents})
+
+        body = {
+            "anthropic_version": "bedrock-2023-05-31",
+            "messages": messages,
+            "max_tokens": self.parameters.max_tokens,
+            "temperature": self.parameters.temperature,
+        }
+
+        if system_blocks:
+            body["system"] = system_blocks
+
+        return body

--- a/examples/workflows/custom_prompt_node/nodes/settle_down.py
+++ b/examples/workflows/custom_prompt_node/nodes/settle_down.py
@@ -1,0 +1,41 @@
+from vellum import ChatMessagePromptBlock, PlainTextPromptBlock, RichTextPromptBlock, VariablePromptBlock
+
+from ..inputs import Inputs
+from .local_bedrock_node import LocalBedrockNode
+
+
+class SettleDownPrompt(LocalBedrockNode):
+    ml_model = "aws-bedrock//anthropic/claude-3-5-sonnet-20240620-v1:0/us-west-2"
+
+    blocks = [
+        ChatMessagePromptBlock(
+            chat_role="SYSTEM",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        PlainTextPromptBlock(
+                            text="""\
+You will be given a message from the user that is already categorized as angry.
+
+Give a short, concise response that helps the user calm down.
+"""
+                        )
+                    ]
+                )
+            ],
+        ),
+        ChatMessagePromptBlock(
+            chat_role="USER",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        VariablePromptBlock(input_variable="message"),
+                    ]
+                )
+            ],
+        ),
+    ]
+
+    prompt_inputs = {
+        "message": Inputs.message,
+    }

--- a/examples/workflows/custom_prompt_node/sandbox.py
+++ b/examples/workflows/custom_prompt_node/sandbox.py
@@ -1,0 +1,12 @@
+from vellum.workflows.sandbox import WorkflowSandboxRunner
+
+from .inputs import Inputs
+from .workflow import Workflow
+
+if __name__ != "__main__":
+    raise Exception("This file is not meant to be imported")
+
+
+workflow = Workflow()
+runner = WorkflowSandboxRunner(workflow, inputs=[Inputs(message="It's such a beautiful day today!")])
+runner.run()

--- a/examples/workflows/custom_prompt_node/workflow.py
+++ b/examples/workflows/custom_prompt_node/workflow.py
@@ -1,0 +1,19 @@
+from classifier.nodes.bot_response import BotResponse
+
+from vellum.workflows import BaseWorkflow
+
+from .nodes.be_happy import BeHappyPrompt
+from .nodes.cheer_up import CheerUpPrompt
+from .nodes.detect_tone_prompt import DetectTonePrompt
+from .nodes.settle_down import SettleDownPrompt
+
+
+class Workflow(BaseWorkflow):
+    graph = {
+        DetectTonePrompt.Ports.happy >> BeHappyPrompt,
+        DetectTonePrompt.Ports.sad >> CheerUpPrompt,
+        DetectTonePrompt.Ports.angry >> SettleDownPrompt,
+    } >> BotResponse
+
+    class Outputs(BaseWorkflow.Outputs):
+        response = BotResponse.Outputs.value

--- a/examples/workflows/poetry.lock
+++ b/examples/workflows/poetry.lock
@@ -53,6 +53,47 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "boto3"
+version = "1.38.4"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "boto3-1.38.4-py3-none-any.whl", hash = "sha256:ab315d38409f5b3262b653a10b0fac786bcff7e51e03dcb99ff38ba16bf85630"},
+    {file = "boto3-1.38.4.tar.gz", hash = "sha256:4990df0087fe7be944ba06c2d1e6512b5a24f821af5a4881f24309e13ae29e68"},
+]
+
+[package.dependencies]
+botocore = ">=1.38.4,<1.39.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.12.0,<0.13.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.38.4"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "botocore-1.38.4-py3-none-any.whl", hash = "sha256:6206cf07be1069efaead2ddc858eb752dafef276ebbe88ac32b5c427b1d90570"},
+    {file = "botocore-1.38.4.tar.gz", hash = "sha256:6143546bb56f1da4dff8d285cb6a3b8b0b6442451fe5937cb48a62bf7275386f"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = [
+    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
+    {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
+]
+
+[package.extras]
+crt = ["awscrt (==0.23.8)"]
+
+[[package]]
 name = "cattrs"
 version = "24.1.3"
 description = "Composable complex class support for attrs and dataclasses."
@@ -490,6 +531,17 @@ files = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
+
+[[package]]
 name = "jsii"
 version = "1.111.0"
 description = "Python client for jsii runtime"
@@ -924,6 +976,23 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "s3transfer"
+version = "0.12.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "s3transfer-0.12.0-py3-none-any.whl", hash = "sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18"},
+    {file = "s3transfer-0.12.0.tar.gz", hash = "sha256:8ac58bc1989a3fdb7c7f3ee0918a66b160d038a147c7b5db1500930a607e9a1c"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1019,6 +1088,22 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "urllib3"
+version = "1.26.20"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+files = [
+    {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
+    {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
+]
+
+[package.extras]
+brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "urllib3"
 version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
@@ -1086,4 +1171,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "ba81685c2502a9ae8e1fbb0af1265de92f49b2238f86a51142cccda5b9fda83d"
+content-hash = "31af9419e6f1e24693f4facfd174545a8b50e21b1658dca8c28cacd7b8f3e2bd"

--- a/examples/workflows/pyproject.toml
+++ b/examples/workflows/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 vellum-ai = "0.14.48"
+boto3 = "^1.38.4"
 
 
 [build-system]


### PR DESCRIPTION
Discussed with @awlevin earlier today, and we agreed on the SDK's `examples/workflows` repo being the new home for workflows 

Migrating the custom-prompt-node [example](https://github.com/vellum-ai/vellum-example-apps/tree/main/examples/custom-prompt-node) we spun up in the examples repo over to here. We can successfully keep the deps needed for these examples from polluting the sdk's dependencies since we have a dedicated pyproject.toml and poetry environment nested in the repo for these examples.