### PR TITLE
Make 400 push API errors cleaner to end users

### DIFF
--- a/ee/vellum_cli/logger.py
+++ b/ee/vellum_cli/logger.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Optional
 
 
 class CLIFormatter(logging.Formatter):
@@ -34,3 +35,14 @@ def load_cli_logger() -> logging.Logger:
     logger.addHandler(handler)
 
     return logger
+
+
+def handle_cli_error(logger: logging.Logger, title: str, message: str, suggestion: Optional[str] = None):
+    logger.error("\n\033[1;31m✖ {}\033[0m".format(title))  # Bold red X and title
+    logger.error("\n\033[1m{}\033[0m".format(message))  # Bold message
+    if suggestion:
+        logger.error("\n\033[1;34mNext steps:\033[0m")  # Bold blue
+        logger.error(suggestion)
+
+    logger.error(f"{title}: {message}")
+    exit(1)

--- a/ee/vellum_cli/push.py
+++ b/ee/vellum_cli/push.py
@@ -211,14 +211,14 @@ def push_command(
             )
 
             reported_diffs = f"""\
-    {e.body.get("detail")}
+{e.body.get("detail")}
 
-    {generated_only_str}
+{generated_only_str}
 
-    {original_only_str}
+{original_only_str}
 
-    {modified_str}
-    """
+{modified_str}
+"""
             logger.error(reported_diffs)
             return
 


### PR DESCRIPTION
Here's the error message I hit trying to push a workflow again to the base_custom_node example:

<img width="953" alt="Screenshot 2025-05-03 at 3 05 56 PM" src="https://github.com/user-attachments/assets/4c424816-d1af-4853-ae93-617b7ab71e6d" />

All user errors going forward _should not_ show the stack trace of the CLI. This PR introduces the pattern of how we could make these errors more user facing