### PR TITLE
Copy custom base node example into SDK

### DIFF
--- a/examples/workflows/custom_base_node/__init__.py
+++ b/examples/workflows/custom_base_node/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa: F401, F403
+
+from .display import *

--- a/examples/workflows/custom_base_node/chat.py
+++ b/examples/workflows/custom_base_node/chat.py
@@ -1,0 +1,32 @@
+from dotenv import load_dotenv
+
+from vellum.workflows.workflows.event_filters import root_workflow_event_filter
+
+from .inputs import Inputs
+from .workflow import IndeedWorkflow
+
+
+def main():
+    load_dotenv()
+    workflow = IndeedWorkflow()
+
+    while True:
+        query = input("Hi! I'm an Indeed Chatbot. What can I do for you today? ")
+        inputs = Inputs(query=query)
+
+        stream = workflow.stream(inputs=inputs, event_filter=root_workflow_event_filter)
+        error = None
+        for event in stream:
+            if event.name == "node.execution.fulfilled":
+                print("Finished Node", event.node_definition)  # noqa: T201
+            elif event.name == "workflow.execution.fulfilled":
+                print(event.outputs["answer"])  # noqa: T201
+            elif event.name == "workflow.execution.rejected":
+                error = event.error.message
+
+        if error:
+            raise Exception(error)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/workflows/custom_base_node/display/__init__.py
+++ b/examples/workflows/custom_base_node/display/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa: F401, F403
+
+from .nodes import *
+from .workflow import *

--- a/examples/workflows/custom_base_node/display/nodes/__init__.py
+++ b/examples/workflows/custom_base_node/display/nodes/__init__.py
@@ -1,0 +1,17 @@
+from .conditional_router import ConditionalRouterDisplay
+from .echo_request import EchoRequestDisplay
+from .error_node import ErrorNodeDisplay
+from .exit_node import ExitNodeDisplay
+from .fibonacci import FibonacciDisplay
+from .get_temperature import GetTemperatureDisplay
+from .my_prompt import MyPromptDisplay
+
+__all__ = [
+    "ConditionalRouterDisplay",
+    "ErrorNodeDisplay",
+    "ExitNodeDisplay",
+    "MyPromptDisplay",
+    "GetTemperatureDisplay",
+    "FibonacciDisplay",
+    "EchoRequestDisplay",
+]

--- a/examples/workflows/custom_base_node/display/nodes/conditional_router.py
+++ b/examples/workflows/custom_base_node/display/nodes/conditional_router.py
@@ -1,0 +1,18 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+
+from ...nodes.conditional_router import ConditionalRouter
+
+
+class ConditionalRouterDisplay(BaseNodeDisplay[ConditionalRouter]):
+    port_displays = {
+        ConditionalRouter.Ports.exit: PortDisplayOverrides(id=UUID("4614e935-1a99-48c5-a3dd-46d4d97a883a")),
+        ConditionalRouter.Ports.get_temperature: PortDisplayOverrides(id=UUID("1ba9260f-39b3-48f0-a1c9-a042346fb961")),
+        ConditionalRouter.Ports.echo_request: PortDisplayOverrides(id=UUID("2834c6c6-0bbc-4d76-becd-de6abdbe0410")),
+        ConditionalRouter.Ports.fibonacci: PortDisplayOverrides(id=UUID("ce38e395-c5a4-4550-b950-8994dff781b2")),
+        ConditionalRouter.Ports.unknown: PortDisplayOverrides(id=UUID("c094a2db-3d76-46ee-8d44-eb255402e32d")),
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None)

--- a/examples/workflows/custom_base_node/display/nodes/echo_request.py
+++ b/examples/workflows/custom_base_node/display/nodes/echo_request.py
@@ -1,0 +1,12 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+
+from ...nodes.echo_request import EchoRequest
+
+
+class EchoRequestDisplay(BaseNodeDisplay[EchoRequest]):
+    port_displays = {EchoRequest.Ports.default: PortDisplayOverrides(id=UUID("615b3eb7-f1e3-4f23-9743-9a90044d9500"))}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None)

--- a/examples/workflows/custom_base_node/display/nodes/error_node.py
+++ b/examples/workflows/custom_base_node/display/nodes/error_node.py
@@ -1,0 +1,16 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseErrorNodeDisplay
+
+from ...nodes.error_node import ErrorNode
+
+
+class ErrorNodeDisplay(BaseErrorNodeDisplay[ErrorNode]):
+    name = "error-node"
+    node_id = UUID("92e401f1-110f-4edc-8bb0-cad879e1ea08")
+    label = "Error Node"
+    # error_output_id = UUID("None")
+    target_handle_id = UUID("c1b30829-76af-4d99-bf83-b030c551a7cf")
+    node_input_ids_by_name = {"error_source_input_id": UUID("02d8ab87-a237-4892-81bc-9e532c73064e")}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None)

