### PR TITLE
Non-Decorator Global Execution Context Store [WIP]

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,6 @@ import sys
 import threading
 import time
 import traceback
-from unittest.mock import Mock, patch
 from uuid import UUID, uuid4
 from typing import Any, Callable, Generator, List
 
@@ -12,7 +11,6 @@ from dotenv import dotenv_values
 from pytest_mock import MockerFixture
 import requests_mock
 
-from vellum.client.core import http_client as http_client_module
 from vellum.client.environment import VellumEnvironment
 from vellum.workflows.logging import load_logger
 
@@ -23,35 +21,6 @@ def pytest_collection_modifyitems(session, config, items):
         os.environ["_PYTEST_SINGLE_TEST"] = "1"
     else:
         os.environ["_PYTEST_SINGLE_TEST"] = "0"
-
-
-# To avoid 429 errors from the Monitoring API during tests
-@pytest.fixture(scope="session", autouse=True)
-def mock_vellum_emitter_requests() -> Generator[None, None, None]:
-    """Mock only the VellumEmitter network requests (v1/events) to prevent real HTTP calls.
-
-    This keeps emitters enabled for tests that rely on them, while ensuring we don't hit the network.
-    """
-
-    original_request = http_client_module.HttpClient.request
-
-    def _request_wrapper(self, *args, **kwargs):  # type: ignore[no-untyped-def]
-        path = kwargs.get("path") if "path" in kwargs else (args[0] if len(args) > 0 else None)
-        if path == "v1/events":
-            mock_response = Mock()
-            mock_response.raise_for_status.return_value = None
-            mock_response.status_code = 200
-            mock_response.text = ""
-            mock_response.headers = {}
-            return mock_response
-        return original_request(self, *args, **kwargs)
-
-    patcher = patch("vellum.client.core.http_client.HttpClient.request", autospec=True, side_effect=_request_wrapper)
-    patcher.start()
-    try:
-        yield
-    finally:
-        patcher.stop()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/ee/automation/src/auto-merge.ts
+++ b/ee/automation/src/auto-merge.ts
@@ -59,7 +59,7 @@ const main = async () => {
   console.log(`PR #${PR_NUMBER} is open, has release label, and was opened by authorized user (${pr.user?.login}), waiting for checks...`);
 
   const startTime = Date.now();
-  
+
   while (Date.now() - startTime < MAX_WAIT_TIME) {
     try {
       const { data: checkRuns } = await octokit.rest.checks.listForRef({
@@ -78,7 +78,7 @@ const main = async () => {
 
       const autoMergeChecks = checks.filter(check => isAutoMergeCheck(check.name));
       if (autoMergeChecks.length > 0) {
-        console.log(`Excluding ${autoMergeChecks.length} auto-merge checks:`, 
+        console.log(`Excluding ${autoMergeChecks.length} auto-merge checks:`,
           autoMergeChecks.map(c => c.name).join(', '));
       }
 
@@ -88,19 +88,19 @@ const main = async () => {
         continue;
       }
 
-      const pendingChecks = checks.filter(check => 
+      const pendingChecks = checks.filter(check =>
         check.status !== 'completed' && !isAutoMergeCheck(check.name)
       );
       if (pendingChecks.length > 0) {
-        console.log(`Waiting for ${pendingChecks.length} checks to complete:`, 
+        console.log(`Waiting for ${pendingChecks.length} checks to complete:`,
           pendingChecks.map(c => c.name).join(', '));
         await sleep(POLL_INTERVAL);
         continue;
       }
 
-      const failedChecks = checks.filter(check => 
-        check.conclusion !== 'success' && 
-        check.conclusion !== 'neutral' && 
+      const failedChecks = checks.filter(check =>
+        check.conclusion !== 'success' &&
+        check.conclusion !== 'neutral' &&
         check.conclusion !== 'skipped' &&
         !isAutoMergeCheck(check.name)
       );

--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -1260,10 +1260,6 @@ from vellum.workflows.sandbox import WorkflowSandboxRunner
 from .inputs import Inputs
 from .workflow import Workflow
 
-if __name__ != "__main__":
-    raise Exception("This file is not meant to be imported")
-
-
 dataset = [
     Inputs(
         input="foo",
@@ -1294,7 +1290,8 @@ dataset = [
 
 runner = WorkflowSandboxRunner(workflow=Workflow(), dataset=dataset)
 
-runner.run()
+if __name__ == "__main__":
+    runner.run()
 "
 `;
 

--- a/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/workflow-sandbox.test.ts.snap
@@ -6,10 +6,6 @@ exports[`Workflow Sandbox > write > should generate correct code for camel case 
 from .inputs import Inputs
 from .workflow import TestWorkflow
 
-if __name__ != "__main__":
-    raise Exception("This file is not meant to be imported")
-
-
 dataset = [
     Inputs(someFoo="some-value"),
     Inputs(someBar="some-value"),
@@ -17,7 +13,8 @@ dataset = [
 
 runner = WorkflowSandboxRunner(workflow=TestWorkflow(), dataset=dataset)
 
-runner.run()
+if __name__ == "__main__":
+    runner.run()
 "
 `;
 
@@ -27,10 +24,6 @@ exports[`Workflow Sandbox > write > should generate correct code for snake case 
 from .inputs import Inputs
 from .workflow import TestWorkflow
 
-if __name__ != "__main__":
-    raise Exception("This file is not meant to be imported")
-
-
 dataset = [
     Inputs(some_foo="some-value"),
     Inputs(some_bar="some-value"),
@@ -38,7 +31,8 @@ dataset = [
 
 runner = WorkflowSandboxRunner(workflow=TestWorkflow(), dataset=dataset)
 
-runner.run()
+if __name__ == "__main__":
+    runner.run()
 "
 `;
 
@@ -48,10 +42,6 @@ exports[`Workflow Sandbox > write > should generate correct code given inputs 1`
 from .inputs import Inputs
 from .workflow import TestWorkflow
 
-if __name__ != "__main__":
-    raise Exception("This file is not meant to be imported")
-
-
 dataset = [
     Inputs(some_foo="some-value"),
     Inputs(some_bar="some-value"),
@@ -59,7 +49,8 @@ dataset = [
 
 runner = WorkflowSandboxRunner(workflow=TestWorkflow(), dataset=dataset)
 
-runner.run()
+if __name__ == "__main__":
+    runner.run()
 "
 `;
 
@@ -69,17 +60,14 @@ exports[`Workflow Sandbox > write > should generate correct code given optional 
 from .inputs import Inputs
 from .workflow import TestWorkflow
 
-if __name__ != "__main__":
-    raise Exception("This file is not meant to be imported")
-
-
 dataset = [
     Inputs(),
 ]
 
 runner = WorkflowSandboxRunner(workflow=TestWorkflow(), dataset=dataset)
 
-runner.run()
+if __name__ == "__main__":
+    runner.run()
 "
 `;
 
@@ -89,16 +77,13 @@ exports[`Workflow Sandbox > write > should properly handle special characters wi
 from .inputs import Inputs
 from .workflow import TestWorkflow
 
-if __name__ != "__main__":
-    raise Exception("This file is not meant to be imported")
-
-
 dataset = [
     Inputs(special_characters_input='"special characters"'),
 ]
 
 runner = WorkflowSandboxRunner(workflow=TestWorkflow(), dataset=dataset)
 
-runner.run()
+if __name__ == "__main__":
+    runner.run()
 "
 `;

--- a/ee/codegen/src/generators/workflow-sandbox-file.ts
+++ b/ee/codegen/src/generators/workflow-sandbox-file.ts
@@ -70,15 +70,14 @@ export class WorkflowSandboxFile extends BasePersistedFile {
     this.inheritReferences(sandboxRunnerField);
 
     return [
-      python.codeBlock(`\
-if __name__ != "__main__":
-    raise Exception("This file is not meant to be imported")
-`),
       datasetField,
       sandboxRunnerField,
       // Using code block instead of method invocation since the latter tries to import `runner.run` after
       // specifying as a reference, even though it's a locally defined variable.
-      python.codeBlock(`runner.run()`),
+      python.codeBlock(`\
+if __name__ == "__main__":
+    runner.run()
+`),
     ];
   }
 

--- a/src/vellum/workflows/context.py
+++ b/src/vellum/workflows/context.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from typing import Iterator, Optional, cast
 
 from vellum.client.core import UniversalBaseModel
+from vellum.workflows.events.context import DEFAULT_TRACE_ID, MonitoringContextStore
 from vellum.workflows.events.types import ParentContext
 
 
@@ -17,15 +18,38 @@ _CONTEXT_KEY = "_execution_context"
 
 local = threading.local()
 
+monitoring_context_store = MonitoringContextStore()
+
 
 def get_execution_context() -> ExecutionContext:
-    """Retrieve the current execution context."""
-    return getattr(local, _CONTEXT_KEY, ExecutionContext())
+    """Get the current monitoring execution context, with intelligent fallback."""
+    context = getattr(local, _CONTEXT_KEY, ExecutionContext())
+    if context.trace_id != DEFAULT_TRACE_ID or context.parent_context:
+        return context
+
+    # If no thread-local context, try to restore from global store using current trace_id
+    trace_id = monitoring_context_store.get_current_trace_id()
+    span_id = monitoring_context_store.get_current_span_id()
+    if trace_id and trace_id != DEFAULT_TRACE_ID:
+        context = monitoring_context_store.retrieve_context(trace_id, span_id)
+        if context and (context.parent_context or context.trace_id != DEFAULT_TRACE_ID):
+            set_execution_context(context)
+            return context
+    return ExecutionContext()
 
 
 def set_execution_context(context: ExecutionContext) -> None:
-    """Set the current execution context."""
+    """Set the current monitoring execution context and persist it for cross-boundary access."""
     setattr(local, _CONTEXT_KEY, context)
+
+    # Always store in global store for cross-thread access
+    monitoring_context_store.store_context(context)
+    
+    # Set current trace and span IDs for this thread
+    if context.trace_id and context.trace_id != DEFAULT_TRACE_ID:
+        monitoring_context_store.set_current_trace_id(context.trace_id)
+    if context.parent_context:
+        monitoring_context_store.set_current_span_id(context.parent_context.span_id)
 
 
 def get_parent_context() -> ParentContext:

--- a/src/vellum/workflows/context.py
+++ b/src/vellum/workflows/context.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from typing import Iterator, Optional, cast
 
 from vellum.client.core import UniversalBaseModel
-from vellum.workflows.events.context import DEFAULT_TRACE_ID, MonitoringContextStore
+from vellum.workflows.events.context import MonitoringContextStore
 from vellum.workflows.events.types import ParentContext
 
 
@@ -24,17 +24,14 @@ monitoring_context_store = MonitoringContextStore()
 def get_execution_context() -> ExecutionContext:
     """Get the current monitoring execution context, with intelligent fallback."""
     context = getattr(local, _CONTEXT_KEY, ExecutionContext())
-    if context.trace_id != DEFAULT_TRACE_ID or context.parent_context:
+    if context.parent_context:
         return context
 
     # If no thread-local context, try to restore from global store using current trace_id
-    trace_id = monitoring_context_store.get_current_trace_id()
-    span_id = monitoring_context_store.get_current_span_id()
-    if trace_id and trace_id != DEFAULT_TRACE_ID:
-        context = monitoring_context_store.retrieve_context(trace_id, span_id)
-        if context and (context.parent_context or context.trace_id != DEFAULT_TRACE_ID):
-            set_execution_context(context)
-            return context
+    context = monitoring_context_store.retrieve_context()
+    if context and context.parent_context:
+        set_execution_context(context)
+        return context
     return ExecutionContext()
 
 
@@ -44,12 +41,13 @@ def set_execution_context(context: ExecutionContext) -> None:
 
     # Always store in global store for cross-thread access
     monitoring_context_store.store_context(context)
-    
-    # Set current trace and span IDs for this thread
-    if context.trace_id and context.trace_id != DEFAULT_TRACE_ID:
-        monitoring_context_store.set_current_trace_id(context.trace_id)
-    if context.parent_context:
-        monitoring_context_store.set_current_span_id(context.parent_context.span_id)
+
+
+def clear_execution_context() -> None:
+    """Clear the current monitoring execution context."""
+    if hasattr(local, _CONTEXT_KEY):
+        delattr(local, _CONTEXT_KEY)
+    monitoring_context_store.clear_context()
 
 
 def get_parent_context() -> ParentContext:

--- a/src/vellum/workflows/emitters/vellum_emitter.py
+++ b/src/vellum/workflows/emitters/vellum_emitter.py
@@ -1,12 +1,9 @@
 import logging
-import time
-from typing import Any, Dict, Optional
+from typing import Optional
 
-import httpx
-
+from vellum.core.request_options import RequestOptions
 from vellum.workflows.emitters.base import BaseWorkflowEmitter
-from vellum.workflows.events.types import default_serializer
-from vellum.workflows.events.workflow import WorkflowEvent
+from vellum.workflows.events.workflow import WorkflowEvent as SDKWorkflowEvent
 from vellum.workflows.state.base import BaseState
 
 logger = logging.getLogger(__name__)
@@ -43,9 +40,8 @@ class VellumEmitter(BaseWorkflowEmitter):
         super().__init__()
         self._timeout = timeout
         self._max_retries = max_retries
-        self._events_endpoint = "v1/events"  # TODO: make this configurable with the correct url
 
-    def emit_event(self, event: WorkflowEvent) -> None:
+    def emit_event(self, event: SDKWorkflowEvent) -> None:
         """
         Emit a workflow event to Vellum's infrastructure.
 
@@ -59,9 +55,7 @@ class VellumEmitter(BaseWorkflowEmitter):
             return
 
         try:
-            event_data = default_serializer(event)
-
-            self._send_event(event_data)
+            self._send_event(event)
 
         except Exception as e:
             logger.exception(f"Failed to emit event {event.name}: {e}")
@@ -75,70 +69,23 @@ class VellumEmitter(BaseWorkflowEmitter):
         """
         pass
 
-    def _send_event(self, event_data: Dict[str, Any]) -> None:
+    def _send_event(self, event: SDKWorkflowEvent) -> None:
         """
-        Send event data to Vellum's events endpoint with retry logic.
+        Send event to Vellum's events endpoint using client.events.create.
 
         Args:
-            event_data: The serialized event data to send.
+            event: The WorkflowEvent object to send.
         """
         if not self._context:
             logger.warning("Cannot send event: No workflow context registered")
             return
 
         client = self._context.vellum_client
-
-        for attempt in range(self._max_retries + 1):
-            try:
-                # Use the Vellum client's underlying HTTP client to make the request
-                # For proper authentication headers and configuration
-                base_url = client._client_wrapper.get_environment().default
-                response = client._client_wrapper.httpx_client.request(
-                    method="POST",
-                    base_url=base_url,
-                    path=self._events_endpoint,  # TODO: will be replaced with the correct url
-                    json=event_data,
-                    headers=client._client_wrapper.get_headers(),
-                    request_options={"timeout_in_seconds": self._timeout},
-                )
-
-                response.raise_for_status()
-
-                if attempt > 0:
-                    logger.info(f"Event sent successfully after {attempt + 1} attempts")
-                return
-
-            except httpx.HTTPStatusError as e:
-                if e.response.status_code >= 500:
-                    # Server errors might be transient, retry
-                    if attempt < self._max_retries:
-                        wait_time = min(2**attempt, 60)  # Exponential backoff, max 60s
-                        logger.warning(
-                            f"Server error emitting event (attempt {attempt + 1}/{self._max_retries + 1}): "
-                            f"{e.response.status_code}. Retrying in {wait_time}s..."
-                        )
-                        time.sleep(wait_time)
-                        continue
-                    else:
-                        logger.exception(
-                            f"Server error emitting event after {self._max_retries + 1} attempts: "
-                            f"{e.response.status_code} {e.response.text}"
-                        )
-                        return
-                else:
-                    # Client errors (4xx) are not retriable
-                    logger.exception(f"Client error emitting event: {e.response.status_code} {e.response.text}")
-                    return
-
-            except httpx.RequestError as e:
-                if attempt < self._max_retries:
-                    wait_time = min(2**attempt, 60)  # Exponential backoff, max 60s
-                    logger.warning(
-                        f"Network error emitting event (attempt {attempt + 1}/{self._max_retries + 1}): "
-                        f"{e}. Retrying in {wait_time}s..."
-                    )
-                    time.sleep(wait_time)
-                    continue
-                else:
-                    logger.exception(f"Network error emitting event after {self._max_retries + 1} attempts: {e}")
-                    return
+        request_options = RequestOptions(timeout_in_seconds=self._timeout, max_retries=self._max_retries)
+        client.events.create(
+            # The API accepts a ClientWorkflowEvent but our SDK emits an SDKWorkflowEvent. These shapes are
+            # meant to be identical, just with different helper methods. We may consolidate the two in the future.
+            # But for now, the type ignore allows us to avoid an additional Model -> json -> Model conversion.
+            request=event,  # type: ignore[arg-type]
+            request_options=request_options,
+        )

--- a/src/vellum/workflows/events/context.py
+++ b/src/vellum/workflows/events/context.py
@@ -2,9 +2,7 @@
 
 import threading
 from uuid import UUID
-from typing import Dict, Optional
-
-from vellum.workflows.context import ExecutionContext
+from typing import Dict, Optional, TYPE_CHECKING, Type
 
 DEFAULT_TRACE_ID = UUID("00000000-0000-0000-0000-000000000000")
 
@@ -12,9 +10,13 @@ DEFAULT_TRACE_ID = UUID("00000000-0000-0000-0000-000000000000")
 _monitoring_execution_context: threading.local = threading.local()
 # Thread-local storage for current span_id
 _current_span_id: threading.local = threading.local()
+threading.
+
+if TYPE_CHECKING:
+    from vellum.workflows.context import ExecutionContext
 
 
-class _MonitoringContextStore:
+class MonitoringContextStore:
     """
     thread-safe storage for monitoring contexts.
     handles context persistence and retrieval across threads.
@@ -23,13 +25,14 @@ class _MonitoringContextStore:
 
     def __init__(self):
         self._lock = threading.Lock()
-        self._contexts: Dict[str, ExecutionContext] = {}
-        self._thread_contexts: Dict[int, ExecutionContext] = {}
+        self._contexts: Dict[str, Type["ExecutionContext"]] = {}
+        self._thread_contexts: Dict[int, Type["ExecutionContext"]] = {}
         self._current_trace_id: Optional[UUID] = None
 
     def set_current_trace_id(self, trace_id: UUID) -> None:
         """Set the current active trace_id that should be used by all threads."""
-        if trace_id != DEFAULT_TRACE_ID:
+        current = self.get_current_trace_id()
+        if current in [DEFAULT_TRACE_ID, None]:
             with self._lock:
                 self._current_trace_id = trace_id
 
@@ -46,45 +49,46 @@ class _MonitoringContextStore:
         """Get the current active span_id for this thread."""
         return getattr(_current_span_id, "span_id", None)
 
-    def store_context(self, context: Optional[ExecutionContext]) -> None:
+    def store_context(self, context: Optional["ExecutionContext"]) -> None:
         """Store monitoring parent context using multiple keys for reliable retrieval."""
-        if not context or context.parent_context is None:
-            return
-
-        thread_id = threading.get_ident()
-        trace_id = self.get_current_trace_id()
-        if context.trace_id != DEFAULT_TRACE_ID and trace_id is None:
+        # Use the context's trace_id if available, otherwise use the current trace_id
+        trace_id = context.trace_id if context and context.trace_id != DEFAULT_TRACE_ID else self.get_current_trace_id()
+        span_id = self.get_current_span_id() or (context.parent_context.span_id if context and context.parent_context else None)
+        
+        # Set the current trace_id if it's not set or is default
+        if context and context.trace_id and context.trace_id != DEFAULT_TRACE_ID:
             self.set_current_trace_id(context.trace_id)
+            trace_id = context.trace_id
 
         with self._lock:
             # Use trace:span:thread for unique context storage
             trace_span_thread_key = (
-                f"trace:{str(trace_id)}:span:{str(context.parent_context.span_id)}:thread:{thread_id}"
+                f"trace:{str(trace_id)}:span:{str(span_id)}"
             )
             self._contexts[trace_span_thread_key] = context
 
-    def retrieve_context(self, trace_id: UUID, span_id: Optional[UUID] = None) -> Optional[ExecutionContext]:
+    def retrieve_context(self, trace_id: UUID, span_id: Optional[UUID] = None) -> Optional[Type["ExecutionContext"]]:
         """Retrieve monitoring parent context with multiple fallback strategies."""
-        thread_id = threading.get_ident()
         with self._lock:
-            if not span_id:
-                span_id = getattr(_current_span_id, "span_id", None)
-                if not span_id:
-                    return None
-
-            span_key = f"trace:{str(trace_id)}:span:{str(span_id)}:thread:{thread_id}"
+            # Try exact match first
+            span_key = f"trace:{str(trace_id)}:span:{str(span_id)}"
             if span_key in self._contexts:
                 result = self._contexts[span_key]
                 return result
+            
+            # If exact match fails, try to find any context with the same trace_id
+            for key, context in self._contexts.items():
+                if key.startswith(f"trace:{str(trace_id)}:"):
+                    return context
 
         return None
 
 
 # Global instance for cross-boundary context persistence
-_monitoring_context_store = _MonitoringContextStore()
+monitoring_context_store = MonitoringContextStore()
 
 
-def get_monitoring_execution_context() -> ExecutionContext:
+def get_monitoring_execution_context() -> Optional[Type["ExecutionContext"]]:
     """Get the current monitoring execution context, with intelligent fallback."""
     if hasattr(_monitoring_execution_context, "context"):
         context = _monitoring_execution_context.context
@@ -92,20 +96,20 @@ def get_monitoring_execution_context() -> ExecutionContext:
             return context
 
     # If no thread-local context, try to restore from global store using current trace_id
-    trace_id = _monitoring_context_store.get_current_trace_id()
+    trace_id = monitoring_context_store.get_current_trace_id()
     span_id = _current_span_id.span_id if hasattr(_current_span_id, "span_id") else None
     if trace_id:
         if trace_id != DEFAULT_TRACE_ID:
-            context = _monitoring_context_store.retrieve_context(trace_id, span_id)
+            context = monitoring_context_store.retrieve_context(trace_id, span_id)
             if context:
                 _monitoring_execution_context.context = context
                 return context
-    return ExecutionContext()
+    return None
 
 
-def set_monitoring_execution_context(context: ExecutionContext) -> None:
+def set_monitoring_execution_context(context: Type["ExecutionContext"]) -> None:
     """Set the current monitoring execution context and persist it for cross-boundary access."""
     _monitoring_execution_context.context = context
 
     if context.trace_id and context.parent_context:
-        _monitoring_context_store.store_context(context)
+        monitoring_context_store.store_context(context)

--- a/src/vellum/workflows/events/relational_threads.py
+++ b/src/vellum/workflows/events/relational_threads.py
@@ -1,0 +1,16 @@
+import threading
+from typing import Optional
+
+
+class RelationalThread(threading.Thread):
+    _parent_thread: Optional[int] = None
+
+    def __init__(self, *args, **kwargs):
+        self._collect_parent_thread()
+        threading.Thread.__init__(self, *args, **kwargs)
+
+    def _collect_parent_thread(self) -> None:
+        self._parent_thread = threading.get_ident()
+
+    def get_parent_thread(self) -> Optional[int]:
+        return self._parent_thread

--- a/src/vellum/workflows/events/tests/test_basic_workflow.py
+++ b/src/vellum/workflows/events/tests/test_basic_workflow.py
@@ -1,0 +1,41 @@
+import logging
+from uuid import uuid4
+
+from vellum.workflows.context import execution_context
+from vellum.workflows.workflows.event_filters import all_workflow_event_filter
+
+from tests.workflows.trivial.workflow import TrivialWorkflow
+
+logger = logging.getLogger(__name__)
+
+
+def test_basic_workflow_monitoring_context_flow():
+    """Test that monitoring creates the correct workflow→node context hierarchy using streamed events.
+    What's missing:
+    - span_id from previous event mapping to parent context
+    """
+
+    workflow = TrivialWorkflow()
+
+    with execution_context(trace_id=uuid4()):
+        events = list(workflow.stream(event_filter=all_workflow_event_filter))
+
+    # Verify workflow succeeded
+    assert len(events) >= 2
+    assert events[0].name == "workflow.execution.initiated"
+    assert events[-1].name == "workflow.execution.fulfilled"
+
+    # Collect all events with parent context
+    events_with_parent = [event for event in events if event.parent is not None]
+
+    assert len(events_with_parent) > 0, "Expected at least some events with parent context"
+
+    # Filter for node events
+    node_events = [event for event in events if event.name.startswith("node.")]
+    assert len(node_events) > 0, "Expected at least some node events"
+
+    # Verify each node event has the workflow as its parent context
+    for event in node_events:
+        assert event.parent is not None, "Node event should have parent context"
+        assert event.parent.type == "WORKFLOW", "Node event parent should be workflow"
+        assert event.parent.workflow_definition.name == "TrivialWorkflow", "Parent workflow name mismatch"

--- a/src/vellum/workflows/events/workflow.py
+++ b/src/vellum/workflows/events/workflow.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, Literal, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Iterable, Literal, Optional, Type, Union
 from typing_extensions import TypeGuard
 
 from pydantic import field_serializer
@@ -84,6 +84,9 @@ class WorkflowExecutionInitiatedBody(_BaseWorkflowExecutionBody, Generic[InputsT
     @field_serializer("initial_state")
     def serialize_initial_state(self, initial_state: Optional[StateType], _info: Any) -> Optional[Dict[str, Any]]:
         return default_serializer(initial_state)
+
+
+EventEnricher = Callable[["_BaseWorkflowEvent"], dict]
 
 
 class WorkflowExecutionInitiatedEvent(_BaseWorkflowEvent, Generic[InputsType, StateType]):

--- a/src/vellum/workflows/nodes/core/map_node/node.py
+++ b/src/vellum/workflows/nodes/core/map_node/node.py
@@ -166,6 +166,9 @@ class MapNode(BaseAdornmentNode[StateType], Generic[StateType, MapNodeItemType])
             self._run_subworkflow(item=item, index=index)
 
     def _run_subworkflow(self, *, item: MapNodeItemType, index: int) -> None:
+        # sets context for this parent thread, to then pass on --
+        # TODO - get all threads to just auto collect
+        get_execution_context()
         context = WorkflowContext.create_from(self._context)
         subworkflow = self.subworkflow(
             parent_state=self.state,

--- a/src/vellum/workflows/nodes/core/map_node/node.py
+++ b/src/vellum/workflows/nodes/core/map_node/node.py
@@ -166,9 +166,6 @@ class MapNode(BaseAdornmentNode[StateType], Generic[StateType, MapNodeItemType])
             self._run_subworkflow(item=item, index=index)
 
     def _run_subworkflow(self, *, item: MapNodeItemType, index: int) -> None:
-        # sets context for this parent thread, to then pass on --
-        # TODO - get all threads to just auto collect
-        get_execution_context()
         context = WorkflowContext.create_from(self._context)
         subworkflow = self.subworkflow(
             parent_state=self.state,

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -521,7 +521,14 @@ class WorkflowRunner(Generic[StateType]):
             state.meta.node_execution_cache.initiate_node_execution(node_class, node_span_id)
             self._active_nodes_by_execution_id[node_span_id] = ActiveNode(node=node)
 
-            worker_thread = self._create_worker_thread(node, node_span_id)
+            get_execution_context()
+            worker_thread = Thread(
+                target=self._run_work_item,
+                kwargs={
+                    "node": node,
+                    "span_id": node_span_id,
+                },
+            )
             worker_thread.start()
 
     def _handle_work_item_event(self, event: WorkflowEvent) -> Optional[WorkflowError]:

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -456,16 +456,6 @@ class WorkflowRunner(Generic[StateType]):
 
         return None
 
-    def _create_worker_thread(self, node: BaseNode[StateType], span_id: UUID) -> Thread:
-        """Create a worker thread with proper execution context."""
-        return Thread(
-            target=self._run_work_item,
-            kwargs={
-                "node": node,
-                "span_id": span_id,
-            },
-        )
-
     def _handle_invoked_ports(
         self,
         state: StateType,

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import logging
 from queue import Empty, Queue
 import sys
-from threading import Event as ThreadingEvent, Thread
+from threading import Event as ThreadingEvent
 import traceback
 from uuid import UUID, uuid4
 from typing import (
@@ -25,7 +25,7 @@ from typing import (
 )
 
 from vellum.workflows.constants import undefined
-from vellum.workflows.context import ExecutionContext, execution_context, get_execution_context, set_execution_context
+from vellum.workflows.context import ExecutionContext, clear_execution_context, execution_context, get_execution_context
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.errors import WorkflowError, WorkflowErrorCode
 from vellum.workflows.events import (
@@ -46,7 +46,8 @@ from vellum.workflows.events.node import (
     NodeExecutionRejectedBody,
     NodeExecutionStreamingBody,
 )
-from vellum.workflows.events.types import BaseEvent, NodeParentContext, ParentContext, WorkflowParentContext
+from vellum.workflows.events.relational_threads import RelationalThread as Thread
+from vellum.workflows.events.types import BaseEvent, NodeParentContext, WorkflowParentContext
 from vellum.workflows.events.workflow import (
     WorkflowEventStream,
     WorkflowExecutionFulfilledBody,
@@ -457,7 +458,6 @@ class WorkflowRunner(Generic[StateType]):
 
     def _create_worker_thread(self, node: BaseNode[StateType], span_id: UUID) -> Thread:
         """Create a worker thread with proper execution context."""
-        
         return Thread(
             target=self._run_work_item,
             kwargs={
@@ -517,10 +517,6 @@ class WorkflowRunner(Generic[StateType]):
             if not node_class.Trigger.should_initiate(state, all_deps, node_span_id):
                 return
 
-            execution = get_execution_context()
-            # Ensure the current context is stored globally before creating the worker thread
-            set_execution_context(execution)
-            
             node = node_class(state=state, context=self.workflow.context)
             state.meta.node_execution_cache.initiate_node_execution(node_class, node_span_id)
             self._active_nodes_by_execution_id[node_span_id] = ActiveNode(node=node)
@@ -867,6 +863,14 @@ class WorkflowRunner(Generic[StateType]):
 
         self._background_thread_queue.put(None)
         cancel_thread_kill_switch.set()
+
+        # Clear MonitoringContextStore at the end of root workflow execution
+        # Only clear if this is a root workflow (no parent context)
+        if not self._execution_context.parent_context or self._execution_context.parent_context.type in [
+            "WORKFLOW_RELEASE_TAG",
+            "WORKFLOW_SANDBOX",
+        ]:
+            clear_execution_context()
 
     def stream(self) -> WorkflowEventStream:
         return WorkflowEventGenerator(self._generate_events(), self._initial_state.meta.span_id)

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -537,7 +537,14 @@ class WorkflowRunner(Generic[StateType]):
             state.meta.node_execution_cache.initiate_node_execution(node_class, node_span_id)
             self._active_nodes_by_execution_id[node_span_id] = ActiveNode(node=node)
 
-            worker_thread = self._create_worker_thread(node, node_span_id)
+            get_execution_context()
+            worker_thread = Thread(
+                target=self._run_work_item,
+                kwargs={
+                    "node": node,
+                    "span_id": node_span_id,
+                },
+            )
             worker_thread.start()
 
     def _handle_work_item_event(self, event: WorkflowEvent) -> Optional[WorkflowError]:

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -25,7 +25,7 @@ from typing import (
 )
 
 from vellum.workflows.constants import undefined
-from vellum.workflows.context import ExecutionContext, execution_context, get_execution_context
+from vellum.workflows.context import ExecutionContext, execution_context, get_execution_context, set_execution_context
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.errors import WorkflowError, WorkflowErrorCode
 from vellum.workflows.events import (
@@ -188,15 +188,16 @@ class WorkflowRunner(Generic[StateType]):
         ]
 
     def _snapshot_state(self, state: StateType, deltas: List[StateDelta]) -> StateType:
+        execution = get_execution_context()
         self._workflow_event_inner_queue.put(
             WorkflowExecutionSnapshottedEvent(
-                trace_id=self._execution_context.trace_id,
+                trace_id=execution.trace_id,
                 span_id=state.meta.span_id,
                 body=WorkflowExecutionSnapshottedBody(
                     workflow_definition=self.workflow.__class__,
                     state=state,
                 ),
-                parent=self._execution_context.parent_context,
+                parent=execution.parent_context,
             )
         )
 
@@ -454,18 +455,16 @@ class WorkflowRunner(Generic[StateType]):
 
         return None
 
-    def _context_run_work_item(
-        self,
-        node: BaseNode[StateType],
-        span_id: UUID,
-        parent_context: ParentContext,
-        trace_id: UUID,
-    ) -> None:
-        with execution_context(
-            parent_context=parent_context,
-            trace_id=trace_id,
-        ):
-            self._run_work_item(node, span_id)
+    def _create_worker_thread(self, node: BaseNode[StateType], span_id: UUID) -> Thread:
+        """Create a worker thread with proper execution context."""
+        
+        return Thread(
+            target=self._run_work_item,
+            kwargs={
+                "node": node,
+                "span_id": span_id,
+            },
+        )
 
     def _handle_invoked_ports(
         self,
@@ -535,19 +534,14 @@ class WorkflowRunner(Generic[StateType]):
                 raise e
 
             execution = get_execution_context()
+            # Ensure the current context is stored globally before creating the worker thread
+            set_execution_context(execution)
+            
             node = node_class(state=state, context=self.workflow.context)
             state.meta.node_execution_cache.initiate_node_execution(node_class, node_span_id)
             self._active_nodes_by_execution_id[node_span_id] = ActiveNode(node=node)
 
-            worker_thread = Thread(
-                target=self._context_run_work_item,
-                kwargs={
-                    "node": node,
-                    "span_id": node_span_id,
-                    "parent_context": execution.parent_context,
-                    "trace_id": execution.trace_id,
-                },
-            )
+            worker_thread = self._create_worker_thread(node, node_span_id)
             worker_thread.start()
 
     def _handle_work_item_event(self, event: WorkflowEvent) -> Optional[WorkflowError]:
@@ -627,69 +621,75 @@ class WorkflowRunner(Generic[StateType]):
         return None
 
     def _initiate_workflow_event(self) -> WorkflowExecutionInitiatedEvent:
+        execution = get_execution_context()
         return WorkflowExecutionInitiatedEvent(
-            trace_id=self._execution_context.trace_id,
+            trace_id=execution.trace_id,
             span_id=self._initial_state.meta.span_id,
             body=WorkflowExecutionInitiatedBody(
                 workflow_definition=self.workflow.__class__,
                 inputs=self._initial_state.meta.workflow_inputs,
                 initial_state=deepcopy(self._initial_state) if self._should_emit_initial_state else None,
             ),
-            parent=self._execution_context.parent_context,
+            parent=execution.parent_context,
         )
 
     def _stream_workflow_event(self, output: BaseOutput) -> WorkflowExecutionStreamingEvent:
+        execution = get_execution_context()
         return WorkflowExecutionStreamingEvent(
-            trace_id=self._execution_context.trace_id,
+            trace_id=execution.trace_id,
             span_id=self._initial_state.meta.span_id,
             body=WorkflowExecutionStreamingBody(
                 workflow_definition=self.workflow.__class__,
                 output=output,
             ),
-            parent=self._execution_context.parent_context,
+            parent=execution.parent_context,
         )
 
     def _fulfill_workflow_event(self, outputs: OutputsType) -> WorkflowExecutionFulfilledEvent:
+        execution = get_execution_context()
         return WorkflowExecutionFulfilledEvent(
-            trace_id=self._execution_context.trace_id,
+            trace_id=execution.trace_id,
             span_id=self._initial_state.meta.span_id,
             body=WorkflowExecutionFulfilledBody(
                 workflow_definition=self.workflow.__class__,
                 outputs=outputs,
             ),
-            parent=self._execution_context.parent_context,
+            parent=execution.parent_context,
         )
 
     def _reject_workflow_event(self, error: WorkflowError) -> WorkflowExecutionRejectedEvent:
+        execution = get_execution_context()
         return WorkflowExecutionRejectedEvent(
-            trace_id=self._execution_context.trace_id,
+            trace_id=execution.trace_id,
             span_id=self._initial_state.meta.span_id,
             body=WorkflowExecutionRejectedBody(
                 workflow_definition=self.workflow.__class__,
                 error=error,
             ),
-            parent=self._execution_context.parent_context,
+            parent=execution.parent_context,
         )
 
     def _resume_workflow_event(self) -> WorkflowExecutionResumedEvent:
+        execution = get_execution_context()
         return WorkflowExecutionResumedEvent(
-            trace_id=self._execution_context.trace_id,
+            trace_id=execution.trace_id,
             span_id=self._initial_state.meta.span_id,
             body=WorkflowExecutionResumedBody(
                 workflow_definition=self.workflow.__class__,
             ),
-            parent=self._execution_context.parent_context,
+            parent=execution.parent_context,
         )
 
     def _pause_workflow_event(self, external_inputs: Iterable[ExternalInputReference]) -> WorkflowExecutionPausedEvent:
+        execution = get_execution_context()
         return WorkflowExecutionPausedEvent(
-            trace_id=self._execution_context.trace_id,
+            trace_id=execution.trace_id,
             span_id=self._initial_state.meta.span_id,
             body=WorkflowExecutionPausedBody(
                 workflow_definition=self.workflow.__class__,
                 external_inputs=external_inputs,
             ),
-            parent=self._execution_context.parent_context,
+            parent=execution.parent_context,
         )
 
     def _stream(self) -> None:


### PR DESCRIPTION
there's some flakiness I'm seeing when testing tho :/ 

main changes:
- context store now only accepts thread_id as a key
- introduction of relational threads -> storing parent thread id to retrieve their context
- adding global store support in current execution context manager
- removing run_item_with_context ( or w/ it was called) we can now directly access thread context via global store