### PR TITLE
Adding a hacky workaround to resupport Workflow output deltas

### DIFF
--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -10,6 +10,7 @@ from vellum.workflows.constants import undefined
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.descriptors.utils import is_unresolved, resolve_value
 from vellum.workflows.errors.types import WorkflowErrorCode
+from vellum.workflows.events.node import NodeExecutionStreamingEvent
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.graph import Graph
 from vellum.workflows.graph.graph import GraphTarget
@@ -486,3 +487,16 @@ class BaseNode(Generic[StateType], ABC, metaclass=BaseNodeMeta):
 
     def __repr__(self) -> str:
         return str(self.__class__)
+
+    __simulates_workflow_output__ = False
+
+    def __directly_emit_workflow_output__(
+        self, event: NodeExecutionStreamingEvent, workflow_output_descriptor: OutputReference
+    ) -> bool:
+        """
+        In the legacy workflow runner, there was support for emitting streaming workflow outputs for prompt nodes
+        connected to terminal nodes. These two private methods provides a hacky, intentionally short-lived workaround
+        for us to enable this until we can directly reference prompt outputs from the UI.
+        """
+
+        return False

--- a/src/vellum/workflows/nodes/displayable/final_output_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/final_output_node/node.py
@@ -61,3 +61,5 @@ class FinalOutputNode(BaseNode[StateType], Generic[StateType, _OutputType], meta
                 self.__class__.get_output_type(),
             )
         )
+
+    __simulates_workflow_output__ = True

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -467,6 +467,19 @@ class WorkflowRunner(Generic[StateType]):
 
         if event.name == "node.execution.streaming":
             for workflow_output_descriptor in self.workflow.Outputs:
+                if node.__directly_emit_workflow_output__(event, workflow_output_descriptor):
+                    active_node.was_outputs_streamed = True
+                    self._workflow_event_outer_queue.put(
+                        self._stream_workflow_event(
+                            BaseOutput(
+                                name=workflow_output_descriptor.name,
+                                value=event.output.value,
+                                delta=event.output.delta,
+                            )
+                        )
+                    )
+                    return None
+
                 node_output_descriptor = workflow_output_descriptor.instance
                 if not isinstance(node_output_descriptor, OutputReference):
                     continue

--- a/tests/workflows/stream_final_output_node/tests/test_workflow.py
+++ b/tests/workflows/stream_final_output_node/tests/test_workflow.py
@@ -1,4 +1,3 @@
-import pytest
 from uuid import uuid4
 from typing import Any, Iterator, List
 
@@ -47,7 +46,6 @@ def test_workflow__happy_path(vellum_adhoc_prompt_client):
     assert streaming_event.output.value == "Hello, world!"
 
 
-@pytest.mark.skip(reason="Finishing it up in https://github.com/vellum-ai/vellum-python-sdks/pull/1578")
 def test_workflow__prompt_chunks(vellum_adhoc_prompt_client):
     # GIVEN a workflow with a prompt and a final output
     workflow = StreamFinalOutputWorkflow()
@@ -100,15 +98,15 @@ def test_workflow__prompt_chunks(vellum_adhoc_prompt_client):
 
     streaming_event = streaming_events[1]
     assert streaming_event.output.is_streaming
-    assert streaming_event.output.value == "Hello"
+    assert streaming_event.output.delta == "Hello"
 
     streaming_event = streaming_events[2]
     assert streaming_event.output.is_streaming
-    assert streaming_event.output.value == ", "
+    assert streaming_event.output.delta == ", "
 
     streaming_event = streaming_events[3]
     assert streaming_event.output.is_streaming
-    assert streaming_event.output.value == "world!"
+    assert streaming_event.output.delta == "world!"
 
     streaming_event = streaming_events[4]
     assert streaming_event.output.is_fulfilled


### PR DESCRIPTION
Old workflow runner used to support the idea of streaming workflow outputs when a prompt node was connected to a terminal node. The goal of this PR was to bring back this behavior.

The first attempt was through node-to-node streaming, which could be found here: https://github.com/vellum-ai/vellum-python-sdks/pull/1578/files. This got really hairy, and didn't even get to a stable place. Given that Terminal nodes will be gone in some medium term future, I decided to stop investing in node to node streaming support and invest in an alternative approach.

This PR enables the idea that any node in the graph could define a custom method for when one of its streaming events could act as a workflow level streaming event. Long term, the hope is that this gets replaced with direct referencing of workflow outputs to node outputs without needing terminal nodes.

Going to sleep on this before trying to publish and test tm morning, but this feels overall far less risky than the original approach.