### PR TITLE
Refactor node execution cache.dependencies invoked to have full history of execution chain

### DIFF
--- a/src/vellum/workflows/workflows/tests/test_base_workflow.py
+++ b/src/vellum/workflows/workflows/tests/test_base_workflow.py
@@ -368,7 +368,7 @@ def test_base_workflow__deserialize_state():
                 },
                 "node_execution_cache": {
                     "dependencies_invoked": {
-                        last_span_id: [str(node_a_id)],
+                        last_span_id: [],
                     },
                     "node_executions_initiated": {
                         str(node_a_id): [last_span_id],
@@ -396,7 +396,7 @@ def test_base_workflow__deserialize_state():
     assert state.meta.node_execution_cache._node_executions_initiated == {NodeA: {UUID(last_span_id)}}
     assert state.meta.node_execution_cache._node_executions_fulfilled == {NodeA: Stack.from_list([UUID(last_span_id)])}
     assert state.meta.node_execution_cache._node_executions_queued == {NodeA: []}
-    assert state.meta.node_execution_cache._dependencies_invoked == {UUID(last_span_id): {NodeA}}
+    assert state.meta.node_execution_cache._dependencies_invoked == {UUID(last_span_id): set()}
 
 
 def test_base_workflow__deserialize_legacy_node_execution_cache():
@@ -422,7 +422,7 @@ def test_base_workflow__deserialize_legacy_node_execution_cache():
             "meta": {
                 "node_execution_cache": {
                     "dependencies_invoked": {
-                        last_span_id: [node_a_full_name],
+                        last_span_id: [],
                     },
                     "node_executions_initiated": {
                         node_a_full_name: [last_span_id],
@@ -442,7 +442,7 @@ def test_base_workflow__deserialize_legacy_node_execution_cache():
     assert state.meta.node_execution_cache._node_executions_initiated == {NodeA: {UUID(last_span_id)}}
     assert state.meta.node_execution_cache._node_executions_fulfilled == {NodeA: Stack.from_list([UUID(last_span_id)])}
     assert state.meta.node_execution_cache._node_executions_queued == {NodeA: []}
-    assert state.meta.node_execution_cache._dependencies_invoked == {UUID(last_span_id): {NodeA}}
+    assert state.meta.node_execution_cache._dependencies_invoked == {UUID(last_span_id): set()}
 
 
 def test_base_workflow__deserialize_legacy_node_outputs():

--- a/tests/workflows/circular_loop/tests/test_workflow.py
+++ b/tests/workflows/circular_loop/tests/test_workflow.py
@@ -2,8 +2,7 @@ import pytest
 
 from vellum.workflows.types.core import MergeBehavior
 
-from tests.workflows.await_any_conditional_loops.workflow import TopNode
-from tests.workflows.circular_loop.workflow import CircularLoopWorkflow
+from tests.workflows.circular_loop.workflow import CircularLoopWorkflow, TopNode
 
 
 def test_workflow__happy_path():


### PR DESCRIPTION
This is part 1 of 2 for fixing a gnarly await any loop bug. This PR should introduce no user facing changes. It's main goal is to update our dependency tracking so that we have the full history of execution invoked ids, with dependencies. This will allow us in the next PR to answer the question, for any loop of await any, whether this is a new iteration or an old iteration, solving the gnarly loop bug.