### PR TITLE
support final output node streaming from prompt nodes

### DIFF
--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -281,6 +281,7 @@ class BaseNode(Generic[StateType], ABC, metaclass=BaseNodeMeta):
     class Trigger(metaclass=_BaseNodeTriggerMeta):
         node_class: Type["BaseNode"]
         merge_behavior = MergeBehavior.AWAIT_ATTRIBUTES
+        is_streamable = False
 
         @classmethod
         def should_initiate(

--- a/src/vellum/workflows/nodes/displayable/bases/base_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/base_prompt_node/node.py
@@ -37,9 +37,8 @@ class BasePromptNode(BaseNode, Generic[StateType]):
                 return super().__call__(outputs, state)
 
         def __lt__(self, output: BaseOutput) -> Set[Port]:
-            if output.is_initiated:
-                if self.__is_streamable__():
-                    return {self.default}
+            if output.is_initiated and self.__is_streamable__() and output.name == "text":
+                return {self.default}
 
             return set()
 

--- a/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
@@ -63,7 +63,9 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
     class Trigger(BasePromptNode.Trigger):
         merge_behavior = MergeBehavior.AWAIT_ANY
 
-    def _extract_required_input_variables(self, blocks: Union[List[PromptBlock], List[RichTextChildBlock]]) -> Set[str]:
+    def _extract_required_input_variables(
+        self, blocks: Union[List[PromptBlock], List[RichTextChildBlock]]
+    ) -> Set[str]:
         required_variables = set()
 
         for block in blocks:
@@ -175,6 +177,9 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
             if event.state == "INITIATED":
                 continue
             elif event.state == "STREAMING":
+                if event.output.type == "STRING":
+                    yield BaseOutput(name="text", delta=event.output.value)
+
                 yield BaseOutput(name="results", delta=event.output.value)
             elif event.state == "FULFILLED":
                 outputs = event.outputs

--- a/src/vellum/workflows/nodes/displayable/final_output_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/final_output_node/node.py
@@ -1,9 +1,11 @@
+import types
 from typing import Any, Dict, Generic, Tuple, Type, TypeVar, get_args
 
 from vellum.workflows.constants import undefined
 from vellum.workflows.nodes.bases import BaseNode
-from vellum.workflows.nodes.bases.base import BaseNodeMeta
+from vellum.workflows.nodes.bases.base import BaseNodeMeta, NodeRunResponse
 from vellum.workflows.nodes.utils import cast_to_output_type
+from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.types import MergeBehavior
 from vellum.workflows.types.generics import StateType
 from vellum.workflows.types.utils import get_original_base
@@ -53,8 +55,15 @@ class FinalOutputNode(BaseNode[StateType], Generic[StateType, _OutputType], meta
         # for downstream references to this output.
         value: _OutputType = undefined  # type: ignore[valid-type]
 
-    def run(self) -> Outputs:
+    def run(self) -> NodeRunResponse:
         original_outputs = self.Outputs()
+        print("RUN", original_outputs.value)
+
+        if isinstance(original_outputs.value, types.GeneratorType):
+            for value in original_outputs.value:
+                yield BaseOutput(delta=value, name="value")
+
+            return
 
         return self.Outputs(
             value=cast_to_output_type(

--- a/src/vellum/workflows/nodes/displayable/final_output_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/final_output_node/node.py
@@ -46,6 +46,7 @@ class FinalOutputNode(BaseNode[StateType], Generic[StateType, _OutputType], meta
 
     class Trigger(BaseNode.Trigger):
         merge_behavior = MergeBehavior.AWAIT_ANY
+        is_streamable = True
 
     class Outputs(BaseNode.Outputs):
         # We use our mypy plugin to override the _OutputType with the actual output type

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -247,6 +247,7 @@ class WorkflowRunner(Generic[StateType]):
                         instance=None,
                         outputs_class=node.Outputs,
                     )
+                    print("INITIATED OUTPUT", output.name)
                     with node.state.__quiet__():
                         node.state.meta.node_outputs[output_descriptor] = streaming_output_queues[output.name]
                     initiated_output: BaseOutput = BaseOutput(name=output.name)
@@ -316,6 +317,7 @@ class WorkflowRunner(Generic[StateType]):
                     node.state.meta.node_outputs[descriptor] = output_value
 
             invoked_ports = ports(outputs, node.state)
+            print("FULFILLED OUTPUT", outputs)
             self._workflow_event_inner_queue.put(
                 NodeExecutionFulfilledEvent(
                     trace_id=execution.trace_id,

--- a/src/vellum/workflows/state/base.py
+++ b/src/vellum/workflows/state/base.py
@@ -10,6 +10,7 @@ from uuid import UUID, uuid4
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Type, Union, cast
 from typing_extensions import dataclass_transform
 
+import types
 from pydantic import GetCoreSchemaHandler, ValidationInfo, field_serializer, field_validator
 from pydantic_core import core_schema
 
@@ -210,7 +211,8 @@ class NodeExecutionCache:
                 for execution_id, dependencies in self._dependencies_invoked.items()
             },
             "node_executions_initiated": {
-                str(node.__id__): list(execution_ids) for node, execution_ids in self._node_executions_initiated.items()
+                str(node.__id__): list(execution_ids)
+                for node, execution_ids in self._node_executions_initiated.items()
             },
             "node_executions_fulfilled": {
                 str(node.__id__): execution_ids.dump()
@@ -391,6 +393,10 @@ class StateMeta(UniversalBaseModel):
     def __deepcopy__(self, memo: Optional[Dict[int, Any]] = None) -> "StateMeta":
         if not memo:
             memo = {}
+
+        for key, value in self.node_outputs.items():
+            if isinstance(value, types.GeneratorType):
+                breakpoint()
 
         new_node_outputs = {
             descriptor: value if isinstance(value, Queue) else deepcopy(value, memo)

--- a/tests/workflows/stream_final_output_node/tests/test_workflow.py
+++ b/tests/workflows/stream_final_output_node/tests/test_workflow.py
@@ -47,7 +47,6 @@ def test_workflow__happy_path(vellum_adhoc_prompt_client):
     assert streaming_event.output.value == "Hello, world!"
 
 
-@pytest.mark.skip(reason="Finishing it up in https://github.com/vellum-ai/vellum-python-sdks/pull/1578")
 def test_workflow__prompt_chunks(vellum_adhoc_prompt_client):
     # GIVEN a workflow with a prompt and a final output
     workflow = StreamFinalOutputWorkflow()


### PR DESCRIPTION
Original Workflows supported streaming through Final Output Nodes, mostly bc of special casing for those nodes. This PR explores how we could have first class support for streaming through terminal nodes.

I wanted to get this launched soon for the demo, but would be too high risk so am going to roll this out more slowly