### PR TITLE
Dump tool call result

### DIFF
--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
@@ -5,6 +5,7 @@ from typing import Any, Iterator, List, Optional, Type, cast
 from vellum import ChatMessage, FunctionDefinition, PromptBlock
 from vellum.client.types.function_call_chat_message_content import FunctionCallChatMessageContent
 from vellum.client.types.function_call_chat_message_content_value import FunctionCallChatMessageContentValue
+from vellum.client.types.string_chat_message_content import StringChatMessageContent
 from vellum.client.types.variable_prompt_block import VariablePromptBlock
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.displayable.inline_prompt_node.node import InlinePromptNode
@@ -130,7 +131,12 @@ def create_function_node(function: Callable[..., Any], tool_router_node: Type[To
         # Call the original function directly with the arguments
         result = function(**arguments)
 
-        self.state.chat_history.append(ChatMessage(role="FUNCTION", text=result))
+        self.state.chat_history.append(
+            ChatMessage(
+                role="FUNCTION",
+                content=StringChatMessageContent(value=json.dumps(result)),
+            )
+        )
 
         return self.Outputs()
 

--- a/tests/workflows/basic_tool_calling_node/tests/test_workflow.py
+++ b/tests/workflows/basic_tool_calling_node/tests/test_workflow.py
@@ -18,6 +18,7 @@ from vellum.client.types.prompt_request_chat_history_input import PromptRequestC
 from vellum.client.types.prompt_request_json_input import PromptRequestJsonInput
 from vellum.client.types.prompt_request_string_input import PromptRequestStringInput
 from vellum.client.types.rich_text_prompt_block import RichTextPromptBlock
+from vellum.client.types.string_chat_message_content import StringChatMessageContent
 from vellum.client.types.string_vellum_value import StringVellumValue
 from vellum.client.types.variable_prompt_block import VariablePromptBlock
 from vellum.client.types.vellum_variable import VellumVariable
@@ -96,14 +97,21 @@ def test_get_current_weather_workflow(vellum_adhoc_prompt_client, mock_uuid4_gen
                     id="call_7115tNTmEACTsQRGwKpJipJK",
                 ),
             ),
+            source=None,
         ),
         ChatMessage(
-            text="The current weather in Miami is sunny with a temperature of 70 degrees celsius.",
+            text=None,
             role="FUNCTION",
+            content=StringChatMessageContent(
+                type="STRING", value='"The current weather in Miami is sunny with a temperature of 70 degrees celsius."'
+            ),
+            source=None,
         ),
         ChatMessage(
             text="Based on the function call, the current temperature in Miami is 70 degrees celsius.",
             role="ASSISTANT",
+            content=None,
+            source=None,
         ),
     ]
 
@@ -220,10 +228,16 @@ def test_get_current_weather_workflow(vellum_adhoc_prompt_client, mock_uuid4_gen
                                 id="call_7115tNTmEACTsQRGwKpJipJK",
                             ),
                         ),
+                        source=None,
                     ),
                     ChatMessage(
-                        text="The current weather in Miami is sunny with a temperature of 70 degrees celsius.",
+                        text=None,
                         role="FUNCTION",
+                        content=StringChatMessageContent(
+                            type="STRING",
+                            value='"The current weather in Miami is sunny with a temperature of 70 degrees celsius."',
+                        ),
+                        source=None,
                     ),
                 ],
             ),

--- a/tests/workflows/basic_tool_calling_node_multi_tool/tests/test_workflow.py
+++ b/tests/workflows/basic_tool_calling_node_multi_tool/tests/test_workflow.py
@@ -18,6 +18,7 @@ from vellum.client.types.prompt_request_chat_history_input import PromptRequestC
 from vellum.client.types.prompt_request_json_input import PromptRequestJsonInput
 from vellum.client.types.prompt_request_string_input import PromptRequestStringInput
 from vellum.client.types.rich_text_prompt_block import RichTextPromptBlock
+from vellum.client.types.string_chat_message_content import StringChatMessageContent
 from vellum.client.types.string_vellum_value import StringVellumValue
 from vellum.client.types.variable_prompt_block import VariablePromptBlock
 from vellum.client.types.vellum_variable import VellumVariable
