### PR TITLE
[APO-550] Fix conflict function dir name

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -310,8 +310,8 @@ exports[`WorkflowProjectGenerator > function > should generate <function_name>.p
 `;
 
 exports[`WorkflowProjectGenerator > function > should generate <function_name>.py file 4`] = `
-"from .get_current_weather_node.format_answer import format_answer
-from .get_current_weather_node.get_current_weather import get_current_weather
+"from .get_current_weather_node_functions.format_answer import format_answer
+from .get_current_weather_node_functions.get_current_weather import get_current_weather
 from typing import List
 
 from vellum import ChatMessage, ChatMessagePromptBlock, PlainTextPromptBlock, RichTextPromptBlock, VariablePromptBlock

--- a/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
@@ -30,7 +30,7 @@ class ToolCallingNodeDisplay(BaseNodeDisplay[ToolCallingNode]):
 `;
 
 exports[`ToolCallingNode > basic > getNodeFile 1`] = `
-"from .tool_calling_node.get_current_weather import get_current_weather
+"from .tool_calling_node_functions.get_current_weather import get_current_weather
 
 from vellum import (
     ChatMessagePromptBlock,

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -3682,19 +3682,19 @@ baz = foo + bar
       expectProjectFileToMatchSnapshot([
         "code",
         "nodes",
-        "get_current_weather_node",
+        "get_current_weather_node_functions",
         "__init__.py",
       ]);
       expectProjectFileToMatchSnapshot([
         "code",
         "nodes",
-        "get_current_weather_node",
+        "get_current_weather_node_functions",
         "get_current_weather.py",
       ]);
       expectProjectFileToMatchSnapshot([
         "code",
         "nodes",
-        "get_current_weather_node",
+        "get_current_weather_node_functions",
         "format_answer.py",
       ]);
       expectProjectFileToMatchSnapshot(["code", "nodes", "tool_call.py"]);

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -101,7 +101,9 @@ export class GenericNode extends BaseSingleFileNode<
                     return python.reference({
                       name: snakeName,
                       modulePath: [
-                        `.${toPythonSafeSnakeCase(nodeName)}.${snakeName}`,
+                        `.${toPythonSafeSnakeCase(
+                          nodeName
+                        )}_functions.${snakeName}`,
                       ],
                     });
                   })
@@ -257,7 +259,9 @@ export class GenericNode extends BaseSingleFileNode<
     const nodeName = this.nodeContext.getNodeLabel();
 
     const baseModule = this.workflowContext.moduleName;
-    const basePath = `${baseModule}/nodes/${toPythonSafeSnakeCase(nodeName)}`;
+    const basePath = `${baseModule}/nodes/${toPythonSafeSnakeCase(
+      nodeName
+    )}_functions`;
 
     const nodeDir = join(absolutePath, basePath);
     await mkdir(nodeDir, { recursive: true });


### PR DESCRIPTION
We now have `get_current_weather_node.py` and `get_current_weather_node` folder which causes conflict