### PR TITLE
Preserve context for tool calling node inline workflow

### DIFF
--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/tests/test_node.py
@@ -1,7 +1,17 @@
+import json
+from typing import Any, List
+
+from vellum import ChatMessage
 from vellum.client.types.function_call import FunctionCall
 from vellum.client.types.function_call_vellum_value import FunctionCallVellumValue
-from vellum.workflows.nodes.experimental.tool_calling_node.utils import create_tool_router_node
+from vellum.client.types.string_chat_message_content import StringChatMessageContent
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.inputs.base import BaseInputs
+from vellum.workflows.nodes.bases import BaseNode
+from vellum.workflows.nodes.experimental.tool_calling_node.utils import create_function_node, create_tool_router_node
+from vellum.workflows.outputs.base import BaseOutputs
 from vellum.workflows.state.base import BaseState, StateMeta
+from vellum.workflows.state.context import WorkflowContext
 
 
 def first_function() -> str:
@@ -51,3 +61,69 @@ def test_port_condition_match_function_name():
     # AND the default port should be false
     default_port = getattr(router_node.Ports, "default")
     assert default_port.resolve_condition(state) is False
+
+
+def test_tool_calling_node_inline_workflow_context():
+    """
+    Test that the tool calling node correctly passes the context to the inline workflow.
+    This specifically tests that inline workflows receive the correct context.
+    """
+
+    # GIVEN a test workflow that captures its context
+    class MyNode(BaseNode):
+        class Outputs(BaseOutputs):
+            generated_files: Any
+
+        def run(self) -> Outputs:
+            return self.Outputs(generated_files=self._context.generated_files)
+
+    class MyWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+        graph = MyNode
+
+        class Outputs(BaseOutputs):
+            generated_files = MyNode.Outputs.generated_files
+
+    # GIVEN a tool router node
+    tool_router_node = create_tool_router_node(
+        ml_model="test-model",
+        blocks=[],
+        functions=[MyWorkflow],
+        prompt_inputs=None,
+    )
+
+    # WHEN we create a function node for the workflow
+    function_node_class = create_function_node(
+        function=MyWorkflow,
+        tool_router_node=tool_router_node,
+    )
+
+    # AND we create an instance with a context containing generated_files
+    function_node = function_node_class()
+
+    # Create a parent context with test data
+    parent_context = WorkflowContext(
+        generated_files={"script.py": "print('hello world')"},
+    )
+    function_node._context = parent_context
+
+    # Create a state with chat_history for the function node
+    class TestState(BaseState):
+        chat_history: List[ChatMessage] = []
+
+    function_node.state = TestState(meta=StateMeta(node_outputs={tool_router_node.Outputs.text: '{"arguments": {}}'}))
+
+    # WHEN the function node runs
+    outputs = function_node.run()
+
+    # THEN the workflow should have run successfully
+    assert outputs is not None
+
+    # AND the chat history should contain a function response
+    assert len(function_node.state.chat_history) == 1
+    function_response = function_node.state.chat_history[0]
+    assert function_response.role == "FUNCTION"
+
+    # AND the response should contain the generated files
+    assert isinstance(function_response.content, StringChatMessageContent)
+    data = json.loads(function_response.content.value)
+    assert data["generated_files"] == {"script.py": "print('hello world')"}

--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
@@ -22,6 +22,7 @@ from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.ports.port import Port
 from vellum.workflows.references.lazy import LazyReference
 from vellum.workflows.state.base import BaseState
+from vellum.workflows.state.context import WorkflowContext
 from vellum.workflows.state.encoder import DefaultStateEncoder
 from vellum.workflows.types.core import EntityInputsInterface, MergeBehavior
 from vellum.workflows.types.generics import is_workflow_class

--- a/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/experimental/tool_calling_node/utils.py
@@ -152,8 +152,7 @@ def create_function_node(
 
             # Call the function based on its type
             inputs_instance = function.get_inputs_class()(**arguments)
-
-            workflow = function()
+            workflow = function(context=WorkflowContext.create_from(self._context))
             terminal_event = workflow.run(
                 inputs=inputs_instance,
             )


### PR DESCRIPTION
While trying to use a code execution node in inline workflow in FE, found that it couldn't access generated files