### PR TITLE
Add function calling demo to examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--keep-runtime-typing]
+        exclude: examples/workflows/.+/script\.py
 
   - repo: https://github.com/psf/black
     rev: 24.8.0
@@ -48,7 +49,7 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
-        exclude: (src/vellum/client|tests/client)
+        exclude: (src/vellum/client|tests/client|examples/workflows/.+/script\.py)
 
   - repo: local
     hooks:

--- a/examples/workflows/function_calling_demo/__init__.py
+++ b/examples/workflows/function_calling_demo/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa: F401, F403
+
+from .display import *

--- a/examples/workflows/function_calling_demo/display/__init__.py
+++ b/examples/workflows/function_calling_demo/display/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa: F401, F403
+
+from .nodes import *
+from .workflow import *

--- a/examples/workflows/function_calling_demo/display/nodes/__init__.py
+++ b/examples/workflows/function_calling_demo/display/nodes/__init__.py
@@ -1,0 +1,23 @@
+from .accumulate_chat_history import AccumulateChatHistoryDisplay
+from .conditional_node import ConditionalNodeDisplay
+from .conditional_node_10 import ConditionalNode10Display
+from .error_node import ErrorNodeDisplay
+from .final_accumulation_of_chat_history import FinalAccumulationOfChatHistoryDisplay
+from .final_output import FinalOutputDisplay
+from .get_current_weather import GetCurrentWeatherDisplay
+from .output_type import OutputTypeDisplay
+from .parse_function_call import ParseFunctionCallDisplay
+from .prompt_node import PromptNodeDisplay
+
+__all__ = [
+    "AccumulateChatHistoryDisplay",
+    "ConditionalNode10Display",
+    "ConditionalNodeDisplay",
+    "ErrorNodeDisplay",
+    "FinalAccumulationOfChatHistoryDisplay",
+    "FinalOutputDisplay",
+    "GetCurrentWeatherDisplay",
+    "OutputTypeDisplay",
+    "ParseFunctionCallDisplay",
+    "PromptNodeDisplay",
+]

--- a/examples/workflows/function_calling_demo/display/nodes/accumulate_chat_history.py
+++ b/examples/workflows/function_calling_demo/display/nodes/accumulate_chat_history.py
@@ -1,0 +1,35 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from ...nodes.accumulate_chat_history import AccumulateChatHistory
+
+
+class AccumulateChatHistoryDisplay(BaseCodeExecutionNodeDisplay[AccumulateChatHistory]):
+    label = "Accumulate Chat History"
+    node_id = UUID("4787115e-23b9-4980-bf51-655da351d9e7")
+    target_handle_id = UUID("6456c31d-1631-46d3-aaed-bbcad9e9be62")
+    output_id = UUID("9e6d85b4-6941-4758-9304-99b94122868d")
+    log_output_id = UUID("60c8dade-d9a9-441a-8997-e77afc7ec38d")
+    node_input_ids_by_name = {
+        "code_inputs.tool_id": UUID("eab3c9f4-78ef-4b16-afa8-dcdeffcd5af2"),
+        "code_inputs.function_result": UUID("29e037ad-b6e4-40ec-a816-2fce11671f04"),
+        "code": UUID("c5dc64de-d70e-4b99-a15f-0cf2c853a856"),
+        "runtime": UUID("b7a6a274-756e-4983-93d4-93e4c8ee2a9b"),
+        "code_inputs.assistant_message": UUID("8f59e730-6da8-4418-b5d7-e001e3b1869b"),
+        "code_inputs.current_chat_history": UUID("92f43842-3d2e-47e4-8fc2-1fc62391a72c"),
+    }
+    output_display = {
+        AccumulateChatHistory.Outputs.result: NodeOutputDisplay(
+            id=UUID("9e6d85b4-6941-4758-9304-99b94122868d"), name="result"
+        ),
+        AccumulateChatHistory.Outputs.log: NodeOutputDisplay(
+            id=UUID("60c8dade-d9a9-441a-8997-e77afc7ec38d"), name="log"
+        ),
+    }
+    port_displays = {
+        AccumulateChatHistory.Ports.default: PortDisplayOverrides(id=UUID("66a7143a-15c6-4f85-9b0b-029653f488ff"))
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=5700, y=-45), width=449, height=381)

--- a/examples/workflows/function_calling_demo/display/nodes/conditional_node.py
+++ b/examples/workflows/function_calling_demo/display/nodes/conditional_node.py
@@ -1,0 +1,46 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.nodes.vellum.conditional_node import ConditionId, RuleIdMap
+
+from ...nodes.conditional_node import ConditionalNode
+
+
+class ConditionalNodeDisplay(BaseConditionalNodeDisplay[ConditionalNode]):
+    label = "Conditional Node"
+    node_id = UUID("a3f2fd3d-0c58-48d8-bdfc-9f16591b1964")
+    target_handle_id = UUID("e07139df-febe-43fb-8e2c-11b85464dcde")
+    source_handle_ids = {
+        0: UUID("b032aa36-545e-4499-b7ba-2750e19b61d1"),
+        1: UUID("60b2218f-1481-41e3-bc39-943033285d76"),
+    }
+    rule_ids = [
+        RuleIdMap(
+            id="4913d8e4-6cfe-4826-b722-3af118d788c9",
+            lhs=RuleIdMap(
+                id="f860841f-da06-45c2-ad50-c63f975469a8",
+                lhs=None,
+                rhs=None,
+                field_node_input_id="4dd04a7d-7a12-43b1-9a0b-b2dc182227c6",
+                value_node_input_id="95b497b8-7357-4f74-a86f-b65f4ae14dcf",
+            ),
+            rhs=None,
+            field_node_input_id=None,
+            value_node_input_id=None,
+        )
+    ]
+    condition_ids = [
+        ConditionId(id="708ee94b-62f1-46cf-ac1b-157548dd6e40", rule_group_id="4913d8e4-6cfe-4826-b722-3af118d788c9"),
+        ConditionId(id="dbd8983a-63a5-432b-a1c7-4ddf612010f5", rule_group_id=None),
+    ]
+    node_input_ids_by_name = {
+        "226cdc38-6029-4e73-8d88-a283cd6dc0de.field": UUID("4dd04a7d-7a12-43b1-9a0b-b2dc182227c6"),
+        "226cdc38-6029-4e73-8d88-a283cd6dc0de.value": UUID("95b497b8-7357-4f74-a86f-b65f4ae14dcf"),
+    }
+    port_displays = {
+        ConditionalNode.Ports.branch_1: PortDisplayOverrides(id=UUID("b032aa36-545e-4499-b7ba-2750e19b61d1")),
+        ConditionalNode.Ports.branch_2: PortDisplayOverrides(id=UUID("60b2218f-1481-41e3-bc39-943033285d76")),
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=3405, y=-90), width=457, height=177)

--- a/examples/workflows/function_calling_demo/display/nodes/conditional_node_10.py
+++ b/examples/workflows/function_calling_demo/display/nodes/conditional_node_10.py
@@ -1,0 +1,46 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.nodes.vellum.conditional_node import ConditionId, RuleIdMap
+
+from ...nodes.conditional_node_10 import ConditionalNode10
+
+
+class ConditionalNode10Display(BaseConditionalNodeDisplay[ConditionalNode10]):
+    label = "Conditional Node 10"
+    node_id = UUID("3ab8c006-2d4e-4025-b39d-314ac549afd6")
+    target_handle_id = UUID("a5a91252-cd98-44d9-a19e-683bd8da7d01")
+    source_handle_ids = {
+        0: UUID("cb376fec-4053-4ecc-8acd-118ac972b393"),
+        1: UUID("ca10ed22-f23f-4a50-ac36-a64877d13b9c"),
+    }
+    rule_ids = [
+        RuleIdMap(
+            id="c125682f-b736-40fa-a9e2-bfafcbc2312b",
+            lhs=RuleIdMap(
+                id="d0a1fbec-f2f9-4c3a-9756-9865e92d41fe",
+                lhs=None,
+                rhs=None,
+                field_node_input_id="fc26c9a7-f514-4bdb-93b4-374fd6272afc",
+                value_node_input_id="42d853d9-dcd0-4309-baed-4f74317e778c",
+            ),
+            rhs=None,
+            field_node_input_id=None,
+            value_node_input_id=None,
+        )
+    ]
+    condition_ids = [
+        ConditionId(id="777fa95e-3442-4f46-83f2-c1ff8b609ec9", rule_group_id="c125682f-b736-40fa-a9e2-bfafcbc2312b"),
+        ConditionId(id="89ea5a9b-2330-46dc-a075-04c8608bc0c1", rule_group_id=None),
+    ]
+    node_input_ids_by_name = {
+        "b946ebf5-6865-4f84-a08e-9bb1ed2867df.field": UUID("fc26c9a7-f514-4bdb-93b4-374fd6272afc"),
+        "b946ebf5-6865-4f84-a08e-9bb1ed2867df.value": UUID("42d853d9-dcd0-4309-baed-4f74317e778c"),
+    }
+    port_displays = {
+        ConditionalNode10.Ports.branch_1: PortDisplayOverrides(id=UUID("cb376fec-4053-4ecc-8acd-118ac972b393")),
+        ConditionalNode10.Ports.branch_2: PortDisplayOverrides(id=UUID("ca10ed22-f23f-4a50-ac36-a64877d13b9c")),
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=2156.6652061538634, y=240), width=460, height=177)

