### PR TITLE
[APO-485] Add timeout support to API node codegen

### DIFF
--- a/ee/codegen/src/__test__/helpers/node-data-factories.ts
+++ b/ee/codegen/src/__test__/helpers/node-data-factories.ts
@@ -1018,6 +1018,7 @@ export interface ApiNodeFactoryProps {
   body?: Record<string, unknown> | null;
   statusCodeOutputId?: string;
   id?: string;
+  attributes?: NodeAttribute[];
 }
 
 export function apiNodeFactory({
@@ -1031,6 +1032,7 @@ export function apiNodeFactory({
   url = "https://example.vellum.ai",
   method = "POST",
   body = {},
+  attributes,
 }: ApiNodeFactoryProps = {}): NodeDataFactoryBuilder<ApiNode> {
   const bearerTokenInput = bearerToken ?? {
     id: "931502c1-23a5-4e2a-a75e-80736c42f3c9",
@@ -1294,6 +1296,7 @@ export function apiNodeFactory({
       sourceHandleId: "c38a71f6-3ffb-45fa-9eea-93c6984a9e3e",
     },
     inputs: inputs,
+    attributes: attributes,
     displayData: {
       width: 462,
       height: 288,

--- a/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/api-node.test.ts.snap
@@ -1,5 +1,66 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ApiNode > api node with timeout > should generate timeout field when timeout attribute is present 1`] = `
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "https://example.vellum.ai"
+    method = APIRequestMethod.POST
+    headers = {
+        "foo": "foo-value",
+        "bar": "bar-value",
+        "baz": "baz-value",
+    }
+    api_key_header_key = None
+    authorization_type = AuthorizationType.API_KEY
+    api_key_header_value = "<my-api-value>"
+    bearer_token_value = "<my-bearer-token>"
+    timeout = 30
+"
+`;
+
+exports[`ApiNode > api node with timeout > should not generate timeout field when timeout attribute is not present 1`] = `
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "https://example.vellum.ai"
+    method = APIRequestMethod.POST
+    headers = {
+        "foo": "foo-value",
+        "bar": "bar-value",
+        "baz": "baz-value",
+    }
+    api_key_header_key = None
+    authorization_type = AuthorizationType.API_KEY
+    api_key_header_value = "<my-api-value>"
+    bearer_token_value = "<my-bearer-token>"
+"
+`;
+
+exports[`ApiNode > api node with timeout > should not generate timeout field when timeout attribute is null 1`] = `
+"from vellum.workflows.constants import APIRequestMethod, AuthorizationType
+from vellum.workflows.nodes.displayable import APINode as BaseAPINode
+
+
+class APINode(BaseAPINode):
+    url = "https://example.vellum.ai"
+    method = APIRequestMethod.POST
+    headers = {
+        "foo": "foo-value",
+        "bar": "bar-value",
+        "baz": "baz-value",
+    }
+    api_key_header_key = None
+    authorization_type = AuthorizationType.API_KEY
+    api_key_header_value = "<my-api-value>"
+    bearer_token_value = "<my-bearer-token>"
+"
+`;
+
 exports[`ApiNode > basic > getNodeDisplayFile 1`] = `
 "from uuid import UUID
 

--- a/ee/codegen/src/__test__/nodes/api-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/api-node.test.ts
@@ -351,4 +351,76 @@ describe("ApiNode", () => {
       expect(error?.severity).toBe("WARNING");
     });
   });
+
+  describe("api node with timeout", () => {
+    it("should generate timeout field when timeout attribute is present", async () => {
+      const nodeData = apiNodeFactory({
+        attributes: [
+          {
+            id: "timeout-attr-id",
+            name: "timeout",
+            value: {
+              type: "CONSTANT_VALUE",
+              value: { type: "NUMBER", value: 30 },
+            },
+          },
+        ],
+      }).build();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      node = new ApiNode({
+        workflowContext: workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should not generate timeout field when timeout attribute is not present", async () => {
+      const nodeData = apiNodeFactory().build();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      node = new ApiNode({
+        workflowContext: workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should not generate timeout field when timeout attribute is null", async () => {
+      const nodeData = apiNodeFactory({
+        attributes: [
+          {
+            id: "timeout-attr-id",
+            name: "timeout",
+            value: null,
+          },
+        ],
+      }).build();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as ApiNodeContext;
+
+      node = new ApiNode({
+        workflowContext: workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });

--- a/ee/codegen/src/generators/nodes/api-node.ts
+++ b/ee/codegen/src/generators/nodes/api-node.ts
@@ -7,6 +7,7 @@ import { ApiNodeContext } from "src/context/node-context/api-node";
 import { NodeInput } from "src/generators";
 import { NodeAttributeGenerationError } from "src/generators/errors";
 import { BaseNode } from "src/generators/nodes/bases/base";
+import { WorkflowValueDescriptor } from "src/generators/workflow-value-descriptor";
 import { ApiNode as ApiNodeType, ConstantValuePointer } from "src/types/vellum";
 
 const BODY_INPUT_KEY = "body";
@@ -170,6 +171,26 @@ export class ApiNode extends BaseNode<ApiNodeType, ApiNodeContext> {
           })
         );
       }
+    }
+
+    const timeoutAttribute = this.nodeData.attributes?.find(
+      (attr) => attr.name === "timeout"
+    );
+
+    if (
+      timeoutAttribute &&
+      !this.isAttributeDefault(timeoutAttribute.value, { defaultValue: null })
+    ) {
+      statements.push(
+        python.field({
+          name: "timeout",
+          initializer: new WorkflowValueDescriptor({
+            nodeContext: this.nodeContext,
+            workflowContext: this.workflowContext,
+            workflowValueDescriptor: timeoutAttribute.value,
+          }),
+        })
+      );
     }
 
     return statements;


### PR DESCRIPTION
The purpose of this PR is to include the `APINode`'s new `timeout` attribute when generating that node's python code.