### PR TITLE
[codegen] Bump SDK version to 1.2.1

### DIFF
--- a/ee/codegen/package-lock.json
+++ b/ee/codegen/package-lock.json
@@ -13,7 +13,7 @@
         "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
         "lodash": "^4.17.21",
         "uuid": "^11.0.3",
-        "vellum-ai": "0.14.55"
+        "vellum-ai": "1.2.1"
       },
       "devDependencies": {
         "@octokit/auth-app": "^7.1.3",
@@ -6130,9 +6130,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
       "engines": {
         "node": ">=18.17"
       }
@@ -6189,9 +6189,9 @@
       "dev": true
     },
     "node_modules/vellum-ai": {
-      "version": "0.14.55",
-      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-0.14.55.tgz",
-      "integrity": "sha512-dT67NJH20OF0B7aEqz1mxnTTm3I7ZLt9rkuveYNMux8Vxa6/A/an14d0Mhl7umss/03qBkWRYJYjtMBRf/ut3Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-1.2.1.tgz",
+      "integrity": "sha512-s+aDzNlkrTLCkPQAGISUGAEkKeUpcG8Zjzxhh0dEuafG3LPvdv1MGsCoyoj+KMyVHl8bu2RKrYR4nCDjOsnz8A==",
       "dependencies": {
         "cdktf": "^0.20.5",
         "constructs": "10.3.0",
@@ -6201,7 +6201,7 @@
         "node-fetch": "^2.7.0",
         "qs": "^6.13.1",
         "readable-stream": "^4.5.2",
-        "undici": "6.21.1",
+        "undici": "6.21.2",
         "url-join": "4.0.1"
       }
     },
@@ -10617,9 +10617,9 @@
       }
     },
     "undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ=="
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g=="
     },
     "undici-types": {
       "version": "6.20.0",
@@ -10665,9 +10665,9 @@
       "dev": true
     },
     "vellum-ai": {
-      "version": "0.14.55",
-      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-0.14.55.tgz",
-      "integrity": "sha512-dT67NJH20OF0B7aEqz1mxnTTm3I7ZLt9rkuveYNMux8Vxa6/A/an14d0Mhl7umss/03qBkWRYJYjtMBRf/ut3Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-1.2.1.tgz",
+      "integrity": "sha512-s+aDzNlkrTLCkPQAGISUGAEkKeUpcG8Zjzxhh0dEuafG3LPvdv1MGsCoyoj+KMyVHl8bu2RKrYR4nCDjOsnz8A==",
       "requires": {
         "cdktf": "^0.20.5",
         "constructs": "10.3.0",
@@ -10677,7 +10677,7 @@
         "node-fetch": "^2.7.0",
         "qs": "^6.13.1",
         "readable-stream": "^4.5.2",
-        "undici": "6.21.1",
+        "undici": "6.21.2",
         "url-join": "4.0.1"
       }
     },

--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -36,7 +36,7 @@
     "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
     "lodash": "^4.17.21",
     "uuid": "^11.0.3",
