### PR TITLE
Handle serialization of prompt blocks as an attribute

### DIFF
--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node.py
@@ -16,6 +16,7 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     node_input_ids_by_name = {"prompt_inputs.var_1": UUID("183b03e5-b903-4d39-abe4-9267c78285f6")}
     attribute_ids_by_name = {
         "ml_model": UUID("3e918914-3f95-4404-8c98-3b66cda834cd"),
+        "blocks": UUID("96f1c44f-1ba8-4096-aaa6-ce798f9dc585"),
         "prompt_inputs": UUID("b35a446c-1e59-4119-b7e0-529b7628b561"),
         "functions": UUID("4f0822c2-4be5-4b5d-9fd7-c45e88b64e70"),
     }

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_14.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_14.py
@@ -16,6 +16,7 @@ class PromptNode14Display(BaseInlinePromptNodeDisplay[PromptNode14]):
     node_input_ids_by_name = {"prompt_inputs.chat_history": UUID("b6524b5f-7697-4923-8b87-f85baadb505a")}
     attribute_ids_by_name = {
         "ml_model": UUID("4c6baea4-e4c9-4ea2-bffd-88d0b7210725"),
+        "blocks": UUID("e8c2a5b2-0706-4598-bb54-f5b3ac613bdc"),
         "prompt_inputs": UUID("5736796a-5529-4cbe-a930-9b2067e21aca"),
         "functions": UUID("1a360feb-6271-4b9c-a543-6ff1af06391d"),
     }

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_16.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_16.py
@@ -16,6 +16,7 @@ class PromptNode16Display(BaseInlinePromptNodeDisplay[PromptNode16]):
     node_input_ids_by_name = {"prompt_inputs.most_recent_message": UUID("0f0f394c-dc7d-46a1-9217-24c1e59b273a")}
     attribute_ids_by_name = {
         "ml_model": UUID("35c7463b-4fb3-44aa-8c2b-1f30ab4b71ac"),
+        "blocks": UUID("805ae978-3d9f-4d39-a433-d7812542c532"),
         "prompt_inputs": UUID("35ae3ecc-030b-479d-b6c8-c2ccdd7ae984"),
         "functions": UUID("e9e50650-027f-4595-9479-b4e488153402"),
     }

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_18.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_18.py
@@ -16,6 +16,7 @@ class PromptNode18Display(BaseInlinePromptNodeDisplay[PromptNode18]):
     node_input_ids_by_name = {"prompt_inputs.text": UUID("fbd03331-bbef-45f3-98fd-2106fd3cdb8a")}
     attribute_ids_by_name = {
         "ml_model": UUID("268adb20-f526-4c8f-853d-aebf808925cb"),
+        "blocks": UUID("c82ae1f2-18f6-4951-9fd6-22564cd2ec03"),
         "prompt_inputs": UUID("92d646e7-8288-4b3e-bd50-b10dbe8c782e"),
         "functions": UUID("7fd8ceb5-0d07-4ce2-9df1-784a501cd6ab"),
     }

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_19.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_19.py
@@ -15,6 +15,7 @@ class PromptNode19Display(BaseInlinePromptNodeDisplay[PromptNode19]):
     target_handle_id = UUID("35b77bfb-91d3-4e5b-8032-9786b9cc05c3")
     attribute_ids_by_name = {
         "ml_model": UUID("2010abdf-1f16-4979-96e4-c6bae7c4cd52"),
+        "blocks": UUID("2d47190b-bba2-4546-88af-b2dc723365a1"),
         "prompt_inputs": UUID("091ee33c-abc5-461a-9d95-c15cccbcaf39"),
         "functions": UUID("f916eaa5-ac97-46f8-842c-ad2e65baf9ae"),
     }

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_9.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/prompt_node_9.py
@@ -19,6 +19,7 @@ class PromptNode9Display(BaseInlinePromptNodeDisplay[PromptNode9]):
     }
     attribute_ids_by_name = {
         "ml_model": UUID("8ae0df7b-2d57-48d7-a396-37f3e3ef4c75"),
+        "blocks": UUID("bd31dcbe-3a12-4bc1-948f-8fab8a2519ea"),
         "prompt_inputs": UUID("8036c42e-206f-4185-ad09-2f7abdddc125"),
         "functions": UUID("a3293819-18fa-45d7-9aa8-048d68e517e0"),
     }

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/display_data/faa_q_and_a_bot.json
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/display_data/faa_q_and_a_bot.json
@@ -147,9 +147,7 @@
                   "name": "Classification",
                   "schema": {
                     "type": "object",
-                    "required": [
-                      "classification"
-                    ],
+                    "required": ["classification"],
                     "properties": {
                       "classification": {
                         "type": "string",
@@ -249,6 +247,64 @@
               "value": {
                 "type": "STRING",
                 "value": "gpt-4o"
+              }
+            }
+          },
+          {
+            "id": "96f1c44f-1ba8-4096-aaa6-ce798f9dc585",
+            "name": "blocks",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {
+                "type": "JSON",
+                "value": [
+                  {
+                    "block_type": "CHAT_MESSAGE",
+                    "state": null,
+                    "cache_config": null,
+                    "chat_role": "SYSTEM",
+                    "chat_source": null,
+                    "chat_message_unterminated": null,
+                    "blocks": [
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": "You are an expert classifier. You will analyze the chat and output one of the following in JSON format: \n\n1. \"weather\" if it is a question about the weather\n2. \"flight status\" if it is about which flights are currently in transit at a certain airport\n3. \"faa\" if the question is about any FAA related aviation policies\n4. \"other\" if the question is about anything else"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "block_type": "CHAT_MESSAGE",
+                    "state": null,
+                    "cache_config": null,
+                    "chat_role": "USER",
+                    "chat_source": null,
+                    "chat_message_unterminated": null,
+                    "blocks": [
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "VARIABLE",
+                            "state": null,
+                            "cache_config": null,
+                            "input_variable": "var_1"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
             }
           },
@@ -1132,6 +1188,72 @@
             }
           },
           {
+            "id": "bd31dcbe-3a12-4bc1-948f-8fab8a2519ea",
+            "name": "blocks",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {
+                "type": "JSON",
+                "value": [
+                  {
+                    "block_type": "CHAT_MESSAGE",
+                    "state": null,
+                    "cache_config": null,
+                    "chat_role": "SYSTEM",
+                    "chat_source": null,
+                    "chat_message_unterminated": null,
+                    "blocks": [
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": " Question:\n---------------\n"
+                          },
+                          {
+                            "block_type": "VARIABLE",
+                            "state": null,
+                            "cache_config": null,
+                            "input_variable": "question"
+                          },
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": "\n\nPolicy Quotes:\n-----------------------\n"
+                          },
+                          {
+                            "block_type": "VARIABLE",
+                            "state": null,
+                            "cache_config": null,
+                            "input_variable": "context"
+                          }
+                        ]
+                      },
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": "You are an expert on FAA rules, guidelines, and safety. Answer the above question given the context. Provide citation of the policy you got it from at the end of the response. If you don't know the answer, say \"Sorry, I don't know\"\n\nLimit your response to 250 words. Just use plain text, no special characters, no commas, no mathematical signs like + -"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
             "id": "8036c42e-206f-4185-ad09-2f7abdddc125",
             "name": "prompt_inputs",
             "value": {
@@ -1328,6 +1450,47 @@
               "value": {
                 "type": "STRING",
                 "value": "gpt-4o"
+              }
+            }
+          },
+          {
+            "id": "805ae978-3d9f-4d39-a433-d7812542c532",
+            "name": "blocks",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {
+                "type": "JSON",
+                "value": [
+                  {
+                    "block_type": "CHAT_MESSAGE",
+                    "state": null,
+                    "cache_config": null,
+                    "chat_role": "SYSTEM",
+                    "chat_source": null,
+                    "chat_message_unterminated": null,
+                    "blocks": [
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": "Respond with the IATA airport name this incoming message is about. For example, respond only with \"SJC\", \"SFO\", \"EWR\" or \"JFK\"\n\n"
+                          },
+                          {
+                            "block_type": "VARIABLE",
+                            "state": null,
+                            "cache_config": null,
+                            "input_variable": "most_recent_message"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
             }
           },
@@ -1875,6 +2038,93 @@
             }
           },
           {
+            "id": "c82ae1f2-18f6-4951-9fd6-22564cd2ec03",
+            "name": "blocks",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {
+                "type": "JSON",
+                "value": [
+                  {
+                    "block_type": "CHAT_MESSAGE",
+                    "state": null,
+                    "cache_config": null,
+                    "chat_role": "USER",
+                    "chat_source": null,
+                    "chat_message_unterminated": null,
+                    "blocks": [
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": "Based on the below JSON response from an airline flight status tracker API, which flights are on the ground? And which airports are they going from and to? Where are they right now?\n\n"
+                          },
+                          {
+                            "block_type": "VARIABLE",
+                            "state": null,
+                            "cache_config": null,
+                            "input_variable": "text"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "block_type": "CHAT_MESSAGE",
+                    "state": null,
+                    "cache_config": null,
+                    "chat_role": "USER",
+                    "chat_source": null,
+                    "chat_message_unterminated": null,
+                    "blocks": [
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": " Respond in the following format\n\nThe flights that are on the ground are:\n\n1. **Flight Number:** WN597\n   - **Departure Airport:** LAS (Las Vegas McCarran International Airport)\n   - **Arrival Airport:** SJC (San Jose International Airport)\n   - **Current Location:** Latitude 37.3664, Longitude -121.929 (San Jose International Airport)\n"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "block_type": "CHAT_MESSAGE",
+                    "state": null,
+                    "cache_config": null,
+                    "chat_role": "USER",
+                    "chat_source": null,
+                    "chat_message_unterminated": null,
+                    "blocks": [
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": " Just use plain text and no special characters"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
             "id": "92d646e7-8288-4b3e-bd50-b10dbe8c782e",
             "name": "prompt_inputs",
             "value": {
@@ -2024,6 +2274,41 @@
               "value": {
                 "type": "STRING",
                 "value": "gpt-4o-2024-05-13"
+              }
+            }
+          },
+          {
+            "id": "2d47190b-bba2-4546-88af-b2dc723365a1",
+            "name": "blocks",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {
+                "type": "JSON",
+                "value": [
+                  {
+                    "block_type": "CHAT_MESSAGE",
+                    "state": null,
+                    "cache_config": null,
+                    "chat_role": "SYSTEM",
+                    "chat_source": null,
+                    "chat_message_unterminated": null,
+                    "blocks": [
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": "Respond with \"Sorry I don't know\""
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
             }
           },
@@ -2275,6 +2560,47 @@
               "value": {
                 "type": "STRING",
                 "value": "gpt-4o-mini"
+              }
+            }
+          },
+          {
+            "id": "e8c2a5b2-0706-4598-bb54-f5b3ac613bdc",
+            "name": "blocks",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {
+                "type": "JSON",
+                "value": [
+                  {
+                    "block_type": "CHAT_MESSAGE",
+                    "state": null,
+                    "cache_config": null,
+                    "chat_role": "SYSTEM",
+                    "chat_source": null,
+                    "chat_message_unterminated": null,
+                    "blocks": [
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": "Summarize the weather. Just use plain text, no special characters, no commas, no mathematical signs like + -"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "block_type": "VARIABLE",
+                    "state": null,
+                    "cache_config": null,
+                    "input_variable": "chat_history"
+                  }
+                ]
               }
             }
           },

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/code/display/nodes/prompt_node.py
@@ -17,6 +17,7 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     node_input_ids_by_name = {"prompt_inputs.text": UUID("b2bc9402-6e50-4982-800c-1662c188899b")}
     attribute_ids_by_name = {
         "ml_model": UUID("38f60afe-cd5f-4950-8674-18e17567a784"),
+        "blocks": UUID("35a10b43-ece9-40de-93a4-c1590cfa2c9f"),
         "prompt_inputs": UUID("91448235-24d7-4ee1-bba4-3bbce03ebdcb"),
         "functions": UUID("6052c618-675a-4e6b-9276-498ab97deba7"),
     }

--- a/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
+++ b/ee/codegen_integration/fixtures/simple_node_with_try_wrap/display_data/simple_node_with_try_wrap.json
@@ -129,6 +129,47 @@
             }
           },
           {
+            "id": "35a10b43-ece9-40de-93a4-c1590cfa2c9f",
+            "name": "blocks",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {
+                "type": "JSON",
+                "value": [
+                  {
+                    "block_type": "CHAT_MESSAGE",
+                    "state": null,
+                    "cache_config": null,
+                    "chat_role": "SYSTEM",
+                    "chat_source": null,
+                    "chat_message_unterminated": null,
+                    "blocks": [
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": "What is the origin of the following phrase\n\n"
+                          },
+                          {
+                            "block_type": "VARIABLE",
+                            "state": null,
+                            "cache_config": null,
+                            "input_variable": "text"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
             "id": "91448235-24d7-4ee1-bba4-3bbce03ebdcb",
             "name": "prompt_inputs",
             "value": {

--- a/ee/codegen_integration/fixtures/simple_prompt_node/code/display/nodes/prompt_node.py
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/code/display/nodes/prompt_node.py
@@ -16,6 +16,7 @@ class PromptNodeDisplay(BaseInlinePromptNodeDisplay[PromptNode]):
     node_input_ids_by_name = {"prompt_inputs.text": UUID("7b8af68b-cf60-4fca-9c57-868042b5b616")}
     attribute_ids_by_name = {
         "ml_model": UUID("bb466968-7547-458c-8e8f-5d0fb1eb33f5"),
+        "blocks": UUID("6a3ab4d8-4ff6-43fe-a919-93b2a05fa0a6"),
         "prompt_inputs": UUID("84bafdbf-3ca8-4e48-9ea6-380e90756a7f"),
         "functions": UUID("2a8be1e2-2dad-4a2f-80be-01c4723ce1da"),
     }

--- a/ee/codegen_integration/fixtures/simple_prompt_node/display_data/simple_prompt_node.json
+++ b/ee/codegen_integration/fixtures/simple_prompt_node/display_data/simple_prompt_node.json
@@ -180,6 +180,47 @@
             }
           },
           {
+            "id": "6a3ab4d8-4ff6-43fe-a919-93b2a05fa0a6",
+            "name": "blocks",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {
+                "type": "JSON",
+                "value": [
+                  {
+                    "block_type": "CHAT_MESSAGE",
+                    "state": null,
+                    "cache_config": null,
+                    "chat_role": "SYSTEM",
+                    "chat_source": null,
+                    "chat_message_unterminated": null,
+                    "blocks": [
+                      {
+                        "block_type": "RICH_TEXT",
+                        "state": null,
+                        "cache_config": null,
+                        "blocks": [
+                          {
+                            "block_type": "PLAIN_TEXT",
+                            "state": null,
+                            "cache_config": null,
+                            "text": "Summarize the following text:\n\n"
+                          },
+                          {
+                            "block_type": "VARIABLE",
+                            "state": null,
+                            "cache_config": null,
+                            "input_variable": "text"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
             "id": "84bafdbf-3ca8-4e48-9ea6-380e90756a7f",
             "name": "prompt_inputs",
             "value": {

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
@@ -2,6 +2,7 @@ from uuid import UUID
 from typing import Callable, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
 
 from vellum import FunctionDefinition, PromptBlock, RichTextChildBlock, VellumVariable
+from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.nodes import InlinePromptNode
 from vellum.workflows.types.core import JsonObject
 from vellum.workflows.utils.functions import compile_function_definition
@@ -18,9 +19,10 @@ _InlinePromptNodeType = TypeVar("_InlinePromptNodeType", bound=InlinePromptNode)
 
 
 class BaseInlinePromptNodeDisplay(BaseNodeDisplay[_InlinePromptNodeType], Generic[_InlinePromptNodeType]):
-    __serializable_inputs__ = {InlinePromptNode.prompt_inputs, InlinePromptNode.functions}
+    __serializable_inputs__ = {
+        InlinePromptNode.prompt_inputs,
+    }
     __unserializable_attributes__ = {
-        InlinePromptNode.blocks,
         InlinePromptNode.parameters,
         InlinePromptNode.settings,
         InlinePromptNode.expand_meta,
@@ -45,7 +47,9 @@ class BaseInlinePromptNodeDisplay(BaseNodeDisplay[_InlinePromptNodeType], Generi
         ml_model = str(raise_if_descriptor(node.ml_model))
 
         blocks: list = [
-            self._generate_prompt_block(block, input_variable_id_by_name, [i]) for i, block in enumerate(node_blocks)
+            self._generate_prompt_block(block, input_variable_id_by_name, [i])
+            for i, block in enumerate(node_blocks)
+            if not isinstance(block, BaseDescriptor)
         ]
 
         functions = (

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_inline_prompt_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_inline_prompt_node_serialization.py
@@ -175,6 +175,34 @@ def test_serialize_workflow():
                     "value": {"type": "CONSTANT_VALUE", "value": {"type": "STRING", "value": "gpt-4o"}},
                 },
                 {
+                    "id": "25f935f3-363f-4ead-a5a0-db234ca67e1e",
+                    "name": "blocks",
+                    "value": {
+                        "type": "CONSTANT_VALUE",
+                        "value": {
+                            "type": "JSON",
+                            "value": [
+                                {
+                                    "block_type": "CHAT_MESSAGE",
+                                    "state": None,
+                                    "cache_config": None,
+                                    "chat_role": "SYSTEM",
+                                    "chat_source": None,
+                                    "chat_message_unterminated": None,
+                                    "blocks": [
+                                        {
+                                            "block_type": "JINJA",
+                                            "state": None,
+                                            "cache_config": None,
+                                            "template": "What's your favorite {{noun}}?",
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                    },
+                },
+                {
                     "id": "ffabe7d2-8ab6-4201-9d41-c4d7be1386e1",
                     "name": "prompt_inputs",
                     "value": {


### PR DESCRIPTION
This PR adds support for serializing the `blocks` attribute on inline prompt node _as_ an attribute. Most changes are snapshot changes, actual implementation is ~10 lines.

The first attempt was made here: https://github.com/vellum-ai/vellum-python-sdks/pull/1816, but prompt node serialization is so complex atm that Devin couldn't handle