### PR TITLE
Add ABC to BaseNode and BaseNodeAdornment

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/map_node.py
@@ -3,6 +3,7 @@ from typing import Generic, Optional, TypeVar, cast
 
 from vellum.workflows.nodes import MapNode
 from vellum.workflows.types.core import JsonObject
+from vellum.workflows.workflows.base import BaseWorkflow
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.base_adornment_node import BaseAdornmentNodeDisplay
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
@@ -21,7 +22,7 @@ class BaseMapNodeDisplay(BaseAdornmentNodeDisplay[_MapNodeType], Generic[_MapNod
         node = self._node
         node_id = self.node_id
 
-        subworkflow = raise_if_descriptor(node.subworkflow)
+        subworkflow = cast(type[BaseWorkflow], raise_if_descriptor(node.subworkflow))
 
         items_node_input = create_node_input(
             node_id=node_id,

--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -1,3 +1,4 @@
+from abc import ABC, ABCMeta
 from dataclasses import field
 from functools import cached_property, reduce
 import inspect
@@ -50,7 +51,7 @@ def _is_annotated(cls: Type, name: str) -> bool:
     return False
 
 
-class BaseNodeMeta(type):
+class BaseNodeMeta(ABCMeta):
     def __new__(mcs, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
         if "Outputs" in dct:
             outputs_class = dct["Outputs"]
@@ -258,7 +259,7 @@ class _BaseNodeExecutionMeta(type):
 NodeRunResponse = Union[BaseOutputs, Iterator[BaseOutput]]
 
 
-class BaseNode(Generic[StateType], metaclass=BaseNodeMeta):
+class BaseNode(Generic[StateType], ABC, metaclass=BaseNodeMeta):
     __id__: UUID = uuid4_from_hash(__qualname__)
     __output_ids__: Dict[str, UUID] = {}
     state: StateType

--- a/src/vellum/workflows/nodes/bases/base_adornment_node.py
+++ b/src/vellum/workflows/nodes/bases/base_adornment_node.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from typing import TYPE_CHECKING, Any, Dict, Generic, Optional, Tuple, Type
 
 from vellum.workflows.inputs.base import BaseInputs
@@ -67,6 +68,7 @@ class _BaseAdornmentNodeMeta(BaseNodeMeta):
 class BaseAdornmentNode(
     BaseNode[StateType],
     Generic[StateType],
+    ABC,
     metaclass=_BaseAdornmentNodeMeta,
 ):
     """


### PR DESCRIPTION
This lays some of the initial foundation to allow for Node Classes to be defined as Abstract.

With this, we can do stuff like:
```
class SearchNode(BaseSearchNode[StateType], ABC):
    ...
```

And use the presence of the `ABC` parent class to differentiate between node classes and their concrete usages.