-    "vellum-ai": "0.14.55"
+    "vellum-ai": "1.2.1"
   },
   "devDependencies": {
     "@octokit/auth-app": "^7.1.3",

--- a/ee/codegen/src/__test__/__snapshots__/chat-message-content.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/chat-message-content.test.ts.snap
@@ -96,3 +96,15 @@ exports[`ChatMessageContent > IMAGE > should write an image content correctly 1`
 exports[`ChatMessageContent > STRING > should write a string content correctly 1`] = `"StringChatMessageContent(value="Hello, AI!")"`;
 
 exports[`ChatMessageContent > STRING > should write a string with nested quotes correctly 1`] = `"StringChatMessageContent(value="{\\"tool_calls\\":[{\\"id\\":\\"call_123\\",\\"type\\":\\"function\\",\\"function\\":{\\"name\\":\\"generate_query\\",\\"arguments\\":\\"{\\"query\\":\\"SELECT * FROM users WHERE id = 1\\"}\\"}}]}")"`;
+
+exports[`ChatMessageContent > VIDEO > should write a video content correctly 1`] = `
+"VideoChatMessageContent(
+    value=VellumVideo(
+        src="https://example.com/video.mp4",
+        metadata={
+            "key": "value",
+        },
+    )
+)
+"
+`;

--- a/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
@@ -90,6 +90,11 @@ exports[`VellumValue > STRING > should write a STRING value correctly 1`] = `
 "
 `;
 
+exports[`VellumValue > THINKING > should write a THINKING value correctly 1`] = `
+"StringVellumValue(value="Hello, World!")
+"
+`;
+
 exports[`VellumValue > VIDEO > should write a VIDEO value correctly 1`] = `
 "VellumVideo(src="https://example.com/video.mp4")
 "

--- a/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/vellum-variable-value.test.ts.snap
@@ -89,3 +89,8 @@ exports[`VellumValue > STRING > should write a STRING value correctly 1`] = `
 ""Hello, World!"
 "
 `;
+
+exports[`VellumValue > VIDEO > should write a VIDEO value correctly 1`] = `
+"VellumVideo(src="https://example.com/video.mp4")
+"
+`;

--- a/ee/codegen/src/__test__/__snapshots__/vellum-variable.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/vellum-variable.test.ts.snap
@@ -70,6 +70,11 @@ exports[`VellumVariableField > StringVellumVariable snapshot 1`] = `
 "
 `;
 
+exports[`VellumVariableField > ThinkingVellumVariable snapshot 1`] = `
+"test: StringVellumValue
+"
+`;
+
 exports[`VellumVariableField > VideoVellumVariable snapshot 1`] = `
 "test: VellumVideo
 "

--- a/ee/codegen/src/__test__/__snapshots__/vellum-variable.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/vellum-variable.test.ts.snap
@@ -5,6 +5,11 @@ exports[`VellumVariableField > ArrayVellumVariable snapshot 1`] = `
 "
 `;
 
+exports[`VellumVariableField > AudioVellumVariable snapshot 1`] = `
+"test: VellumAudio
+"
+`;
+
 exports[`VellumVariableField > ChatHistoryVellumVariable snapshot 1`] = `
 "test: List[ChatMessage]
 "
@@ -62,5 +67,10 @@ exports[`VellumVariableField > SearchResultsVellumVariable snapshot 1`] = `
 
 exports[`VellumVariableField > StringVellumVariable snapshot 1`] = `
 "test: str
+"
+`;
+
+exports[`VellumVariableField > VideoVellumVariable snapshot 1`] = `
+"test: VellumVideo
 "
 `;

--- a/ee/codegen/src/__test__/chat-message-content.test.ts
+++ b/ee/codegen/src/__test__/chat-message-content.test.ts
@@ -168,4 +168,21 @@ describe("ChatMessageContent", () => {
       expect(chatMessageContent.getReferences()).toHaveLength(2);
     });
   });
+
+  describe("VIDEO", () => {
+    it("should write a video content correctly", async () => {
+      const chatMessageContent = new ChatMessageContent({
+        chatMessageContent: {
+          type: "VIDEO",
+          value: {
+            src: "https://example.com/video.mp4",
+            metadata: { key: "value" },
+          },
+        },
+      });
+      chatMessageContent.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(chatMessageContent.getReferences()).toHaveLength(2);
+    });
+  });
 });

--- a/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
+++ b/ee/codegen/src/__test__/nodes/multiple-nodes.test.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 import { WorkflowDeploymentRelease } from "vellum-ai/api";
 import { Deployments as PromptDeploymentReleaseClient } from "vellum-ai/api/resources/deployments/client/Client";
 import { MetricDefinitions as MetricDefinitionsClient } from "vellum-ai/api/resources/metricDefinitions/client/Client";
-import { ReleaseReviews as WorkflowReleaseClient } from "vellum-ai/api/resources/releaseReviews/client/Client";
+import { WorkflowDeployments as WorkflowReleaseClient } from "vellum-ai/api/resources/workflowDeployments/client/Client";
 import { MetricDefinitionHistoryItem } from "vellum-ai/api/types/MetricDefinitionHistoryItem";
 import { PromptDeploymentRelease } from "vellum-ai/api/types/PromptDeploymentRelease";
 import { beforeEach, expect, vi } from "vitest";

--- a/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/subworkflow-deployment-node.test.ts
@@ -1,6 +1,6 @@
 import { Writer } from "@fern-api/python-ast/core/Writer";
 import { WorkflowDeploymentRelease } from "vellum-ai/api";
-import { ReleaseReviews as WorkflowReleaseClient } from "vellum-ai/api/resources/releaseReviews/client/Client";
+import { WorkflowDeployments as WorkflowReleaseClient } from "vellum-ai/api/resources/workflowDeployments/client/Client";
 import { VellumError } from "vellum-ai/errors";
 import { beforeEach, vi } from "vitest";
 

--- a/ee/codegen/src/__test__/utils/SpyMocks.ts
+++ b/ee/codegen/src/__test__/utils/SpyMocks.ts
@@ -1,6 +1,6 @@
 import { MetricDefinitionHistoryItem } from "vellum-ai/api";
 import { MetricDefinitions as MetricDefinitionsClient } from "vellum-ai/api/resources/metricDefinitions/client/Client";