--- a/examples/workflows/function_calling_demo/display/nodes/error_node.py
+++ b/examples/workflows/function_calling_demo/display/nodes/error_node.py
@@ -1,0 +1,16 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
+
+from ...nodes.error_node import ErrorNode
+
+
+class ErrorNodeDisplay(BaseErrorNodeDisplay[ErrorNode]):
+    name = "error-node"
+    node_id = UUID("456afdb9-4d76-40b8-a032-0bddf0583632")
+    label = "Error Node"
+    error_output_id = UUID("8fd34ccf-aadb-4fab-b450-11b247737548")
+    target_handle_id = UUID("a815d06f-b3af-46de-a53b-b2e38f0e3ea3")
+    node_input_ids_by_name = {"error_source_input_id": UUID("d88e2764-a9b0-4b13-aa04-d7a5bdd54785")}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=4260, y=780), width=364, height=124)

--- a/examples/workflows/function_calling_demo/display/nodes/final_accumulation_of_chat_history.py
+++ b/examples/workflows/function_calling_demo/display/nodes/final_accumulation_of_chat_history.py
@@ -1,0 +1,35 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from ...nodes.final_accumulation_of_chat_history import FinalAccumulationOfChatHistory
+
+
+class FinalAccumulationOfChatHistoryDisplay(BaseCodeExecutionNodeDisplay[FinalAccumulationOfChatHistory]):
+    label = "Final Accumulation of Chat History"
+    node_id = UUID("d1855d88-8316-4377-8e95-9395c8f75855")
+    target_handle_id = UUID("92fc3b35-8e45-473f-ba98-c7664714c1f9")
+    output_id = UUID("1c8268a2-4e31-4fd5-b493-0a9f28b7ec19")
+    log_output_id = UUID("a97f5cbf-3a00-4af7-921d-c553c8b3243f")
+    node_input_ids_by_name = {
+        "code": UUID("ec9748c7-a43c-4a94-9772-ee747cf4e361"),
+        "runtime": UUID("df07ce66-fe48-4787-b210-087bb3b2a337"),
+        "code_inputs.current_chat_history": UUID("b9fe0d7b-be2c-43fc-8c65-57300e40fb20"),
+        "code_inputs.assistant_message": UUID("18dfa292-1cc8-4549-847e-152a5e7782df"),
+    }
+    output_display = {
+        FinalAccumulationOfChatHistory.Outputs.result: NodeOutputDisplay(
+            id=UUID("1c8268a2-4e31-4fd5-b493-0a9f28b7ec19"), name="result"
+        ),
+        FinalAccumulationOfChatHistory.Outputs.log: NodeOutputDisplay(
+            id=UUID("a97f5cbf-3a00-4af7-921d-c553c8b3243f"), name="log"
+        ),
+    }
+    port_displays = {
+        FinalAccumulationOfChatHistory.Ports.default: PortDisplayOverrides(
+            id=UUID("619a3089-4a05-4029-a248-cddb50facab7")
+        )
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=2820, y=825), width=466, height=315)

--- a/examples/workflows/function_calling_demo/display/nodes/final_output.py
+++ b/examples/workflows/function_calling_demo/display/nodes/final_output.py
@@ -1,0 +1,19 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
+
+from ...nodes.final_output import FinalOutput
+
+
+class FinalOutputDisplay(BaseFinalOutputNodeDisplay[FinalOutput]):
+    label = "Final Output"
+    node_id = UUID("4a6aadca-4d2f-40b8-a1a1-23db0f6a5767")
+    target_handle_id = UUID("e5ef2f31-2199-4e1b-85d0-b5a79ab0595a")
+    output_name = "final-output"
+    node_input_ids_by_name = {"node_input": UUID("4ad8334f-b66b-49bd-828e-aef443bc3052")}
+    output_display = {
+        FinalOutput.Outputs.value: NodeOutputDisplay(id=UUID("e869f551-b02c-465f-90b3-ad2021b3c618"), name="value")
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=3405, y=900), width=465, height=230)

--- a/examples/workflows/function_calling_demo/display/nodes/get_current_weather.py
+++ b/examples/workflows/function_calling_demo/display/nodes/get_current_weather.py
@@ -1,0 +1,32 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from ...nodes.get_current_weather import GetCurrentWeather
+
+
+class GetCurrentWeatherDisplay(BaseCodeExecutionNodeDisplay[GetCurrentWeather]):
+    label = "Get Current Weather"
+    node_id = UUID("d3734d8b-c3c8-44db-abf8-cbc6c07e20dc")
+    target_handle_id = UUID("4d7e27dc-608a-4486-ab45-fe7a476ee3c0")
+    output_id = UUID("312cdcea-bef2-498e-80d0-32391857ffcc")
+    log_output_id = UUID("fbea8140-56b3-4e34-8550-63c62887c2d5")
+    node_input_ids_by_name = {
+        "code_inputs.kwargs": UUID("5f08cdf0-e683-44a3-96e6-1d42d4d57f28"),
+        "code": UUID("a069f01e-fa1d-48b4-854f-4de6baa0761e"),
+        "runtime": UUID("19da0c1a-1c88-40be-8286-134c551dcb32"),
+        "code_inputs.gmaps_api_key": UUID("2b5a6327-d026-4b54-997b-00e97125f85e"),
+        "code_inputs.openweather_api_key": UUID("32e37882-aee4-47a1-b286-a533b9bf350a"),
+    }
+    output_display = {
+        GetCurrentWeather.Outputs.result: NodeOutputDisplay(
+            id=UUID("312cdcea-bef2-498e-80d0-32391857ffcc"), name="result"
+        ),
+        GetCurrentWeather.Outputs.log: NodeOutputDisplay(id=UUID("fbea8140-56b3-4e34-8550-63c62887c2d5"), name="log"),
+    }
+    port_displays = {
+        GetCurrentWeather.Ports.default: PortDisplayOverrides(id=UUID("f7c33ad9-2414-4c5e-89cb-4cc372ee2adf"))
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=4740, y=-105), width=460, height=327)