--- a/examples/workflows/custom_base_node/display/nodes/exit_node.py
+++ b/examples/workflows/custom_base_node/display/nodes/exit_node.py
@@ -1,0 +1,19 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseFinalOutputNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
+
+from ...nodes.exit_node import ExitNode
+
+
+class ExitNodeDisplay(BaseFinalOutputNodeDisplay[ExitNode]):
+    label = "Exit Node"
+    node_id = UUID("c69f1216-3000-4e69-afa4-4269c734c980")
+    target_handle_id = UUID("674e0ef5-8563-466f-9209-93bb4689082f")
+    output_name = "answer"
+    node_input_ids_by_name = {"node_input": UUID("72f69630-7210-47ae-be3b-0b6a04a4488f")}
+    output_display = {
+        ExitNode.Outputs.value: NodeOutputDisplay(id=UUID("708005f3-81e0-4886-95e9-ccb0d6c029d3"), name="value")
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None)

--- a/examples/workflows/custom_base_node/display/nodes/fibonacci.py
+++ b/examples/workflows/custom_base_node/display/nodes/fibonacci.py
@@ -1,0 +1,12 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+
+from ...nodes.fibonacci import Fibonacci
+
+
+class FibonacciDisplay(BaseNodeDisplay[Fibonacci]):
+    port_displays = {Fibonacci.Ports.default: PortDisplayOverrides(id=UUID("bfb5c1da-5cf0-40bf-adce-c071f0d09d12"))}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None)

--- a/examples/workflows/custom_base_node/display/nodes/get_temperature.py
+++ b/examples/workflows/custom_base_node/display/nodes/get_temperature.py
@@ -1,0 +1,14 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseNodeDisplay
+from vellum_ee.workflows.display.nodes.types import PortDisplayOverrides
+
+from ...nodes.get_temperature import GetTemperature
+
+
+class GetTemperatureDisplay(BaseNodeDisplay[GetTemperature]):
+    port_displays = {
+        GetTemperature.Ports.default: PortDisplayOverrides(id=UUID("3f774189-4e8e-45b6-a6eb-f62a7a96593c"))
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None)

--- a/examples/workflows/custom_base_node/display/nodes/my_prompt.py
+++ b/examples/workflows/custom_base_node/display/nodes/my_prompt.py
@@ -1,0 +1,23 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseInlinePromptNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from ...nodes.my_prompt import MyPrompt
+
+
+class MyPromptDisplay(BaseInlinePromptNodeDisplay[MyPrompt]):
+    label = "My Prompt"
+    node_id = UUID("805fa2c2-56fb-400d-9ca2-486c753bc81d")
+    output_id = UUID("2bae09e7-f310-446d-9471-563446262d4b")
+    array_output_id = UUID("7a1fd6fd-070e-417a-919b-52520f0429e2")
+    target_handle_id = UUID("7e899794-657a-412f-b72d-8e7e4b151a01")
+    node_input_ids_by_name = {"prompt_inputs.query": UUID("ebae7e5c-c916-4c07-be2c-40929eed766b")}
+    output_display = {
+        MyPrompt.Outputs.text: NodeOutputDisplay(id=UUID("2bae09e7-f310-446d-9471-563446262d4b"), name="text"),
+        MyPrompt.Outputs.results: NodeOutputDisplay(id=UUID("7a1fd6fd-070e-417a-919b-52520f0429e2"), name="results"),
+        MyPrompt.Outputs.json: NodeOutputDisplay(id=UUID("9498ab4d-f0a2-4666-b3eb-59284fe11583"), name="json"),
+    }
+    port_displays = {MyPrompt.Ports.default: PortDisplayOverrides(id=UUID("20d70a2d-01c5-4c98-9fa2-2c1b200d492f"))}
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None)

