### PR TITLE
Multithreaded Execution Context Update

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,20 @@ from pytest_mock import MockerFixture
 import requests_mock
 
 from vellum.client.environment import VellumEnvironment
+from vellum.workflows.context import monitoring_context_store
 from vellum.workflows.logging import load_logger
+
+
+@pytest.fixture(autouse=True)
+def clear_monitoring_context():
+    """Clear the global monitoring context store between tests to prevent collisions."""
+    # Clear before test
+    monitoring_context_store.clear_context()
+
+    yield
+
+    # Clear after test
+    monitoring_context_store.clear_context()
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/src/vellum/workflows/events/context.py
+++ b/src/vellum/workflows/events/context.py
@@ -35,12 +35,12 @@ class MonitoringContextStore:
         with self._lock:
             # Get span_id from RelationalThread first
             span_id = None
-            if hasattr(current_thread, "get_parent_span_id"):
-                span_id = current_thread.get_parent_span_id()
 
-            # Fallback to getting span_id from context
-            if not span_id and context.parent_context and hasattr(context.parent_context, "span_id"):
+            if context.parent_context and hasattr(context.parent_context, "span_id"):
                 span_id = context.parent_context.span_id
+
+            if not span_id and hasattr(current_thread, "get_parent_span_id"):
+                span_id = current_thread.get_parent_span_id()
 
             # Always use trace:span:thread format - require span_id
             if span_id:
@@ -49,8 +49,8 @@ class MonitoringContextStore:
 
     def retrieve_context(self) -> Optional["ExecutionContext"]:
         """Retrieve monitoring parent context using trace:span:thread keys."""
-        current_thread_id = threading.get_ident()
         current_thread = threading.current_thread()
+        current_thread_id = current_thread.ident
 
         # Get trace_id and span_id directly from the thread if it's a RelationalThread
         trace_id = None

--- a/src/vellum/workflows/events/context.py
+++ b/src/vellum/workflows/events/context.py
@@ -2,9 +2,7 @@
 
 import threading
 from uuid import UUID
-from typing import Dict, Optional
-
-from vellum.workflows.context import ExecutionContext
+from typing import TYPE_CHECKING, Dict, Optional
 
 DEFAULT_TRACE_ID = UUID("00000000-0000-0000-0000-000000000000")
 
@@ -13,99 +11,67 @@ _monitoring_execution_context: threading.local = threading.local()
 # Thread-local storage for current span_id
 _current_span_id: threading.local = threading.local()
 
+if TYPE_CHECKING:
+    from vellum.workflows.context import ExecutionContext
 
-class _MonitoringContextStore:
+
+class MonitoringContextStore:
     """
     thread-safe storage for monitoring contexts.
     handles context persistence and retrieval across threads.
-    relies on the execution context manager for manual retrieval
+    leverages RelationalThread's parent-child relationships and trace tracking
     """
 
     def __init__(self):
         self._lock = threading.Lock()
-        self._contexts: Dict[str, ExecutionContext] = {}
-        self._thread_contexts: Dict[int, ExecutionContext] = {}
-        self._current_trace_id: Optional[UUID] = None
-
-    def set_current_trace_id(self, trace_id: UUID) -> None:
-        """Set the current active trace_id that should be used by all threads."""
-        if trace_id != DEFAULT_TRACE_ID:
-            with self._lock:
-                self._current_trace_id = trace_id
+        self._contexts: Dict[str, "ExecutionContext"] = {}
 
     def get_current_trace_id(self) -> Optional[UUID]:
         """Get the current active trace_id that should be used by all threads."""
         with self._lock:
-            return self._current_trace_id
+            current_context = self.retrieve_context()
+            return current_context.trace_id if current_context else None
 