--- a/examples/workflows/function_calling_demo/display/nodes/output_type.py
+++ b/examples/workflows/function_calling_demo/display/nodes/output_type.py
@@ -1,0 +1,22 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from ...nodes.output_type import OutputType
+
+
+class OutputTypeDisplay(BaseTemplatingNodeDisplay[OutputType]):
+    label = "Output Type"
+    node_id = UUID("122e6aed-eee1-448c-8fb0-9746aa3c63f4")
+    target_handle_id = UUID("7bad755b-7f00-4c5f-a66d-4e099902cb4f")
+    node_input_ids_by_name = {
+        "inputs.output": UUID("76a43566-ea34-4547-bded-0f77652671ae"),
+        "template": UUID("15e4e329-b479-4b66-a105-2420c8796970"),
+    }
+    output_display = {
+        OutputType.Outputs.result: NodeOutputDisplay(id=UUID("7d17e99d-3929-4672-9fbd-ad7eb5cae0d2"), name="result")
+    }
+    port_displays = {OutputType.Ports.default: PortDisplayOverrides(id=UUID("457cd3cf-893d-421d-a4f0-47872d7df7ac"))}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=1485, y=285), width=453, height=221)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/__init__.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/__init__.py
@@ -1,0 +1,33 @@
+# flake8: noqa: F401, F403
+
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from ....nodes.parse_function_call import ParseFunctionCall
+from .nodes import *
+from .workflow import *
+
+
+class ParseFunctionCallDisplay(BaseInlineSubworkflowNodeDisplay[ParseFunctionCall]):
+    label = "Parse Function Call"
+    node_id = UUID("345d09e7-0117-4aef-aba4-ac7f3ce1b4a7")
+    target_handle_id = UUID("f5f2f53a-4867-4bf0-b07b-8b39d39c6a03")
+    workflow_input_ids_by_name = {}
+    output_display = {
+        ParseFunctionCall.Outputs.function_args: NodeOutputDisplay(
+            id=UUID("d520f0a1-c28f-4007-acf9-2758871f2250"), name="function-args"
+        ),
+        ParseFunctionCall.Outputs.function_name: NodeOutputDisplay(
+            id=UUID("680f2d8d-b03a-43b9-9d77-626044e03227"), name="function-name"
+        ),
+        ParseFunctionCall.Outputs.tool_id: NodeOutputDisplay(
+            id=UUID("764c26a4-b0c4-4a52-9e19-96e651eccbd3"), name="tool-id"
+        ),
+    }
+    port_displays = {
+        ParseFunctionCall.Ports.default: PortDisplayOverrides(id=UUID("b0b8c13c-4c55-4c38-9e00-412000f517b3"))
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=2850, y=75), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/__init__.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/__init__.py
@@ -1,0 +1,33 @@
+from .allowed_function_names import AllowedFunctionNamesDisplay
+from .args import ArgsDisplay
+from .conditional_node import ConditionalNode1Display
+from .conditional_node_1 import ConditionalNode2Display
+from .error_message import ErrorMessageDisplay
+from .error_node import ErrorNode1Display
+from .error_node_1 import ErrorNode2Display
+from .is_valid_function_name import IsValidFunctionNameDisplay
+from .merge_node import MergeNodeDisplay
+from .name import NameDisplay
+from .parse_function_args import ParseFunctionArgsDisplay
+from .parse_function_call import ParseFunctionCall1Display
+from .parse_function_name import ParseFunctionNameDisplay
+from .parse_tool_id import ParseToolIDDisplay
+from .tool_id import ToolIDDisplay
+
+__all__ = [
+    "AllowedFunctionNamesDisplay",
+    "ArgsDisplay",
+    "ConditionalNode1Display",
+    "ConditionalNode2Display",
+    "ErrorMessageDisplay",
+    "ErrorNode1Display",
+    "ErrorNode2Display",
+    "IsValidFunctionNameDisplay",
+    "MergeNodeDisplay",
+    "NameDisplay",
+    "ParseFunctionArgsDisplay",
+    "ParseFunctionCall1Display",
+    "ParseFunctionNameDisplay",
+    "ParseToolIDDisplay",
+    "ToolIDDisplay",
+]

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/allowed_function_names.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/allowed_function_names.py
@@ -1,0 +1,23 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from .....nodes.parse_function_call.nodes.allowed_function_names import AllowedFunctionNames
+
+
+class AllowedFunctionNamesDisplay(BaseTemplatingNodeDisplay[AllowedFunctionNames]):
+    label = "Allowed Function Names"
+    node_id = UUID("a5d4f0d5-747d-4469-8501-d8ee3165050e")
+    target_handle_id = UUID("42ad9447-9fea-4e21-9ef8-dc5908e33ad9")
+    node_input_ids_by_name = {"template": UUID("669d0c45-0f73-493e-85d9-bcc815419229")}
+    output_display = {
+        AllowedFunctionNames.Outputs.result: NodeOutputDisplay(
+            id=UUID("c1f68169-345d-456d-afc6-0a5eb6db1f41"), name="result"
+        )
+    }
+    port_displays = {
+        AllowedFunctionNames.Ports.default: PortDisplayOverrides(id=UUID("1b86b935-cb3e-41ed-9477-e820e56c042c"))
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=2910, y=1965), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/args.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/args.py
@@ -1,0 +1,19 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
+
+from .....nodes.parse_function_call.nodes.args import Args
+
+
+class ArgsDisplay(BaseFinalOutputNodeDisplay[Args]):
+    label = "Args"
+    node_id = UUID("2bb745c2-6405-4c79-9659-c35bf6a0331a")
+    target_handle_id = UUID("b1eb4d88-5d4e-473a-bf74-e86e6f5b5c71")
+    output_name = "function-args"
+    node_input_ids_by_name = {"node_input": UUID("37038db4-ad28-4270-a256-32302a0962e1")}
+    output_display = {
+        Args.Outputs.value: NodeOutputDisplay(id=UUID("d520f0a1-c28f-4007-acf9-2758871f2250"), name="value")
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=5535, y=345), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/conditional_node.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/conditional_node.py
@@ -1,0 +1,45 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.nodes.vellum.conditional_node import ConditionId, RuleIdMap
+
+from .....nodes.parse_function_call.nodes.conditional_node import ConditionalNode1
+
+
+class ConditionalNode1Display(BaseConditionalNodeDisplay[ConditionalNode1]):
+    label = "Conditional Node"
+    node_id = UUID("fb53aa28-21ac-41ff-8df5-0c6d25643b2c")
+    target_handle_id = UUID("9f7922c6-23ca-4116-aa18-759406198e68")
+    source_handle_ids = {
+        0: UUID("1eca0f4d-7182-4b2e-873b-4030019a8bbd"),
+        1: UUID("0c290732-913b-4490-a3bd-e43c23bbace4"),
+    }
+    rule_ids = [
+        RuleIdMap(
+            id="db16af99-4a75-4780-8bb0-56fb0a2931a3",
+            lhs=RuleIdMap(
+                id="75519ec6-2fc1-4dc0-ae32-392a70c30109",
+                lhs=None,
+                rhs=None,
+                field_node_input_id="0362e67a-b95c-4d2e-94cb-0d748605e184",
+                value_node_input_id=None,
+            ),
+            rhs=None,
+            field_node_input_id=None,
+            value_node_input_id=None,
+        )
+    ]
+    condition_ids = [
+        ConditionId(id="4e6a6025-b056-4040-b15a-7856a66e1bb6", rule_group_id="db16af99-4a75-4780-8bb0-56fb0a2931a3"),
+        ConditionId(id="4d7fe0c2-9ea3-4ddb-b460-03d5a84163f6", rule_group_id=None),
+    ]
+    node_input_ids_by_name = {
+        "c4d96230-bb08-4aab-b63e-48191c472605.field": UUID("0362e67a-b95c-4d2e-94cb-0d748605e184")
+    }
+    port_displays = {
+        ConditionalNode1.Ports.branch_1: PortDisplayOverrides(id=UUID("1eca0f4d-7182-4b2e-873b-4030019a8bbd")),
+        ConditionalNode1.Ports.branch_2: PortDisplayOverrides(id=UUID("0c290732-913b-4490-a3bd-e43c23bbace4")),
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=2130, y=435), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/conditional_node_1.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/conditional_node_1.py
@@ -1,0 +1,46 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseConditionalNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+from vellum_ee.workflows.display.nodes.vellum.conditional_node import ConditionId, RuleIdMap
+
+from .....nodes.parse_function_call.nodes.conditional_node_1 import ConditionalNode2
+
+
+class ConditionalNode2Display(BaseConditionalNodeDisplay[ConditionalNode2]):
+    label = "Conditional Node"
+    node_id = UUID("f5ccd090-d6f8-44c8-8e1a-23abb3e0cce2")
+    target_handle_id = UUID("ec011887-0213-4667-90d3-fcf0b1e170ca")
+    source_handle_ids = {
+        0: UUID("f40a1638-e846-4aa1-9dda-0d5fe439697a"),
+        1: UUID("a58748f1-8ae4-470f-9e3e-80478f567f5d"),
+    }
+    rule_ids = [
+        RuleIdMap(
+            id="d16245e8-5465-4f2c-a7e9-f7091e6ad2dd",
+            lhs=RuleIdMap(
+                id="1a4cc082-17bf-4cd3-bd9d-f84b209a5008",
+                lhs=None,
+                rhs=None,
+                field_node_input_id="839e9337-765e-4a3a-a8ca-74acb91014a2",
+                value_node_input_id="754fa31d-451d-4669-977b-8d5f23a4b542",
+            ),
+            rhs=None,
+            field_node_input_id=None,
+            value_node_input_id=None,
+        )
+    ]
+    condition_ids = [
+        ConditionId(id="4ca649ff-199b-4f31-8bf5-57063305d35c", rule_group_id="d16245e8-5465-4f2c-a7e9-f7091e6ad2dd"),
+        ConditionId(id="1c58d548-5ea6-4037-b4e6-589a98a911af", rule_group_id=None),
+    ]
+    node_input_ids_by_name = {
+        "5b5a07bf-0b78-48bb-8fdc-ae0c0c5266b7.field": UUID("839e9337-765e-4a3a-a8ca-74acb91014a2"),
+        "5b5a07bf-0b78-48bb-8fdc-ae0c0c5266b7.value": UUID("754fa31d-451d-4669-977b-8d5f23a4b542"),
+    }
+    port_displays = {
+        ConditionalNode2.Ports.branch_1: PortDisplayOverrides(id=UUID("f40a1638-e846-4aa1-9dda-0d5fe439697a")),
+        ConditionalNode2.Ports.branch_2: PortDisplayOverrides(id=UUID("a58748f1-8ae4-470f-9e3e-80478f567f5d")),
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=4515, y=885), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/error_message.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/error_message.py
@@ -1,0 +1,22 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from .....nodes.parse_function_call.nodes.error_message import ErrorMessage
+
+
+class ErrorMessageDisplay(BaseTemplatingNodeDisplay[ErrorMessage]):
+    label = "Error Message"
+    node_id = UUID("d5c71b95-8f26-46b9-b0ba-25ba723b7886")
+    target_handle_id = UUID("db91f735-b082-4762-8125-63880c5e380d")
+    node_input_ids_by_name = {
+        "inputs.invalid_function_name": UUID("f34229bf-1912-451c-8d4e-cf8d061ddf32"),
+        "template": UUID("438b35a2-5163-4978-af95-fb85e2023035"),
+    }
+    output_display = {
+        ErrorMessage.Outputs.result: NodeOutputDisplay(id=UUID("b777ddb5-87c7-4939-8cc8-7ee31d322d5a"), name="result")
+    }
+    port_displays = {ErrorMessage.Ports.default: PortDisplayOverrides(id=UUID("e985f530-f306-4ab9-9b8b-ca54c64a4b81"))}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=5355, y=1275), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/error_node.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/error_node.py
@@ -1,0 +1,16 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
+
+from .....nodes.parse_function_call.nodes.error_node import ErrorNode1
+
+
+class ErrorNode1Display(BaseErrorNodeDisplay[ErrorNode1]):
+    name = "error-node"
+    node_id = UUID("2f1c13c1-7ffe-48a2-b1f5-f99d711c3880")
+    label = "Error Node"
+    error_output_id = UUID("d1c9c405-b96c-4648-bf87-52d7e3898fac")
+    target_handle_id = UUID("4f5ecc8a-bf35-4ce3-b4ec-fc7f675da3d9")
+    node_input_ids_by_name = {"error_source_input_id": UUID("a3c25a49-cb6e-4d92-abe0-30fcc257d81a")}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=6000, y=1380), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/error_node_1.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/error_node_1.py
@@ -1,0 +1,16 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
+
+from .....nodes.parse_function_call.nodes.error_node_1 import ErrorNode2
+
+
+class ErrorNode2Display(BaseErrorNodeDisplay[ErrorNode2]):
+    name = "error-node"
+    node_id = UUID("0dde89cd-b006-48f4-a5cb-03f4898d4dee")
+    label = "Error Node"
+    error_output_id = UUID("9df35350-bbf0-471f-9d6d-6316c6cb87ea")
+    target_handle_id = UUID("d78e9d18-cc2f-47fa-98d0-040320be29a0")
+    node_input_ids_by_name = {"error_source_input_id": UUID("5efc9a7e-5138-4cb7-91e2-4618dd5bfdcc")}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=3150, y=225), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/is_valid_function_name.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/is_valid_function_name.py
@@ -1,0 +1,31 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseCodeExecutionNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from .....nodes.parse_function_call.nodes.is_valid_function_name import IsValidFunctionName
+
+
+class IsValidFunctionNameDisplay(BaseCodeExecutionNodeDisplay[IsValidFunctionName]):
+    label = "Is Valid Function Name"
+    node_id = UUID("644b84f0-2e9f-4ca3-b91d-0f63d431ce2f")
+    target_handle_id = UUID("d41fa741-3e2f-4d6b-8608-d6ab6926e01f")
+    output_id = UUID("377c6fd6-73de-4cf6-8437-f12738f9b077")
+    log_output_id = UUID("dd1ea277-eaec-4c59-b5ed-23017940b5f5")
+    node_input_ids_by_name = {
+        "code_inputs.function_name": UUID("cc496e6f-4983-4db0-96fd-36e6976bcd8d"),
+        "code_inputs.allowed_function_names": UUID("131d9183-afcf-446b-b1f6-9979cad15858"),
+        "code": UUID("d498be92-0470-4c47-b9d4-5087e54a8116"),
+        "runtime": UUID("a8098cf8-d647-4495-9f3c-24b43fabf979"),
+    }
+    output_display = {
+        IsValidFunctionName.Outputs.result: NodeOutputDisplay(
+            id=UUID("377c6fd6-73de-4cf6-8437-f12738f9b077"), name="result"
+        ),
+        IsValidFunctionName.Outputs.log: NodeOutputDisplay(id=UUID("dd1ea277-eaec-4c59-b5ed-23017940b5f5"), name="log"),
+    }
+    port_displays = {
+        IsValidFunctionName.Ports.default: PortDisplayOverrides(id=UUID("0d1a598d-d40f-41fa-8025-c81e188647b4"))
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=4050, y=960), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/merge_node.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/merge_node.py
@@ -1,0 +1,20 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseMergeNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+
+from .....nodes.parse_function_call.nodes.merge_node import MergeNode
+
+
+class MergeNodeDisplay(BaseMergeNodeDisplay[MergeNode]):
+    label = "Merge Node"
+    node_id = UUID("bafc16db-a476-436d-9dde-fb74e8c294a0")
+    target_handle_ids = [
+        UUID("d3539134-8ba5-461f-b96c-8dda2b2bcc18"),
+        UUID("9dd8f0b4-dc15-456b-af35-68ca7c0ab1d7"),
+        UUID("a783d560-204c-45de-b8eb-ede63936ddaf"),
+        UUID("0d6fd7aa-1ca0-4246-8920-e1f00272ca78"),
+    ]
+    port_displays = {MergeNode.Ports.default: PortDisplayOverrides(id=UUID("c3beb021-47d9-44b1-bd2b-81b11168e76d"))}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=3480, y=1005), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/name.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/name.py
@@ -1,0 +1,19 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
+
+from .....nodes.parse_function_call.nodes.name import Name
+
+
+class NameDisplay(BaseFinalOutputNodeDisplay[Name]):
+    label = "Name"
+    node_id = UUID("fa12bb7f-c8e4-4d5d-9916-c348109c0ffb")
+    target_handle_id = UUID("a435166f-a65a-40a4-95e7-ad7def5491d2")
+    output_name = "function-name"
+    node_input_ids_by_name = {"node_input": UUID("d2ecd03e-b443-482c-838a-2dc345dbf8ed")}
+    output_display = {
+        Name.Outputs.value: NodeOutputDisplay(id=UUID("680f2d8d-b03a-43b9-9d77-626044e03227"), name="value")
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=5520, y=-135), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/parse_function_args.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/parse_function_args.py
@@ -1,0 +1,26 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from .....nodes.parse_function_call.nodes.parse_function_args import ParseFunctionArgs
+
+
+class ParseFunctionArgsDisplay(BaseTemplatingNodeDisplay[ParseFunctionArgs]):
+    label = "Parse Function Args"
+    node_id = UUID("8578e405-2e94-4603-88b2-f6420af5135b")
+    target_handle_id = UUID("8d4f5e8c-3124-4049-89d5-1261f6838400")
+    node_input_ids_by_name = {
+        "inputs.function_call": UUID("5b3a91bc-4375-45a1-9fa7-c61f52484678"),
+        "template": UUID("09cae3d9-6444-4352-9d04-532a0b703303"),
+    }
+    output_display = {
+        ParseFunctionArgs.Outputs.result: NodeOutputDisplay(
+            id=UUID("aa9c4408-4251-4a48-9b8f-882912966dec"), name="result"
+        )
+    }
+    port_displays = {
+        ParseFunctionArgs.Ports.default: PortDisplayOverrides(id=UUID("553960a1-8c83-4da5-9484-cf96c625cd9d"))
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=2925, y=1035), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/parse_function_call.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/parse_function_call.py
@@ -1,0 +1,27 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay, BaseTryNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from .....nodes.parse_function_call.nodes.parse_function_call import ParseFunctionCall1
+
+
+@BaseTryNodeDisplay.wrap(node_id=UUID("91c2815e-c42e-44ee-a1a2-23c7878eeca1"))
+class ParseFunctionCall1Display(BaseTemplatingNodeDisplay[ParseFunctionCall1]):
+    label = "Parse Function Call"
+    node_id = UUID("40f2e0f6-9d30-4c94-a09d-d88be7c871d6")
+    target_handle_id = UUID("f3ae9773-9729-4ae9-a608-3cc2a5a0ade8")
+    node_input_ids_by_name = {
+        "inputs.output": UUID("69e35fe1-9920-450c-b524-757d5900f810"),
+        "template": UUID("ddf266be-2166-404c-986f-631cffa05fbc"),
+    }
+    output_display = {
+        ParseFunctionCall1.Outputs.result: NodeOutputDisplay(
+            id=UUID("a165e831-0c3d-414e-85a0-f17d53166759"), name="result"
+        )
+    }
+    port_displays = {
+        ParseFunctionCall1.Ports.default: PortDisplayOverrides(id=UUID("4a5084ce-5c40-4af7-917f-e412e86f21e6"))
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=1725, y=495), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/parse_function_name.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/parse_function_name.py
@@ -1,0 +1,26 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from .....nodes.parse_function_call.nodes.parse_function_name import ParseFunctionName
+
+
+class ParseFunctionNameDisplay(BaseTemplatingNodeDisplay[ParseFunctionName]):
+    label = "Parse Function Name"
+    node_id = UUID("14d5c7b2-e434-46a6-8b97-47450ea77dcd")
+    target_handle_id = UUID("d2761e82-367e-4a10-b886-21413e52d9d5")
+    node_input_ids_by_name = {
+        "inputs.function_call": UUID("d15756f7-9021-469f-8e91-04f3008feaa3"),
+        "template": UUID("4239a502-567a-4224-8f37-354883502192"),
+    }
+    output_display = {
+        ParseFunctionName.Outputs.result: NodeOutputDisplay(
+            id=UUID("063d66ff-547c-49c4-b62a-c0ca172f63c7"), name="result"
+        )
+    }
+    port_displays = {
+        ParseFunctionName.Ports.default: PortDisplayOverrides(id=UUID("5e7848c8-057e-404d-b00a-a4e198904bc2"))
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=2955, y=630), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/parse_tool_id.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/parse_tool_id.py
@@ -1,0 +1,22 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseTemplatingNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from .....nodes.parse_function_call.nodes.parse_tool_id import ParseToolID
+
+
+class ParseToolIDDisplay(BaseTemplatingNodeDisplay[ParseToolID]):
+    label = "Parse Tool ID"
+    node_id = UUID("189de97f-9ae4-4af5-a816-0b54dbef616b")
+    target_handle_id = UUID("0c3ad9b3-23cc-412a-a73e-b16622ab5cab")
+    node_input_ids_by_name = {
+        "inputs.function_call": UUID("b67b9af7-df91-4002-b501-aa8c7389f565"),
+        "template": UUID("d8d8f969-ad9a-443c-9b15-0e53db265fa7"),
+    }
+    output_display = {
+        ParseToolID.Outputs.result: NodeOutputDisplay(id=UUID("6df79e21-6e5d-45db-84e7-b16ec91f2302"), name="result")
+    }
+    port_displays = {ParseToolID.Ports.default: PortDisplayOverrides(id=UUID("3919adb3-bb78-4668-9dc1-22fca2c1e945"))}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=2925, y=1500), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/tool_id.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/nodes/tool_id.py
@@ -1,0 +1,19 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
+
+from .....nodes.parse_function_call.nodes.tool_id import ToolID
+
+
+class ToolIDDisplay(BaseFinalOutputNodeDisplay[ToolID]):
+    label = "Tool ID"
+    node_id = UUID("b20229cd-8fd7-4cab-8e8f-d3fbaa8f6712")
+    target_handle_id = UUID("260b40f0-9fbe-4c84-84f3-aadc01f122f8")
+    output_name = "tool-id"
+    node_input_ids_by_name = {"node_input": UUID("aa57a708-d7e7-40f9-853d-fc1d66ac62b3")}
+    output_display = {
+        ToolID.Outputs.value: NodeOutputDisplay(id=UUID("764c26a4-b0c4-4a52-9e19-96e651eccbd3"), name="value")
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=5505, y=825), width=None, height=None)

