### PR TITLE
[APO-485] Support timeout attribute on APINode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1018,6 +1018,7 @@ export interface ApiNodeFactoryProps {
   body?: Record<string, unknown> | null;
   statusCodeOutputId?: string;
   id?: string;
+  timeout?: NodeInput | null;
 }
 
 export function apiNodeFactory({
@@ -1031,6 +1032,7 @@ export function apiNodeFactory({
   url = "https://example.vellum.ai",
   method = "POST",
   body = {},
+  timeout,
 }: ApiNodeFactoryProps = {}): NodeDataFactoryBuilder<ApiNode> {
   const bearerTokenInput = bearerToken ?? {
     id: "931502c1-23a5-4e2a-a75e-80736c42f3c9",
@@ -1264,6 +1266,7 @@ export function apiNodeFactory({
     },
     apiKeyHeaderValueInput,
     ...additionalHeaderInputs.flatMap(({ key, value }) => [key, value]),
+    ...(timeout ? [timeout] : []),
   ];
 
   const nodeData: ApiNode = {
@@ -1292,6 +1295,7 @@ export function apiNodeFactory({
       errorOutputId,
       targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
       sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
+      timeoutInputId: timeout?.id,
     },
     inputs: inputs,
     displayData: {

--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1266,7 +1266,9 @@ export function apiNodeFactory({
     },
     apiKeyHeaderValueInput,
     ...additionalHeaderInputs.flatMap(({ key, value }) => [key, value]),
-    ...(timeout ? [timeout] : []),
+    ...(timeout
+      ? [{ ...timeout, id: "b4b4f46d-3e2b-4b93-aae9-6998bbbe2a62" }]
+      : []),
   ];
 
   const nodeData: ApiNode = {
@@ -1295,7 +1297,7 @@ export function apiNodeFactory({
       errorOutputId,
       targetHandleId: "06573a05-e6f0-48b9-bc6e-07e06d0bc1b1",
       sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
-      timeoutInputId: timeout?.id,
+      timeoutInputId: timeout?.id ? "b4b4f46d-3e2b-4b93-aae9-6998bbbe2a62" : "",
     },
     inputs: inputs,
     displayData: {

--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -314,3 +314,155 @@ class APINode(BaseAPINode):
     bearer_token_value = VellumSecretReference("some-non-existent-workspace-secret-id")
 "
 `;
+
+exports[`ApiNode > timeout functionality > should generate timeout field when timeoutInputId is provided 1`] = `
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "https://example.vellum.ai"
+    method = APIRequestMethod.POST
+    headers = {
+        "foo": "foo-value",
+        "bar": "bar-value",
+        "baz": "baz-value",
+    }
+    api_key_header_key = None
+    authorization_type = AuthorizationType.API_KEY
+    api_key_header_value = "<my-api-value>"
+    bearer_token_value = "<my-bearer-token>"
+    timeout = 30
+"
+`;
+
+exports[`ApiNode > timeout functionality > should generate timeout_input_id in display class when timeoutInputId is provided 1`] = `
+"from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseAPINodeDisplay
+from vellum_ee.workflows.display.nodes.types import (
+    NodeOutputDisplay,
+    PortDisplayOverrides,
+)
+
+from ...nodes.api_node import APINode
+
+
+class APINodeDisplay(BaseAPINodeDisplay[APINode]):
+    label = "API Node"
+    node_id = UUID("2cd960a3-cb8a-43ed-9e3f-f003fc480951")
+    target_handle_id = UUID("06573a05-e6f0-48b9-bc6e-07e06d0bc1b1")
+    timeout_input_id = UUID("b4b4f46d-3e2b-4b93-aae9-6998bbbe2a62")
+    additional_header_key_input_ids = {
+        "foo": UUID("8ad006f3-d19e-4af1-931f-3e955152cd91"),
+        "bar": UUID("3075be8c-248b-421d-9266-7779297be883"),
+        "baz": UUID("13c2dd5e-cdd0-431b-aa91-46ad8da1cb51"),
+    }
+    additional_header_value_input_ids = {
+        "foo": UUID("36865dca-40b4-432c-bab4-1e11bb9f4083"),
+        "bar": UUID("00baaee1-b785-403d-b391-f68b3aea334f"),
+        "baz": UUID("408c2b3d-7c30-4e01-a2e3-276753beadbc"),
+    }
+    node_input_ids_by_name = {
+        "method": UUID("9bf086d4-feed-47ff-9736-a5a6aa3a11cc"),
+        "url": UUID("480a4c12-22d6-4223-a38a-85db5eda118c"),
+        "json": UUID("74865eb7-cdaf-4d40-a499-0a6505e72680"),
+        "authorization_type": UUID("de330dac-05b1-4e78-bee7-7452203af3d5"),
+        "bearer_token_value": UUID("931502c1-23a5-4e2a-a75e-80736c42f3c9"),
+        "api_key_header_key": UUID("96c8343d-cc94-4df0-9001-eb2905a00be7"),
+        "api_key_header_value": UUID("bfc2e790-66fd-42fd-acf7-3b2c785c1a0a"),
+        "additional_header_key_1": UUID("8ad006f3-d19e-4af1-931f-3e955152cd91"),
+        "additional_header_value_1": UUID("36865dca-40b4-432c-bab4-1e11bb9f4083"),
+        "additional_header_key_2": UUID("3075be8c-248b-421d-9266-7779297be883"),
+        "additional_header_value_2": UUID("00baaee1-b785-403d-b391-f68b3aea334f"),
+        "additional_header_key_3": UUID("13c2dd5e-cdd0-431b-aa91-46ad8da1cb51"),
+        "additional_header_value_3": UUID("408c2b3d-7c30-4e01-a2e3-276753beadbc"),
+        "timeout": UUID("b4b4f46d-3e2b-4b93-aae9-6998bbbe2a62"),
+    }
+    output_display = {
+        APINode.Outputs.json: NodeOutputDisplay(
+            id=UUID("af576eaa-d39d-4c19-8992-1f01a65a709a"), name="json"
+        ),
+        APINode.Outputs.status_code: NodeOutputDisplay(
+            id=UUID("69250713-617d-42a4-9326-456c70d0ef20"), name="status_code"
+        ),
+        APINode.Outputs.text: NodeOutputDisplay(
+            id=UUID("81b270c0-4deb-4db3-aae5-138f79531b2b"), name="text"
+        ),
+    }
+    port_displays = {
+        APINode.Ports.default: PortDisplayOverrides(
+            id=UUID("c38a71f6-3ffb-45fa-9eea-93c6984a9e3e")
+        )
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=2075.7067885117494, y=234.65663468515768),
+        width=462,
+        height=288,
+    )
+"
+`;
+
+exports[`ApiNode > timeout functionality > should not generate timeout field when timeout is null 1`] = `
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "https://example.vellum.ai"
+    method = APIRequestMethod.POST
+    headers = {
+        "foo": "foo-value",
+        "bar": "bar-value",
+        "baz": "baz-value",
+    }
+    api_key_header_key = None
+    authorization_type = AuthorizationType.API_KEY
+    api_key_header_value = "<my-api-value>"
+    bearer_token_value = "<my-bearer-token>"
+"
+`;
+
+exports[`ApiNode > timeout functionality > should not generate timeout field when timeoutInputId is undefined 1`] = `
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "https://example.vellum.ai"
+    method = APIRequestMethod.POST
+    headers = {
+        "foo": "foo-value",
+        "bar": "bar-value",
+        "baz": "baz-value",
+    }
+    api_key_header_key = None
+    authorization_type = AuthorizationType.API_KEY
+    api_key_header_value = "<my-api-value>"
+    bearer_token_value = "<my-bearer-token>"
+"
+`;
+
+exports[`ApiNode > timeout functionality > should support timeout with input variable reference 1`] = `
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+from ..inputs import Inputs
+
+
+class APINode(BaseAPINode):
+    url = "https://example.vellum.ai"
+    method = APIRequestMethod.POST
+    headers = {
+        "foo": "foo-value",
+        "bar": "bar-value",
+        "baz": "baz-value",
+    }
+    api_key_header_key = None
+    authorization_type = AuthorizationType.API_KEY
+    api_key_header_value = "<my-api-value>"
+    bearer_token_value = "<my-bearer-token>"
+    timeout = Inputs.additional_header_value
+"
+`;

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -388,7 +388,7 @@ describe("ApiNode", () => {
           value: {
             type: "CONSTANT_VALUE",
             data: {
-              type: "NULL",
+              type: "NUMBER",
               value: null,
             },
           },

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -351,4 +351,156 @@ describe("ApiNode", () => {
       expect(error?.severity).toBe("WARNING");
     });
   });
+
+  describe("timeout functionality", () => {
+    it("should generate timeout field when timeoutInputId is provided", async () => {
+      const nodeData = apiNodeFactory({
+        timeout: nodeInputFactory({
+          key: "timeout",
+          value: {
+            type: "CONSTANT_VALUE",
+            data: {
+              type: "NUMBER",
+              value: 30,
+            },
+          },
+        }),
+      }).build();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should not generate timeout field when timeout is null", async () => {
+      const nodeData = apiNodeFactory({
+        timeout: nodeInputFactory({
+          key: "timeout",
+          value: {
+            type: "CONSTANT_VALUE",
+            data: {
+              type: "NULL",
+              value: null,
+            },
+          },
+        }),
+      }).build();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should not generate timeout field when timeoutInputId is undefined", async () => {
+      const nodeData = apiNodeFactory({
+        timeout: null,
+      }).build();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should generate timeout_input_id in display class when timeoutInputId is provided", async () => {
+      const nodeData = apiNodeFactory({
+        timeout: nodeInputFactory({
+          key: "timeout",
+          value: {
+            type: "CONSTANT_VALUE",
+            data: {
+              type: "NUMBER",
+              value: 30,
+            },
+          },
+        }),
+      }).build();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeDisplayFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should throw error when timeoutInputId is provided but input is missing", async () => {
+      const nodeData = apiNodeFactory().build();
+      // Manually set timeoutInputId without adding corresponding input
+      nodeData.data.timeoutInputId = "missing-timeout-input-id";
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      expect(() => {
+        node.getNodeFile().write(writer);
+      }).toThrow('No inputs have timeout id of missing-timeout-input-id');
+    });
+
+    it("should support timeout with input variable reference", async () => {
+      const nodeData = apiNodeFactory({
+        timeout: nodeInputFactory({
+          key: "timeout",
+          value: {
+            type: "INPUT_VARIABLE",
+            data: {
+              inputVariableId: "5f64210f-ec43-48ce-ae40-40a9ba4c4c11",
+            },
+          },
+        }),
+      }).build();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      const node = new ApiNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -172,6 +172,32 @@ export class ApiNode extends BaseNode<ApiNodeType, ApiNodeContext> {
       }
     }
 
+    if (this.nodeData.data.timeoutInputId) {
+      const timeoutInput = this.nodeData.inputs.find(
+        (input) => input.id === this.nodeData.data.timeoutInputId
+      );
+      if (!timeoutInput) {
+        throw new NodeAttributeGenerationError(
+          `No inputs have timeout id of ${this.nodeData.data.timeoutInputId}`
+        );
+      }
+      const timeout = this.nodeInputsByKey.get(timeoutInput.key);
+      if (!timeout) {
+        throw new NodeAttributeGenerationError(
+          `No inputs have key of ${timeoutInput.key}`
+        );
+      }
+      // Only add timeout field if it's not the default value (null)
+      if (timeout.toString() !== "None") {
+        statements.push(
+          python.field({
+            name: "timeout",
+            initializer: timeout,
+          })
+        );
+      }
+    }
+
     return statements;
   }
 
@@ -186,6 +212,20 @@ export class ApiNode extends BaseNode<ApiNodeType, ApiNodeContext> {
         ),
       })
     );
+
+    if (this.nodeData.data.timeoutInputId) {
+      const timeoutInput = this.nodeData.inputs.find(
+        (input) => input.id === this.nodeData.data.timeoutInputId
+      );
+      if (timeoutInput) {
+        statements.push(
+          python.field({
+            name: "timeout_input_id",
+            initializer: python.TypeInstantiation.uuid(this.nodeData.data.timeoutInputId),
+          })
+        );
+      }
+    }
 
     if (!isNil(this.nodeData.data.additionalHeaders)) {
       statements.push(

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -221,7 +221,9 @@ export class ApiNode extends BaseNode<ApiNodeType, ApiNodeContext> {
         statements.push(
           python.field({
             name: "timeout_input_id",
-            initializer: python.TypeInstantiation.uuid(this.nodeData.data.timeoutInputId),
+            initializer: python.TypeInstantiation.uuid(
+              this.nodeData.data.timeoutInputId
+            ),
           })
         );
       }

--- a/ee/codegen/src/generators/nodes/constants.ts
+++ b/ee/codegen/src/generators/nodes/constants.ts
@@ -1,3 +1,5 @@
+import { ApiNode } from "./api-node";
+
 export enum AttributeType {
   WorkflowErrorCode = "WorkflowErrorCode",
   PromptBlocks = "PromptBlocks",
@@ -40,6 +42,11 @@ export const NODE_ATTRIBUTES: Record<
     functions: {
       defaultValue: null,
       type: AttributeType.Functions,
+    },
+  },
+  ApiNode: {
+    timeout: {
+      defaultValue: null,
     },
   },
 };

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -621,6 +621,7 @@ export interface ApiNodeData {
   errorOutputId?: string;
   targetHandleId: string;
   sourceHandleId: string;
+  timeoutInputId?: string;
 }
 
 export interface ApiNode extends BaseDisplayableWorkflowNode {

--- a/poetry.lock
+++ b/poetry.lock
@@ -1535,27 +1535,31 @@ files = [
 
 [[package]]
 name = "pywin32"
-version = "310"
+version = "311"
 description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pywin32-310-cp310-cp310-win32.whl", hash = "sha256:6dd97011efc8bf51d6793a82292419eba2c71cf8e7250cfac03bba284454abc1"},
-    {file = "pywin32-310-cp310-cp310-win_amd64.whl", hash = "sha256:c3e78706e4229b915a0821941a84e7ef420bf2b77e08c9dae3c76fd03fd2ae3d"},
-    {file = "pywin32-310-cp310-cp310-win_arm64.whl", hash = "sha256:33babed0cf0c92a6f94cc6cc13546ab24ee13e3e800e61ed87609ab91e4c8213"},
-    {file = "pywin32-310-cp311-cp311-win32.whl", hash = "sha256:1e765f9564e83011a63321bb9d27ec456a0ed90d3732c4b2e312b855365ed8bd"},
-    {file = "pywin32-310-cp311-cp311-win_amd64.whl", hash = "sha256:126298077a9d7c95c53823934f000599f66ec9296b09167810eb24875f32689c"},
-    {file = "pywin32-310-cp311-cp311-win_arm64.whl", hash = "sha256:19ec5fc9b1d51c4350be7bb00760ffce46e6c95eaf2f0b2f1150657b1a43c582"},
-    {file = "pywin32-310-cp312-cp312-win32.whl", hash = "sha256:8a75a5cc3893e83a108c05d82198880704c44bbaee4d06e442e471d3c9ea4f3d"},
-    {file = "pywin32-310-cp312-cp312-win_amd64.whl", hash = "sha256:bf5c397c9a9a19a6f62f3fb821fbf36cac08f03770056711f765ec1503972060"},
-    {file = "pywin32-310-cp312-cp312-win_arm64.whl", hash = "sha256:2349cc906eae872d0663d4d6290d13b90621eaf78964bb1578632ff20e152966"},
-    {file = "pywin32-310-cp313-cp313-win32.whl", hash = "sha256:5d241a659c496ada3253cd01cfaa779b048e90ce4b2b38cd44168ad555ce74ab"},
-    {file = "pywin32-310-cp313-cp313-win_amd64.whl", hash = "sha256:667827eb3a90208ddbdcc9e860c81bde63a135710e21e4cb3348968e4bd5249e"},
-    {file = "pywin32-310-cp313-cp313-win_arm64.whl", hash = "sha256:e308f831de771482b7cf692a1f308f8fca701b2d8f9dde6cc440c7da17e47b33"},
-    {file = "pywin32-310-cp38-cp38-win32.whl", hash = "sha256:0867beb8addefa2e3979d4084352e4ac6e991ca45373390775f7084cc0209b9c"},
-    {file = "pywin32-310-cp38-cp38-win_amd64.whl", hash = "sha256:30f0a9b3138fb5e07eb4973b7077e1883f558e40c578c6925acc7a94c34eaa36"},
-    {file = "pywin32-310-cp39-cp39-win32.whl", hash = "sha256:851c8d927af0d879221e616ae1f66145253537bbdd321a77e8ef701b443a9a1a"},
-    {file = "pywin32-310-cp39-cp39-win_amd64.whl", hash = "sha256:96867217335559ac619f00ad70e513c0fcf84b8a3af9fc2bba3b59b97da70475"},
+    {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
+    {file = "pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b"},
+    {file = "pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b"},
+    {file = "pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151"},
+    {file = "pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503"},
+    {file = "pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2"},
+    {file = "pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31"},
+    {file = "pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067"},
+    {file = "pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852"},
+    {file = "pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d"},
+    {file = "pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d"},
+    {file = "pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a"},
+    {file = "pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee"},
+    {file = "pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87"},
+    {file = "pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42"},
+    {file = "pywin32-311-cp38-cp38-win32.whl", hash = "sha256:6c6f2969607b5023b0d9ce2541f8d2cbb01c4f46bc87456017cf63b73f1e2d8c"},
+    {file = "pywin32-311-cp38-cp38-win_amd64.whl", hash = "sha256:c8015b09fb9a5e188f83b7b04de91ddca4658cee2ae6f3bc483f0b21a77ef6cd"},
+    {file = "pywin32-311-cp39-cp39-win32.whl", hash = "sha256:aba8f82d551a942cb20d4a83413ccbac30790b50efb89a75e4f586ac0bb8056b"},
+    {file = "pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91"},
+    {file = "pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d"},
 ]
 
 [[package]]

--- a/src/vellum/workflows/nodes/displayable/bases/api_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/api_node/node.py
@@ -4,6 +4,7 @@ from requests import Request, RequestException, Session
 from requests.exceptions import JSONDecodeError
 
 from vellum.client import ApiError
+from vellum.client.core.request_options import RequestOptions
 from vellum.client.types.vellum_secret import VellumSecret as ClientVellumSecret
 from vellum.workflows.constants import APIRequestMethod
 from vellum.workflows.errors.types import WorkflowErrorCode
@@ -100,10 +101,13 @@ class BaseAPINode(BaseNode, Generic[StateType]):
     def _vellum_execute_api(self, bearer_token, data, headers, method, url, timeout):
         client_vellum_secret = ClientVellumSecret(name=bearer_token.name) if bearer_token else None
         try:
-            # Note: timeout parameter may not be supported by vellum_client.execute_api
-            # This would need to be implemented in the Vellum API client
             vellum_response = self._context.vellum_client.execute_api(
-                url=url, method=method.value, body=data, headers=headers, bearer_token=client_vellum_secret
+                url=url,
+                method=method.value,
+                body=data,
+                headers=headers,
+                bearer_token=client_vellum_secret,
+                request_options=RequestOptions(timeout_in_seconds=timeout),
             )
         except ApiError as e:
             raise NodeException(f"Failed to prepare HTTP request: {e}", code=WorkflowErrorCode.NODE_EXECUTION)

--- a/src/vellum/workflows/nodes/displayable/bases/api_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/api_node/node.py
@@ -34,7 +34,7 @@ class BaseAPINode(BaseNode, Generic[StateType]):
     data: Optional[str] = None
     json: Optional[Json] = None
     headers: Optional[Dict[str, Union[str, VellumSecret]]] = None
-    timeout: Optional[Union[int, float]] = None
+    timeout: Optional[int] = None
 
     class Outputs(BaseOutputs):
         json: Optional[Json]
@@ -59,7 +59,7 @@ class BaseAPINode(BaseNode, Generic[StateType]):
         json: Any = None,
         headers: Any = None,
         bearer_token: Optional[VellumSecret] = None,
-        timeout: Optional[Union[int, float]] = None,
+        timeout: Optional[int] = None,
     ) -> Outputs:
         self._validate()
 

--- a/tests/workflows/basic_api_node_with_timeout/tests/test_workflow.py
+++ b/tests/workflows/basic_api_node_with_timeout/tests/test_workflow.py
@@ -1,8 +1,5 @@
 import requests_mock.mocker
 
-from vellum.workflows.constants import APIRequestMethod
-from vellum.workflows.nodes.displayable import APINode
-
 from tests.workflows.basic_api_node_with_timeout.workflow import (
     APINodeWithoutTimeoutWorkflow,
     APINodeWithTimeoutWorkflow,
@@ -73,25 +70,3 @@ def test_api_node_with_timeout__timeout_respected():
     # THEN the timeout should be set correctly in the class definition
     assert hasattr(APINodeWithTimeout, "timeout")
     assert APINodeWithTimeout.timeout.instance == 30
-
-
-def test_api_node_timeout_attribute_types():
-    """Test that timeout attribute can handle different value types."""
-
-    class APINodeWithIntTimeout(APINode):
-        method = APIRequestMethod.POST
-        url = "https://api.vellum.ai"
-        timeout = 60  # integer
-        json = {"test": "data"}
-
-    class APINodeWithFloatTimeout(APINode):
-        method = APIRequestMethod.POST
-        url = "https://api.vellum.ai"
-        timeout = 30.5  # float
-        json = {"test": "data"}
-
-    # Test integer timeout
-    assert APINodeWithIntTimeout.timeout.instance == 60
-
-    # Test float timeout
-    assert APINodeWithFloatTimeout.timeout.instance == 30.5

--- a/tests/workflows/basic_api_node_with_timeout/tests/test_workflow.py
+++ b/tests/workflows/basic_api_node_with_timeout/tests/test_workflow.py
@@ -1,0 +1,97 @@
+import requests_mock.mocker
+
+from vellum.workflows.constants import APIRequestMethod
+from vellum.workflows.nodes.displayable import APINode
+
+from tests.workflows.basic_api_node_with_timeout.workflow import (
+    APINodeWithoutTimeoutWorkflow,
+    APINodeWithTimeoutWorkflow,
+)
+
+
+def test_api_node_with_timeout__happy_path(requests_mock: requests_mock.mocker.Mocker):
+    """Test that APINode with timeout attribute works correctly."""
+    # GIVEN an API request that will return a 200 OK response
+    response_mock = requests_mock.post(
+        "https://api.vellum.ai",
+        json={"data": [1, 2, 3]},
+        status_code=200,
+    )
+
+    # AND a workflow that has an API node with timeout configured
+    workflow = APINodeWithTimeoutWorkflow()
+
+    # WHEN we run the workflow
+    terminal_event = workflow.run()
+
+    # THEN we should see the expected outputs
+    assert terminal_event.name == "workflow.execution.fulfilled"
+    assert terminal_event.outputs == {
+        "json": {"data": [1, 2, 3]},
+        "status_code": 200,
+        "text": '{"data": [1, 2, 3]}',
+    }
+
+    # AND the mock should have been called with the expected body
+    assert response_mock.last_request
+    assert response_mock.last_request.json() == {"key": "value"}
+
+
+def test_api_node_without_timeout__happy_path(requests_mock: requests_mock.mocker.Mocker):
+    """Test that APINode without timeout attribute works correctly (backward compatibility)."""
+    # GIVEN an API request that will return a 200 OK response
+    response_mock = requests_mock.get(
+        "https://api.vellum.ai",
+        json={"status": "ok"},
+        status_code=200,
+    )
+
+    # AND a workflow that has an API node without timeout configured
+    workflow = APINodeWithoutTimeoutWorkflow()
+
+    # WHEN we run the workflow
+    terminal_event = workflow.run()
+
+    # THEN we should see the expected outputs
+    assert terminal_event.name == "workflow.execution.fulfilled"
+    assert terminal_event.outputs == {
+        "json": {"status": "ok"},
+        "status_code": 200,
+        "text": '{"status": "ok"}',
+    }
+
+    # AND the mock should have been called
+    assert response_mock.called
+
+
+def test_api_node_with_timeout__timeout_respected():
+    """Test that timeout attribute is properly set on the node class."""
+    # GIVEN a workflow with timeout configured
+    from tests.workflows.basic_api_node_with_timeout.workflow import APINodeWithTimeout
+
+    # WHEN we check the node class's timeout attribute
+    # THEN the timeout should be set correctly in the class definition
+    assert hasattr(APINodeWithTimeout, "timeout")
+    assert APINodeWithTimeout.timeout.instance == 30
+
+
+def test_api_node_timeout_attribute_types():
+    """Test that timeout attribute can handle different value types."""
+
+    class APINodeWithIntTimeout(APINode):
+        method = APIRequestMethod.POST
+        url = "https://api.vellum.ai"
+        timeout = 60  # integer
+        json = {"test": "data"}
+
+    class APINodeWithFloatTimeout(APINode):
+        method = APIRequestMethod.POST
+        url = "https://api.vellum.ai"
+        timeout = 30.5  # float
+        json = {"test": "data"}
+
+    # Test integer timeout
+    assert APINodeWithIntTimeout.timeout.instance == 60
+
+    # Test float timeout
+    assert APINodeWithFloatTimeout.timeout.instance == 30.5

--- a/tests/workflows/basic_api_node_with_timeout/workflow.py
+++ b/tests/workflows/basic_api_node_with_timeout/workflow.py
@@ -1,0 +1,36 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.constants import APIRequestMethod
+from vellum.workflows.nodes.displayable import APINode
+
+
+class APINodeWithTimeout(APINode):
+    method = APIRequestMethod.POST
+    url = "https://api.vellum.ai"
+    timeout = 30
+    json = {
+        "key": "value",
+    }
+
+
+class APINodeWithTimeoutWorkflow(BaseWorkflow):
+    graph = APINodeWithTimeout
+
+    class Outputs(BaseWorkflow.Outputs):
+        json = APINodeWithTimeout.Outputs.json
+        status_code = APINodeWithTimeout.Outputs.status_code
+        text = APINodeWithTimeout.Outputs.text
+
+
+class APINodeWithoutTimeout(APINode):
+    method = APIRequestMethod.GET
+    url = "https://api.vellum.ai"
+    # No timeout attribute - should use default behavior
+
+
+class APINodeWithoutTimeoutWorkflow(BaseWorkflow):
+    graph = APINodeWithoutTimeout
+
+    class Outputs(BaseWorkflow.Outputs):
+        json = APINodeWithoutTimeout.Outputs.json
+        status_code = APINodeWithoutTimeout.Outputs.status_code
+        text = APINodeWithoutTimeout.Outputs.text


### PR DESCRIPTION
The purpose of this PR is to add a `timeout` attribute to the `APINode`. This addresses a user-reported issue in which execution of their `APINode` was hanging.