-import { ReleaseReviews as WorkflowReleaseClient } from "vellum-ai/api/resources/releaseReviews/client/Client";
+import { WorkflowDeployments as WorkflowReleaseClient } from "vellum-ai/api/resources/workflowDeployments/client/Client";
 import { MockInstance, vi } from "vitest";
 
 export class SpyMocks {

--- a/ee/codegen/src/__test__/vellum-variable-value.test.ts
+++ b/ee/codegen/src/__test__/vellum-variable-value.test.ts
@@ -259,4 +259,20 @@ describe("VellumValue", () => {
       expect(searchResultsValue.getReferences()).toHaveLength(4);
     });
   });
+
+  describe("VIDEO", () => {
+    it("should write a VIDEO value correctly", async () => {
+      const videoValue = codegen.vellumValue({
+        vellumValue: {
+          type: "VIDEO",
+          value: {
+            src: "https://example.com/video.mp4",
+          },
+        },
+      });
+      videoValue.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(videoValue.getReferences()).toHaveLength(1);
+    });
+  });
 });

--- a/ee/codegen/src/__test__/vellum-variable-value.test.ts
+++ b/ee/codegen/src/__test__/vellum-variable-value.test.ts
@@ -275,4 +275,21 @@ describe("VellumValue", () => {
       expect(videoValue.getReferences()).toHaveLength(1);
     });
   });
+
+  describe("THINKING", () => {
+    it("should write a THINKING value correctly", async () => {
+      const thinkingValue = codegen.vellumValue({
+        vellumValue: {
+          type: "THINKING",
+          value: {
+            type: "STRING",
+            value: "Hello, World!",
+          },
+        },
+      });
+      thinkingValue.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+      expect(thinkingValue.getReferences()).toHaveLength(1);
+    });
+  });
 });

--- a/ee/codegen/src/__test__/vellum-variable.test.ts
+++ b/ee/codegen/src/__test__/vellum-variable.test.ts
@@ -140,4 +140,12 @@ describe("VellumVariableField", () => {
     optionalVar.write(writer);
     expect(await writer.toStringFormatted()).toMatchSnapshot();
   });
+
+  test("ThinkingVellumVariable snapshot", async () => {
+    const thinkingVar = codegen.vellumVariable({
+      variable: { id: "1", name: "test", type: "THINKING", required: true },
+    });
+    thinkingVar.write(writer);
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
 });

--- a/ee/codegen/src/__test__/vellum-variable.test.ts
+++ b/ee/codegen/src/__test__/vellum-variable.test.ts
@@ -33,6 +33,22 @@ describe("VellumVariableField", () => {
     expect(await writer.toStringFormatted()).toMatchSnapshot();
   });
 