--- a/examples/workflows/function_calling_demo/display/nodes/parse_function_call/workflow.py
+++ b/examples/workflows/function_calling_demo/display/nodes/parse_function_call/workflow.py
@@ -1,0 +1,81 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.base import EdgeDisplay, EntrypointDisplay, WorkflowMetaDisplay, WorkflowOutputDisplay
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
+
+from ....nodes.parse_function_call.nodes.allowed_function_names import AllowedFunctionNames
+from ....nodes.parse_function_call.nodes.args import Args
+from ....nodes.parse_function_call.nodes.conditional_node import ConditionalNode1
+from ....nodes.parse_function_call.nodes.conditional_node_1 import ConditionalNode2
+from ....nodes.parse_function_call.nodes.error_message import ErrorMessage
+from ....nodes.parse_function_call.nodes.error_node import ErrorNode1
+from ....nodes.parse_function_call.nodes.error_node_1 import ErrorNode2
+from ....nodes.parse_function_call.nodes.is_valid_function_name import IsValidFunctionName
+from ....nodes.parse_function_call.nodes.merge_node import MergeNode
+from ....nodes.parse_function_call.nodes.name import Name
+from ....nodes.parse_function_call.nodes.parse_function_args import ParseFunctionArgs
+from ....nodes.parse_function_call.nodes.parse_function_call import ParseFunctionCall1
+from ....nodes.parse_function_call.nodes.parse_function_name import ParseFunctionName
+from ....nodes.parse_function_call.nodes.parse_tool_id import ParseToolID
+from ....nodes.parse_function_call.nodes.tool_id import ToolID
+from ....nodes.parse_function_call.workflow import ParseFunctionCallWorkflow
+
+
+class ParseFunctionCallWorkflowDisplay(BaseWorkflowDisplay[ParseFunctionCallWorkflow]):
+    workflow_display = WorkflowMetaDisplay(
+        entrypoint_node_id=UUID("b0a312c5-c07e-4ba8-b434-575646ca8320"),
+        entrypoint_node_source_handle_id=UUID("be47c6ac-495c-498d-b318-f479c02c687a"),
+        entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=1170, y=585), width=None, height=None),
+        display_data=WorkflowDisplayData(
+            viewport=WorkflowDisplayDataViewport(x=-76.39160156249994, y=147.875, zoom=0.25)
+        ),
+    )
+    inputs_display = {}
+    entrypoint_displays = {
+        ParseFunctionCall1: EntrypointDisplay(
+            id=UUID("b0a312c5-c07e-4ba8-b434-575646ca8320"),
+            edge_display=EdgeDisplay(id=UUID("d4104764-f0ce-4c79-86d0-9dbca9dc3e9e")),
+        )
+    }
+    edge_displays = {
+        (ConditionalNode1.Ports.branch_2, ParseFunctionName): EdgeDisplay(
+            id=UUID("3c8a7288-2816-413b-a835-e9576dceb3c6")
+        ),
+        (ConditionalNode1.Ports.branch_2, ParseFunctionArgs): EdgeDisplay(
+            id=UUID("e1f8cc9d-8991-497a-ae85-c9b0addf79f7")
+        ),
+        (ParseFunctionName.Ports.default, MergeNode): EdgeDisplay(id=UUID("21b5c3b3-6b17-49d2-8042-d9ed0b5fc2b6")),
+        (ParseFunctionArgs.Ports.default, MergeNode): EdgeDisplay(id=UUID("73fd983e-ec53-4b8a-bb6e-bd4284450a12")),
+        (ConditionalNode1.Ports.branch_1, ErrorNode2): EdgeDisplay(id=UUID("e773fe7a-aafa-4644-9294-d804c9906c6e")),
+        (MergeNode.Ports.default, IsValidFunctionName): EdgeDisplay(id=UUID("269aed35-de3f-4d49-af39-534c7e69b404")),
+        (ConditionalNode1.Ports.branch_2, AllowedFunctionNames): EdgeDisplay(
+            id=UUID("be74615e-f7e9-4467-a9de-b612975a6f9d")
+        ),
+        (IsValidFunctionName.Ports.default, ConditionalNode2): EdgeDisplay(
+            id=UUID("fc6f2bb0-3287-4a37-895f-840f7eacb31c")
+        ),
+        (ConditionalNode2.Ports.branch_1, Name): EdgeDisplay(id=UUID("55c22812-f470-4ea9-8509-89d398df8ce7")),
+        (ConditionalNode2.Ports.branch_2, ErrorMessage): EdgeDisplay(id=UUID("3c890c21-4e40-4b11-8e68-8663609bc622")),
+        (ErrorMessage.Ports.default, ErrorNode1): EdgeDisplay(id=UUID("5eecd64f-68e4-4695-8977-2cd78874a129")),
+        (ConditionalNode2.Ports.branch_1, Args): EdgeDisplay(id=UUID("57778d49-b44c-4c62-9198-c848b20c4d4f")),
+        (ParseFunctionCall1.Ports.default, ConditionalNode1): EdgeDisplay(
+            id=UUID("9e705a8f-699c-45ab-b390-cd6e91ee0a00")
+        ),
+        (ConditionalNode1.Ports.branch_2, ParseToolID): EdgeDisplay(id=UUID("be6cc434-ab29-4cfb-aef3-6815bee41acf")),
+        (ParseToolID.Ports.default, MergeNode): EdgeDisplay(id=UUID("0074731f-548f-4ba0-bdc8-a024c9aef5fb")),
+        (AllowedFunctionNames.Ports.default, MergeNode): EdgeDisplay(id=UUID("37a1b5b8-9c33-47fb-a3a3-4c5eae1247a8")),
+        (ConditionalNode2.Ports.branch_1, ToolID): EdgeDisplay(id=UUID("51ab1ee1-57d6-4d18-bdb0-c3dc85e40a71")),
+    }
+    output_displays = {
+        ParseFunctionCallWorkflow.Outputs.function_args: WorkflowOutputDisplay(
+            id=UUID("d520f0a1-c28f-4007-acf9-2758871f2250"), name="function-args"
+        ),
+        ParseFunctionCallWorkflow.Outputs.function_name: WorkflowOutputDisplay(
+            id=UUID("680f2d8d-b03a-43b9-9d77-626044e03227"), name="function-name"
+        ),
+        ParseFunctionCallWorkflow.Outputs.tool_id: WorkflowOutputDisplay(
+            id=UUID("764c26a4-b0c4-4a52-9e19-96e651eccbd3"), name="tool-id"
+        ),
+    }