-    def set_current_span_id(self, span_id: UUID) -> None:
-        """Set the current active span_id for this thread."""
-        _current_span_id.span_id = span_id
-
-    def get_current_span_id(self) -> Optional[UUID]:
-        """Get the current active span_id for this thread."""
-        return getattr(_current_span_id, "span_id", None)
-
-    def store_context(self, context: Optional[ExecutionContext]) -> None:
-        """Store monitoring parent context using multiple keys for reliable retrieval."""
-        if not context or context.parent_context is None:
-            return
-
+    def store_context(self, context: "ExecutionContext") -> None:
+        """Store monitoring parent context using simple thread-based keys."""
         thread_id = threading.get_ident()
-        trace_id = self.get_current_trace_id()
-        if context.trace_id != DEFAULT_TRACE_ID and trace_id is None:
-            self.set_current_trace_id(context.trace_id)
 
         with self._lock:
-            # Use trace:span:thread for unique context storage
-            trace_span_thread_key = (
-                f"trace:{str(trace_id)}:span:{str(context.parent_context.span_id)}:thread:{thread_id}"
-            )
-            self._contexts[trace_span_thread_key] = context
+            # Simple thread-based storage - RelationalThread handles the relationships
+            context_key = f"thread:{thread_id}"
+            self._contexts[context_key] = context
 
-    def retrieve_context(self, trace_id: UUID, span_id: Optional[UUID] = None) -> Optional[ExecutionContext]:
-        """Retrieve monitoring parent context with multiple fallback strategies."""
-        thread_id = threading.get_ident()
+    def retrieve_context(self) -> Optional["ExecutionContext"]:
+        """Retrieve monitoring parent context using RelationalThread relationships."""
+        current_thread_id = threading.get_ident()
+        current_thread = threading.current_thread()
+
         with self._lock:
-            if not span_id:
-                span_id = getattr(_current_span_id, "span_id", None)
-                if not span_id:
-                    return None
+            # Strategy 1: Try current thread
+            thread_key = f"thread:{current_thread_id}"
+            if thread_key in self._contexts:
+                return self._contexts[thread_key]
 
-            span_key = f"trace:{str(trace_id)}:span:{str(span_id)}:thread:{thread_id}"
-            if span_key in self._contexts:
-                result = self._contexts[span_key]
-                return result
+            # Strategy 2: If this is a RelationalThread, try parent thread
+            if hasattr(current_thread, "get_parent_thread"):
+                parent_thread_id = current_thread.get_parent_thread()
+                if parent_thread_id:
+                    parent_key = f"thread:{parent_thread_id}"
+                    if parent_key in self._contexts:
+                        return self._contexts[parent_key]
+
+            # Strategy 3: If RelationalThread has trace_id, find matching context
+            if hasattr(current_thread, "get_trace_id"):
+                thread_trace_id = current_thread.get_trace_id()
+                if thread_trace_id:
+                    # Find any context with matching trace_id
+                    for context in self._contexts.values():
+                        if context.trace_id == thread_trace_id:
+                            return context
 
         return None
 
-
-# Global instance for cross-boundary context persistence
-_monitoring_context_store = _MonitoringContextStore()
-
-
-def get_monitoring_execution_context() -> ExecutionContext:
-    """Get the current monitoring execution context, with intelligent fallback."""
-    if hasattr(_monitoring_execution_context, "context"):
-        context = _monitoring_execution_context.context
-        if context.trace_id != DEFAULT_TRACE_ID and context.parent_context:
-            return context
-
-    # If no thread-local context, try to restore from global store using current trace_id
-    trace_id = _monitoring_context_store.get_current_trace_id()
-    span_id = _current_span_id.span_id if hasattr(_current_span_id, "span_id") else None
-    if trace_id:
-        if trace_id != DEFAULT_TRACE_ID:
-            context = _monitoring_context_store.retrieve_context(trace_id, span_id)
-            if context:
-                _monitoring_execution_context.context = context
-                return context
-    return ExecutionContext()
-
-
-def set_monitoring_execution_context(context: ExecutionContext) -> None:
-    """Set the current monitoring execution context and persist it for cross-boundary access."""
-    _monitoring_execution_context.context = context
-
-    if context.trace_id and context.parent_context:
-        _monitoring_context_store.store_context(context)
+    def clear_context(self):
+        """Clear all stored contexts."""
+        with self._lock:
+            self._contexts.clear()

