### PR TITLE
[codegen] Support prompt blocks for file input

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/stateful-prompt-block.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/stateful-prompt-block.test.ts.snap
@@ -1,5 +1,50 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`StatefulPromptBlock > AUDIO > should generate a basic audio block 1`] = `
+"AudioPromptBlock(
+    src="https://example.com/audio.mp3",
+    metadata={
+        "key": "value",
+        "detail": "high",
+    },
+)
+"
+`;
+
+exports[`StatefulPromptBlock > CHAT_MESSAGE with file input block > should generate a chat message block with static file input blocks 1`] = `
+"ChatMessagePromptBlock(
+    chat_role="USER", blocks=[ImagePromptBlock(src="https://example.com/image.png")]
+)
+"
+`;
+
+exports[`StatefulPromptBlock > DOCUMENT > should generate a basic document block 1`] = `
+"DocumentPromptBlock(
+    src="https://example.com/document.pdf",
+    metadata={
+        "key": "value",
+        "detail": "high",
+    },
+)
+"
+`;
+
+exports[`StatefulPromptBlock > IMAGE > should generate a basic image block 1`] = `
+"ImagePromptBlock(src="https://example.com/image.png")
+"
+`;
+
+exports[`StatefulPromptBlock > IMAGE with metadata > should generate an image block with metadata 1`] = `
+"ImagePromptBlock(
+    src="https://example.com/image.png",
+    metadata={
+        "key": "value",
+        "detail": "high",
+    },
+)
+"
+`;
+
 exports[`StatefulPromptBlock > JINJA > should generate a basic jinja block 1`] = `
 "JinjaPromptBlock(template="""Hello, {{ name }}!""")
 "
@@ -20,5 +65,16 @@ exports[`StatefulPromptBlock > JINJA > should handle double quotes in jinja temp
 
 exports[`StatefulPromptBlock > PLAIN_TEXT > should generate regular quotes for empty text 1`] = `
 "PlainTextPromptBlock(text="")
+"
+`;
+
+exports[`StatefulPromptBlock > VIDEO > should generate a basic video block 1`] = `
+"VideoPromptBlock(
+    src="https://example.com/video.mp4",
+    metadata={
+        "key": "value",
+        "detail": "high",
+    },
+)
 "
 `;

--- a/ee/codegen/src/__test__/stateful-prompt-block.test.ts
+++ b/ee/codegen/src/__test__/stateful-prompt-block.test.ts
@@ -89,4 +89,139 @@ describe("StatefulPromptBlock", () => {
       expect(await writer.toStringFormatted()).toMatchSnapshot();
     });
   });
