### PR TITLE
Split out codegen service upgrade to its own job

### DIFF
--- a/.github/workflows/ci-codegen.yaml
+++ b/.github/workflows/ci-codegen.yaml
@@ -98,7 +98,28 @@ jobs:
           npm publish
         working-directory: ee/codegen
 
-      - name: Bump codegen-service
+  upgrade-codegen-service:
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    needs: [publish]
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.17.0"
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ee/codegen
+
+      - name: Upgrade codegen-service
         env:
           VELLUM_AUTOMATION_APP_ID: ${{ secrets.VELLUM_AUTOMATION_APP_ID }}
           VELLUM_AUTOMATION_PRIVATE_KEY: ${{ secrets.VELLUM_AUTOMATION_PRIVATE_KEY }}

--- a/ee/codegen/package-lock.json
+++ b/ee/codegen/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^22.10.2",
         "@typescript-eslint/eslint-plugin": "^8.9.0",
         "@typescript-eslint/parser": "^8.9.0",
+        "dotenv": "^16.5.0",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-import-resolver-typescript": "^3.5.5",
@@ -2845,6 +2846,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -8311,6 +8324,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true
     },
     "dunder-proto": {
       "version": "1.0.1",

--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -44,6 +44,7 @@
     "@types/node": "^22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.9.0",
     "@typescript-eslint/parser": "^8.9.0",
+    "dotenv": "^16.5.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-import-resolver-typescript": "^3.5.5",

--- a/ee/codegen/scripts/upgrade-codegen-service.mts
+++ b/ee/codegen/scripts/upgrade-codegen-service.mts
@@ -4,6 +4,9 @@ import { execSync } from "child_process";
 import packageJson from "../package.json" assert { type: "json" };
 import { readFileSync, writeFileSync } from "node:fs";
 import { getGithubToken } from "./get-github-token.mjs";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 const main = async () => {
   const version = packageJson.version;


### PR DESCRIPTION
This PR splits out the codegen service script into its own job. this allows us to rerun just the codegen service upgrade if it fails on a previous step for whatever reason, avoiding the [failure](https://github.com/vellum-ai/vellum-python-sdks/actions/runs/14721692793/job/41345671385) on trying to republish the same npm package.

To fix 0.14.48, I'm just going to do the steps manually