### PR TITLE
[APO-1030] Codegen function definitions given json representation of them

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-prompt-node.test.ts.snap
@@ -1343,6 +1343,73 @@ class PromptNode(InlinePromptNode):
 "
 `;
 
+exports[`InlinePromptNode > with functions attribute > should generate FunctionDefinition objects for CONSTANT_VALUE functions 1`] = `
+"from vellum import FunctionDefinition, JinjaPromptBlock, PromptParameters
+from vellum.workflows.nodes.displayable import InlinePromptNode
+
+from ..inputs import Inputs
+
+
+class PromptNode(InlinePromptNode):
+    ml_model = "gpt-4o-mini"
+    blocks = [
+        JinjaPromptBlock(template="""Summarize what this means {{ INPUT_VARIABLE }}"""),
+    ]
+    prompt_inputs = {
+        "text": Inputs.text,
+    }
+    functions = [
+        FunctionDefinition(
+            name="parse_text_elements",
+            description="Extracts and analyzes key elements from provided text",
+            parameters={
+                "type": "object",
+                "required": [
+                    "noun",
+                    "verb",
+                    "adjective",
+                    "summary",
+                    "explain",
+                ],
+                "properties": {
+                    "noun": {
+                        "type": "string",
+                        "description": "A key noun or main subject identified in the text",
+                    },
+                    "verb": {
+                        "type": "string",
+                        "description": "A significant action or verb from the text",
+                    },
+                    "explain": {
+                        "type": "string",
+                        "description": "A concise explanation of why you chose these specific elements",
+                    },
+                    "summary": {
+                        "type": "string",
+                        "description": "A brief summary of the main idea or theme",
+                    },
+                    "adjective": {
+                        "type": "string",
+                        "description": "A descriptive adjective that characterizes the text or its subject",
+                    },
+                },
+            },
+        ),
+    ]
+    parameters = PromptParameters(
+        stop=[],
+        temperature=0,
+        max_tokens=1000,
+        top_p=1,
+        top_k=0,
+        frequency_penalty=0,
+        presence_penalty=0,
+        logit_bias={},
+        custom_parameters={},
+    )
+"
+`;
+
 exports[`InlinePromptNode > with functions attribute > should generate functions field with WorkflowValueDescriptor for upstream node output 1`] = `
 "from vellum import JinjaPromptBlock, PromptParameters
 from vellum.workflows.nodes.displayable import InlinePromptNode

--- a/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/inline-prompt-node.test.ts
@@ -513,4 +513,76 @@ describe("InlinePromptNode", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });
+
+  describe("with functions attribute", () => {
+    it("should generate FunctionDefinition objects for CONSTANT_VALUE functions", async () => {
+      const functionsAttribute: NodeAttributeType = {
+        id: "4ef3f825-2b51-4fe2-bf9f-21a7492f6f87",
+        name: "functions",
+        value: {
+          type: "CONSTANT_VALUE",
+          value: {
+            type: "JSON",
+            value: [
+              {
+                name: "parse_text_elements",
+                state: null,
+                forced: null,
+                strict: null,
+                parameters: {
+                  type: "object",
+                  required: ["noun", "verb", "adjective", "summary", "explain"],
+                  properties: {
+                    noun: {
+                      type: "string",
+                      description:
+                        "A key noun or main subject identified in the text",
+                    },
+                    verb: {
+                      type: "string",
+                      description: "A significant action or verb from the text",
+                    },
+                    explain: {
+                      type: "string",
+                      description:
+                        "A concise explanation of why you chose these specific elements",
+                    },
+                    summary: {
+                      type: "string",
+                      description: "A brief summary of the main idea or theme",
+                    },
+                    adjective: {
+                      type: "string",
+                      description:
+                        "A descriptive adjective that characterizes the text or its subject",
+                    },
+                  },
+                },
+                description:
+                  "Extracts and analyzes key elements from provided text",
+                cache_config: null,
+              },
+            ],
+          },
+        },
+      };
+
+      const nodeData = inlinePromptNodeDataInlineVariantFactory({})
+        .withAttributes([functionsAttribute])
+        .build();
+
+      const nodeContext = (await createNodeContext({
+        workflowContext,
+        nodeData,
+      })) as InlinePromptNodeContext;
+
+      const node = new InlinePromptNode({
+        workflowContext,
+        nodeContext,
+      });
+
+      node.getNodeFile().write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
As discussed, this would produce diffs when coming from a push first workflow where a user has something like
 `functions=[some_function_definition_producing_function()]`

since this would get evaluated at runtime