+
+  describe("IMAGE", () => {
+    it("should generate a basic image block", async () => {
+      const block = new StatefulPromptBlock({
+        workflowContext,
+        promptBlock: {
+          id: "1",
+          blockType: "IMAGE",
+          state: "ENABLED",
+          src: "https://example.com/image.png",
+        },
+        inputVariableNameById: {},
+      });
+
+      block.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+
+  describe("IMAGE with metadata", () => {
+    it("should generate an image block with metadata", async () => {
+      const block = new StatefulPromptBlock({
+        workflowContext,
+        promptBlock: {
+          id: "1",
+          blockType: "IMAGE",
+          state: "ENABLED",
+          src: "https://example.com/image.png",
+          metadata: {
+            key: "value",
+            detail: "high",
+          },
+        },
+        inputVariableNameById: {},
+      });
+
+      block.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+
+  describe("CHAT_MESSAGE with file input block", () => {
+    it("should generate a chat message block with static file input blocks", async () => {
+      const block = new StatefulPromptBlock({
+        workflowContext,
+        promptBlock: {
+          id: "1",
+          blockType: "CHAT_MESSAGE",
+          state: "ENABLED",
+          properties: {
+            chatRole: "USER",
+            chatMessageUnterminated: false,
+            blocks: [
+              {
+                id: "2",
+                blockType: "IMAGE",
+                state: "ENABLED",
+                src: "https://example.com/image.png",
+              },
+            ],
+          },
+        },
+        inputVariableNameById: {},
+      });
+
+      block.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+
+  describe("AUDIO", () => {
+    it("should generate a basic audio block", async () => {
+      const block = new StatefulPromptBlock({
+        workflowContext,
+        promptBlock: {
+          id: "1",
+          blockType: "AUDIO",
+          state: "ENABLED",
+          src: "https://example.com/audio.mp3",
+          metadata: {
+            key: "value",
+            detail: "high",
+          },
+        },
+        inputVariableNameById: {},
+      });
+
+      block.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+
+  describe("VIDEO", () => {
+    it("should generate a basic video block", async () => {
+      const block = new StatefulPromptBlock({
+        workflowContext,
+        promptBlock: {
+          id: "1",
+          blockType: "VIDEO",
+          state: "ENABLED",
+          src: "https://example.com/video.mp4",
+          metadata: {
+            key: "value",
+            detail: "high",
+          },
+        },
+        inputVariableNameById: {},
+      });
+
+      block.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
+
+  describe("DOCUMENT", () => {
+    it("should generate a basic document block", async () => {
+      const block = new StatefulPromptBlock({
+        workflowContext,
+        promptBlock: {
+          id: "1",
+          blockType: "DOCUMENT",
+          state: "ENABLED",
+          src: "https://example.com/document.pdf",
+          metadata: {
+            key: "value",
+            detail: "high",
+          },
+        },
+        inputVariableNameById: {},
+      });
+
+      block.write(writer);
+      expect(await writer.toStringFormatted()).toMatchSnapshot();
+    });
+  });
 });

--- a/ee/codegen/src/generators/stateful-prompt-block.ts
+++ b/ee/codegen/src/generators/stateful-prompt-block.ts
@@ -11,12 +11,15 @@ import {
   PromptTemplateBlockExcludingFunctionDefinition,
 } from "src/generators/base-prompt-block";
 import {
+  AudioPromptTemplateBlock,
   ChatMessagePromptTemplateBlock,
+  DocumentPromptTemplateBlock,
   ImagePromptTemplateBlock,
   JinjaPromptTemplateBlock,
   PlainTextPromptTemplateBlock,
   RichTextPromptTemplateBlock,
   VariablePromptTemplateBlock,
+  VideoPromptTemplateBlock,
 } from "src/types/vellum";
 
 // Flesh out unit tests for various prompt configurations
@@ -36,8 +39,14 @@ export class StatefulPromptBlock extends BasePromptBlock<PromptTemplateBlockExcl
         return this.generateRichTextPromptBlock(promptBlock);
       case "PLAIN_TEXT":
         return this.generatePlainTextPromptBlock(promptBlock);
+      case "AUDIO":
+        return this.generateAudioPromptBlock(promptBlock);
+      case "VIDEO":
+        return this.generateVideoPromptBlock(promptBlock);
       case "IMAGE":
         return this.generateImagePromptBlock(promptBlock);
+      case "DOCUMENT":
+        return this.generateDocumentPromptBlock(promptBlock);
     }
   }
 
@@ -61,8 +70,17 @@ export class StatefulPromptBlock extends BasePromptBlock<PromptTemplateBlockExcl
       case "PLAIN_TEXT":
         pathName = "PlainTextPromptBlock";
         break;
+      case "AUDIO":
+        pathName = "AudioPromptBlock";
+        break;
+      case "VIDEO":
+        pathName = "VideoPromptBlock";
+        break;
       case "IMAGE":
         pathName = "ImagePromptBlock";
+        break;
+      case "DOCUMENT":
+        pathName = "DocumentPromptBlock";
         break;
     }
     return python.reference({
@@ -258,12 +276,14 @@ export class StatefulPromptBlock extends BasePromptBlock<PromptTemplateBlockExcl
     return richBlock;
   }
 
-  private generateImagePromptBlock(
-    promptBlock: ImagePromptTemplateBlock
-  ): python.ClassInstantiation {
-    const classArgs: MethodArgument[] = [
-      ...this.constructCommonClassArguments(promptBlock),
-    ];
+  private generateCommonFileInputArguments(
+    promptBlock:
+      | AudioPromptTemplateBlock
+      | VideoPromptTemplateBlock
+      | ImagePromptTemplateBlock
+      | DocumentPromptTemplateBlock
+  ): MethodArgument[] {
+    const classArgs: MethodArgument[] = [];
 
     classArgs.push(
       new MethodArgument({
@@ -282,6 +302,51 @@ export class StatefulPromptBlock extends BasePromptBlock<PromptTemplateBlockExcl
       );
     }
 
+    return classArgs;
+  }
+
+  private generateAudioPromptBlock(
+    promptBlock: AudioPromptTemplateBlock
+  ): python.ClassInstantiation {
+    const classArgs: MethodArgument[] = [
+      ...this.constructCommonClassArguments(promptBlock),
+      ...this.generateCommonFileInputArguments(promptBlock),
+    ];
+
+    const audioBlock = python.instantiateClass({
+      classReference: this.getPromptBlockRef(promptBlock),
+      arguments_: classArgs,
+    });
+
+    this.inheritReferences(audioBlock);
+    return audioBlock;
+  }
+
+  private generateVideoPromptBlock(
+    promptBlock: VideoPromptTemplateBlock
+  ): python.ClassInstantiation {
+    const classArgs: MethodArgument[] = [
+      ...this.constructCommonClassArguments(promptBlock),
+      ...this.generateCommonFileInputArguments(promptBlock),
+    ];
+
+    const videoBlock = python.instantiateClass({
+      classReference: this.getPromptBlockRef(promptBlock),
+      arguments_: classArgs,
+    });
+
+    this.inheritReferences(videoBlock);
+    return videoBlock;
+  }
+
+  private generateImagePromptBlock(
+    promptBlock: ImagePromptTemplateBlock
+  ): python.ClassInstantiation {
+    const classArgs: MethodArgument[] = [
+      ...this.constructCommonClassArguments(promptBlock),
+      ...this.generateCommonFileInputArguments(promptBlock),
+    ];
+
     const imageBlock = python.instantiateClass({
       classReference: this.getPromptBlockRef(promptBlock),
       arguments_: classArgs,
@@ -289,5 +354,22 @@ export class StatefulPromptBlock extends BasePromptBlock<PromptTemplateBlockExcl
 
     this.inheritReferences(imageBlock);
     return imageBlock;
+  }
+
+  private generateDocumentPromptBlock(
+    promptBlock: DocumentPromptTemplateBlock
+  ): python.ClassInstantiation {
+    const classArgs: MethodArgument[] = [
+      ...this.constructCommonClassArguments(promptBlock),
+      ...this.generateCommonFileInputArguments(promptBlock),
+    ];
+
+    const documentBlock = python.instantiateClass({
+      classReference: this.getPromptBlockRef(promptBlock),
+      arguments_: classArgs,
+    });
+
+    this.inheritReferences(documentBlock);
+    return documentBlock;
   }
 }

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -326,9 +326,36 @@ export interface FunctionDefinitionPromptTemplateBlock {
   };
 }
 
+export interface AudioPromptTemplateBlock {
+  id: string;
+  blockType: "AUDIO";
+  state: PromptBlockState;
+  cacheConfig?: CacheConfig;
+  src: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface VideoPromptTemplateBlock {
+  id: string;
+  blockType: "VIDEO";
+  state: PromptBlockState;
+  cacheConfig?: CacheConfig;
+  src: string;
+  metadata?: Record<string, unknown>;
+}
+
 export interface ImagePromptTemplateBlock {
   id: string;
   blockType: "IMAGE";
+  state: PromptBlockState;
+  cacheConfig?: CacheConfig;
+  src: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface DocumentPromptTemplateBlock {
+  id: string;
+  blockType: "DOCUMENT";
   state: PromptBlockState;
   cacheConfig?: CacheConfig;
   src: string;
@@ -341,7 +368,10 @@ export type PromptTemplateBlock =
   | VariablePromptTemplateBlock
   | RichTextPromptTemplateBlock
   | FunctionDefinitionPromptTemplateBlock
-  | ImagePromptTemplateBlock;
+  | AudioPromptTemplateBlock
+  | VideoPromptTemplateBlock
+  | ImagePromptTemplateBlock
+  | DocumentPromptTemplateBlock;
 
 export interface PromptTemplateBlockData {
   version: number;

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -326,12 +326,22 @@ export interface FunctionDefinitionPromptTemplateBlock {
   };
 }
 
+export interface ImagePromptTemplateBlock {
+  id: string;
+  blockType: "IMAGE";
+  state: PromptBlockState;
+  cacheConfig?: CacheConfig;
+  src: string;
+  metadata?: Record<string, unknown>;
+}
+
 export type PromptTemplateBlock =
   | JinjaPromptTemplateBlock
   | ChatMessagePromptTemplateBlock
   | VariablePromptTemplateBlock
   | RichTextPromptTemplateBlock
-  | FunctionDefinitionPromptTemplateBlock;
+  | FunctionDefinitionPromptTemplateBlock
+  | ImagePromptTemplateBlock;
 
 export interface PromptTemplateBlockData {
   version: number;


### PR DESCRIPTION
Intended use case is to have a `CHAT_MESSAGE` block with some static file input blocks.

I can also extend support for the normal `PromptBlock` generator used in Generic Nodes if needed: https://github.com/vellum-ai/vellum-python-sdks/blob/bf3f82e31dd5f5ba9f7319dc4f087068cfd850f4/ee/codegen/src/generators/prompt-block.ts#L19