### PR TITLE
Skip codegenning prompt_inputs if it's empty

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -180,7 +180,6 @@ from vellum.workflows.nodes.displayable import InlinePromptNode
 class Prompt(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = []
-    prompt_inputs = {}
     parameters = PromptParameters(
         stop=[],
         temperature=None,
@@ -206,7 +205,6 @@ from vellum.workflows.nodes.displayable import InlinePromptNode
 class Prompt(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = []
-    prompt_inputs = {}
     parameters = PromptParameters(
         stop=[],
         temperature=None,
@@ -232,7 +230,6 @@ from vellum.workflows.nodes.displayable import InlinePromptNode
 class Prompt(InlinePromptNode):
     ml_model = "gpt-4o-mini"
     blocks = []
-    prompt_inputs = {}
     parameters = PromptParameters(
         stop=[],
         temperature=None,

--- a/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/prompt-deployment-node.test.ts.snap
@@ -49,7 +49,6 @@ exports[`PromptDeploymentNode > basic > getNodeFile 1`] = `
 class PromptDeploymentNode(BasePromptDeploymentNode):
     deployment = "some-unique-deployment-name"
     release_tag = "LATEST"
-    prompt_inputs = {}
 "
 `;
 
@@ -63,7 +62,6 @@ class PromptDeploymentNode(BasePromptDeploymentNode):
     ml_model_fallbacks = ["model1"]
     deployment = "some-unique-deployment-name"
     release_tag = "LATEST"
-    prompt_inputs = {}
 "
 `;
 
@@ -78,7 +76,6 @@ from vellum.workflows.nodes.displayable import (
 class PromptDeploymentNode(BasePromptDeploymentNode):
     deployment = UUID("afd05488-7a25-4ff2-b87b-878e9552474e")
     release_tag = "LATEST"
-    prompt_inputs = {}
 "
 `;
 

--- a/ee/codegen/src/generators/nodes/inline-prompt-node.ts
+++ b/ee/codegen/src/generators/nodes/inline-prompt-node.ts
@@ -118,7 +118,7 @@ export class InlinePromptNode extends BaseSingleFileNode<
           }),
         })
       );
-    } else {
+    } else if (this.nodeInputsByKey.size > 0) {
       statements.push(
         python.field({
           name: INPUTS_PREFIX,

--- a/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
+++ b/ee/codegen/src/generators/nodes/prompt-deployment-node.ts
@@ -70,20 +70,22 @@ export class PromptDeploymentNode extends BaseSingleFileNode<
       })
     );
 
-    statements.push(
-      python.field({
-        name: INPUTS_PREFIX,
-        initializer: python.TypeInstantiation.dict(
-          Array.from(this.nodeInputsByKey.entries()).map(([key, value]) => ({
-            key: python.TypeInstantiation.str(key),
-            value: value,
-          })),
-          {
-            endWithComma: true,
-          }
-        ),
-      })
-    );
+    if (this.nodeInputsByKey.size > 0) {
+      statements.push(
+        python.field({
+          name: INPUTS_PREFIX,
+          initializer: python.TypeInstantiation.dict(
+            Array.from(this.nodeInputsByKey.entries()).map(([key, value]) => ({
+              key: python.TypeInstantiation.str(key),
+              value: value,
+            })),
+            {
+              endWithComma: true,
+            }
+          ),
+        })
+      );
+    }
 
     return statements;
   }


### PR DESCRIPTION
We support defaulting prompt_inputs to an empty dict, so this is redundant