### PR TITLE
[APO-485] Add timeout serialization support to APINode

### DIFF
--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/display_data/faa_q_and_a_bot.json
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/display_data/faa_q_and_a_bot.json
@@ -1949,14 +1949,6 @@
         ],
         "attributes": [
           {
-            "id": "e96c33a1-3fac-4273-95cf-a2074820edfd",
-            "name": "data",
-            "value": {
-              "type": "CONSTANT_VALUE",
-              "value": {"type": "JSON", "value": null}
-            }
-          },
-          {
             "id": "bd625080-9c90-43b5-8093-d12977814df8",
             "name": "timeout",
             "value": {

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/display_data/faa_q_and_a_bot.json
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/display_data/faa_q_and_a_bot.json
@@ -1946,6 +1946,24 @@
             "name": "default",
             "type": "DEFAULT"
           }
+        ],
+        "attributes": [
+          {
+            "id": "e96c33a1-3fac-4273-95cf-a2074820edfd",
+            "name": "data",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {"type": "JSON", "value": null}
+            }
+          },
+          {
+            "id": "bd625080-9c90-43b5-8093-d12977814df8",
+            "name": "timeout",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {"type": "JSON", "value": null}
+            }
+          }
         ]
       },
       {

--- a/ee/codegen_integration/fixtures/simple_api_node/display_data/simple_api_node.json
+++ b/ee/codegen_integration/fixtures/simple_api_node/display_data/simple_api_node.json
@@ -270,14 +270,6 @@
         ],
         "attributes": [
           {
-            "id": "b98f5cf8-0bfd-4a2f-ba4e-92c5ffc94566",
-            "name": "data",
-            "value": {
-              "type": "CONSTANT_VALUE",
-              "value": {"type": "JSON", "value": null}
-            }
-          },
-          {
             "id": "63c3fb19-534a-4a75-b868-35e42a9e866b",
             "name": "timeout",
             "value": {

--- a/ee/codegen_integration/fixtures/simple_api_node/display_data/simple_api_node.json
+++ b/ee/codegen_integration/fixtures/simple_api_node/display_data/simple_api_node.json
@@ -267,6 +267,24 @@
             "name": "default",
             "type": "DEFAULT"
           }
+        ],
+        "attributes": [
+          {
+            "id": "b98f5cf8-0bfd-4a2f-ba4e-92c5ffc94566",
+            "name": "data",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {"type": "JSON", "value": null}
+            }
+          },
+          {
+            "id": "63c3fb19-534a-4a75-b868-35e42a9e866b",
+            "name": "timeout",
+            "value": {
+              "type": "CONSTANT_VALUE",
+              "value": {"type": "JSON", "value": null}
+            }
+          }
         ]
       },
       {

--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -247,9 +247,9 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
 
         return ports
 
-    def _serialize_attributes(self, display_context: "WorkflowDisplayContext"):
+    def _serialize_attributes(self, display_context: "WorkflowDisplayContext") -> JsonArray:
         """Serialize node attributes, skipping unserializable ones."""
-        attributes = []
+        attributes: JsonArray = []
         for attribute in self._node:
             if attribute in self.__unserializable_attributes__:
                 continue
@@ -260,13 +260,12 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
                 else str(uuid4_from_hash(f"{self.node_id}|{attribute.name}"))
             )
             try:
-                attributes.append(
-                    {
-                        "id": id,
-                        "name": attribute.name,
-                        "value": serialize_value(display_context, attribute.instance),
-                    }
-                )
+                attribute_dict: JsonObject = {
+                    "id": id,
+                    "name": attribute.name,
+                    "value": serialize_value(display_context, attribute.instance),
+                }
+                attributes.append(attribute_dict)
             except ValueError as e:
                 raise ValueError(f"Failed to serialize attribute '{attribute.name}': {e}")
 

--- a/ee/vellum_ee/workflows/display/nodes/base_node_display.py
+++ b/ee/vellum_ee/workflows/display/nodes/base_node_display.py
@@ -247,6 +247,31 @@ class BaseNodeDisplay(Generic[NodeType], metaclass=BaseNodeDisplayMeta):
 
         return ports
 
