### PR TITLE
Resolve gnarly looping bug for nodes with AWAIT ATTRIBUTES merge behavior

### DIFF
--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -431,7 +431,7 @@ class WorkflowRunner(Generic[StateType]):
                     return
 
             all_deps = self._dependencies[node_class]
-            node_span_id = state.meta.node_execution_cache.queue_node_execution(node_class, all_deps, invoked_by)
+            node_span_id = node_class.Trigger._queue_node_execution(state, all_deps, invoked_by)
             if not node_class.Trigger.should_initiate(state, all_deps, node_span_id):
                 return
 

--- a/tests/workflows/basic_await_any/workflow.py
+++ b/tests/workflows/basic_await_any/workflow.py
@@ -2,6 +2,7 @@ import time
 
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.state.base import BaseState
+from vellum.workflows.types.core import MergeBehavior
 from vellum.workflows.workflows.base import BaseWorkflow
 
 
@@ -24,6 +25,9 @@ class BottomNode(BaseNode):
 
 class AwaitAnyNode(BaseNode[BaseState]):
     top = TopNode.Outputs.total
+
+    class Trigger(BaseNode.Trigger):
+        merge_behavior = MergeBehavior.AWAIT_ANY
 
     class Outputs(BaseNode.Outputs):
         total: int

--- a/tests/workflows/basic_await_attributes/tests/test_workflow.py
+++ b/tests/workflows/basic_await_attributes/tests/test_workflow.py
@@ -14,4 +14,4 @@ def test_workflow__happy_path():
 
     # THEN the Workflow completes successfully
     assert final_event.name == "workflow.execution.fulfilled"
-    assert final_event.outputs.final_value == 2
+    assert final_event.outputs.final_value == 3

--- a/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
+++ b/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
@@ -25,8 +25,9 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
     state_id_generator = mock_uuid4_generator("vellum.workflows.state.base.uuid4")
     state_id = state_id_generator()
     workflow_span_id = state_id_generator()
-    start_node_span_id = state_id_generator()
-    next_node_span_id = state_id_generator()
+    base_node_id_generator = mock_uuid4_generator("vellum.workflows.nodes.bases.base.uuid4")
+    start_node_span_id = base_node_id_generator()
+    next_node_span_id = base_node_id_generator()
 
     # AND a workflow that uses a custom event emitter
     trace_id = uuid4()
@@ -120,12 +121,8 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
                     serialized_start_node_id: [str(start_node_span_id)],
                     serialized_next_node_id: [str(next_node_span_id)],
                 },
-                "node_executions_queued": {
-                    serialized_next_node_id: [],
-                },
-                "dependencies_invoked": {
-                    str(next_node_span_id): [serialized_start_node_id],
-                },
+                "node_executions_queued": {},
+                "dependencies_invoked": {},
             },
             "workflow_definition": {
                 "name": "BasicEmitterWorkflow",
@@ -157,12 +154,8 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
                     serialized_start_node_id: [str(start_node_span_id)],
                     serialized_next_node_id: [str(next_node_span_id)],
                 },
-                "node_executions_queued": {
-                    serialized_next_node_id: [],
-                },
-                "dependencies_invoked": {
-                    str(next_node_span_id): [serialized_start_node_id],
-                },
+                "node_executions_queued": {},
+                "dependencies_invoked": {},
             },
             "parent": None,
             "workflow_definition": {

--- a/tests/workflows/circular_loop/tests/test_workflow.py
+++ b/tests/workflows/circular_loop/tests/test_workflow.py
@@ -1,11 +1,11 @@
 import pytest
 
+from vellum.workflows.types.core import MergeBehavior
+
+from tests.workflows.await_any_conditional_loops.workflow import TopNode
 from tests.workflows.circular_loop.workflow import CircularLoopWorkflow
 
 
-@pytest.mark.skip(
-    reason="https://linear.app/vellum/issue/APO-390/workflow-erronously-terminates-in-looping-edge-case-with-prefixed-node"  # noqa: E501
-)
 def test_workflow__happy_path():
     """
     This test is not happy now.
@@ -23,3 +23,34 @@ def test_workflow__happy_path():
 
     assert terminal_event.outputs.counter == 2
     assert terminal_event.outputs.completed is True
+
+
+@pytest.mark.skip(
+    reason="https://linear.app/vellum/issue/APO-390/workflow-erronously-terminates-in-looping-edge-case-with-prefixed-node"  # noqa: E501
+)
+def test_workflow__top_node_awaits_any():
+    """
+    This test solves the same problem as the previous test, but considers the case where the TopNode
+    uses an AWAIT ANY merge behavior.
+
+    The key problem is:
+    1. TopNode after IncrementCounterNode will not be executed
+    2. This breaks the loop and the workflow terminates prematurely
+    """
+
+    # GIVEN a workflow with a TopNode that uses an AWAIT ANY merge behavior
+    workflow = CircularLoopWorkflow()
+    TopNode.Trigger.merge_behavior = MergeBehavior.AWAIT_ANY
+
+    # WHEN we run the workflow
+    terminal_event = workflow.run()
+
+    # THEN the workflow terminates successfully
+    assert terminal_event.name == "workflow.execution.fulfilled", terminal_event.body
+
+    # AND the outputs are as expected
+    assert terminal_event.outputs.counter == 2
+    assert terminal_event.outputs.completed is True
+
+    # AND we cleanup the changes
+    TopNode.Trigger.merge_behavior = MergeBehavior.AWAIT_ATTRIBUTES

--- a/tests/workflows/multi_branch_merge_loop/workflow.py
+++ b/tests/workflows/multi_branch_merge_loop/workflow.py
@@ -5,6 +5,7 @@ from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.ports.port import Port
 from vellum.workflows.state.base import BaseState
+from vellum.workflows.types.core import MergeBehavior
 
 
 class State(BaseState):
@@ -48,6 +49,9 @@ class LoopNode(BaseNode[State]):
 
     class Outputs(BaseNode.Outputs):
         value = TopNode.Outputs.value.coalesce(BottomNode.Outputs.value)
+
+    class Trigger(BaseNode.Trigger):
+        merge_behavior = MergeBehavior.AWAIT_ANY
 
     def run(self) -> BaseNode.Outputs:
         self.state.counter += 1


### PR DESCRIPTION
We have an issue with AWAIT_ANY nodes where loops in the middle of a graph never execute. Turns out this problem _also_ existed for AWAIT_ATTRIBUTES node.

It should've never existed for the latter - those nodes only execute based on their attribute definitions. This PR moves the `queue_node_execution` into the `BaseNode.Trigger` class so that we can discriminate that step based on merge behavior. This solves this gnarly edge case for `AWAIT_ATTRIBUTES` nodes while deferring our need to fix it for AWAIT_ANY node in the future