--- a/src/vellum/workflows/events/context.py
+++ b/src/vellum/workflows/events/context.py
@@ -27,50 +27,54 @@ class MonitoringContextStore:
             return current_context.trace_id if current_context else None
 
     def store_context(self, context: "ExecutionContext") -> None:
-        """Store monitoring parent context using thread_id:trace_id keys."""
+        """Store monitoring parent context using trace:span:thread keys."""
         thread_id = threading.get_ident()
+        current_thread = threading.current_thread()
         trace_id = context.trace_id
 
         with self._lock:
-            # Always use thread_id:trace_id format
-            context_key = f"thread:{thread_id}:trace:{trace_id}"
-            self._contexts[context_key] = context
+            # Get span_id from RelationalThread first
+            span_id = None
+            if hasattr(current_thread, "get_parent_span_id"):
+                span_id = current_thread.get_parent_span_id()
+
+            # Fallback to getting span_id from context
+            if not span_id and context.parent_context and hasattr(context.parent_context, "span_id"):
+                span_id = context.parent_context.span_id
+
+            # Always use trace:span:thread format - require span_id
+            if span_id:
+                context_key = f"trace:{str(trace_id)}:span:{str(span_id)}:thread:{thread_id}"
+                self._contexts[context_key] = context
 
     def retrieve_context(self) -> Optional["ExecutionContext"]:
-        """Retrieve monitoring parent context using trace_id from thread."""
+        """Retrieve monitoring parent context using trace:span:thread keys."""
         current_thread_id = threading.get_ident()
         current_thread = threading.current_thread()
 
-        # Get trace_id directly from the thread if it's a RelationalThread
+        # Get trace_id and span_id directly from the thread if it's a RelationalThread
         trace_id = None
+        span_id = None
         if hasattr(current_thread, "get_trace_id"):
             trace_id = current_thread.get_trace_id()
+        if hasattr(current_thread, "get_parent_span_id"):
+            span_id = current_thread.get_parent_span_id()
 
-        # If no trace_id on current thread, try to get it from parent thread
-        if not trace_id and hasattr(current_thread, "get_parent_thread"):
-            parent_thread_id = current_thread.get_parent_thread()
-            if parent_thread_id:
-                # Find parent thread and get its trace_id
-                for t in threading.enumerate():
-                    if t.ident == parent_thread_id and hasattr(t, "get_trace_id"):
-                        trace_id = t.get_trace_id()
-                        if trace_id:
-                            break
-
-        if not trace_id:
+        # Require both trace_id and span_id - no fallback searching
+        if not trace_id or not span_id:
             return None
 
         with self._lock:
-            # Try current thread with trace_id
-            current_key = f"thread:{current_thread_id}:trace:{trace_id}"
+            # Try current thread
+            current_key = f"trace:{str(trace_id)}:span:{str(span_id)}:thread:{current_thread_id}"
             if current_key in self._contexts:
                 return self._contexts[current_key]
 
-            # Try parent thread with same trace_id (child inherits parent's trace)
+            # Try parent thread with same trace and span
             if hasattr(current_thread, "get_parent_thread"):
                 parent_thread_id = current_thread.get_parent_thread()
                 if parent_thread_id:
-                    parent_key = f"thread:{parent_thread_id}:trace:{trace_id}"
+                    parent_key = f"trace:{str(trace_id)}:span:{str(span_id)}:thread:{parent_thread_id}"
                     if parent_key in self._contexts:
                         return self._contexts[parent_key]
 

--- a/src/vellum/workflows/events/relational_threads.py
+++ b/src/vellum/workflows/events/relational_threads.py
@@ -9,20 +9,33 @@ if TYPE_CHECKING:
 class RelationalThread(threading.Thread):
     _parent_thread: Optional[int] = None
     _trace_id: Optional[UUID] = None
