### PR TITLE
support nullable state_variables field

### DIFF
--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -1399,7 +1399,6 @@ baz = foo + bar
           edges: [],
         },
         input_variables: [],
-        state_variables: [],
         output_variables: [],
       };
 

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -331,13 +331,15 @@ ${errors.slice(0, 3).map((err) => {
       this.workflowContext.addInputVariableContext(inputVariableContext);
     });
 
-    this.workflowVersionExecConfig.stateVariables.forEach((stateVariable) => {
-      const stateVariableContext = new StateVariableContext({
-        stateVariableData: stateVariable,
-        workflowContext: this.workflowContext,
+    if (this.workflowVersionExecConfig.stateVariables) {
+      this.workflowVersionExecConfig.stateVariables.forEach((stateVariable) => {
+        const stateVariableContext = new StateVariableContext({
+          stateVariableData: stateVariable,
+          workflowContext: this.workflowContext,
+        });
+        this.workflowContext.addStateVariableContext(stateVariableContext);
       });
-      this.workflowContext.addStateVariableContext(stateVariableContext);
-    });
+    }
 
     // TODO: Invert / remove this logic once output values are default and terminal nodes don't exist.
     // We are prioritizing terminal nodes as a temporary workaround to bad data from output values lingering in workflows.

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -2152,7 +2152,7 @@ export const WorkflowVersionExecConfigSerializer: ObjectSchema<
   ),
   stateVariables: propertySchema(
     "state_variables",
-    listSchema(VellumVariableSerializer)
+    listSchema(VellumVariableSerializer).optional()
   ),
   runnerConfig: propertySchema(
     "runner_config",
@@ -2173,7 +2173,7 @@ export declare namespace WorkflowVersionExecConfigSerializer {
   interface Raw {
     workflow_raw_data: WorkflowRawDataSerializer.Raw;
     input_variables: VellumVariableSerializer.Raw[];
-    state_variables: VellumVariableSerializer.Raw[];
+    state_variables?: VellumVariableSerializer.Raw[] | null;
     output_variables: VellumVariableSerializer.Raw[];
     runner_config?: {
       container_image_name?: string | null;

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -734,7 +734,7 @@ export interface RunnerConfig {
 export interface WorkflowVersionExecConfig {
   workflowRawData: WorkflowRawData;
   inputVariables: VellumVariable[];
-  stateVariables: VellumVariable[];
+  stateVariables?: VellumVariable[];
   outputVariables: VellumVariable[];
   runnerConfig?: RunnerConfig;
 }


### PR DESCRIPTION
We have workflows on the vellum side that actually have this field nullable. This change helps protect us in that situation