+    def _serialize_attributes(self, display_context: "WorkflowDisplayContext"):
+        """Serialize node attributes, skipping unserializable ones."""
+        attributes = []
+        for attribute in self._node:
+            if attribute in self.__unserializable_attributes__:
+                continue
+
+            id = (
+                str(self.attribute_ids_by_name[attribute.name])
+                if self.attribute_ids_by_name.get(attribute.name)
+                else str(uuid4_from_hash(f"{self.node_id}|{attribute.name}"))
+            )
+            try:
+                attributes.append(
+                    {
+                        "id": id,
+                        "name": attribute.name,
+                        "value": serialize_value(display_context, attribute.instance),
+                    }
+                )
+            except ValueError as e:
+                raise ValueError(f"Failed to serialize attribute '{attribute.name}': {e}")
+
+        return attributes
+
     def get_base(self) -> CodeResourceDefinition:
         node = self._node
 

--- a/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
@@ -4,12 +4,10 @@ from typing import ClassVar, Dict, Generic, Optional, TypeVar, cast
 from vellum.workflows.nodes.displayable import APINode
 from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
-from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum_ee.workflows.display.utils.expressions import serialize_value
 from vellum_ee.workflows.display.utils.vellum import WorkspaceSecretPointer
 
 _APINodeType = TypeVar("_APINodeType", bound=APINode)
@@ -226,27 +224,3 @@ class BaseAPINodeDisplay(BaseNodeDisplay[_APINodeType], Generic[_APINodeType]):
             serialized_node["attributes"] = attributes
 
         return serialized_node
-
-    def _serialize_attributes(self, display_context: "WorkflowDisplayContext"):
-        attributes = []
-        for attribute in self._node:
-            if attribute in self.__unserializable_attributes__:
-                continue
-
-            id = (
-                str(self.attribute_ids_by_name[attribute.name])
-                if self.attribute_ids_by_name.get(attribute.name)
-                else str(uuid4_from_hash(f"{self.node_id}|{attribute.name}"))
-            )
-            try:
-                attributes.append(
-                    {
-                        "id": id,
-                        "name": attribute.name,
-                        "value": serialize_value(display_context, attribute.instance),
-                    }
-                )
-            except ValueError as e:
-                raise ValueError(f"Failed to serialize attribute '{attribute.name}': {e}")
-
-        return attributes

--- a/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
@@ -31,7 +31,7 @@ class BaseAPINodeDisplay(BaseNodeDisplay[_APINodeType], Generic[_APINodeType]):
         APINode.authorization_type,
     }
 
-    # HACK: Only serialize timeout attribute, exclude all others
+    # TODO: Only serialize attributes not inputs
     __unserializable_attributes__ = {
         APINode.data,
         APINode.url,

--- a/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
@@ -184,7 +184,7 @@ class BaseAPINodeDisplay(BaseNodeDisplay[_APINodeType], Generic[_APINodeType]):
             cast(OutputReference, node.Outputs.status_code)
         ]
 