+    _parent_span_id: Optional[UUID] = None
 
     def __init__(self, *args, execution_context: Optional["ExecutionContext"] = None, **kwargs):
         self._collect_parent_context(execution_context)
         threading.Thread.__init__(self, *args, **kwargs)
 
     def _collect_parent_context(self, execution_context: Optional["ExecutionContext"] = None) -> None:
-        """Collect parent thread ID and trace ID from passed execution context."""
+        """Collect parent thread ID, trace ID, and parent span ID from passed execution context."""
         self._parent_thread = threading.get_ident()
 
         # Only use explicitly passed execution context
-        self._trace_id = execution_context.trace_id if execution_context else None
+        if execution_context:
+            self._trace_id = execution_context.trace_id
+            self._parent_span_id = (
+                execution_context.parent_context.span_id
+                if execution_context.parent_context and hasattr(execution_context.parent_context, "span_id")
+                else None
+            )
+        else:
+            self._trace_id = None
+            self._parent_span_id = None
 
     def get_parent_thread(self) -> Optional[int]:
         return self._parent_thread
 
     def get_trace_id(self) -> Optional[UUID]:
         return self._trace_id
+
+    def get_parent_span_id(self) -> Optional[UUID]:
+        return self._parent_span_id

--- a/src/vellum/workflows/events/relational_threads.py
+++ b/src/vellum/workflows/events/relational_threads.py
@@ -1,0 +1,32 @@
+import threading
+from uuid import UUID
+from typing import Optional
+
+
+class RelationalThread(threading.Thread):
+    _parent_thread: Optional[int] = None
+    _trace_id: Optional[UUID] = None
+
+    def __init__(self, *args, **kwargs):
+        self._collect_parent_context()
+        threading.Thread.__init__(self, *args, **kwargs)
+
+    def _collect_parent_context(self) -> None:
+        """Collect parent thread ID and trace ID from current execution context."""
+        self._parent_thread = threading.get_ident()
+
+        # Import here to avoid circular imports
+        from vellum.workflows.context import get_execution_context
+
+        try:
+            current_context = get_execution_context()
+            self._trace_id = current_context.trace_id if current_context else None
+        except Exception:
+            # If we can't get the execution context, that's okay - we'll fall back to None
+            self._trace_id = None
+
+    def get_parent_thread(self) -> Optional[int]:
+        return self._parent_thread
+
+    def get_trace_id(self) -> Optional[UUID]:
+        return self._trace_id

--- a/src/vellum/workflows/events/tests/test_basic_workflow.py
+++ b/src/vellum/workflows/events/tests/test_basic_workflow.py
@@ -1,0 +1,50 @@
+import logging
+from uuid import uuid4
+
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.context import execution_context
+from vellum.workflows.nodes.bases import BaseNode
+from vellum.workflows.workflows.event_filters import all_workflow_event_filter
+
+
+class StartNode(BaseNode):
+    pass
+
+
+class TrivialWorkflow(BaseWorkflow):
+    graph = StartNode
+
+
+logger = logging.getLogger(__name__)
+
+
+def test_basic_workflow_monitoring_context_flow():
+    """Test that monitoring creates the correct workflow→node context hierarchy using streamed events.
+    What's missing:
+    - span_id from previous event mapping to parent context
+    """
+
+    workflow = TrivialWorkflow()
+
+    with execution_context(trace_id=uuid4()):
+        events = list(workflow.stream(event_filter=all_workflow_event_filter))
+
+    # Verify workflow succeeded
+    assert len(events) >= 2
+    assert events[0].name == "workflow.execution.initiated"
+    assert events[-1].name == "workflow.execution.fulfilled"
+
+    # Collect all events with parent context
+    events_with_parent = [event for event in events if event.parent is not None]
+
+    assert len(events_with_parent) > 0, "Expected at least some events with parent context"
+
+    # Filter for node events
+    node_events = [event for event in events if event.name.startswith("node.")]
+    assert len(node_events) > 0, "Expected at least some node events"
+
+    # Verify each node event has the workflow as its parent context
+    for event in node_events:
+        assert event.parent is not None, "Node event should have parent context"
+        assert event.parent.type == "WORKFLOW", "Node event parent should be workflow"
+        assert event.parent.workflow_definition.name == "TrivialWorkflow", "Parent workflow name mismatch"

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import logging
 from queue import Empty, Queue
 import sys
