### PR TITLE
Add dependencies in await attribute

### DIFF
--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -351,6 +351,9 @@ class BaseNode(Generic[StateType], metaclass=BaseNodeMeta):
                 return execution_id
 
             if cls.merge_behavior not in {MergeBehavior.AWAIT_ANY, MergeBehavior.AWAIT_ALL}:
+                # Keep track of the dependencies that have invoked this node
+                # This would be needed while climbing the history in the loop
+                state.meta.node_execution_cache._dependencies_invoked[execution_id].add(invoked_by)
                 return execution_id
 
             for queued_node_execution_id in state.meta.node_execution_cache._node_executions_queued[cls.node_class]:

--- a/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
+++ b/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
@@ -122,7 +122,9 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
                     serialized_next_node_id: [str(next_node_span_id)],
                 },
                 "node_executions_queued": {},
-                "dependencies_invoked": {},
+                "dependencies_invoked": {
+                    str(next_node_span_id): [str(start_node_span_id)],
+                },
             },
             "workflow_definition": {
                 "name": "BasicEmitterWorkflow",
@@ -155,7 +157,9 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
                     serialized_next_node_id: [str(next_node_span_id)],
                 },
                 "node_executions_queued": {},
-                "dependencies_invoked": {},
+                "dependencies_invoked": {
+                    str(next_node_span_id): [str(start_node_span_id)],
+                },
             },
             "parent": None,
             "workflow_definition": {


### PR DESCRIPTION
We might need to know each `invoke_by` for each node to climb up the history to see if we are in the loop