--- a/examples/workflows/function_calling_demo/display/nodes/prompt_node.py
+++ b/examples/workflows/function_calling_demo/display/nodes/prompt_node.py
@@ -1,0 +1,24 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from ...nodes.prompt_node import PromptNode
+
+
+class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
+    label = "Prompt Node"
+    node_id = UUID("2f1fa0d5-ef23-4738-9fd5-216407c18fb1")
+    output_id = UUID("76d8986c-3248-4a84-9780-97bd56b57cd7")
+    array_output_id = UUID("044296d4-bfa5-43c5-9055-0d1d440cc05e")
+    target_handle_id = UUID("b839c700-cbc7-442a-936a-a245a692df65")
+    node_input_ids_by_name = {"prompt_inputs.chat_history": UUID("1cf292a8-a99b-460b-8348-392e4b3e8dee")}
+    attribute_ids_by_name = {"ml_model": UUID("577cb543-4a7f-4f8a-8fce-56478c698511")}
+    output_display = {
+        PromptNode.Outputs.text: NodeOutputDisplay(id=UUID("76d8986c-3248-4a84-9780-97bd56b57cd7"), name="text"),
+        PromptNode.Outputs.results: NodeOutputDisplay(id=UUID("044296d4-bfa5-43c5-9055-0d1d440cc05e"), name="results"),
+        PromptNode.Outputs.json: NodeOutputDisplay(id=UUID("fdddc12a-b7ad-412e-b870-000567ec88a0"), name="json"),
+    }
+    port_displays = {PromptNode.Ports.default: PortDisplayOverrides(id=UUID("1aeebd8b-69c6-4051-af0e-01e628d81e3c"))}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=690, y=271.3250297289478), width=480, height=208)

