### PR TITLE
[APO-1007] Add parent context for subworkflow tool

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_tool_calling_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_tool_calling_node.py
@@ -394,6 +394,7 @@ def test_serialize_node__tool_calling_node__subworkflow_with_parent_input_refere
     nodes = data["exec_config"]["workflow_raw_data"]["nodes"]
     code_exec_node = next((node for node in nodes if node["type"] == "CODE_EXECUTION"), None)
 
+    assert code_exec_node is not None
     text_input = next((input for input in code_exec_node["inputs"] if input["key"] == "text"), None)
     assert text_input == {
         "id": "da92a1c4-d37c-4008-a1ab-c0bcc0cd20d0",

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -349,7 +349,11 @@ def serialize_value(display_context: "WorkflowDisplayContext", value: Any) -> Js
     if is_workflow_class(value):
         from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
-        workflow_display = get_workflow_display(workflow_class=value)
+        # Pass the parent display context so the subworkflow can resolve parent workflow inputs
+        workflow_display = get_workflow_display(
+            workflow_class=value,
+            parent_display_context=display_context,
+        )
         serialized_value: dict = workflow_display.serialize()
         name = serialized_value["workflow_raw_data"]["definition"]["name"]
         description = value.__doc__ or ""


### PR DESCRIPTION
This PR fix that when a subworkflow tool reference parent workflow, it would fail during serialization