### PR TITLE
new codegen service action action is missing creds

### DIFF
--- a/.github/workflows/ci-codegen.yaml
+++ b/.github/workflows/ci-codegen.yaml
@@ -133,5 +133,6 @@ jobs:
           VELLUM_AUTOMATION_APP_ID: ${{ secrets.VELLUM_AUTOMATION_APP_ID }}
           VELLUM_AUTOMATION_PRIVATE_KEY: ${{ secrets.VELLUM_AUTOMATION_PRIVATE_KEY }}
           VELLUM_AUTOMATION_INSTALLATION_ID: ${{ secrets.VELLUM_AUTOMATION_INSTALLATION_ID }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
         run: npm run upgrade-codegen-service
         working-directory: ee/codegen


### PR DESCRIPTION
We didn't need this before, so I'm confused why we need it [now](https://github.com/vellum-ai/vellum-python-sdks/actions/runs/14782445051). Hopefully should be the last of our codegen service problems