### PR TITLE
[APO-485] Include attributes field in APINodeSerializer schema

### DIFF
--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -1935,6 +1935,7 @@ export const ApiNodeSerializer: ObjectSchema<
   definition: CodeResourceDefinitionSerializer.optional(),
   adornments: listSchema(AdornmentNodeSerializer).optional(),
   ports: listSchema(NodePortSerializer).optional(),
+  attributes: listSchema(NodeAttributeSerializer).optional(),
 });
 
 export declare namespace ApiNodeSerializer {

--- a/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/api_node.py
+++ b/ee/codegen_integration/fixtures/faa_q_and_a_bot/code/display/nodes/api_node.py
@@ -22,6 +22,7 @@ class APINodeDisplay(BaseAPINodeDisplay[APINode]):
         "api_key_header_key": UUID("bcf3aac0-536e-42d5-b666-22cfe40eae98"),
         "api_key_header_value": UUID("bc73ee61-ca29-48fe-b3f2-fea5d8f638f6"),
     }
+    attribute_ids_by_name = {"timeout": UUID("bd625080-9c90-43b5-8093-d12977814df8")}
     output_display = {
         APINode.Outputs.json: NodeOutputDisplay(id=UUID("c3c38fac-f413-4dad-863d-3d388231ba22"), name="json"),
         APINode.Outputs.status_code: NodeOutputDisplay(

--- a/ee/codegen_integration/fixtures/simple_api_node/code/display/nodes/api_node.py
+++ b/ee/codegen_integration/fixtures/simple_api_node/code/display/nodes/api_node.py
@@ -30,6 +30,7 @@ class ApiNodeDisplay(BaseAPINodeDisplay[ApiNode]):
         "additional_header_key": UUID("4e7557f4-16ec-4fec-97a6-fe221eae1ee5"),
         "additional_header_value": UUID("58099189-1676-4d89-a01d-9c1d79ba833a"),
     }
+    attribute_ids_by_name = {"timeout": UUID("63c3fb19-534a-4a75-b868-35e42a9e866b")}
     output_display = {
         ApiNode.Outputs.json: NodeOutputDisplay(id=UUID("f6f469ae-3f50-4276-a294-43d8d0fcf477"), name="json"),
         ApiNode.Outputs.status_code: NodeOutputDisplay(


### PR DESCRIPTION
The purpose of this PR is to include the `attributes` field in the APINodeSerializer schema so that we actually use it when generating the node's python code.