### PR TITLE
Add the MCP example

### DIFF
--- a/examples/workflows/mcp_demo/README.md
+++ b/examples/workflows/mcp_demo/README.md
@@ -1,0 +1,18 @@
+# MCP Demo
+
+_NOTE: This Workflow is still under development and is not yet ready for reuse_
+
+This Workflow is an example of how to use a Vellum Workflow as an [MCP](https://modelcontextprotocol.io/introduction) Client. It depends on the [Github MCP Server](https://github.com/github/github-mcp-server) for performing actions on the user's GitHub account on their behalf.
+
+To use locally, you should create a [GitHub personal access token](https://github.com/settings/personal-access-tokens) and save it in a local `.env` file:
+
+```bash
+VELLUM_API_KEY=***********************
+GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_**********************
+```
+
+We include a `chat.py` file with the module for help running locally. Invoke it by running:
+
+```bash
+python -m mcp_demo.chat
+```

--- a/examples/workflows/mcp_demo/chat.py
+++ b/examples/workflows/mcp_demo/chat.py
@@ -1,0 +1,32 @@
+from dotenv import load_dotenv
+
+from .inputs import Inputs
+from .workflow import MCPDemoWorkflow
+
+
+def main():
+    load_dotenv()
+    workflow = MCPDemoWorkflow()
+
+    while True:
+        query = input("Hi! I'm an MCP Chatbot for Github. What can I do for you today? ")
+        inputs = Inputs(query=query)
+
+        event_filter_set = {"node.execution.fulfilled", "workflow.execution.fulfilled", "workflow.execution.rejected"}
+        stream = workflow.stream(inputs=inputs, event_filter=lambda workflow, event: event.name in event_filter_set)
+        is_rejected = False
+        for event in stream:
+            if event.name == "node.execution.fulfilled":
+                print("Finished Node", event.node_definition, "thinking", event.outputs["thinking"])  # noqa: T201
+            elif event.name == "workflow.execution.fulfilled":
+                print(event.outputs["answer"])  # noqa: T201
+            elif event.name == "workflow.execution.rejected":
+                print("Workflow rejected", event.error.code, event.error.message)  # noqa: T201
+                is_rejected = True
+
+        if is_rejected:
+            exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/workflows/mcp_demo/inputs.py
+++ b/examples/workflows/mcp_demo/inputs.py
@@ -1,0 +1,5 @@
+from vellum.workflows.inputs import BaseInputs
+
+
+class Inputs(BaseInputs):
+    query: str

--- a/examples/workflows/mcp_demo/nodes/execute_action_node.py
+++ b/examples/workflows/mcp_demo/nodes/execute_action_node.py
@@ -1,0 +1,65 @@
+import asyncio
+import os
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from vellum import ChatMessage, FunctionCallChatMessageContent, StringChatMessageContent
+from vellum.workflows.nodes import BaseNode
+
+from ..state import State
+from .my_prompt_node import MyPromptNode
+
+
+class ExecuteActionNode(BaseNode[State]):
+    action = MyPromptNode.Outputs.results[0]
+
+    class Outputs(BaseNode.Outputs):
+        action_result: str
+        thinking: str
+
+    def run(self) -> Outputs:
+        if self.action.type != "FUNCTION_CALL":
+            raise ValueError(f"Action is not a function call: {self.action}")
+
+        self.state.chat_history.append(
+            ChatMessage(
+                role="ASSISTANT",
+                content=FunctionCallChatMessageContent.model_validate(self.action.model_dump()),
+            )
+        )
+
+        server_params = StdioServerParameters(
+            command="/usr/local/bin/docker",
+            args=["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "ghcr.io/github/github-mcp-server"],
+            env={
+                "GITHUB_PERSONAL_ACCESS_TOKEN": os.environ["GITHUB_PERSONAL_ACCESS_TOKEN"],
+            },
+        )
+
+        async def run_stdio():
+            async with stdio_client(server_params) as stdio_transport:
+                stdio_stream, write_stream = stdio_transport
+                async with ClientSession(stdio_stream, write_stream) as session:
+                    await session.initialize()
+                    response = await session.call_tool(
+                        name=self.action.value.name,
+                        arguments=self.action.value.arguments,
+                    )
+
+            return response.content
+
+        action_results = asyncio.run(run_stdio())
+        compiled_action_result = "\n".join([res.text for res in action_results if res.type == "text"])
+        self.state.chat_history.append(
+            ChatMessage(
+                role="FUNCTION",
+                content=StringChatMessageContent(value=compiled_action_result),
+                source=self.action.value.id,
+            )
+        )
+
+        return self.Outputs(
+            action_result=compiled_action_result,
+            thinking=f"Executed tool: {self.action.value.name}",
+        )

--- a/examples/workflows/mcp_demo/nodes/exit_node.py
+++ b/examples/workflows/mcp_demo/nodes/exit_node.py
@@ -1,0 +1,9 @@
+from vellum.workflows.nodes import BaseNode
+
+from .my_prompt_node import MyPromptNode
+
+
+class ExitNode(BaseNode):
+    class Outputs(BaseNode.Outputs):
+        answer = MyPromptNode.Outputs.text
+        thinking = "Returning..."

--- a/examples/workflows/mcp_demo/nodes/mcp_client_node.py
+++ b/examples/workflows/mcp_demo/nodes/mcp_client_node.py
@@ -1,0 +1,47 @@
+import asyncio
+import os
+from typing import List
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from vellum import FunctionDefinition
+from vellum.workflows.nodes import BaseNode
+
+
+class MCPClientNode(BaseNode):
+    class Outputs(BaseNode.Outputs):
+        tools: List[FunctionDefinition]
+        thinking: str
+
+    def run(self) -> Outputs:
+        server_params = StdioServerParameters(
+            command="/usr/local/bin/docker",
+            args=["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "ghcr.io/github/github-mcp-server"],
+            env={
+                "GITHUB_PERSONAL_ACCESS_TOKEN": os.environ["GITHUB_PERSONAL_ACCESS_TOKEN"],
+            },
+        )
+
+        async def run_stdio():
+            async with stdio_client(server_params) as stdio_transport:
+                stdio_stream, write_stream = stdio_transport
+                async with ClientSession(stdio_stream, write_stream) as session:
+                    await session.initialize()
+                    response = await session.list_tools()
+
+            return response.tools
+
+        mcp_tools = asyncio.run(run_stdio())
+
+        return self.Outputs(
+            tools=[
+                FunctionDefinition(
+                    name=tool.name,
+                    description=tool.description,
+                    parameters=tool.inputSchema,
+                )
+                for tool in mcp_tools
+            ],
+            thinking=f"Retrieved {len(mcp_tools)} tools from MCP Server...",
+        )

--- a/examples/workflows/mcp_demo/nodes/my_prompt_node.py
+++ b/examples/workflows/mcp_demo/nodes/my_prompt_node.py
@@ -1,0 +1,50 @@
+from vellum import ChatMessagePromptBlock, PlainTextPromptBlock, RichTextPromptBlock, VariablePromptBlock
+from vellum.workflows.nodes import InlinePromptNode
+from vellum.workflows.ports import Port
+from vellum.workflows.references import LazyReference
+
+from ..inputs import Inputs
+from ..state import State
+from .mcp_client_node import MCPClientNode
+
+
+class MyPromptNode(InlinePromptNode):
+    ml_model = "gpt-4o-mini"
+    blocks = [
+        ChatMessagePromptBlock(
+            chat_role="SYSTEM",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        PlainTextPromptBlock(
+                            text="You are a helpful assistant that will manage the user's Github account on their behalf.",
+                        )
+                    ]
+                )
+            ],
+        ),
+        ChatMessagePromptBlock(
+            chat_role="USER",
+            blocks=[
+                VariablePromptBlock(
+                    input_variable="query",
+                ),
+            ],
+        ),
+        VariablePromptBlock(
+            input_variable="chat_history",
+        ),
+    ]
+    prompt_inputs = {
+        "query": Inputs.query,
+        "chat_history": State.chat_history,
+    }
+    # Our mypy plugin is not handling list of pydantic models properly
+    functions = MCPClientNode.Outputs.tools  # type: ignore[assignment]
+
+    class Ports(InlinePromptNode.Ports):
+        action = Port.on_if(LazyReference(lambda: MyPromptNode.Outputs.results[0]["type"].equals("FUNCTION_CALL")))
+        exit = Port.on_if(LazyReference(lambda: MyPromptNode.Outputs.results[0]["type"].equals("STRING")))
+
+    class Outputs(InlinePromptNode.Outputs):
+        thinking = "Asking the model..."

--- a/examples/workflows/mcp_demo/state.py
+++ b/examples/workflows/mcp_demo/state.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from vellum import ChatMessage
+from vellum.workflows.state import BaseState
+
+
+class State(BaseState):
+    chat_history: List[ChatMessage] = []

--- a/examples/workflows/mcp_demo/workflow.py
+++ b/examples/workflows/mcp_demo/workflow.py
@@ -1,0 +1,25 @@
+from vellum.workflows import BaseWorkflow
+
+from .inputs import Inputs
+from .nodes.execute_action_node import ExecuteActionNode
+from .nodes.exit_node import ExitNode
+from .nodes.mcp_client_node import MCPClientNode
+from .nodes.my_prompt_node import MyPromptNode
+from .state import State
+
+
+class MCPDemoWorkflow(BaseWorkflow[Inputs, State]):
+    """
+    An example workflow that acts as an MCP Client. It's currently hardcoded to interact with the
+    Github MCP Server, found here: https://github.com/github/github-mcp-server. To run this demo,
+    - Create a Github Access Token and export it as the environment variable `GITHUB_PERSONAL_ACCESS_TOKEN`
+    - Run this workflow: `python -m examples.mcp_demo.chat`
+    """
+
+    graph = MCPClientNode >> {
+        MyPromptNode.Ports.action >> ExecuteActionNode >> MCPClientNode,
+        MyPromptNode.Ports.exit >> ExitNode,
+    }
+
+    class Outputs:
+        answer = ExitNode.Outputs.answer

--- a/examples/workflows/poetry.lock
+++ b/examples/workflows/poetry.lock
@@ -100,10 +100,7 @@ files = [
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = [
-    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
-    {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
-]
+urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
 
 [package.extras]
 crt = ["awscrt (==0.23.8)"]
@@ -433,6 +430,17 @@ socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.0"
+description = "Consume Server-Sent Event (SSE) messages with HTTPX."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721"},
+    {file = "httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f"},
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -456,9 +464,6 @@ files = [
     {file = "importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec"},
     {file = "importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c"},
 ]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
@@ -506,7 +511,6 @@ prompt-toolkit = ">=3.0.41,<3.1.0"
 pygments = ">=2.4.0"
 stack-data = "*"
 traitlets = ">=5"
-typing-extensions = {version = "*", markers = "python_version < \"3.10\""}
 
 [package.extras]
 all = ["black", "curio", "docrepr", "exceptiongroup", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.22)", "pandas", "pickleshare", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio (<0.22)", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
@@ -756,6 +760,25 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
+
+[[package]]
+name = "mcp"
+version = "1.1.1"
+description = "Model Context Protocol SDK"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "mcp-1.1.1-py3-none-any.whl", hash = "sha256:29f693a54ca1d3730e625dcc06732bc83b52d64b993d253881de576a1d66feed"},
+    {file = "mcp-1.1.1.tar.gz", hash = "sha256:44d9c12461b640c4431618a3ebf1be4178d35511e9169e25c9b1afeb59313b99"},
+]
+
+[package.dependencies]
+anyio = ">=4.5"
+httpx = ">=0.27"
+httpx-sse = ">=0.4"
+pydantic = ">=2.7.2"
+sse-starlette = ">=2.0"
+starlette = ">=0.27"
 
 [[package]]
 name = "openai"
@@ -1223,6 +1246,25 @@ files = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "2.3.4"
+description = "SSE plugin for Starlette"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "sse_starlette-2.3.4-py3-none-any.whl", hash = "sha256:b8100694f3f892b133d0f7483acb7aacfcf6ed60f863b31947664b6dc74e529f"},
+    {file = "sse_starlette-2.3.4.tar.gz", hash = "sha256:0ffd6bed217cdbb74a84816437c609278003998b4991cd2e6872d0b35130e4d5"},
+]
+
+[package.dependencies]
+anyio = ">=4.7.0"
+starlette = ">=0.41.3"
+
+[package.extras]
+examples = ["fastapi"]
+uvicorn = ["uvicorn (>=0.34.0)"]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -1240,6 +1282,23 @@ pure-eval = "*"
 
 [package.extras]
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
+
+[[package]]
+name = "starlette"
+version = "0.46.2"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35"},
+    {file = "starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "tomli"
@@ -1330,22 +1389,6 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "urllib3"
-version = "1.26.20"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-files = [
-    {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
-    {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
-]
-
-[package.extras]
-brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
-
-[[package]]
-name = "urllib3"
 version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
@@ -1402,26 +1445,7 @@ files = [
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
 ]
 
-[[package]]
-name = "zipp"
-version = "3.21.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"},
-    {file = "zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy"]
-
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9,<4.0"
-content-hash = "2d6ade59efdd3fc46fc4591383da6a2f4ab40bd79f7bffc404d336dbd23a6a71"
+python-versions = ">=3.10,<4.0"
+content-hash = "6e9f477e6e81aea8b47f027030c1500fe5a41950780fa92f4b0263dfaeb86d20"

--- a/examples/workflows/pyproject.toml
+++ b/examples/workflows/pyproject.toml
@@ -7,9 +7,10 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+python = ">=3.10,<4.0"
 vellum-ai = "0.14.54"
 boto3 = "^1.38.4"
+mcp = "1.1.1"
 
 [tool.poetry.group.dev.dependencies]
 ipdb = "^0.13.13"


### PR DESCRIPTION
Adds the MCP Demo from our prototype repo into our public examples. Does not currently push to vellum due to not knowing how to serialize the dynamic function definition bit yet. We have a warning in the README for any prospects we share it with, but should be runnable locally