--- a/examples/workflows/function_calling_demo/display/workflow.py
+++ b/examples/workflows/function_calling_demo/display/workflow.py
@@ -1,0 +1,74 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.base import (
+    EdgeDisplay,
+    EntrypointDisplay,
+    WorkflowInputsDisplay,
+    WorkflowMetaDisplay,
+    WorkflowOutputDisplay,
+)
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
+
+from ..inputs import Inputs
+from ..nodes.accumulate_chat_history import AccumulateChatHistory
+from ..nodes.conditional_node import ConditionalNode
+from ..nodes.conditional_node_10 import ConditionalNode10
+from ..nodes.error_node import ErrorNode
+from ..nodes.final_accumulation_of_chat_history import FinalAccumulationOfChatHistory
+from ..nodes.final_output import FinalOutput
+from ..nodes.get_current_weather import GetCurrentWeather
+from ..nodes.output_type import OutputType
+from ..nodes.parse_function_call import ParseFunctionCall
+from ..nodes.prompt_node import PromptNode
+from ..workflow import Workflow
+
+
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
+    workflow_display = WorkflowMetaDisplay(
+        entrypoint_node_id=UUID("8d9848b6-37f1-433d-9eb9-d85788007e8b"),
+        entrypoint_node_source_handle_id=UUID("39eb234b-7594-4855-9cb8-dfcaff48963c"),
+        entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=165, y=315), width=124, height=48),
+        display_data=WorkflowDisplayData(
+            viewport=WorkflowDisplayDataViewport(x=-730.0959027261842, y=128.0011183508181, zoom=0.49585442352220244)
+        ),
+    )
+    inputs_display = {
+        Inputs.chat_history: WorkflowInputsDisplay(id=UUID("b120c597-1e61-4779-b8d1-34676f9ecabc"), name="chat_history")
+    }
+    entrypoint_displays = {
+        PromptNode: EntrypointDisplay(
+            id=UUID("8d9848b6-37f1-433d-9eb9-d85788007e8b"),
+            edge_display=EdgeDisplay(id=UUID("894bb47f-c560-463a-8516-1f1dd9a45463")),
+        )
+    }
+    edge_displays = {
+        (ParseFunctionCall.Ports.default, ConditionalNode): EdgeDisplay(
+            id=UUID("413c943d-3aa0-459e-971d-ff89a286108f")
+        ),
+        (ConditionalNode.Ports.branch_1, GetCurrentWeather): EdgeDisplay(
+            id=UUID("ce18995e-2f1e-481e-bcf0-bfa1e9d6db8e")
+        ),
+        (GetCurrentWeather.Ports.default, AccumulateChatHistory): EdgeDisplay(
+            id=UUID("1efde279-9cd7-4917-b508-bb57768bd5e6")
+        ),
+        (AccumulateChatHistory.Ports.default, PromptNode): EdgeDisplay(id=UUID("7fd1861c-0b94-4e14-a724-88a5a67b8b02")),
+        (PromptNode.Ports.default, OutputType): EdgeDisplay(id=UUID("76dfcf8c-ccd0-4142-83de-f63662af6474")),
+        (OutputType.Ports.default, ConditionalNode10): EdgeDisplay(id=UUID("20afd4d8-bf0c-402b-a5ec-d231ed819e92")),
+        (ConditionalNode10.Ports.branch_1, ParseFunctionCall): EdgeDisplay(
+            id=UUID("b7cade05-cec8-459f-8113-e334a8f761f5")
+        ),
+        (ConditionalNode.Ports.branch_2, ErrorNode): EdgeDisplay(id=UUID("b5adfbdd-38f2-4377-8eee-d539f7747c26")),
+        (ConditionalNode10.Ports.branch_2, FinalAccumulationOfChatHistory): EdgeDisplay(
+            id=UUID("588faf16-b4b9-45f4-bdd1-b18926f6c5e5")
+        ),
+        (FinalAccumulationOfChatHistory.Ports.default, FinalOutput): EdgeDisplay(
+            id=UUID("988f4094-ec68-4123-b0ca-2990e973dce9")
+        ),
+    }
+    output_displays = {
+        Workflow.Outputs.final_output: WorkflowOutputDisplay(
+            id=UUID("e869f551-b02c-465f-90b3-ad2021b3c618"), name="final-output"
+        )
+    }

--- a/examples/workflows/function_calling_demo/inputs.py
+++ b/examples/workflows/function_calling_demo/inputs.py
@@ -1,0 +1,8 @@
+from typing import List, Optional
+
+from vellum import ChatMessage
+from vellum.workflows.inputs import BaseInputs
+
+
+class Inputs(BaseInputs):
+    chat_history: Optional[List[ChatMessage]] = None

--- a/examples/workflows/function_calling_demo/nodes/__init__.py
+++ b/examples/workflows/function_calling_demo/nodes/__init__.py
@@ -1,0 +1,23 @@
+from .accumulate_chat_history import AccumulateChatHistory
+from .conditional_node import ConditionalNode
+from .conditional_node_10 import ConditionalNode10
+from .error_node import ErrorNode
+from .final_accumulation_of_chat_history import FinalAccumulationOfChatHistory
+from .final_output import FinalOutput
+from .get_current_weather import GetCurrentWeather
+from .output_type import OutputType
+from .parse_function_call import ParseFunctionCall
+from .prompt_node import PromptNode
+
+__all__ = [
+    "AccumulateChatHistory",
+    "ConditionalNode",
+    "ConditionalNode10",
+    "ErrorNode",
+    "FinalAccumulationOfChatHistory",
+    "FinalOutput",
+    "GetCurrentWeather",
+    "OutputType",
+    "ParseFunctionCall",
+    "PromptNode",
+]

--- a/examples/workflows/function_calling_demo/nodes/accumulate_chat_history/__init__.py
+++ b/examples/workflows/function_calling_demo/nodes/accumulate_chat_history/__init__.py
@@ -1,0 +1,22 @@
+from typing import List
+
+from vellum import ChatMessage
+from vellum.workflows.nodes.displayable import CodeExecutionNode
+from vellum.workflows.references import LazyReference
+from vellum.workflows.state import BaseState
+
+from ...inputs import Inputs
+from ..get_current_weather import GetCurrentWeather
+from ..parse_function_call import ParseFunctionCall
+
+
+class AccumulateChatHistory(CodeExecutionNode[BaseState, List[ChatMessage]]):
+    filepath = "./script.py"
+    code_inputs = {
+        "tool_id": ParseFunctionCall.Outputs.tool_id,
+        "function_result": GetCurrentWeather.Outputs.result,
+        "assistant_message": LazyReference("PromptNode.Outputs.results"),
+        "current_chat_history": Inputs.chat_history,
+    }
+    runtime = "PYTHON_3_11_6"
+    packages = []

--- a/examples/workflows/function_calling_demo/nodes/accumulate_chat_history/script.py
+++ b/examples/workflows/function_calling_demo/nodes/accumulate_chat_history/script.py
@@ -1,0 +1,22 @@
+def main(
+    tool_id,
+    function_result,
+    assistant_message,
+    current_chat_history,
+) -> int:
+    return [
+        *current_chat_history,
+        {
+            "role": "ASSISTANT",
+            "content": assistant_message[0],
+        },
+        {
+            "role": "FUNCTION",
+            "content": {
+              "type": "STRING",
+              "value": json.dumps(function_result)
+            },
+            "source": tool_id
+        }
+    ]
+    

--- a/examples/workflows/function_calling_demo/nodes/conditional_node.py
+++ b/examples/workflows/function_calling_demo/nodes/conditional_node.py
@@ -1,0 +1,10 @@
+from vellum.workflows.nodes.displayable import ConditionalNode as BaseConditionalNode
+from vellum.workflows.ports import Port
+
+from .parse_function_call import ParseFunctionCall
+
+
+class ConditionalNode(BaseConditionalNode):
+    class Ports(BaseConditionalNode.Ports):
+        branch_1 = Port.on_if(ParseFunctionCall.Outputs.function_name.equals("get_current_weather"))
+        branch_2 = Port.on_else()

--- a/examples/workflows/function_calling_demo/nodes/conditional_node_10.py
+++ b/examples/workflows/function_calling_demo/nodes/conditional_node_10.py
@@ -1,0 +1,9 @@
+from vellum.workflows.nodes.displayable import ConditionalNode
+from vellum.workflows.ports import Port
+from vellum.workflows.references import LazyReference
+
+
+class ConditionalNode10(ConditionalNode):
+    class Ports(ConditionalNode.Ports):
+        branch_1 = Port.on_if(LazyReference("OutputType.Outputs.result").equals("FUNCTION_CALL"))
+        branch_2 = Port.on_else()

--- a/examples/workflows/function_calling_demo/nodes/error_node.py
+++ b/examples/workflows/function_calling_demo/nodes/error_node.py
@@ -1,0 +1,6 @@
+from vellum import VellumError
+from vellum.workflows.nodes.displayable import ErrorNode as BaseErrorNode
+
+
+class ErrorNode(BaseErrorNode):
+    error = VellumError(message="Unrecognized function call", code="USER_DEFINED_ERROR")

