### PR TITLE
[APO-927] Fix composio codegen bug

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
@@ -99,7 +99,7 @@ class ToolCallingNode(BaseToolCallingNode):
     functions = [
         ComposioToolDefinition(
             toolkit="GITHUB",
-            action="UNKNOWN",
+            action="GITHUB_CREATE_AN_ISSUE",
             description="Create a new issue in a GitHub repository",
             display_name="Create GitHub Issue",
         )

--- a/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
@@ -99,7 +99,7 @@ class ToolCallingNode(BaseToolCallingNode):
     functions = [
         ComposioToolDefinition(
             toolkit="GITHUB",
-            action="GITHUB_CREATE_AN_ISSUE",
+            action="UNKNOWN",
             description="Create a new issue in a GitHub repository",
             display_name="Create GitHub Issue",
         )

--- a/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
@@ -107,7 +107,7 @@ class ToolCallingNode(BaseToolCallingNode):
 "
 `;
 
-exports[`ToolCallingNode > composio tool > should handle composio tool with missing toolkit/action fields 1`] = `
+exports[`ToolCallingNode > composio tool > should handle composio tool with integration_name & tool_slug fields 1`] = `
 "from vellum.workflows.nodes.displayable.tool_calling_node import (
     ToolCallingNode as BaseToolCallingNode,
 )

--- a/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
@@ -107,6 +107,25 @@ class ToolCallingNode(BaseToolCallingNode):
 "
 `;
 
+exports[`ToolCallingNode > composio tool > should handle composio tool with missing toolkit/action fields 1`] = `
+"from vellum.workflows.nodes.displayable.tool_calling_node import (
+    ToolCallingNode as BaseToolCallingNode,
+)
+from vellum.workflows.types.definition import ComposioToolDefinition
+
+
+class ToolCallingNode(BaseToolCallingNode):
+    functions = [
+        ComposioToolDefinition(
+            toolkit="gmail",
+            action="GMAIL_CREATE_EMAIL_DRAFT",
+            description="Creates a gmail email draft, supporting to/cc/bcc, subject, plain/html body (ensure \`is html=true\` for html), attachments, and threading.",
+            display_name="Create email draft",
+        )
+    ]
+"
+`;
+
 exports[`ToolCallingNode > deployment workflow > should generate latest release tag if release_tag is null 1`] = `
 "from vellum.workflows.nodes.displayable.tool_calling_node import (
     ToolCallingNode as BaseToolCallingNode,

--- a/ee/codegen/src/__test__/nodes/tool-calling-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/tool-calling-node.test.ts
@@ -158,7 +158,7 @@ describe("ToolCallingNode", () => {
       type: "COMPOSIO",
       name: "github_create_an_issue",
       integration_name: "GITHUB",
-      tool_name: "GITHUB_CREATE_AN_ISSUE",
+      tool_slug: "GITHUB_CREATE_AN_ISSUE",
       description: "Create a new issue in a GitHub repository",
       display_name: "Create GitHub Issue",
       parameters: {

--- a/ee/codegen/src/__test__/nodes/tool-calling-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/tool-calling-node.test.ts
@@ -161,6 +161,16 @@ describe("ToolCallingNode", () => {
       action: "GITHUB_CREATE_AN_ISSUE",
       description: "Create a new issue in a GitHub repository",
       display_name: "Create GitHub Issue",
+      parameters: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          body: { type: "string" },
+          owner: { type: "string" },
+          repo: { type: "string" },
+        },
+        required: ["title", "owner", "repo"],
+      },
     };
 
     it("should generate composio tool", async () => {
@@ -197,6 +207,58 @@ describe("ToolCallingNode", () => {
         nodeContext,
       });
 
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+
+    it("should handle composio tool with missing toolkit/action fields", async () => {
+      const nodePortData: NodePort[] = [
+        nodePortFactory({
+          id: "port-id",
+        }),
+      ];
+
+      // This simulates the problematic data structure that causes the TypeError
+      const problematicComposioTool = {
+        type: "COMPOSIO",
+        name: "GMAIL_CREATE_EMAIL_DRAFT",
+        tool_name: "Create email draft",
+        tool_slug: "GMAIL_CREATE_EMAIL_DRAFT",
+        description:
+          "Creates a gmail email draft, supporting to/cc/bcc, subject, plain/html body (ensure `is html=true` for html), attachments, and threading.",
+        connection_id: "ca_QoaKIKPlluHk",
+        integration_name: "gmail",
+        // Note: toolkit and action are missing, which causes the TypeError
+      };
+
+      const functionsAttribute = nodeAttributeFactory(
+        "functions-attr-id",
+        "functions",
+        [
+          {
+            ...problematicComposioTool,
+            id: "composio-tool-function-id",
+            name: "GMAIL_CREATE_EMAIL_DRAFT",
+          },
+        ]
+      );
+
+      const nodeData = toolCallingNodeFactory({
+        nodePorts: nodePortData,
+        nodeAttributes: [functionsAttribute],
+      });
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as GenericNodeContext;
+
+      const node = new GenericNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      // This should not throw a TypeError
       node.getNodeFile().write(writer);
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });

--- a/ee/codegen/src/__test__/nodes/tool-calling-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/tool-calling-node.test.ts
@@ -157,8 +157,8 @@ describe("ToolCallingNode", () => {
     const composioToolFunction: ComposioToolFunctionArgs = {
       type: "COMPOSIO",
       name: "github_create_an_issue",
-      toolkit: "GITHUB",
-      action: "GITHUB_CREATE_AN_ISSUE",
+      integration_name: "GITHUB",
+      tool_name: "GITHUB_CREATE_AN_ISSUE",
       description: "Create a new issue in a GitHub repository",
       display_name: "Create GitHub Issue",
       parameters: {
@@ -219,7 +219,7 @@ describe("ToolCallingNode", () => {
       ];
 
       // This simulates the problematic data structure that causes the TypeError
-      const problematicComposioTool = {
+      const composioToolFunction = {
         type: "COMPOSIO",
         name: "GMAIL_CREATE_EMAIL_DRAFT",
         tool_name: "Create email draft",
@@ -228,7 +228,6 @@ describe("ToolCallingNode", () => {
           "Creates a gmail email draft, supporting to/cc/bcc, subject, plain/html body (ensure `is html=true` for html), attachments, and threading.",
         connection_id: "ca_QoaKIKPlluHk",
         integration_name: "gmail",
-        // Note: toolkit and action are missing, which causes the TypeError
       };
 
       const functionsAttribute = nodeAttributeFactory(
@@ -236,9 +235,8 @@ describe("ToolCallingNode", () => {
         "functions",
         [
           {
-            ...problematicComposioTool,
+            ...composioToolFunction,
             id: "composio-tool-function-id",
-            name: "GMAIL_CREATE_EMAIL_DRAFT",
           },
         ]
       );

--- a/ee/codegen/src/__test__/nodes/tool-calling-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/tool-calling-node.test.ts
@@ -211,14 +211,15 @@ describe("ToolCallingNode", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
 
-    it("should handle composio tool with missing toolkit/action fields", async () => {
+    // TODO: Combine this with the test above once attributes are finalized
+    // This test was written to repro a codegen bug that is now fixed
+    it("should handle composio tool with integration_name & tool_slug fields", async () => {
       const nodePortData: NodePort[] = [
         nodePortFactory({
           id: "port-id",
         }),
       ];
 
-      // This simulates the problematic data structure that causes the TypeError
       const composioToolFunction = {
         type: "COMPOSIO",
         name: "GMAIL_CREATE_EMAIL_DRAFT",

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -206,17 +206,9 @@ export class GenericNode extends BaseNode<GenericNodeType, GenericNodeContext> {
                   const composioTool = f as ComposioToolFunctionArgs;
 
                   // Validate required fields and provide fallbacks for missing fields
-                  const toolkit =
-                    composioTool.toolkit ||
-                    composioTool.integration_name ||
-                    "UNKNOWN";
-                  const action =
-                    composioTool.action ||
-                    composioTool.tool_slug ||
-                    composioTool.name ||
-                    "UNKNOWN";
-                  const description =
-                    composioTool.description || "No description provided";
+                  const toolkit = composioTool.integration_name || "UNKNOWN";
+                  const action = composioTool.tool_slug || "UNKNOWN";
+                  const description = composioTool.description || "UNKNOWN";
 
                   const args = [
                     python.methodArgument({

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -204,30 +204,42 @@ export class GenericNode extends BaseNode<GenericNodeType, GenericNodeContext> {
                 }
                 case "COMPOSIO": {
                   const composioTool = f as ComposioToolFunctionArgs;
+
+                  // Validate required fields and provide fallbacks for missing fields
+                  const toolkit =
+                    composioTool.toolkit ||
+                    composioTool.integration_name ||
+                    "UNKNOWN";
+                  const action =
+                    composioTool.action ||
+                    composioTool.tool_slug ||
+                    composioTool.name ||
+                    "UNKNOWN";
+                  const description =
+                    composioTool.description || "No description provided";
+
                   const args = [
                     python.methodArgument({
                       name: "toolkit",
-                      value: python.TypeInstantiation.str(composioTool.toolkit),
+                      value: python.TypeInstantiation.str(toolkit),
                     }),
                     python.methodArgument({
                       name: "action",
-                      value: python.TypeInstantiation.str(composioTool.action),
+                      value: python.TypeInstantiation.str(action),
                     }),
                     python.methodArgument({
                       name: "description",
-                      value: python.TypeInstantiation.str(
-                        composioTool.description
-                      ),
+                      value: python.TypeInstantiation.str(description),
                     }),
                   ];
 
-                  if (composioTool.display_name) {
+                  const displayName =
+                    composioTool.display_name || composioTool.tool_name;
+                  if (displayName) {
                     args.push(
                       python.methodArgument({
                         name: "display_name",
-                        value: python.TypeInstantiation.str(
-                          composioTool.display_name
-                        ),
+                        value: python.TypeInstantiation.str(displayName),
                       })
                     );
                   }

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -927,8 +927,13 @@ export type DeploymentWorkflowFunctionArgs = {
 
 export type ComposioToolFunctionArgs = {
   type: "COMPOSIO";
-  toolkit: string;
-  action: string;
+  toolkit?: string;
+  action?: string;
   description: string;
   display_name?: string | null;
+  parameters?: Record<string, unknown> | null;
+  tool_name?: string;
+  tool_slug?: string;
+  connection_id?: string;
+  integration_name?: string;
 } & NameDescription;

--- a/ee/codegen_integration/fixtures/simple_composio_tool_calling_node/display_data/simple_composio_tool_calling_node.json
+++ b/ee/codegen_integration/fixtures/simple_composio_tool_calling_node/display_data/simple_composio_tool_calling_node.json
@@ -89,7 +89,10 @@
                     "toolkit": "GITHUB",
                     "action": "GITHUB_CREATE_AN_ISSUE",
                     "description": "Create a new issue in a GitHub repository",
-                    "display_name": "Create GitHub Issue"
+                    "display_name": "Create GitHub Issue",
+                    "parameters": null,
+                    "version": null,
+                    "tags": null
                   }
                 ]
               }

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_composio_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_composio_serialization.py
@@ -54,6 +54,9 @@ def test_serialize_workflow():
         "action": "GITHUB_CREATE_AN_ISSUE",
         "description": "Create a new issue in a GitHub repository",
         "display_name": "Create GitHub Issue",
+        "parameters": None,
+        "version": None,
+        "tags": None,
     }
 
     # AND the rest of the node structure should be correct

--- a/src/vellum/workflows/types/definition.py
+++ b/src/vellum/workflows/types/definition.py
@@ -2,7 +2,7 @@ import importlib
 import inspect
 from types import FrameType
 from uuid import UUID
-from typing import Annotated, Any, Dict, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BeforeValidator
 
@@ -109,8 +109,10 @@ class ComposioToolDefinition(UniversalBaseModel):
     action: str  # Specific action like "GITHUB_CREATE_AN_ISSUE"
     description: str
 
-    # Optional cached metadata
     display_name: Optional[str] = None
+    parameters: Optional[Dict[str, Any]] = None
+    version: Optional[str] = None
+    tags: Optional[List[str]] = None
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
This fixes a codegen bug that was throwing a TypeError when deserializing Composio tools in the TCN. Now the code is generated as follows:
```python
functions = [
        ComposioToolDefinition(
            toolkit="gmail",
            action="GMAIL_CREATE_EMAIL_DRAFT",
            description="Creates a gmail email draft, supporting to/cc/bcc, subject, plain/html body (ensure `is html=true` for html), attachments, and threading.",
            display_name="Create email draft",
        )
    ]
```

Now that we've switched from the Composio python packages to straight API requests the responses have changed, hence the growing list of optional fields on the ComposioToolDefinition. Cleanup is tracked by APO-951.