### PR TITLE
[APO-945] Validate code execution node path during serialization

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
@@ -2,6 +2,7 @@ import inspect
 from uuid import UUID
 from typing import ClassVar, Generic, Optional, TypeVar
 
+from vellum.workflows.exceptions import NodeException, WorkflowErrorCode
 from vellum.workflows.nodes.displayable.code_execution_node import CodeExecutionNode
 from vellum.workflows.nodes.displayable.code_execution_node.utils import read_file_from_path
 from vellum.workflows.types.core import JsonObject
@@ -40,6 +41,11 @@ class BaseCodeExecutionNodeDisplay(BaseNodeDisplay[_CodeExecutionNodeType], Gene
                 node_filepath=node_file_path,
                 script_filepath=filepath,
             )
+            if not file_code:
+                raise NodeException(
+                    message=f"Filepath '{filepath}' of node {node.__name__} does not exist",
+                    code=WorkflowErrorCode.INVALID_INPUTS,
+                )
             code_value = file_code
         else:
             code_value = ""

--- a/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
@@ -2,7 +2,6 @@ import inspect
 from uuid import UUID
 from typing import ClassVar, Generic, Optional, TypeVar
 
-from vellum.workflows.exceptions import NodeException, WorkflowErrorCode
 from vellum.workflows.nodes.displayable.code_execution_node import CodeExecutionNode
 from vellum.workflows.nodes.displayable.code_execution_node.utils import read_file_from_path
 from vellum.workflows.types.core import JsonObject

--- a/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
@@ -42,10 +42,7 @@ class BaseCodeExecutionNodeDisplay(BaseNodeDisplay[_CodeExecutionNodeType], Gene
                 script_filepath=filepath,
             )
             if not file_code:
-                raise NodeException(
-                    message=f"Filepath '{filepath}' of node {node.__name__} does not exist",
-                    code=WorkflowErrorCode.INVALID_INPUTS,
-                )
+                raise Exception(f"Filepath '{filepath}' of node {node.__name__} does not exist")
             code_value = file_code
         else:
             code_value = ""

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_code_execution_node.py
@@ -167,6 +167,6 @@ def test_serialize_node__with_non_exist_code_input_path():
 
     # WHEN we serialize the workflow
     workflow_display = get_workflow_display(workflow_class=Workflow)
-    with pytest.raises(NodeException) as exc_info:
+    with pytest.raises(Exception) as exc_info:
         workflow_display.serialize()
     assert "Filepath 'non_existent_file.py' of node MyNode does not exist" in str(exc_info.value)

--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_code_execution_node.py
@@ -3,7 +3,6 @@ from uuid import UUID
 from typing import Type
 
 from vellum.client.core.api_error import ApiError
-from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.displayable.code_execution_node.node import CodeExecutionNode
 from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.workflows.base import BaseWorkflow


### PR DESCRIPTION
before the fix if the filepath is not found it will be none


  ```
 'inputs': [{'id': '59c49667-189f-40f5-a86a-ea0d9c0acb29',

     'key': 'code',

     'value': {'rules': [{'data': {'type': 'JSON', 'value': None},

        'type': 'CONSTANT_VALUE'}],

      'combinator': 'OR'}},
```

correct file content will be
   ```
'inputs': [{'id': '59c49667-189f-40f5-a86a-ea0d9c0acb29',

     'key': 'code',

     'value': {'rules': [{'data': {'type': 'STRING', 'value': ''},

        'type': 'CONSTANT_VALUE'}],

      'combinator': 'OR'}},
```

we now check if the filepath exists and throw an error if not
<img width="918" height="53" alt="Screenshot 2025-07-24 at 6 06 44 PM" src="https://github.com/user-attachments/assets/0de1034b-fa5d-4872-ace3-e967b60b7331" />

