### PR TITLE
Improve the error message returned for code execution node errors

### DIFF
--- a/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
@@ -850,7 +850,16 @@ def main(arg1: list) -> str:
         node.run()
 
     # AND the result should be the correct output
-    assert exc_info.value.message == "dict has no key: 'invalid'"
+    assert (
+        exc_info.value.message
+        == """\
+Traceback (most recent call last):
+  File "ExampleCodeExecutionNode.code.py", line 2, in main
+    return arg1["invalid"]
+
+AttributeError: dict has no key: 'invalid'
+"""
+    )
 
 
 def test_run_node__execute_code__value_key_access():


### PR DESCRIPTION
Previously, we were returning just the error message with no context (so a `KeyError: 0` was literally just `'0'`). Now, we forward a traceback to the user to help them debug their code nodes