-from threading import Event as ThreadingEvent, Thread
+from threading import Event as ThreadingEvent
 import traceback
 from uuid import UUID, uuid4
 from typing import (
@@ -46,7 +46,8 @@ from vellum.workflows.events.node import (
     NodeExecutionRejectedBody,
     NodeExecutionStreamingBody,
 )
-from vellum.workflows.events.types import BaseEvent, NodeParentContext, ParentContext, WorkflowParentContext
+from vellum.workflows.events.relational_threads import RelationalThread as Thread
+from vellum.workflows.events.types import BaseEvent, NodeParentContext, WorkflowParentContext
 from vellum.workflows.events.workflow import (
     WorkflowEventStream,
     WorkflowExecutionFulfilledBody,
@@ -454,19 +455,6 @@ class WorkflowRunner(Generic[StateType]):
 
         return None
 
-    def _context_run_work_item(
-        self,
-        node: BaseNode[StateType],
-        span_id: UUID,
-        parent_context: ParentContext,
-        trace_id: UUID,
-    ) -> None:
-        with execution_context(
-            parent_context=parent_context,
-            trace_id=trace_id,
-        ):
-            self._run_work_item(node, span_id)
-
     def _handle_invoked_ports(
         self,
         state: StateType,
@@ -540,12 +528,10 @@ class WorkflowRunner(Generic[StateType]):
             self._active_nodes_by_execution_id[node_span_id] = ActiveNode(node=node)
 
             worker_thread = Thread(
-                target=self._context_run_work_item,
+                target=self._run_work_item,
                 kwargs={
                     "node": node,
                     "span_id": node_span_id,
-                    "parent_context": execution.parent_context,
-                    "trace_id": execution.trace_id,
                 },
             )
             worker_thread.start()

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -533,6 +533,7 @@ class WorkflowRunner(Generic[StateType]):
                     "node": node,
                     "span_id": node_span_id,
                 },
+                execution_context=execution,
             )
             worker_thread.start()
 

--- a/src/vellum/workflows/state/context.py
+++ b/src/vellum/workflows/state/context.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from typing import TYPE_CHECKING, Dict, List, Optional, Type
 
 from vellum import Vellum
-from vellum.workflows.context import ExecutionContext, get_execution_context
+from vellum.workflows.context import ExecutionContext, get_execution_context, set_execution_context
 from vellum.workflows.events.types import ExternalParentContext
 from vellum.workflows.nodes.mocks import MockNodeExecution, MockNodeExecutionArg
 from vellum.workflows.outputs.base import BaseOutputs
@@ -36,8 +36,6 @@ class WorkflowContext:
         if self._execution_context.parent_context is None:
             self._execution_context.parent_context = ExternalParentContext(span_id=uuid4())
             # Propagate the updated context back to the global execution context
-            from vellum.workflows.context import set_execution_context
-
             set_execution_context(self._execution_context)
 
         self._generated_files = generated_files

--- a/src/vellum/workflows/state/context.py
+++ b/src/vellum/workflows/state/context.py
@@ -35,6 +35,10 @@ class WorkflowContext:
 
         if self._execution_context.parent_context is None:
             self._execution_context.parent_context = ExternalParentContext(span_id=uuid4())
+            # Propagate the updated context back to the global execution context
+            from vellum.workflows.context import set_execution_context
+
+            set_execution_context(self._execution_context)
 
         self._generated_files = generated_files
 


### PR DESCRIPTION
New Relational Threads - unsued for now so should be safe to merge in asap

changes: 
relational threads - keeps track of span, trace id, and parent thread associated with a threads
updates to global context store - using new span and trace_id in threads
updates to execution context -> ability to use new threads if local excution context does not exist

remove the runner changes, to unblock, iterate