### PR TITLE
[APO-563] Migrate code execution node

### DIFF
--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_serialization.py
@@ -168,9 +168,14 @@ def test_serialize_workflow():
                 },
             },
             {
-                "id": "5c041b7d-732c-4773-a93a-32211f2af0b3",
-                "name": "max_tool_calls",
-                "value": {"type": "CONSTANT_VALUE", "value": {"type": "NUMBER", "value": 1.0}},
+                "id": "b31575f0-633b-4bd0-ba6a-960532f3887a",
+                "name": "function_packages",
+                "value": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": None}},
+            },
+            {
+                "id": "d316c45c-97ea-4f39-9a2d-5c43e2d355de",
+                "name": "runtime",
+                "value": {"type": "CONSTANT_VALUE", "value": {"type": "STRING", "value": "PYTHON_3_11_6"}},
             },
         ],
         "outputs": [

--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/node.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/node.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional, cast
 
 from pydash import snake_case
 

--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/node.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/node.py
@@ -111,7 +111,8 @@ class ToolCallingNode(BaseNode):
             # Get packages for this function if specified
             packages = None
             if self.function_packages and function in self.function_packages:
-                packages = self.function_packages[function]
+                # Cast to tell mypy this is a plain list, not a descriptor
+                packages = cast(List[CodeExecutionPackage], self.function_packages[function])
 
             self._function_nodes[function_name] = create_function_node(
                 function=function,

--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/node.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/node.py
@@ -1,9 +1,10 @@
 from collections.abc import Callable
-from typing import Any, ClassVar, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 from pydash import snake_case
 
 from vellum import ChatMessage, PromptBlock
+from vellum.client.types.code_execution_package import CodeExecutionPackage
 from vellum.workflows.context import execution_context, get_parent_context
 from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
@@ -28,14 +29,16 @@ class ToolCallingNode(BaseNode):
         functions: List[FunctionDefinition] - The functions that can be called
         function_callables: List[Callable] - The callables that can be called
         prompt_inputs: Optional[EntityInputsInterface] - Mapping of input variable names to values
+        function_packages: Optional[Dict[Callable, List[CodeExecutionPackage]]] - Mapping of functions to their packages
+        runtime: str - The runtime to use for code execution (default: "PYTHON_3_11_6")
     """
 
     ml_model: ClassVar[str] = "gpt-4o-mini"
     blocks: ClassVar[List[PromptBlock]] = []
     functions: ClassVar[List[Callable[..., Any]]] = []
     prompt_inputs: ClassVar[Optional[EntityInputsInterface]] = None
-    # TODO: https://linear.app/vellum/issue/APO-342/support-tool-call-max-retries
-    max_tool_calls: ClassVar[int] = 1
+    function_packages: ClassVar[Optional[Dict[Callable[..., Any], List[CodeExecutionPackage]]]] = None
+    runtime: ClassVar[str] = "PYTHON_3_11_6"
 
     class Outputs(BaseOutputs):
         """
@@ -102,13 +105,20 @@ class ToolCallingNode(BaseNode):
             prompt_inputs=self.prompt_inputs,
         )
 
-        self._function_nodes = {
-            snake_case(function.__name__): create_function_node(
+        self._function_nodes = {}
+        for function in self.functions:
+            function_name = snake_case(function.__name__)
+            # Get packages for this function if specified
+            packages = None
+            if self.function_packages and function in self.function_packages:
+                packages = self.function_packages[function]
+
+            self._function_nodes[function_name] = create_function_node(
                 function=function,
                 tool_router_node=self.tool_router_node,
+                packages=packages,
+                runtime=self.runtime,
             )
-            for function in self.functions
-        }
 
         graph_set = set()
 

--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
@@ -135,7 +135,7 @@ def create_function_node(
     Create a FunctionNode class for a given function.
 
     For workflow functions: BaseNode
-    For regular functions: uses CodeExecutionNode with embedded function
+    For regular functions: CodeExecutionNode with embedded function
     Args:
         function: The function to create a node for
         tool_router_node: The tool router node class

--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
@@ -134,9 +134,8 @@ def create_function_node(
     """
     Create a FunctionNode class for a given function.
 
-    For workflow functions: uses BaseNode (current approach)
+    For workflow functions: BaseNode
     For regular functions: uses CodeExecutionNode with embedded function
-
     Args:
         function: The function to create a node for
         tool_router_node: The tool router node class
@@ -145,7 +144,7 @@ def create_function_node(
     """
 
     if is_workflow_class(function):
-        # For workflow functions, use BaseNode approach (keep existing logic)
+
         def execute_function(self) -> BaseNode.Outputs:
             outputs = self.state.meta.node_outputs.get(tool_router_node.Outputs.text)
             # first parse into json

--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
@@ -237,13 +237,7 @@ def main(arguments):
 
         output_type = get_function_output_type()
 
-        base_class: Type[CodeExecutionNode]
-        if output_type != Any:
-            # If we have a specific output type, create a properly typed base class
-            base_class = CodeExecutionNode[BaseState, output_type]  # type: ignore[valid-type]
-        else:
-            # Fall back to Any if no return type annotation
-            base_class = CodeExecutionNode[BaseState, Any]
+        base_class:Type[CodeExecutionNode] = CodeExecutionNode[BaseState, output_type]  #type: ignore[valid-type]
 
         # Create the class with basic attributes
         node = types.new_class(

--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
@@ -1,10 +1,13 @@
 from collections.abc import Callable
+import inspect
 import json
+import types
 from typing import Any, Iterator, List, Optional, Type, cast
 
 from pydash import snake_case
 
 from vellum import ChatMessage, PromptBlock
+from vellum.client.types.code_execution_package import CodeExecutionPackage
 from vellum.client.types.function_call_chat_message_content import FunctionCallChatMessageContent
 from vellum.client.types.function_call_chat_message_content_value import FunctionCallChatMessageContentValue
 from vellum.client.types.string_chat_message_content import StringChatMessageContent
@@ -13,10 +16,12 @@ from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases import BaseNode
+from vellum.workflows.nodes.displayable.code_execution_node.node import CodeExecutionNode
 from vellum.workflows.nodes.displayable.inline_prompt_node.node import InlinePromptNode
 from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.ports.port import Port
 from vellum.workflows.references.lazy import LazyReference
+from vellum.workflows.state.base import BaseState
 from vellum.workflows.state.encoder import DefaultStateEncoder
 from vellum.workflows.types.core import EntityInputsInterface, MergeBehavior
 from vellum.workflows.types.generics import is_workflow_class
@@ -117,26 +122,36 @@ def create_tool_router_node(
             },
         ),
     )
-
     return node
 
 
-def create_function_node(function: Callable[..., Any], tool_router_node: Type[ToolRouterNode]) -> Type[FunctionNode]:
+def create_function_node(
+    function: Callable[..., Any],
+    tool_router_node: Type[ToolRouterNode],
+    packages: Optional[List[CodeExecutionPackage]] = None,
+    runtime: str = "PYTHON_3_11_6",
+) -> Type[FunctionNode]:
     """
     Create a FunctionNode class for a given function.
 
-    This ensures the callable is properly registered and can be called with the expected arguments.
+    For workflow functions: uses BaseNode (current approach)
+    For regular functions: uses CodeExecutionNode with embedded function
+
+    Args:
+        function: The function to create a node for
+        tool_router_node: The tool router node class
+        packages: Optional list of packages to install for code execution (only used for regular functions)
+        runtime: The runtime to use for code execution (default: "PYTHON_3_11_6")
     """
 
-    # Create a class-level wrapper that calls the original function
-    def execute_function(self) -> BaseNode.Outputs:
-        outputs = self.state.meta.node_outputs.get(tool_router_node.Outputs.text)
-        # first parse into json
-        outputs = json.loads(outputs)
-        arguments = outputs["arguments"]
+    if is_workflow_class(function):
+        # For workflow functions, use BaseNode approach (keep existing logic)
+        def execute_function(self) -> BaseNode.Outputs:
+            outputs = self.state.meta.node_outputs.get(tool_router_node.Outputs.text)
+            # first parse into json
+            outputs = json.loads(outputs)
+            arguments = outputs["arguments"]
 
-        # Call the function based on its type
-        if is_workflow_class(function):
             # Dynamically define an Inputs subclass of BaseInputs
             Inputs = type(
                 "Inputs",
@@ -160,26 +175,86 @@ def create_function_node(function: Callable[..., Any], tool_router_node: Type[To
                 result = terminal_event.outputs
             elif terminal_event.name == "workflow.execution.rejected":
                 raise Exception(f"Workflow execution rejected: {terminal_event.error}")
-        else:
-            # If it's a regular callable, call it directly
-            result = function(**arguments)
 
-        self.state.chat_history.append(
-            ChatMessage(
-                role="FUNCTION",
-                content=StringChatMessageContent(value=json.dumps(result, cls=DefaultStateEncoder)),
+            self.state.chat_history.append(
+                ChatMessage(
+                    role="FUNCTION",
+                    content=StringChatMessageContent(value=json.dumps(result, cls=DefaultStateEncoder)),
+                )
             )
+
+            return self.Outputs()
+
+        # Create BaseNode for workflow functions
+        node = type(
+            f"InlineWorkflowNode_{function.__name__}",
+            (FunctionNode,),
+            {
+                "run": execute_function,
+                "__module__": __name__,
+            },
         )
+    else:
+        # For regular functions, use CodeExecutionNode approach
+        function_source = inspect.getsource(function)
+        function_name = function.__name__
 
-        return self.Outputs()
+        _code = f'''
+{function_source}
 
-    node = type(
-        f"FunctionNode_{function.__name__}",
-        (FunctionNode,),
-        {
-            "run": execute_function,
-            "__module__": __name__,
-        },
-    )
+def main(arguments):
+    """Main function that calls the original function with the provided arguments."""
+    return {function_name}(**arguments)
+'''
+        _packages = packages
+        _tool_router_node = tool_router_node
+        _runtime = runtime
+
+        def get_function_output_type() -> Type:
+            return function.__annotations__["return"]
+
+        output_type = get_function_output_type()
+
+        # Create the base class
+        base_class = CodeExecutionNode[BaseState, output_type]
+
+        def execute_function(self):
+            # Get the function call from the tool router output
+            function_call_output = self.state.meta.node_outputs.get(_tool_router_node.Outputs.results)
+            if function_call_output and len(function_call_output) > 0:
+                function_call = function_call_output[0]
+                arguments = function_call.value.arguments
+            else:
+                arguments = {}
+
+            self.code_inputs = {"arguments": arguments}
+
+            outputs = base_class.run(self)
+
+            self.state.chat_history.append(
+                ChatMessage(
+                    role="FUNCTION",
+                    content=StringChatMessageContent(value=json.dumps(outputs.result, cls=DefaultStateEncoder)),
+                )
+            )
+
+            return outputs
+
+        # Create the class with basic attributes
+        node = types.new_class(
+            f"CodeExecutionNode_{function.__name__}",
+            (base_class,),
+            {},
+            lambda ns: ns.update(
+                {
+                    "code": _code,
+                    "code_inputs": {},  # No inputs needed since we handle function call extraction in run()
+                    "run": execute_function,
+                    "runtime": _runtime,
+                    "packages": _packages,
+                    "__module__": __name__,
+                }
+            ),
+        )
 
     return node

--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
@@ -237,7 +237,7 @@ def main(arguments):
 
         output_type = get_function_output_type()
 
-        base_class:Type[CodeExecutionNode] = CodeExecutionNode[BaseState, output_type]  #type: ignore[valid-type]
+        base_class: Type[CodeExecutionNode] = CodeExecutionNode[BaseState, output_type]  # type: ignore[valid-type]
 
         # Create the class with basic attributes
         node = types.new_class(


### PR DESCRIPTION
TODO: 
- split `create_function_node` function node in `node.py` to separate workflow and function on a top level
- serialize/codegen runtime and package 