### PR TITLE
[APO-581] Fix lazy references for prompt inputs

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -663,7 +663,7 @@ export function promptDeploymentNodeDataFactory({
 
 export function templatingNodeFactory({
   id,
-    outputId,
+  outputId,
   label,
   sourceHandleId,
   targetHandleId,

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -663,6 +663,7 @@ export function promptDeploymentNodeDataFactory({
 
 export function templatingNodeFactory({
   id,
+    outputId,
   label,
   sourceHandleId,
   targetHandleId,
@@ -673,6 +674,7 @@ export function templatingNodeFactory({
   template,
 }: {
   id?: string;
+  outputId?: string;
   label?: string;
   sourceHandleId?: string;
   targetHandleId?: string;
@@ -711,7 +713,7 @@ export function templatingNodeFactory({
     type: WorkflowNodeType.TEMPLATING,
     data: {
       label: label ?? "Templating Node",
-      outputId: "2d4f1826-de75-499a-8f84-0a690c8136ad",
+      outputId: outputId ?? "2d4f1826-de75-499a-8f84-0a690c8136ad",
       errorOutputId,
       sourceHandleId: sourceHandleId ?? "6ee2c814-d0a5-4ec9-83b6-45156e2f22c4",
       targetHandleId: targetHandleId ?? "3960c8e1-9baa-4b9c-991d-e399d16a45aa",

--- a/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/multiple-nodes.test.ts.snap
@@ -169,6 +169,34 @@ class TemplatingNode(BaseTemplatingNode[BaseState, str]):
 "
 `;
 
+exports[`InlinePromptNode with prompt inputs generating lazy reference > getNodeFile generates lazy reference 1`] = `
+"from vellum import JinjaPromptBlock, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+from vellum.workflows.references import LazyReference
+
+
+class PromptNode(InlinePromptNode):
+    ml_model = "gpt-4o-mini"
+    blocks = [
+        JinjaPromptBlock(template="""Summarize what this means {{ INPUT_VARIABLE }}"""),
+    ]
+    prompt_inputs = {
+        "text": LazyReference("TemplatingNode.Outputs.result"),
+    }
+    parameters = PromptParameters(
+        stop=[],
+        temperature=0,
+        max_tokens=1000,
+        top_p=1,
+        top_k=0,
+        frequency_penalty=0,
+        presence_penalty=0,
+        logit_bias={},
+        custom_parameters={},
+    )
+"
+`;
+
 exports[`Non-existent Subworkflow Deployment Node referenced by Templating Node > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-value-descriptor-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-value-descriptor-reference.ts
@@ -81,11 +81,13 @@ export class WorkflowValueDescriptorReference extends AstNode {
       }
       case "WORKFLOW_INPUT":
         return new WorkflowInputReference({
+          nodeContext: this.nodeContext,
           workflowContext: this.workflowContext,
           nodeInputWorkflowReferencePointer: workflowValueReferencePointer,
         });
       case "WORKFLOW_STATE":
         return new WorkflowStateReference({
+          nodeContext: this.nodeContext,
           workflowContext: this.workflowContext,
           nodeInputWorkflowReferencePointer: workflowValueReferencePointer,
         });
@@ -99,16 +101,19 @@ export class WorkflowValueDescriptorReference extends AstNode {
         });
       case "VELLUM_SECRET":
         return new VellumSecretWorkflowReference({
+          nodeContext: this.nodeContext,
           workflowContext: this.workflowContext,
           nodeInputWorkflowReferencePointer: workflowValueReferencePointer,
         });
       case "EXECUTION_COUNTER":
         return new ExecutionCounterWorkflowReference({
+          nodeContext: this.nodeContext,
           workflowContext: this.workflowContext,
           nodeInputWorkflowReferencePointer: workflowValueReferencePointer,
         });
       case "DICTIONARY_REFERENCE":
         return new DictionaryWorkflowReference({
+          nodeContext: this.nodeContext,
           workflowContext: this.workflowContext,
           nodeInputWorkflowReferencePointer: workflowValueReferencePointer,
         });


### PR DESCRIPTION
Context: Classic function calling demo was failing because of circular import. We were using node attributes now and need to pass in node context to various workflow descriptor references