### PR TITLE
[APO-1032][Part 1] Add new router node for tool calling node graph

### DIFF
--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/node.py
@@ -15,6 +15,7 @@ from vellum.workflows.nodes.displayable.tool_calling_node.utils import (
     create_else_node,
     create_function_node,
     create_mcp_tool_node,
+    create_router_node,
     create_tool_router_node,
     get_function_name,
     get_mcp_tool_name,
@@ -143,6 +144,11 @@ class ToolCallingNode(BaseNode[StateType], Generic[StateType]):
             prompt_inputs=self.prompt_inputs,
             parameters=self.parameters,
             max_prompt_iterations=self.max_prompt_iterations,
+        )
+
+        self.router_node = create_router_node(
+            functions=self.functions,
+            tool_router_node=self.tool_router_node,
         )
 
         self._function_nodes = {}


### PR DESCRIPTION
This is going to be part 1 of a multi PR stream to introduce a new graph structure for tool calling node. The plan is to split up the existing `ToolRouterNode` into a prompt and router node. What you are seeing here is just the router node. The next PR will be converting the `ToolRouterNode` into a prompt node without its port conditions and then subsequent clean up PRs. The final PR will include new connections and tests