--- a/examples/workflows/custom_base_node/display/workflow.py
+++ b/examples/workflows/custom_base_node/display/workflow.py
@@ -1,0 +1,60 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.base import (
+    EdgeDisplay,
+    EntrypointDisplay,
+    WorkflowInputsDisplay,
+    WorkflowMetaDisplay,
+    WorkflowOutputDisplay,
+)
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
+
+from ..inputs import Inputs
+from ..nodes.conditional_router import ConditionalRouter
+from ..nodes.echo_request import EchoRequest
+from ..nodes.error_node import ErrorNode
+from ..nodes.exit_node import ExitNode
+from ..nodes.fibonacci import Fibonacci
+from ..nodes.get_temperature import GetTemperature
+from ..nodes.my_prompt import MyPrompt
+from ..workflow import IndeedWorkflow
+
+
+class IndeedWorkflowDisplay(BaseWorkflowDisplay[IndeedWorkflow]):
+    workflow_display = WorkflowMetaDisplay(
+        entrypoint_node_id=UUID("5aa611bd-83d6-4a34-b2f4-3b3511c56998"),
+        entrypoint_node_source_handle_id=UUID("213ccd7a-bd48-45a3-8387-af9afa946e0e"),
+        entrypoint_node_display=NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), width=None, height=None),
+        display_data=WorkflowDisplayData(viewport=WorkflowDisplayDataViewport(x=0, y=0, zoom=1)),
+    )
+    inputs_display = {
+        Inputs.query: WorkflowInputsDisplay(id=UUID("a6cc5f97-122f-4d54-b70a-43874e2c6573"), name="query")
+    }
+    entrypoint_displays = {
+        MyPrompt: EntrypointDisplay(
+            id=UUID("5aa611bd-83d6-4a34-b2f4-3b3511c56998"),
+            edge_display=EdgeDisplay(id=UUID("8f376c53-b70a-4c09-a187-27fe25b306bc")),
+        )
+    }
+    edge_displays = {
+        (MyPrompt.Ports.default, ConditionalRouter): EdgeDisplay(id=UUID("af748cf1-8aab-4cfc-b73d-141a4a506d40")),
+        (ConditionalRouter.Ports.echo_request, EchoRequest): EdgeDisplay(
+            id=UUID("47e23829-7b60-4303-b242-64c1ff299e39")
+        ),
+        (EchoRequest.Ports.default, MyPrompt): EdgeDisplay(id=UUID("5a78572f-595e-4fe2-acc5-e45540d2b98b")),
+        (ConditionalRouter.Ports.exit, ExitNode): EdgeDisplay(id=UUID("1a518848-89f6-4036-9f0b-6e1c09b4a8a7")),
+        (ConditionalRouter.Ports.get_temperature, GetTemperature): EdgeDisplay(
+            id=UUID("f8297a07-5d2e-45a0-8610-780b6307c9d5")
+        ),
+        (GetTemperature.Ports.default, MyPrompt): EdgeDisplay(id=UUID("93ddfe51-7ce3-46f4-8c60-0ea2fe2e228e")),
+        (ConditionalRouter.Ports.fibonacci, Fibonacci): EdgeDisplay(id=UUID("038eb1b3-663a-49b5-9c0c-e4f6afef8d46")),
+        (Fibonacci.Ports.default, MyPrompt): EdgeDisplay(id=UUID("1ea51ea2-a74f-4638-88df-496183fc1014")),
+        (ConditionalRouter.Ports.unknown, ErrorNode): EdgeDisplay(id=UUID("414653b1-f3a6-40da-9973-5a5bda741c85")),
+    }
+    output_displays = {
+        IndeedWorkflow.Outputs.answer: WorkflowOutputDisplay(
+            id=UUID("708005f3-81e0-4886-95e9-ccb0d6c029d3"), name="answer"
+        )
+    }

--- a/examples/workflows/custom_base_node/inputs.py
+++ b/examples/workflows/custom_base_node/inputs.py
@@ -1,0 +1,5 @@
+from vellum.workflows.inputs import BaseInputs
+
+
+class Inputs(BaseInputs):
+    query: str

--- a/examples/workflows/custom_base_node/nodes/__init__.py
+++ b/examples/workflows/custom_base_node/nodes/__init__.py
@@ -1,0 +1,17 @@
+from .conditional_router import ConditionalRouter
+from .echo_request import EchoRequest
+from .error_node import ErrorNode
+from .exit_node import ExitNode
+from .fibonacci import Fibonacci
+from .get_temperature import GetTemperature
+from .my_prompt import MyPrompt
+
+__all__ = [
+    "ConditionalRouter",
+    "ErrorNode",
+    "ExitNode",
+    "MyPrompt",
+    "GetTemperature",
+    "Fibonacci",
+    "EchoRequest",
+]