--- a/examples/workflows/function_calling_demo/nodes/final_accumulation_of_chat_history/__init__.py
+++ b/examples/workflows/function_calling_demo/nodes/final_accumulation_of_chat_history/__init__.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from vellum import ChatMessage
+from vellum.workflows.nodes.displayable import CodeExecutionNode
+from vellum.workflows.state import BaseState
+
+from ...inputs import Inputs
+from ..accumulate_chat_history import AccumulateChatHistory
+from ..prompt_node import PromptNode
+
+
+class FinalAccumulationOfChatHistory(CodeExecutionNode[BaseState, List[ChatMessage]]):
+    filepath = "./script.py"
+    code_inputs = {
+        "current_chat_history": AccumulateChatHistory.Outputs.result.coalesce(Inputs.chat_history),
+        "assistant_message": PromptNode.Outputs.results,
+    }
+    runtime = "PYTHON_3_11_6"
+    packages = []

--- a/examples/workflows/function_calling_demo/nodes/final_accumulation_of_chat_history/script.py
+++ b/examples/workflows/function_calling_demo/nodes/final_accumulation_of_chat_history/script.py
@@ -1,0 +1,12 @@
+def main(
+    current_chat_history,
+    assistant_message,
+) -> int:
+    return [
+        *current_chat_history,
+        {
+            "role": "ASSISTANT",
+            "content": assistant_message[0],
+        },
+    ]
+    

--- a/examples/workflows/function_calling_demo/nodes/final_output.py
+++ b/examples/workflows/function_calling_demo/nodes/final_output.py
@@ -1,0 +1,12 @@
+from typing import List
+
+from vellum import ChatMessage
+from vellum.workflows.nodes.displayable import FinalOutputNode
+from vellum.workflows.state import BaseState
+
+from .final_accumulation_of_chat_history import FinalAccumulationOfChatHistory
+
+
+class FinalOutput(FinalOutputNode[BaseState, List[ChatMessage]]):
+    class Outputs(FinalOutputNode.Outputs):
+        value = FinalAccumulationOfChatHistory.Outputs.result

--- a/examples/workflows/function_calling_demo/nodes/get_current_weather/__init__.py
+++ b/examples/workflows/function_calling_demo/nodes/get_current_weather/__init__.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from vellum.types import CodeExecutionPackage
+from vellum.workflows.nodes.displayable import CodeExecutionNode
+from vellum.workflows.references import VellumSecretReference
+from vellum.workflows.state import BaseState
+
+from ..parse_function_call import ParseFunctionCall
+
+
+class GetCurrentWeather(CodeExecutionNode[BaseState, Any]):
+    filepath = "./script.py"
+    code_inputs = {
+        "kwargs": ParseFunctionCall.Outputs.function_args,
+        "gmaps_api_key": VellumSecretReference("GOOGLE_GEOCODING_API_KEY"),
+        "openweather_api_key": VellumSecretReference("OPEN_WEATHER_API_KEY"),
+    }
+    runtime = "PYTHON_3_11_6"
+    packages = [
+        CodeExecutionPackage(name="googlemaps", version="4.10.0"),
+        CodeExecutionPackage(name="requests", version="2.32.3"),
+    ]

--- a/examples/workflows/function_calling_demo/nodes/get_current_weather/script.py
+++ b/examples/workflows/function_calling_demo/nodes/get_current_weather/script.py
@@ -1,0 +1,22 @@
+import googlemaps
+import requests
+
+def main(kwargs, gmaps_api_key, openweather_api_key):
+    location = kwargs["location"]
+
+    gmaps = googlemaps.Client(key=gmaps_api_key)
+
+    # Geocoding an address
+    geocode_result = gmaps.geocode(location)
+    print(geocode_result)
+
+    coordinates = geocode_result[0]["geometry"]["location"]
+    lat = coordinates["lat"]
+    lon = coordinates["lng"]
+
+    url = f"https://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&appid=7b9663b943995d520fdfe643d6838425"
+    response = requests.get(url)
+    data = response.json()
+    
+    return data
+    

--- a/examples/workflows/function_calling_demo/nodes/output_type.py
+++ b/examples/workflows/function_calling_demo/nodes/output_type.py
@@ -1,0 +1,11 @@
+from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+
+from .prompt_node import PromptNode
+
+
+class OutputType(TemplatingNode[BaseState, str]):
+    template = """{{ output[0].type }}"""
+    inputs = {
+        "output": PromptNode.Outputs.results,
+    }

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/__init__.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/__init__.py
@@ -1,0 +1,7 @@
+from vellum.workflows.nodes.displayable import InlineSubworkflowNode
+
+from .workflow import ParseFunctionCallWorkflow
+
+
+class ParseFunctionCall(InlineSubworkflowNode):
+    subworkflow = ParseFunctionCallWorkflow

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/__init__.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/__init__.py
@@ -1,0 +1,33 @@
+from .allowed_function_names import AllowedFunctionNames
+from .args import Args
+from .conditional_node import ConditionalNode1
+from .conditional_node_1 import ConditionalNode2
+from .error_message import ErrorMessage
+from .error_node import ErrorNode1
+from .error_node_1 import ErrorNode2
+from .is_valid_function_name import IsValidFunctionName
+from .merge_node import MergeNode
+from .name import Name
+from .parse_function_args import ParseFunctionArgs
+from .parse_function_call import ParseFunctionCall1
+from .parse_function_name import ParseFunctionName
+from .parse_tool_id import ParseToolID
+from .tool_id import ToolID
+
+__all__ = [
+    "AllowedFunctionNames",
+    "Args",
+    "ConditionalNode1",
+    "ConditionalNode2",
+    "ErrorMessage",
+    "ErrorNode1",
+    "ErrorNode2",
+    "IsValidFunctionName",
+    "MergeNode",
+    "Name",
+    "ParseFunctionArgs",
+    "ParseFunctionCall1",
+    "ParseFunctionName",
+    "ParseToolID",
+    "ToolID",
+]

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/allowed_function_names.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/allowed_function_names.py
@@ -1,0 +1,8 @@
+from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+from vellum.workflows.types.core import Json
+
+
+class AllowedFunctionNames(TemplatingNode[BaseState, Json]):
+    template = """[\"get_current_weather\"]"""
+    inputs = {}

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/args.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/args.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+from vellum.workflows.nodes.displayable import FinalOutputNode
+from vellum.workflows.state import BaseState
+
+from .parse_function_args import ParseFunctionArgs
+
+
+class Args(FinalOutputNode[BaseState, Any]):
+    class Outputs(FinalOutputNode.Outputs):
+        value = ParseFunctionArgs.Outputs.result

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/conditional_node.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/conditional_node.py
@@ -1,0 +1,10 @@
+from vellum.workflows.nodes.displayable import ConditionalNode
+from vellum.workflows.ports import Port
+
+from .parse_function_call import ParseFunctionCall1
+
+
+class ConditionalNode1(ConditionalNode):
+    class Ports(ConditionalNode.Ports):
+        branch_1 = Port.on_if(ParseFunctionCall1.Outputs.error.is_not_nil())
+        branch_2 = Port.on_else()

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/conditional_node_1.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/conditional_node_1.py
@@ -1,0 +1,10 @@
+from vellum.workflows.nodes.displayable import ConditionalNode
+from vellum.workflows.ports import Port
+
+from .is_valid_function_name import IsValidFunctionName
+
+
+class ConditionalNode2(ConditionalNode):
+    class Ports(ConditionalNode.Ports):
+        branch_1 = Port.on_if(IsValidFunctionName.Outputs.result.equals("True"))
+        branch_2 = Port.on_else()

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/error_message.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/error_message.py
@@ -1,0 +1,11 @@
+from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+
+from .parse_function_name import ParseFunctionName
+
+
+class ErrorMessage(TemplatingNode[BaseState, str]):
+    template = """Invalid function name {{ invalid_function_name }}."""
+    inputs = {
+        "invalid_function_name": ParseFunctionName.Outputs.result,
+    }

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/error_node.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/error_node.py
@@ -1,0 +1,7 @@
+from vellum.workflows.nodes.displayable import ErrorNode
+
+from .error_message import ErrorMessage
+
+
+class ErrorNode1(ErrorNode):
+    error = ErrorMessage.Outputs.result

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/error_node_1.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/error_node_1.py
@@ -1,0 +1,6 @@
+from vellum import VellumError
+from vellum.workflows.nodes.displayable import ErrorNode
+
+
+class ErrorNode2(ErrorNode):
+    error = VellumError(message="No function call found.", code="USER_DEFINED_ERROR")

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/is_valid_function_name/__init__.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/is_valid_function_name/__init__.py
@@ -1,0 +1,15 @@
+from vellum.workflows.nodes.displayable import CodeExecutionNode
+from vellum.workflows.state import BaseState
+
+from ..allowed_function_names import AllowedFunctionNames
+from ..parse_function_name import ParseFunctionName
+
+
+class IsValidFunctionName(CodeExecutionNode[BaseState, str]):
+    filepath = "./script.py"
+    code_inputs = {
+        "function_name": ParseFunctionName.Outputs.result,
+        "allowed_function_names": AllowedFunctionNames.Outputs.result,
+    }
+    runtime = "PYTHON_3_11_6"
+    packages = []

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/is_valid_function_name/script.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/is_valid_function_name/script.py
@@ -1,0 +1,6 @@
+def main(
+    function_name,
+    allowed_function_names,
+) -> int:
+    return "True" if function_name in allowed_function_names else "False"
+    

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/merge_node.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/merge_node.py
@@ -1,0 +1,7 @@
+from vellum.workflows.nodes.displayable import MergeNode as BaseMergeNode
+from vellum.workflows.types import MergeBehavior
+
+
+class MergeNode(BaseMergeNode):
+    class Trigger(BaseMergeNode.Trigger):
+        merge_behavior = MergeBehavior.AWAIT_ALL

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/name.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/name.py
@@ -1,0 +1,9 @@
+from vellum.workflows.nodes.displayable import FinalOutputNode
+from vellum.workflows.state import BaseState
+
+from .parse_function_name import ParseFunctionName
+
+
+class Name(FinalOutputNode[BaseState, str]):
+    class Outputs(FinalOutputNode.Outputs):
+        value = ParseFunctionName.Outputs.result

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/parse_function_args.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/parse_function_args.py
@@ -1,0 +1,12 @@
+from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+from vellum.workflows.types.core import Json
+
+from .parse_function_call import ParseFunctionCall1
+
+
+class ParseFunctionArgs(TemplatingNode[BaseState, Json]):
+    template = """{{ function_call.function.arguments }}"""
+    inputs = {
+        "function_call": ParseFunctionCall1.Outputs.result,
+    }

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/parse_function_call.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/parse_function_call.py
@@ -1,0 +1,13 @@
+from vellum.workflows.nodes.core.try_node.node import TryNode
+from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.references import LazyReference
+from vellum.workflows.state import BaseState
+from vellum.workflows.types.core import Json
+
+
+@TryNode.wrap()
+class ParseFunctionCall1(TemplatingNode[BaseState, Json]):
+    template = """{{ json.dumps(json.loads(output).tool_calls[0]) }}"""
+    inputs = {
+        "output": LazyReference("PromptNode.Outputs.text"),
+    }

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/parse_function_name.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/parse_function_name.py
@@ -1,0 +1,11 @@
+from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+
+from .parse_function_call import ParseFunctionCall1
+
+
+class ParseFunctionName(TemplatingNode[BaseState, str]):
+    template = """{{ function_call.function.name }}"""
+    inputs = {
+        "function_call": ParseFunctionCall1.Outputs.result,
+    }

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/parse_tool_id.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/parse_tool_id.py
@@ -1,0 +1,11 @@
+from vellum.workflows.nodes.displayable import TemplatingNode
+from vellum.workflows.state import BaseState
+
+from .parse_function_call import ParseFunctionCall1
+
+
+class ParseToolID(TemplatingNode[BaseState, str]):
+    template = """{{ function_call.id }}"""
+    inputs = {
+        "function_call": ParseFunctionCall1.Outputs.result,
+    }

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/tool_id.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/nodes/tool_id.py
@@ -1,0 +1,9 @@
+from vellum.workflows.nodes.displayable import FinalOutputNode
+from vellum.workflows.state import BaseState
+
+from .parse_tool_id import ParseToolID
+
+
+class ToolID(FinalOutputNode[BaseState, str]):
+    class Outputs(FinalOutputNode.Outputs):
+        value = ParseToolID.Outputs.result