@@ -114,9 +115,11 @@ def test_get_current_weather_workflow(vellum_adhoc_prompt_client, mock_uuid4_gen
             source=None,
         ),
         ChatMessage(
-            text="The current weather in Miami is sunny with a temperature of 70 degrees celsius.",
+            text=None,
             role="FUNCTION",
-            content=None,
+            content=StringChatMessageContent(
+                type="STRING", value='"The current weather in Miami is sunny with a temperature of 70 degrees celsius."'
+            ),
             source=None,
         ),
         ChatMessage(
@@ -135,10 +138,7 @@ def test_get_current_weather_workflow(vellum_adhoc_prompt_client, mock_uuid4_gen
             source=None,
         ),
         ChatMessage(
-            text="Formatted answer: The current weather in Miami is sunny with a temperature of 70 degrees celsius.",
-            role="FUNCTION",
-            content=None,
-            source=None,
+            text=None, role="FUNCTION", content=StringChatMessageContent(type="STRING", value="2"), source=None
         ),
         ChatMessage(
             text="Based on the function call, the current temperature in Miami is 70 degrees celsius.",
@@ -272,8 +272,13 @@ def test_get_current_weather_workflow(vellum_adhoc_prompt_client, mock_uuid4_gen
                         ),
                     ),
                     ChatMessage(
-                        text="The current weather in Miami is sunny with a temperature of 70 degrees celsius.",
+                        text=None,
                         role="FUNCTION",
+                        content=StringChatMessageContent(
+                            type="STRING",
+                            value='"The current weather in Miami is sunny with a temperature of 70 degrees celsius."',
+                        ),
+                        source=None,
                     ),
                 ],
             ),
@@ -392,9 +397,12 @@ def test_get_current_weather_workflow(vellum_adhoc_prompt_client, mock_uuid4_gen
                         source=None,
                     ),
                     ChatMessage(
-                        text="The current weather in Miami is sunny with a temperature of 70 degrees celsius.",
+                        text=None,
                         role="FUNCTION",
-                        content=None,
+                        content=StringChatMessageContent(
+                            type="STRING",
+                            value='"The current weather in Miami is sunny with a temperature of 70 degrees celsius."',
+                        ),
                         source=None,
                     ),
                     ChatMessage(
@@ -413,9 +421,9 @@ def test_get_current_weather_workflow(vellum_adhoc_prompt_client, mock_uuid4_gen
                         source=None,
                     ),
                     ChatMessage(
-                        text="Formatted answer: The current weather in Miami is sunny with a temperature of 70 degrees celsius.",  # noqa: E501
+                        text=None,
                         role="FUNCTION",
-                        content=None,
+                        content=StringChatMessageContent(type="STRING", value="2"),
                         source=None,
                     ),
                 ],

--- a/tests/workflows/basic_tool_calling_node_multi_tool/workflow.py
+++ b/tests/workflows/basic_tool_calling_node_multi_tool/workflow.py
@@ -13,7 +13,7 @@ def get_current_weather(location: str, unit: str) -> str:
     return f"The current weather in {location} is sunny with a temperature of 70 degrees {unit}."
 
 
-def format_answer(answer: str) -> str:
+def format_answer(answer: str) -> int:
     return 1 + 1
 
 

--- a/tests/workflows/basic_tool_calling_node_multi_tool/workflow.py
+++ b/tests/workflows/basic_tool_calling_node_multi_tool/workflow.py
@@ -14,7 +14,7 @@ def get_current_weather(location: str, unit: str) -> str:
 
 
 def format_answer(answer: str) -> str:
-    return f"Formatted answer: {answer}"
+    return 1 + 1
 
 
 class GetCurrentWeatherNode(ToolCallingNode):


### PR DESCRIPTION
Found that we should dump our result into string, following `MockNetworkingClient`

https://github.com/vellum-ai/vellum-python-sdks/blob/462bffd473fa0d3dfbc07367d14dd05dd47e0cda/examples/workflows/custom_base_node/nodes/mock_networking_client.py#L51-L57