### PR TITLE
Clean up vellum emitter and execution context leftovers

### DIFF
--- a/src/vellum/workflows/emitters/vellum_emitter.py
+++ b/src/vellum/workflows/emitters/vellum_emitter.py
@@ -11,6 +11,8 @@ from vellum.workflows.state.base import BaseState
 
 logger = logging.getLogger(__name__)
 
+DISALLOWED_EVENTS = {"workflow.execution.streaming", "node.execution.streaming"}
+
 
 class VellumEmitter(BaseWorkflowEmitter):
     """
@@ -51,6 +53,9 @@ class VellumEmitter(BaseWorkflowEmitter):
             event: The workflow event to emit.
         """
         if not self._context:
+            return
+
+        if event.name in DISALLOWED_EVENTS:
             return
 
         try:

--- a/src/vellum/workflows/state/context.py
+++ b/src/vellum/workflows/state/context.py
@@ -1,12 +1,10 @@
 from functools import cached_property
-import inspect
 from queue import Queue
 from uuid import uuid4
 from typing import TYPE_CHECKING, Dict, List, Optional, Type
 
 from vellum import Vellum
-from vellum.workflows.context import ExecutionContext, get_execution_context, set_execution_context
-from vellum.workflows.emitters.vellum_emitter import VellumEmitter
+from vellum.workflows.context import ExecutionContext, get_execution_context
 from vellum.workflows.events.types import ExternalParentContext
 from vellum.workflows.nodes.mocks import MockNodeExecution, MockNodeExecutionArg
 from vellum.workflows.outputs.base import BaseOutputs
@@ -14,7 +12,6 @@ from vellum.workflows.references.constant import ConstantValueReference
 from vellum.workflows.vellum_client import create_vellum_client
 
 if TYPE_CHECKING:
-    from vellum.workflows.emitters.base import BaseWorkflowEmitter
     from vellum.workflows.events.workflow import WorkflowEvent
 
 
@@ -29,36 +26,15 @@ class WorkflowContext:
         self._vellum_client = vellum_client
         self._event_queue: Optional[Queue["WorkflowEvent"]] = None
         self._node_output_mocks_map: Dict[Type[BaseOutputs], List[MockNodeExecution]] = {}
-        # Clone the current thread-local execution context to avoid mutating global state
-        current_execution_context = get_execution_context()
+        self._execution_context = get_execution_context()
 
-        # Resolve parent_context preference: provided > current > new external
-        resolved_parent_context = (
-            execution_context.parent_context
-            if execution_context is not None and execution_context.parent_context is not None
-            else current_execution_context.parent_context
-        )
-        if resolved_parent_context is None:
-            resolved_parent_context = ExternalParentContext(span_id=uuid4())
+        if execution_context is not None:
+            self._execution_context.trace_id = execution_context.trace_id
+            if execution_context.parent_context is not None:
+                self._execution_context.parent_context = execution_context.parent_context
 
-        # Resolve trace_id preference: provided (if set) > current (if set) > new uuid
-        if execution_context is not None and int(execution_context.trace_id) != 0:
-            resolved_trace_id = execution_context.trace_id
-        elif int(current_execution_context.trace_id) != 0:
-            resolved_trace_id = current_execution_context.trace_id
-        else:
-            resolved_trace_id = uuid4()
-
-        # Construct a single, resolved execution context for this workflow instance
-        self._execution_context = ExecutionContext(
-            parent_context=resolved_parent_context,
-            trace_id=resolved_trace_id,
-        )
-
-        # Ensure the thread-local context has a parent_context for nodes that read it directly
-        if current_execution_context.parent_context is None:
-            current_execution_context.parent_context = resolved_parent_context
-            set_execution_context(current_execution_context)
+        if self._execution_context.parent_context is None:
+            self._execution_context.parent_context = ExternalParentContext(span_id=uuid4())
 
         self._generated_files = generated_files
 
@@ -127,26 +103,6 @@ class WorkflowContext:
         else:
             # For custom domains, assume the same pattern: api.* -> app.*
             return api_url.replace("api.", "app.", 1)
-
-    def get_emitters_for_workflow(self) -> List["BaseWorkflowEmitter"]:
-        """
-        Get the default emitters that should be attached to workflows using this context.
-
-        Returns:
-            List of emitters, including VellumEmitter if monitoring is enabled.
-        """
-        try:
-            frame = inspect.currentframe()
-            caller = frame.f_back if frame else None
-            if caller and "self" in caller.f_locals:
-                workflow_instance = caller.f_locals["self"]
-                class_level_emitters = getattr(workflow_instance.__class__, "emitters", None)
-                if isinstance(class_level_emitters, list) and len(class_level_emitters) > 0:
-                    return class_level_emitters
-        except Exception:
-            pass
-
-        return [VellumEmitter()]
 
     def _emit_subworkflow_event(self, event: "WorkflowEvent") -> None:
         if self._event_queue:

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -241,7 +241,7 @@ class BaseWorkflow(Generic[InputsType, StateType], metaclass=_BaseWorkflowMeta):
     ):
         self._parent_state = parent_state
         self._context = context or WorkflowContext()
-        self.emitters = emitters or self._context.get_emitters_for_workflow()
+        self.emitters = emitters or (self.emitters if hasattr(self, "emitters") else [])
         self.resolvers = resolvers or (self.resolvers if hasattr(self, "resolvers") else [])
         self._store = store or Store()
         self._execution_context = self._context.execution_context


### PR DESCRIPTION
- Reverts the Workflow Context init method back to how we had it before: https://github.com/vellum-ai/vellum-python-sdks/pull/2213/files#diff-462a8c46673e14ca1a4c3a9c37ab32d893172b2af96e916214e61352369f42ff
- [critical] removes `get_emitters_for_workflow` to prevent VellumEmitter from being attached by default
- filter streaming events from vellum emitter