+  test("AudioVellumVariable snapshot", async () => {
+    const audioVar = codegen.vellumVariable({
+      variable: { id: "1", name: "test", type: "AUDIO", required: true },
+    });
+    audioVar.write(writer);
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
+
+  test("VideoVellumVariable snapshot", async () => {
+    const videoVar = codegen.vellumVariable({
+      variable: { id: "1", name: "test", type: "VIDEO", required: true },
+    });
+    videoVar.write(writer);
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
+
   test("ImageVellumVariable snapshot", async () => {
     const imageVar = codegen.vellumVariable({
       variable: { id: "1", name: "test", type: "IMAGE", required: true },

--- a/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
+++ b/ee/codegen/src/context/node-context/subworkflow-deployment-node.ts
@@ -1,5 +1,5 @@
 import { VellumVariableType, WorkflowDeploymentRelease } from "vellum-ai/api";
-import { ReleaseReviews as WorkflowReleaseClient } from "vellum-ai/api/resources/releaseReviews/client/Client";
+import { WorkflowDeployments as WorkflowReleaseClient } from "vellum-ai/api/resources/workflowDeployments/client/Client";
 
 import { BaseNodeContext } from "./base";
 

--- a/ee/codegen/src/generators/chat-message-content.ts
+++ b/ee/codegen/src/generators/chat-message-content.ts
@@ -16,8 +16,8 @@ import {
   VellumAudioRequest as VellumAudioRequestType,
   VellumDocument as VellumDocumentType,
   VellumDocumentRequest as VellumDocumentRequestType,
-  // VellumVideo as VellumVideoType,
-  // VellumVideoRequest as VellumVideoRequestType,
+  VellumVideo as VellumVideoType,
+  VellumVideoRequest as VellumVideoRequestType,
 } from "vellum-ai/api";
 
 import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
@@ -252,7 +252,7 @@ class VideoChatMessageContent extends AstNode {
   private astNode: AstNode;
 
   public constructor(
-    value: unknown, // VellumVideoType | VellumVideoRequestType,
+    value: VellumVideoType | VellumVideoRequestType,
     isRequestType: boolean
   ) {
     super();
@@ -260,7 +260,7 @@ class VideoChatMessageContent extends AstNode {
   }
 
   private generateAstNode(
-    value: unknown, // VellumVideoType | VellumVideoRequestType,
+    value: VellumVideoType | VellumVideoRequestType,
     isRequestType: boolean
   ): AstNode {
     const videoChatMessageContentRequestRef = python.reference({
@@ -271,14 +271,11 @@ class VideoChatMessageContent extends AstNode {
     const videoArgs = [
       python.methodArgument({
         name: "src",
-        // @ts-ignore
         value: python.TypeInstantiation.str(value.src),
       }),
     ];
 
-    // @ts-ignore
     if (!isNil(value.metadata)) {
-      // @ts-ignore
       const metadataJson = new Json(value.metadata);
       videoArgs.push(
         python.methodArgument({
@@ -494,10 +491,8 @@ export class ChatMessageContent extends AstNode {
         );
         break;
       }
-      // @ts-expect-error
       case "VIDEO": {
         astNode = new VideoChatMessageContent(
-          // @ts-expect-error
           chatMessageContent.value,
           isRequestType
         );

--- a/ee/codegen/src/generators/vellum-variable-value.ts
+++ b/ee/codegen/src/generators/vellum-variable-value.ts
@@ -11,7 +11,7 @@ import {
   VellumError,
   VellumImage,
   VellumValue as VellumVariableValueType,
-  // VellumVideo,
+  VellumVideo,
 } from "vellum-ai/api";
 
 import { ChatMessageContent } from "./chat-message-content";
@@ -241,28 +241,23 @@ class AudioVellumValue extends AstNode {
 class VideoVellumValue extends AstNode {
   private astNode: python.AstNode;
 
-  public constructor(value: unknown) {
-    // VellumVideo) {
+  public constructor(value: VellumVideo) {
     super();
     this.astNode = this.generateAstNode(value);
   }
 
-  private generateAstNode(value: unknown): AstNode {
-    // VellumVideo): AstNode {
+  private generateAstNode(value: VellumVideo): AstNode {
     const arguments_ = [
       python.methodArgument({
         name: "src",
-        // @ts-ignore
         value: python.TypeInstantiation.str(value.src),
       }),
     ];
 
-    // @ts-ignore
     if (!isNil(value.metadata)) {
       arguments_.push(
         python.methodArgument({
           name: "metadata",
-          // @ts-ignore
           value: new Json(value.metadata),
         })
       );
@@ -587,9 +582,7 @@ export class VellumValue extends AstNode {
       case "AUDIO":
         this.astNode = new AudioVellumValue(vellumValue.value);
         break;
-      // @ts-expect-error
       case "VIDEO":
-        // @ts-expect-error
         this.astNode = new VideoVellumValue(vellumValue.value);
         break;
       case "IMAGE":

--- a/ee/codegen/src/utils/vellum-variables.ts
+++ b/ee/codegen/src/utils/vellum-variables.ts
@@ -62,13 +62,13 @@ export function getVellumVariablePrimitiveType(
           modulePath: VELLUM_CLIENT_MODULE_PATH,
         })
       );
-    // case "VIDEO":
-    //   return python.Type.reference(
-    //     python.reference({
-    //       name: "VellumVideo",
-    //       modulePath: VELLUM_CLIENT_MODULE_PATH,
-    //     })
-    //   );
+    case "VIDEO":
+      return python.Type.reference(
+        python.reference({
+          name: "VellumVideo",
+          modulePath: VELLUM_CLIENT_MODULE_PATH,
+        })
+      );
     case "IMAGE":
       return python.Type.reference(
         python.reference({

--- a/ee/codegen/src/utils/vellum-variables.ts
+++ b/ee/codegen/src/utils/vellum-variables.ts
@@ -83,6 +83,13 @@ export function getVellumVariablePrimitiveType(
           modulePath: VELLUM_CLIENT_MODULE_PATH,
         })
       );
+    case "THINKING":
+      return python.Type.reference(
+        python.reference({
+          name: "StringVellumValue",
+          modulePath: VELLUM_CLIENT_MODULE_PATH,
+        })
+      );
     case "NULL":
       return python.Type.none();
     default: {


### PR DESCRIPTION
## Changes
Bump SDK version so that we have access to the recently added `VIDEO` type. Recommend reviewing by commit.

Changes to get this working:
1. Update import path for `ReleaseReviews` -> `WorkflowDeployments`. We reordered some tags for the 1.1.0 release (https://github.com/vellum-ai/vellum-python-sdks/pull/2188), so the APIs were moved into another client.
2. Support `VIDEO` types in codegen
3. Suport `THINKING` mode types in codegen