--- a/examples/workflows/function_calling_demo/nodes/parse_function_call/workflow.py
+++ b/examples/workflows/function_calling_demo/nodes/parse_function_call/workflow.py
@@ -1,0 +1,46 @@
+from vellum.workflows import BaseWorkflow
+
+from .nodes.allowed_function_names import AllowedFunctionNames
+from .nodes.args import Args
+from .nodes.conditional_node import ConditionalNode1
+from .nodes.conditional_node_1 import ConditionalNode2
+from .nodes.error_message import ErrorMessage
+from .nodes.error_node import ErrorNode1
+from .nodes.error_node_1 import ErrorNode2
+from .nodes.is_valid_function_name import IsValidFunctionName
+from .nodes.merge_node import MergeNode
+from .nodes.name import Name
+from .nodes.parse_function_args import ParseFunctionArgs
+from .nodes.parse_function_call import ParseFunctionCall1
+from .nodes.parse_function_name import ParseFunctionName
+from .nodes.parse_tool_id import ParseToolID
+from .nodes.tool_id import ToolID
+
+
+class ParseFunctionCallWorkflow(BaseWorkflow):
+    graph = ParseFunctionCall1 >> {
+        ConditionalNode1.Ports.branch_1 >> ErrorNode2,
+        ConditionalNode1.Ports.branch_2
+        >> {
+            ParseFunctionName,
+            ParseFunctionArgs,
+            AllowedFunctionNames,
+            ParseToolID,
+        }
+        >> MergeNode
+        >> IsValidFunctionName
+        >> {
+            ConditionalNode2.Ports.branch_1
+            >> {
+                Name,
+                Args,
+                ToolID,
+            },
+            ConditionalNode2.Ports.branch_2 >> ErrorMessage >> ErrorNode1,
+        },
+    }
+
+    class Outputs(BaseWorkflow.Outputs):
+        function_args = Args.Outputs.value
+        function_name = Name.Outputs.value
+        tool_id = ToolID.Outputs.value

--- a/examples/workflows/function_calling_demo/nodes/prompt_node.py
+++ b/examples/workflows/function_calling_demo/nodes/prompt_node.py
@@ -1,0 +1,61 @@
+from vellum import ChatMessagePromptBlock, FunctionDefinition, JinjaPromptBlock, PromptParameters, VariablePromptBlock
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
+from ..inputs import Inputs
+from .accumulate_chat_history import AccumulateChatHistory
+
+
+class PromptNode(InlinePromptNode):
+    ml_model = "7dd6f3d4-000a-4fa3-952d-9ada6b9b2e38"
+    blocks = [
+        ChatMessagePromptBlock(
+            chat_role="SYSTEM",
+            blocks=[
+                JinjaPromptBlock(
+                    template="""You are an expert meteorologist that helps correctly answer questions about the weather. Answer questions factually based  the information that you\'re provided and ask clarifying questions when needed"""
+                )
+            ],
+        ),
+        VariablePromptBlock(input_variable="chat_history"),
+    ]
+    prompt_inputs = {
+        "chat_history": AccumulateChatHistory.Outputs.result.coalesce(Inputs.chat_history),
+    }
+    functions = [
+        FunctionDefinition(
+            name="get_current_weather",
+            description="Get the current weather in a given location",
+            parameters={
+                "type": "object",
+                "required": [
+                    "location",
+                ],
+                "properties": {
+                    "unit": {
+                        "enum": [
+                            "celsius",
+                            "fahrenheit",
+                        ],
+                        "type": "string",
+                    },
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA",
+                    },
+                },
+            },
+            function_forced=False,
+            function_strict=False,
+        ),
+    ]
+    parameters = PromptParameters(
+        stop=[],
+        temperature=0,
+        max_tokens=1000,
+        top_p=1,
+        top_k=0,
+        frequency_penalty=0,
+        presence_penalty=0,
+        logit_bias={},
+        custom_parameters=None,
+    )

--- a/examples/workflows/function_calling_demo/sandbox.py
+++ b/examples/workflows/function_calling_demo/sandbox.py
@@ -1,0 +1,24 @@
+from vellum.workflows.sandbox import WorkflowSandboxRunner
+
+from .inputs import ChatMessage, Inputs
+from .workflow import Workflow
+
+if __name__ != "__main__":
+    raise Exception("This file is not meant to be imported")
+
+
+workflow = Workflow()
+runner = WorkflowSandboxRunner(
+    workflow,
+    inputs=[
+        Inputs(
+            chat_history=[
+                ChatMessage(
+                    role="USER",
+                    text="What is the weather in San Francisco?",
+                )
+            ]
+        )
+    ],
+)
+runner.run()

--- a/examples/workflows/function_calling_demo/workflow.py
+++ b/examples/workflows/function_calling_demo/workflow.py
@@ -1,0 +1,33 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.state import BaseState
+
+from .inputs import Inputs
+from .nodes.accumulate_chat_history import AccumulateChatHistory
+from .nodes.conditional_node import ConditionalNode
+from .nodes.conditional_node_10 import ConditionalNode10
+from .nodes.error_node import ErrorNode
+from .nodes.final_accumulation_of_chat_history import FinalAccumulationOfChatHistory
+from .nodes.final_output import FinalOutput
+from .nodes.get_current_weather import GetCurrentWeather
+from .nodes.output_type import OutputType
+from .nodes.parse_function_call import ParseFunctionCall
+from .nodes.prompt_node import PromptNode
+
+
+class Workflow(BaseWorkflow[Inputs, BaseState]):
+    graph = (
+        PromptNode
+        >> OutputType
+        >> {
+            ConditionalNode10.Ports.branch_1
+            >> ParseFunctionCall
+            >> {
+                ConditionalNode.Ports.branch_1 >> GetCurrentWeather >> AccumulateChatHistory >> PromptNode,
+                ConditionalNode.Ports.branch_2 >> ErrorNode,
+            },
+            ConditionalNode10.Ports.branch_2 >> FinalAccumulationOfChatHistory >> FinalOutput,
+        }
+    )
+
+    class Outputs(BaseWorkflow.Outputs):
+        final_output = FinalOutput.Outputs.value


### PR DESCRIPTION
I wanted to add the main Function Calling demo workflow to our sdk examples for a few reasons:
- We show it off on calls, so there's definitely value in sharing it with end users
- I want to push it to a few prospects who are interested in the custom docker image version of it to buy some time
- We eventually foresee a release blocking e2e suite which we could use the examples directory to power that automation. The original idea of that automation was motivated by the function calling demo workflow.
- Gives us a canonical example in the SDK repo to improve over time