### PR TITLE
[APO-1098] Fix mcp server name

### DIFF
--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/tests/test_utils.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/tests/test_utils.py
@@ -238,3 +238,15 @@ def test_create_tool_prompt_node_chat_history_block_dict(vellum_adhoc_prompt_cli
         ),
         VariablePromptBlock(block_type="VARIABLE", state=None, cache_config=None, input_variable="chat_history"),
     ]
+
+
+def test_get_mcp_tool_name_snake_case():
+    """Test MCPToolDefinition function name generation with snake case."""
+    mcp_tool = MCPToolDefinition(
+        name="create_repository",
+        server=MCPServer(name="Github Server", url="https://api.github.com"),
+        parameters={"repository_name": "string", "description": "string"},
+    )
+
+    result = get_mcp_tool_name(mcp_tool)
+    assert result == "github_server__create_repository"

--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
@@ -580,4 +580,5 @@ def get_function_name(function: ToolBase) -> str:
 
 
 def get_mcp_tool_name(tool_def: MCPToolDefinition) -> str:
-    return f"{tool_def.server.name}__{tool_def.name}"
+    server_name = snake_case(tool_def.server.name)
+    return f"{server_name}__{tool_def.name}"


### PR DESCRIPTION
`Github server` is not valid for python function name, with the fix it now becomes `github_server`