### PR TITLE
Auto include x api key into API node when invoking a Vellum url

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,7 @@ from dotenv import dotenv_values
 from pytest_mock import MockerFixture
 import requests_mock
 
+from vellum.client.environment import VellumEnvironment
 from vellum.workflows.logging import load_logger
 
 
@@ -61,6 +62,8 @@ def vellum_client_class(mocker: MockerFixture) -> Any:
 @pytest.fixture
 def vellum_client(vellum_client_class) -> Any:
     vellum_client = vellum_client_class.return_value
+    vellum_client._client_wrapper._environment = VellumEnvironment.PRODUCTION
+    vellum_client._client_wrapper.api_key = ""
     return vellum_client
 
 

--- a/src/vellum/workflows/nodes/displayable/api_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/api_node/node.py
@@ -47,11 +47,18 @@ class APINode(BaseAPINode):
             self.bearer_token_value, VellumSecret
         ):
             bearer_token = self.bearer_token_value
+
+        final_headers = {**headers, **header_overrides}
+
+        vellum_client_wrapper = self._context.vellum_client._client_wrapper
+        if self.url.startswith(vellum_client_wrapper._environment.default) and "X-API-Key" not in final_headers:
+            final_headers["X-API-Key"] = vellum_client_wrapper.api_key
+
         return self._run(
             method=self.method,
             url=self.url,
             data=self.data,
             json=self.json,
-            headers={**headers, **header_overrides},
+            headers=final_headers,
             bearer_token=bearer_token,
         )

--- a/src/vellum/workflows/nodes/displayable/api_node/tests/test_api_node.py
+++ b/src/vellum/workflows/nodes/displayable/api_node/tests/test_api_node.py
@@ -19,7 +19,7 @@ def test_run_workflow__secrets(vellum_client):
     class SimpleBaseAPINode(APINode):
         method = APIRequestMethod.POST
         authorization_type = AuthorizationType.BEARER_TOKEN
-        url = "https://api.vellum.ai"
+        url = "https://example.vellum.ai"
         json = {
             "key": "value",
         }
@@ -32,7 +32,9 @@ def test_run_workflow__secrets(vellum_client):
     terminal = node.run()
 
     assert vellum_client.execute_api.call_count == 1
+    assert vellum_client.execute_api.call_args.kwargs["url"] == "https://example.vellum.ai"
     assert vellum_client.execute_api.call_args.kwargs["body"] == {"key": "value"}
+    assert vellum_client.execute_api.call_args.kwargs["headers"] == {"X-Test-Header": "foo"}
     bearer_token = vellum_client.execute_api.call_args.kwargs["bearer_token"]
     assert bearer_token == ClientVellumSecret(name="secret")
     assert terminal.headers == {"X-Response-Header": "bar"}
@@ -45,7 +47,7 @@ def test_api_node_raises_error_when_api_call_fails(vellum_client):
     class SimpleAPINode(APINode):
         method = APIRequestMethod.GET
         authorization_type = AuthorizationType.BEARER_TOKEN
-        url = "https://api.vellum.ai"
+        url = "https://example.vellum.ai"
         json = {
             "key": "value",
         }
@@ -65,7 +67,9 @@ def test_api_node_raises_error_when_api_call_fails(vellum_client):
 
     # AND the API call should have been made
     assert vellum_client.execute_api.call_count == 1
+    assert vellum_client.execute_api.call_args.kwargs["url"] == "https://example.vellum.ai"
     assert vellum_client.execute_api.call_args.kwargs["body"] == {"key": "value"}
+    assert vellum_client.execute_api.call_args.kwargs["headers"] == {"X-Test-Header": "foo"}
 
 
 def test_api_node_defaults_to_get_method(vellum_client):
@@ -80,7 +84,7 @@ def test_api_node_defaults_to_get_method(vellum_client):
     # AND an API node without a method specified
     class SimpleAPINodeWithoutMethod(APINode):
         authorization_type = AuthorizationType.BEARER_TOKEN
-        url = "https://api.vellum.ai"
+        url = "https://example.vellum.ai"
         headers = {
             "X-Test-Header": "foo",
         }
@@ -95,3 +99,62 @@ def test_api_node_defaults_to_get_method(vellum_client):
     assert vellum_client.execute_api.call_count == 1
     method = vellum_client.execute_api.call_args.kwargs["method"]
     assert method == APIRequestMethod.GET.value
+
+
+def test_api_node__detects_client_environment_urls__adds_token(mock_httpx_transport, mock_requests, monkeypatch):
+    # GIVEN an API node with a URL pointing back to Vellum
+    class SimpleAPINodeToVellum(APINode):
+        url = "https://api.vellum.ai"
+
+    # AND a mock request sent to the Vellum API would return a 200
+    mock_response = mock_requests.get(
+        "https://api.vellum.ai",
+        status_code=200,
+        json={"data": [1, 2, 3]},
+    )
+
+    # AND an api key is set
+    monkeypatch.setenv("VELLUM_API_KEY", "vellum-api-key-1234")
+
+    # WHEN we run the node
+    node = SimpleAPINodeToVellum()
+    node.run()
+
+    # THEN the execute_api method should not have been called
+    mock_httpx_transport.handle_request.assert_not_called()
+
+    # AND the vellum API should have been called with the correct headers
+    assert mock_response.last_request
+    assert mock_response.last_request.headers["X-API-Key"] == "vellum-api-key-1234"
+
+
+def test_api_node__detects_client_environment_urls__does_not_override_headers(
+    mock_httpx_transport, mock_requests, monkeypatch
+):
+    # GIVEN an API node with a URL pointing back to Vellum
+    class SimpleAPINodeToVellum(APINode):
+        url = "https://api.vellum.ai"
+        headers = {
+            "X-API-Key": "vellum-api-key-5678",
+        }
+
+    # AND a mock request sent to the Vellum API would return a 200
+    mock_response = mock_requests.get(
+        "https://api.vellum.ai",
+        status_code=200,
+        json={"data": [1, 2, 3]},
+    )
+
+    # AND an api key is set
+    monkeypatch.setenv("VELLUM_API_KEY", "vellum-api-key-1234")
+
+    # WHEN we run the node
+    node = SimpleAPINodeToVellum()
+    node.run()
+
+    # THEN the execute_api method should not have been called
+    mock_httpx_transport.handle_request.assert_not_called()
+
+    # AND the vellum API should have been called with the correct headers
+    assert mock_response.last_request
+    assert mock_response.last_request.headers["X-API-Key"] == "vellum-api-key-5678"


### PR DESCRIPTION
This will relieve GTM from needing to create API Keys + Workspace Secrets on every target workspace they clone API Nodes that use Vellum APIs into. Longer term solutions look like:
- Vembda leases service tokens, we create a descriptor for those to make this look less "magical"
- We create OOTB nodes for other Vellum APIs (eg, GetDocument)