--- a/examples/workflows/custom_base_node/nodes/conditional_router.py
+++ b/examples/workflows/custom_base_node/nodes/conditional_router.py
@@ -1,0 +1,13 @@
+from vellum.workflows.nodes import BaseNode
+from vellum.workflows.ports import Port
+
+from .my_prompt import MyPrompt
+
+
+class ConditionalRouter(BaseNode):
+    class Ports(BaseNode.Ports):
+        exit = Port.on_if(MyPrompt.Outputs.results[0]["type"].equals("STRING"))
+        get_temperature = Port.on_elif(MyPrompt.Outputs.results[0]["value"]["name"].equals("get_temperature"))
+        echo_request = Port.on_elif(MyPrompt.Outputs.results[0]["value"]["name"].equals("echo_request"))
+        fibonacci = Port.on_elif(MyPrompt.Outputs.results[0]["value"]["name"].equals("fibonacci"))
+        unknown = Port.on_else()

--- a/examples/workflows/custom_base_node/nodes/echo_request.py
+++ b/examples/workflows/custom_base_node/nodes/echo_request.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from .mock_networking_client import MockNetworkingClient
+from .my_prompt import MyPrompt
+
+
+class EchoRequest(MockNetworkingClient):
+    action = MyPrompt.Outputs.results[0]["value"]
+
+    class Outputs(MockNetworkingClient.Outputs):
+        response: Any
+
+    "A node that calls our base Mock Networking Client"

--- a/examples/workflows/custom_base_node/nodes/error_node.py
+++ b/examples/workflows/custom_base_node/nodes/error_node.py
@@ -1,0 +1,5 @@
+from vellum.workflows.nodes.displayable import ErrorNode as BaseErrorNode
+
+
+class ErrorNode(BaseErrorNode):
+    error = "Unexpected function call name from the model."

--- a/examples/workflows/custom_base_node/nodes/exit_node.py
+++ b/examples/workflows/custom_base_node/nodes/exit_node.py
@@ -1,0 +1,9 @@
+from vellum.workflows.nodes.displayable import FinalOutputNode
+from vellum.workflows.state import BaseState
+
+from .my_prompt import MyPrompt
+
+
+class ExitNode(FinalOutputNode[BaseState, str]):
+    class Outputs(FinalOutputNode.Outputs):
+        value = MyPrompt.Outputs.text

--- a/examples/workflows/custom_base_node/nodes/fibonacci.py
+++ b/examples/workflows/custom_base_node/nodes/fibonacci.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from .mock_networking_client import MockNetworkingClient
+from .my_prompt import MyPrompt
+
+
+class Fibonacci(MockNetworkingClient):
+    action = MyPrompt.Outputs.results[0]["value"]
+
+    class Outputs(MockNetworkingClient.Outputs):
+        response: Any
+
+    "A node that calls our base Mock Networking Client"

--- a/examples/workflows/custom_base_node/nodes/get_temperature.py
+++ b/examples/workflows/custom_base_node/nodes/get_temperature.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from .mock_networking_client import MockNetworkingClient
+from .my_prompt import MyPrompt
+
+
+class GetTemperature(MockNetworkingClient):
+    action = MyPrompt.Outputs.results[0]["value"]
+
+    class Outputs(MockNetworkingClient.Outputs):
+        response: Any
+
+    "A node that calls our base Mock Networking Client"

--- a/examples/workflows/custom_base_node/nodes/mock_networking_client.py
+++ b/examples/workflows/custom_base_node/nodes/mock_networking_client.py
@@ -1,0 +1,56 @@
+import json
+
+from utils.networking import MyCustomNetworkingClient
+
+from vellum import (
+    ChatMessage,
+    FunctionCall,
+    FunctionCallChatMessageContent,
+    FunctionCallChatMessageContentValue,
+    StringChatMessageContent,
+)
+from vellum.workflows.nodes.bases import BaseNode
+
+from ..state import State
+
+
+class MockNetworkingClient(BaseNode[State]):
+    """
+    A base node for which you can that mimics a networking call.
+
+    Adapt this implementation to handle your own use cases surrounding:
+    - HTTP
+    - gRPC
+    - GraphQL
+    - Web Scraping
+    - Database
+    - and more!
+    """
+
+    action: FunctionCall
+
+    class Outputs(BaseNode.Outputs):
+        response: dict
+
+    def run(self) -> BaseNode.Outputs:
+        self.state.chat_history.append(
+            ChatMessage(
+                role="ASSISTANT",
+                content=FunctionCallChatMessageContent(
+                    value=FunctionCallChatMessageContentValue.model_validate(self.action.model_dump())
+                ),
+            )
+        )
+
+        client = MyCustomNetworkingClient()
+        response = client.invoke_request(name=self.action.name, request=self.action.arguments)
+
+        self.state.chat_history.append(
+            ChatMessage(
+                role="FUNCTION",
+                content=StringChatMessageContent(value=json.dumps(response)),
+                source=self.action.id,
+            )
+        )
+
+        return self.Outputs(response=response)

