### PR TITLE
Fix test

### DIFF
--- a/src/vellum/workflows/nodes/tests/test_utils.py
+++ b/src/vellum/workflows/nodes/tests/test_utils.py
@@ -15,11 +15,7 @@ from vellum.workflows.types.core import Json
 class Person(BaseModel):
     name: str
     age: int
-
-
-class FunctionCall(BaseModel):
-    name: str
-    args: List[int]
+    colors: List[str]
 
 
 @pytest.mark.parametrize(
@@ -61,23 +57,12 @@ def test_parse_type_from_str_basic_cases(input_str, output_type, expected_result
 
 
 def test_parse_type_from_str_pydantic_models():
-    person_json = '{"name": "Alice", "age": 30}'
+    person_json = '{"name": "Alice", "age": 30, "colors": ["red", "blue"]}'
     person = parse_type_from_str(person_json, Person)
     assert isinstance(person, Person)
     assert person.name == "Alice"
     assert person.age == 30
-
-    function_json = '{"name": "test", "args": [1, 2]}'
-    function = parse_type_from_str(function_json, FunctionCall)
-    assert isinstance(function, FunctionCall)
-    assert function.name == "test"
-    assert function.args == [1, 2]
-
-    function_call_json = '{"value": {"name": "test", "args": [1, 2]}}'
-    function = parse_type_from_str(function_call_json, FunctionCall)
-    assert isinstance(function, FunctionCall)
-    assert function.name == "test"
-    assert function.args == [1, 2]
+    assert person.colors == ["red", "blue"]
 
 
 def test_parse_type_from_str_list_of_models():

--- a/src/vellum/workflows/nodes/tests/test_utils.py
+++ b/src/vellum/workflows/nodes/tests/test_utils.py
@@ -66,7 +66,7 @@ def test_parse_type_from_str_pydantic_models():
 
 
 def test_parse_type_from_str_list_of_models():
-    person_list_json = '[{"name": "Alice", "age": 30, "colors": ["red", "blue"]}, {"name": "Bob", "age": 25, "colors": ["green", "yellow"]}]'
+    person_list_json = '[{"name": "Alice", "age": 30, "colors": ["red", "blue"]}, {"name": "Bob", "age": 25, "colors": ["green", "yellow"]}]'  # noqa: E501
     persons = parse_type_from_str(person_list_json, List[Person])
     assert len(persons) == 2
     assert all(isinstance(p, Person) for p in persons)

--- a/src/vellum/workflows/nodes/tests/test_utils.py
+++ b/src/vellum/workflows/nodes/tests/test_utils.py
@@ -66,14 +66,16 @@ def test_parse_type_from_str_pydantic_models():
 
 
 def test_parse_type_from_str_list_of_models():
-    person_list_json = '[{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]'
+    person_list_json = '[{"name": "Alice", "age": 30, "colors": ["red", "blue"]}, {"name": "Bob", "age": 25, "colors": ["green", "yellow"]}]'
     persons = parse_type_from_str(person_list_json, List[Person])
     assert len(persons) == 2
     assert all(isinstance(p, Person) for p in persons)
     assert persons[0].name == "Alice"
     assert persons[0].age == 30
+    assert persons[0].colors == ["red", "blue"]
     assert persons[1].name == "Bob"
     assert persons[1].age == 25
+    assert persons[1].colors == ["green", "yellow"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The original `FunctionCall` class in test is not doing its job cause we define it as `FunctionCall` which hit the incorrect path 

https://github.com/vellum-ai/vellum-python-sdks/blob/c1e770d966b89668b1bfe9172a91792634d2a00a/src/vellum/workflows/nodes/utils.py#L159-L168

I think the original test is not testing anything new so remove it and add an array to the same test

Will clean up naming in the following PR