### PR TITLE
Revert "Add experimental path"

### DIFF
--- a/ee/codegen/src/context/node-context/base.ts
+++ b/ee/codegen/src/context/node-context/base.ts
@@ -59,12 +59,6 @@ export abstract class BaseNodeContext<T extends WorkflowDataNode> {
           .startsWith(VELLUM_WORKFLOW_NODES_MODULE_PATH.join("."))
       ) {
         this.baseNodeClassModulePath = args.nodeData.base.module;
-      } else if (
-        args.nodeData.base &&
-        args.nodeData.base.name === "ToolCallingNode"
-      ) {
-        this.baseNodeClassModulePath =
-          this.workflowContext.sdkModulePathNames.EXPERIMENTAL_NODES_MODULE_PATH;
       } else {
         this.baseNodeClassModulePath = VELLUM_WORKFLOW_NODES_MODULE_PATH;
       }

--- a/ee/codegen/src/context/workflow-context/sdk-module-paths.ts
+++ b/ee/codegen/src/context/workflow-context/sdk-module-paths.ts
@@ -13,10 +13,6 @@ export function generateSdkModulePaths(
     WORKFLOWS_MODULE_PATH: workflowsSdkModulePath,
     CORE_NODES_MODULE_PATH: [...nodesModulePath, "core"] as const,
     DISPLAYABLE_NODES_MODULE_PATH: [...nodesModulePath, "displayable"] as const,
-    EXPERIMENTAL_NODES_MODULE_PATH: [
-      ...nodesModulePath,
-      "experimental",
-    ] as const,
     INPUTS_MODULE_PATH: [
       ...workflowsSdkModulePath,
       GENERATED_INPUTS_MODULE_NAME,

--- a/ee/codegen/src/context/workflow-context/types.ts
+++ b/ee/codegen/src/context/workflow-context/types.ts
@@ -2,7 +2,6 @@ export interface SDK_MODULE_PATHS {
   WORKFLOWS_MODULE_PATH: readonly string[];
   CORE_NODES_MODULE_PATH: readonly string[];
   DISPLAYABLE_NODES_MODULE_PATH: readonly string[];
-  EXPERIMENTAL_NODES_MODULE_PATH: readonly string[];
   INPUTS_MODULE_PATH: readonly string[];
   SANDBOX_RUNNER_MODULE_PATH: readonly string[];
   STATE_MODULE_PATH: readonly string[];


### PR DESCRIPTION
Reverts vellum-ai/vellum-python-sdks#1584

@dvargas92495 should we keep the experimental path? I think we still need to write the path for tool calling node?