--- a/examples/workflows/custom_base_node/nodes/my_prompt.py
+++ b/examples/workflows/custom_base_node/nodes/my_prompt.py
@@ -1,0 +1,54 @@
+from vellum import (
+    ChatMessagePromptBlock,
+    FunctionDefinition,
+    PlainTextPromptBlock,
+    PromptParameters,
+    RichTextPromptBlock,
+    VariablePromptBlock,
+)
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
+from ..inputs import Inputs
+from ..state import State
+
+
+class MyPrompt(InlinePromptNode):
+    ml_model = "gpt-4o-mini"
+    blocks = [
+        ChatMessagePromptBlock(
+            chat_role="SYSTEM",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        PlainTextPromptBlock(
+                            text="""You are a helpful assistant that can answer questions and help with tasks."""
+                        )
+                    ]
+                )
+            ],
+        ),
+        ChatMessagePromptBlock(chat_role="USER", blocks=[VariablePromptBlock(input_variable="query")]),
+        VariablePromptBlock(input_variable="chat_history"),
+    ]
+    prompt_inputs = {
+        "query": Inputs.query,
+        "chat_history": State.chat_history,
+    }
+    functions = [
+        FunctionDefinition(name="get_temperature", description="Use this tool for any questions about the weather."),
+        FunctionDefinition(name="echo_request", description="Use this tool for any questions about job searching."),
+        FunctionDefinition(
+            name="fibonacci", description="Use this tool for any questions about topics outside of work."
+        ),
+    ]
+    parameters = PromptParameters(
+        stop=[],
+        temperature=0,
+        max_tokens=4096,
+        top_p=1,
+        top_k=0,
+        frequency_penalty=0,
+        presence_penalty=0,
+        logit_bias=None,
+        custom_parameters=None,
+    )

--- a/examples/workflows/custom_base_node/state.py
+++ b/examples/workflows/custom_base_node/state.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from vellum import ChatMessage
+from vellum.workflows.state.base import BaseState
+
+
+class State(BaseState):
+    chat_history: List[ChatMessage] = []

--- a/examples/workflows/custom_base_node/workflow.py
+++ b/examples/workflows/custom_base_node/workflow.py
@@ -1,0 +1,25 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.state import BaseState
+
+from .inputs import Inputs
+from .nodes.conditional_router import ConditionalRouter
+from .nodes.echo_request import EchoRequest
+from .nodes.error_node import ErrorNode
+from .nodes.exit_node import ExitNode
+from .nodes.fibonacci import Fibonacci
+from .nodes.get_temperature import GetTemperature
+from .nodes.my_prompt import MyPrompt
+from .state import State
+
+
+class IndeedWorkflow(BaseWorkflow[Inputs, State]):
+    graph = MyPrompt >> {
+        ConditionalRouter.Ports.exit >> ExitNode,
+        ConditionalRouter.Ports.unknown >> ErrorNode,
+        ConditionalRouter.Ports.fibonacci >> Fibonacci >> MyPrompt,
+        ConditionalRouter.Ports.echo_request >> EchoRequest >> MyPrompt,
+        ConditionalRouter.Ports.get_temperature >> GetTemperature >> MyPrompt,
+    }
+
+    class Outputs(BaseWorkflow.Outputs):
+        answer = ExitNode.Outputs.value

--- a/examples/workflows/utils/networking.py
+++ b/examples/workflows/utils/networking.py
@@ -1,0 +1,18 @@
+import random
+import time
+
+
+class MyCustomNetworkingClient:
+    def invoke_request(self, name: str, request: dict) -> dict:
+        if name == "get_temperature":
+            return self._mock_network_response({"temperature": random.randint(60, 80)})
+        elif name == "echo_request":
+            return self._mock_network_response({"foo": "bar", "request": request})
+        elif name == "fibonacci":
+            return self._mock_network_response({"data": [1, 1, 2, 3, 5, 8]})
+        else:
+            raise ValueError(f"Invalid tool name: {name}")
+
+    def _mock_network_response(self, response: dict, latency: int = 1) -> dict:
+        time.sleep(latency)  # Simulate network latency
+        return response


### PR DESCRIPTION
Cleaned up our custom base node example from the prototype repo that we will share with a prospect, and ported into the sdk repo. This workflow features a custom base node that requires custom docker image (emulated by the `utils` directory) and have three nodes that extend from it.