### PR TITLE
Push latest custom docker demos to prod

### DIFF
--- a/examples/workflows/custom_base_node/README.md
+++ b/examples/workflows/custom_base_node/README.md
@@ -1,0 +1,30 @@
+# Custom Base Node
+
+This Workflow is an example of having multiple nodes extending from a Custom Node that the user defines, called `MockNetworkingClient`. This node simulates a client that makes a network call, whether that is HTTP, GraphQL, etc.
+
+The node also imports logic from a module outside of the node, motivating the need for a [Custom Docker Image](https://docs.vellum.ai/developers/workflows-sdk/custom-container-images). The definition for this Docker image is found at `./utils/Dockerfile`. To rebuild locally, run:
+
+```bash
+docker buildx build -f utils/Dockerfile --platform=linux/amd64 -t sdk-examples-utils:1.0.0 .
+```
+
+Then, you could push the image to Vellum,
+
+```bash
+vellum images push sdk-examples-utils:1.0.0
+```
+
+Next, associate the newly created image with your workflow by adding the following to your `pyproject.toml`:
+
+```toml
+[[tool.vellum.workflows]]
+module = "custom_prompt_node"
+container_image_name = "sdk-examples-utils"
+container_image_tag = "1.0.0"
+```
+
+You can then push the Workflow itself,
+
+```bash
+vellum workflows push custom_base_node
+```

--- a/examples/workflows/custom_base_node/README.md
+++ b/examples/workflows/custom_base_node/README.md
@@ -1,5 +1,7 @@
 # Custom Base Node
 
+_NOTE: This Workflow is still under development and is not yet ready for reuse_
+
 This Workflow is an example of having multiple nodes extending from a Custom Node that the user defines, called `MockNetworkingClient`. This node simulates a client that makes a network call, whether that is HTTP, GraphQL, etc.
 
 The node also imports logic from a module outside of the node, motivating the need for a [Custom Docker Image](https://docs.vellum.ai/developers/workflows-sdk/custom-container-images). The definition for this Docker image is found at `./utils/Dockerfile`. To rebuild locally, run:

--- a/examples/workflows/custom_prompt_node/README.md
+++ b/examples/workflows/custom_prompt_node/README.md
@@ -1,5 +1,7 @@
 # Custom Prompt Node
 
+_NOTE: This Workflow is still under development and is not yet ready for reuse_
+
 This Workflow is an example of implementing your _own_ Prompt node that avoids making the round trip to Vellum by invoking the LLM directly. The node, `LocalBedrockNode`, assumes that you have your AWS credentials stored locally in a `.env` file in order to run locally:
 
 ```bash

--- a/examples/workflows/custom_prompt_node/README.md
+++ b/examples/workflows/custom_prompt_node/README.md
@@ -1,0 +1,36 @@
+# Custom Prompt Node
+
+This Workflow is an example of implementing your _own_ Prompt node that avoids making the round trip to Vellum by invoking the LLM directly. The node, `LocalBedrockNode`, assumes that you have your AWS credentials stored locally in a `.env` file in order to run locally:
+
+```bash
+VELLUM_API_KEY=*************************
+AWS_ACCESS_KEY_ID=**********************
+AWS_SECRET_ACCESS_KEY=******************
+```
+
+It also depends on a dependency called `boto3`, which acts as a client to the AWS API. To use it in Vellum, you will need to build the Docker image locally:
+
+```bash
+docker buildx build -f utils/Dockerfile --platform=linux/amd64 -t sdk-examples-utils:1.0.0 .
+```
+
+Then, you could push the image to Vellum,
+
+```bash
+vellum images push sdk-examples-utils:1.0.0
+```
+
+Next, associate the newly created image with your workflow by adding the following to your `pyproject.toml`:
+
+```toml
+[[tool.vellum.workflows]]
+module = "custom_prompt_node"
+container_image_name = "sdk-examples-utils"
+container_image_tag = "1.0.0"
+```
+
+You can then push the Workflow itself,
+
+```bash
+vellum workflows push custom_prompt_node
+```

--- a/examples/workflows/poetry.lock
+++ b/examples/workflows/poetry.lock
@@ -1363,13 +1363,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "vellum-ai"
-version = "0.14.51"
+version = "0.14.53"
 description = ""
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "vellum_ai-0.14.51-py3-none-any.whl", hash = "sha256:7198fedc1508a9c8e33600c708c0bdb3b6c7fff6920c25cec6af29eea1d47991"},
-    {file = "vellum_ai-0.14.51.tar.gz", hash = "sha256:cd87cddadaca2008ca35fab07b9b21059ca475195e7d5224a6d5cb96af8aebfa"},
+    {file = "vellum_ai-0.14.53-py3-none-any.whl", hash = "sha256:c2618dd395ee1d987b0bf2b66bb63b7cff080b60f47b1e10df384666ac547abb"},
+    {file = "vellum_ai-0.14.53.tar.gz", hash = "sha256:457d9c1d14ab2044d595bb0edf98656f2a84be6b02052c725d0635df9a488a18"},
 ]
 
 [package.dependencies]
@@ -1424,4 +1424,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "fc42b864f93eee39e90cc447d238be8758afeaa1439cc1453855b41c5694120d"
+content-hash = "c811e1155b776195c8c1426cdcadb4facdcea80f4041679b3b56975978a1b1ed"

--- a/examples/workflows/pyproject.toml
+++ b/examples/workflows/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-vellum-ai = "0.14.51"
+vellum-ai = "0.14.53"
 boto3 = "^1.38.4"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/workflows/pyproject.toml
+++ b/examples/workflows/pyproject.toml
@@ -17,7 +17,12 @@ ipdb = "^0.13.13"
 [[tool.vellum.workflows]]
 module = "custom_base_node"
 container_image_name = "sdk-examples-utils"
-container_image_tag = "1.0.0"
+container_image_tag = "1.0.2"
+
+[[tool.vellum.workflows]]
+module = "custom_prompt_node"
+container_image_name = "sdk-examples-utils"
+container_image_tag = "1.0.2"
 
 [[tool.vellum.workspaces]]
 name = "aws-staging"

--- a/examples/workflows/utils/Dockerfile
+++ b/examples/workflows/utils/Dockerfile
@@ -1,5 +1,8 @@
 FROM vellumai/python-workflow-runtime:latest
 
+RUN pip install --upgrade pip \
+    && pip install boto3
+
 COPY ./utils /custom/utils
 
 ENV PYTHONPATH="${PYTHONPATH}:/custom"

--- a/examples/workflows/vellum.lock.json
+++ b/examples/workflows/vellum.lock.json
@@ -7,7 +7,7 @@
       "ignore": null,
       "deployments": [],
       "container_image_name": "sdk-examples-utils",
-      "container_image_tag": "1.0.0",
+      "container_image_tag": "1.0.2",
       "workspace": "default",
       "target_directory": null
     },
@@ -16,8 +16,8 @@
       "workflow_sandbox_id": "a8e57295-afb9-4b8c-8182-936000c5b0e2",
       "ignore": null,
       "deployments": [],
-      "container_image_name": null,
-      "container_image_tag": null,
+      "container_image_name": "sdk-examples-utils",
+      "container_image_tag": "1.0.2",
       "workspace": "default",
       "target_directory": null
     },


### PR DESCRIPTION
The goal of this, and future PRs of this sort, is to push the following two demos to prod and have it runnable from the UI:
- `custom_base_node`
- `custom_prompt_node`

This PR includes README's for both and did some additional pushing and QA to note next steps. Here are what's next:
- `custom_base_node`
    - Outputs not showing for some reason:
![Screenshot 2025-05-03 at 8 10 38 PM](https://github.com/user-attachments/assets/babfb653-fd50-48f2-8df1-e5a0ec54e0d3)
    - The function processing nodes are busted:
![Screenshot 2025-05-03 at 8 11 34 PM](https://github.com/user-attachments/assets/2962eba6-2917-4e26-b43c-15f352460537)
    - Codegen still doesn't look right for the functional nodes - I thought we had cleaned up the comment issue:
![Screenshot 2025-05-03 at 8 12 17 PM](https://github.com/user-attachments/assets/83f3fcd6-7ace-4fb0-a2fd-83cd436bceaa)
- `custom_prompt_node`
    - File for `LocalBedrockNode` is missing - another issue that I thought was already solved:
![Screenshot 2025-05-03 at 8 14 42 PM](https://github.com/user-attachments/assets/b2269f99-9ee1-4507-b4ed-1b004b02955e)