-        serialized_node = {
+        serialized_node: JsonObject = {
             "id": str(node_id),
             "type": "API",
             "inputs": [input.dict() for input in inputs],

--- a/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
@@ -35,6 +35,7 @@ class BaseAPINodeDisplay(BaseNodeDisplay[_APINodeType], Generic[_APINodeType]):
 
     # HACK: Only serialize timeout attribute, exclude all others
     __unserializable_attributes__ = {
+        APINode.data,
         APINode.url,
         APINode.method,
         APINode.json,

--- a/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/api_node.py
@@ -33,6 +33,18 @@ class BaseAPINodeDisplay(BaseNodeDisplay[_APINodeType], Generic[_APINodeType]):
         APINode.authorization_type,
     }
 
+    # HACK: Only serialize timeout attribute, exclude all others
+    __unserializable_attributes__ = {
+        APINode.url,
+        APINode.method,
+        APINode.json,
+        APINode.headers,
+        APINode.api_key_header_key,
+        APINode.api_key_header_value,
+        APINode.bearer_token_value,
+        APINode.authorization_type,
+    }
+
     def serialize(
         self, display_context: WorkflowDisplayContext, error_output_id: Optional[UUID] = None, **_kwargs
     ) -> JsonObject:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/inline_prompt_node.py
@@ -11,7 +11,6 @@ from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.utils import raise_if_descriptor
 from vellum_ee.workflows.display.nodes.vellum.utils import create_node_input
 from vellum_ee.workflows.display.types import WorkflowDisplayContext
-from vellum_ee.workflows.display.utils.expressions import serialize_value
 from vellum_ee.workflows.display.utils.vellum import infer_vellum_variable_type
 from vellum_ee.workflows.display.vellum import NodeInput
 
@@ -173,7 +172,6 @@ class BaseInlinePromptNodeDisplay(BaseNodeDisplay[_InlinePromptNodeType], Generi
             }
 
         elif prompt_block.block_type == "CHAT_MESSAGE":
-
             chat_properties: JsonObject = {
                 "chat_role": prompt_block.chat_role,
                 "chat_source": prompt_block.chat_source,
@@ -247,30 +245,6 @@ class BaseInlinePromptNodeDisplay(BaseNodeDisplay[_InlinePromptNodeType], Generi
             block["state"] = "ENABLED"
 
         return block
-
-    def _serialize_attributes(self, display_context: "WorkflowDisplayContext"):
-        attributes = []
-        for attribute in self._node:
-            if attribute in self.__unserializable_attributes__:
-                continue
-
-            id = (
-                str(self.attribute_ids_by_name[attribute.name])
-                if self.attribute_ids_by_name.get(attribute.name)
-                else str(uuid4_from_hash(f"{self.node_id}|{attribute.name}"))
-            )
-            try:
-                attributes.append(
-                    {
-                        "id": id,
-                        "name": attribute.name,
-                        "value": serialize_value(display_context, attribute.instance),
-                    }
-                )
-            except ValueError as e:
-                raise ValueError(f"Failed to serialize attribute '{attribute.name}': {e}")
-
-        return attributes
 
     def _serialize_parameters(self, parameters, display_context: "WorkflowDisplayContext") -> JsonObject:
         """Serialize parameters, returning empty object when nested descriptors are detected."""

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_api_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_api_node.py
@@ -1,0 +1,31 @@
+from vellum.workflows.constants import APIRequestMethod
+from vellum.workflows.nodes.displayable.api_node.node import APINode
+from vellum.workflows.workflows.base import BaseWorkflow
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+
+def test_serialize_node__api_node_with_timeout():
+    # GIVEN an API node with timeout specified
+    class MyAPINode(APINode):
+        url = "https://api.example.com"
+        method = APIRequestMethod.GET
+        timeout = 30  # This is the key attribute we're testing
+
+    # AND a workflow with the API node
+    class Workflow(BaseWorkflow):
+        graph = MyAPINode
+
+    # WHEN the workflow is serialized
+    workflow_display = get_workflow_display(workflow_class=Workflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    # THEN the node should properly serialize the timeout
+    my_api_node = next(node for node in serialized_workflow["workflow_raw_data"]["nodes"] if node["type"] == "API")
+
+    # Assert that timeout is present in the serialized attributes
+    timeout_attribute = next((attr for attr in my_api_node.get("attributes", []) if attr["name"] == "timeout"), None)
+
+    assert timeout_attribute is not None, "timeout attribute should be present in serialized attributes"
+    assert timeout_attribute["value"]["type"] == "CONSTANT_VALUE"
+    assert timeout_attribute["value"]["value"]["type"] == "NUMBER"
+    assert timeout_attribute["value"]["value"]["value"] == 30.0

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_api_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_api_node_serialization.py
@@ -164,14 +164,6 @@ def test_serialize_workflow(vellum_client):
             ],
             "attributes": [
                 {
-                    "id": "71b98df0-1314-4839-b9ba-6f7572af401d",
-                    "name": "data",
-                    "value": {
-                        "type": "CONSTANT_VALUE",
-                        "value": {"type": "JSON", "value": None},
-                    },
-                },
-                {
                     "id": "ad719e65-0032-4012-a0bd-9b5162194bce",
                     "name": "timeout",
                     "value": {

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_api_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_api_node_serialization.py
@@ -162,6 +162,24 @@ def test_serialize_workflow(vellum_client):
                     },
                 },
             ],
+            "attributes": [
+                {
+                    "id": "71b98df0-1314-4839-b9ba-6f7572af401d",
+                    "name": "data",
+                    "value": {
+                        "type": "CONSTANT_VALUE",
+                        "value": {"type": "JSON", "value": None},
+                    },
+                },
+                {
+                    "id": "ad719e65-0032-4012-a0bd-9b5162194bce",
+                    "name": "timeout",
+                    "value": {
+                        "type": "CONSTANT_VALUE",
+                        "value": {"type": "JSON", "value": None},
+                    },
+                },
+            ],
             "data": {
                 "label": "Simple A P I Node",
                 "error_output_id": None,


### PR DESCRIPTION
The purpose of this PR is to include `timeout` in the `APINode`'s serialized `attributes` field. This is the second instance of a node implementing custom attribute serialization, so the logic has been moved out of `BaseInlinePromptNodeDisplay` and into `BaseNodeDisplay` to avoid duplication.