### PR TITLE
Support serialization even if workspace secret fetch fails

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/tests/test_base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/tests/test_base_node_display.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.ports.port import Port
 from vellum.workflows.references.constant import ConstantValueReference
+from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
@@ -99,4 +100,20 @@ def test_serialize_display_data():
     assert data["display_data"] == {
         "position": {"x": 0.0, "y": 0.0},
         "comment": {"value": "I hope this works"},
+    }
+
+
+def test_serialize_node__with_unresolved_secret_references(vellum_client):
+    # GIVEN a node has access to a secret reference
+    class MyNode(BaseNode):
+        api_key = VellumSecretReference("MY_API_KEY")
+
+    # WHEN we serialize the node
+    node_display_class = get_node_display_class(MyNode)
+    data: dict = node_display_class().serialize(WorkflowDisplayContext())
+
+    # THEN the condition should be serialized correctly
+    assert data["attributes"][0]["value"] == {
+        "type": "SECRET_REFERENCE",
+        "secret_reference": "MY_API_KEY",
     }

--- a/ee/vellum_ee/workflows/display/nodes/tests/test_base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/tests/test_base_node_display.py
@@ -4,7 +4,6 @@ from uuid import UUID
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.ports.port import Port
 from vellum.workflows.references.constant import ConstantValueReference
-from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.get_node_display_class import get_node_display_class
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
@@ -100,20 +99,4 @@ def test_serialize_display_data():
     assert data["display_data"] == {
         "position": {"x": 0.0, "y": 0.0},
         "comment": {"value": "I hope this works"},
-    }
-
-
-def test_serialize_node__with_unresolved_secret_references(vellum_client):
-    # GIVEN a node has access to a secret reference
-    class MyNode(BaseNode):
-        api_key = VellumSecretReference("MY_API_KEY")
-
-    # WHEN we serialize the node
-    node_display_class = get_node_display_class(MyNode)
-    data: dict = node_display_class().serialize(WorkflowDisplayContext())
-
-    # THEN the condition should be serialized correctly
-    assert data["attributes"][0]["value"] == {
-        "type": "SECRET_REFERENCE",
-        "secret_reference": "MY_API_KEY",
     }

--- a/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
@@ -79,8 +79,8 @@ class BaseCodeExecutionNodeDisplay(BaseNodeDisplay[_CodeExecutionNodeType], Gene
 
         packages = raise_if_descriptor(node.packages)
 
-        _, output_display = display_context.global_node_output_displays[node.Outputs.result]
-        _, log_output_display = display_context.global_node_output_displays[node.Outputs.log]
+        output_display = self.output_display[node.Outputs.result]
+        log_output_display = self.output_display[node.Outputs.log]
 
         output_type = primitive_type_to_vellum_variable_type(node.get_output_type())
 

--- a/ee/vellum_ee/workflows/display/utils/vellum.py
+++ b/ee/vellum_ee/workflows/display/utils/vellum.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
+from vellum.client.core.api_error import ApiError
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
 from vellum.client.types.array_vellum_value import ArrayVellumValue
 from vellum.client.types.vellum_value import VellumValue
@@ -117,13 +118,18 @@ def create_node_input_value_pointer_rule(
         workflow_input_display = display_context.global_workflow_input_displays[value]
         return InputVariablePointer(data=InputVariableData(input_variable_id=str(workflow_input_display.id)))
     if isinstance(value, VellumSecretReference):
-        workspace_secret = display_context.client.workspace_secrets.retrieve(
-            id=value.name,
-        )
+        try:
+            workspace_secret = display_context.client.workspace_secrets.retrieve(
+                id=value.name,
+            )
+            workspace_secret_id: Optional[str] = str(workspace_secret.id)
+        except ApiError:
+            workspace_secret_id = None
+
         return WorkspaceSecretPointer(
             data=WorkspaceSecretData(
                 type="STRING",
-                workspace_secret_id=str(workspace_secret.id),
+                workspace_secret_id=workspace_secret_id,
             ),
         )
     if isinstance(value, ExecutionCountReference):


### PR DESCRIPTION
This makes it such that a failed api call on workspace secrets won't prevent us from serializing the workflow