### PR TITLE
Fix default function call

### DIFF
--- a/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_code_execution_node.py
@@ -1044,3 +1044,21 @@ Traceback (most recent call last):
 IndexError: list index out of range
 """
     )
+
+
+def test_run_node__default_function_call_type():
+    # GIVEN a node that will return a FunctionCall
+    class ExampleCodeExecutionNode(CodeExecutionNode[BaseState, FunctionCall]):
+        code = """\
+def main(input: str) -> str:
+    return None
+"""
+        runtime = "PYTHON_3_11_6"
+        code_inputs = {"input": "foo"}
+
+    # WHEN we run the node
+    node = ExampleCodeExecutionNode()
+    outputs = node.run()
+
+    # THEN the node should return default function call
+    assert outputs == {"result": FunctionCall(name="", arguments={}), "log": ""}

--- a/src/vellum/workflows/nodes/tests/test_utils.py
+++ b/src/vellum/workflows/nodes/tests/test_utils.py
@@ -143,7 +143,7 @@ def test_parse_type_from_str_error_cases(input_str, output_type, expected_except
         (int, 0),  # Number
         (float, 0.0),  # Number
         (Any, None),  # Json
-        (FunctionCallType, {}),  # FunctionCall
+        (FunctionCallType, FunctionCallType(name="", arguments={})),  # FunctionCall
         (List[ChatMessage], []),  # Chat History
         (List[VellumValue], []),  # Array
         (Union[float, int], 0.0),  # Union

--- a/src/vellum/workflows/nodes/utils.py
+++ b/src/vellum/workflows/nodes/utils.py
@@ -230,7 +230,10 @@ def _get_default_value(output_type: Any) -> Any:
     elif origin is list:
         return []
     elif output_type is FunctionCall:
-        return {}
+        return FunctionCall(
+            name="",
+            arguments={},
+        )
     elif origin is Union:
         # Always use the first argument type's default value
         if args:


### PR DESCRIPTION
Fix code execution default output for `FunctionCall` as name and arguments are required
https://github.com/vellum-ai/vellum-python-sdks/blob/c1e770d966b89668b1bfe9172a91792634d2a00a/src/vellum/client/types/function_call.py#L9-L16