### PR TITLE
[APO-1072] Add Backward Compatibility For TemplatingNode Value/Type Access

### DIFF
--- a/src/vellum/workflows/nodes/core/templating_node/node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/node.py
@@ -7,8 +7,7 @@ from vellum.workflows.errors import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.bases.base import BaseNodeMeta
-from vellum.workflows.nodes.utils import parse_type_from_str
-from vellum.workflows.types.code_execution_node_wrappers import wrap_inputs_for_backward_compatibility
+from vellum.workflows.nodes.utils import parse_type_from_str, wrap_inputs_for_backward_compatibility
 from vellum.workflows.types.core import EntityInputsInterface
 from vellum.workflows.types.generics import StateType
 from vellum.workflows.types.utils import get_original_base

--- a/src/vellum/workflows/nodes/core/templating_node/node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/node.py
@@ -8,6 +8,7 @@ from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.bases.base import BaseNodeMeta
 from vellum.workflows.nodes.utils import parse_type_from_str
+from vellum.workflows.types.code_execution_node_wrappers import wrap_inputs_for_backward_compatibility
 from vellum.workflows.types.core import EntityInputsInterface
 from vellum.workflows.types.generics import StateType
 from vellum.workflows.types.utils import get_original_base
@@ -86,9 +87,10 @@ class TemplatingNode(BaseNode[StateType], Generic[StateType, _OutputType], metac
 
     def _render_template(self) -> str:
         try:
+            wrapped_inputs = wrap_inputs_for_backward_compatibility(self.inputs)
             return render_sandboxed_jinja_template(
                 template=self.template,
-                input_values=self.inputs,
+                input_values=wrapped_inputs,
                 jinja_custom_filters={**self.jinja_custom_filters},
                 jinja_globals=self.jinja_globals,
             )

--- a/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
@@ -317,3 +317,143 @@ def test_api_error_templating_node():
 
     # THEN the output should be empty string
     assert outputs.result == ""
+
+
+def test_templating_node__string_value_access():
+    # GIVEN a templating node that accesses string value
+    class TemplateNode(TemplatingNode[BaseState, str]):
+        template = "{{ text_input.value }}"
+        inputs = {"text_input": "hello world"}
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN the value is accessible
+    assert outputs.result == "hello world"
+
+
+def test_templating_node__string_type_access():
+    # GIVEN a templating node that accesses string type
+    class TemplateNode(TemplatingNode[BaseState, str]):
+        template = "{{ text_input.type }}"
+        inputs = {"text_input": "hello world"}
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN the type is accessible
+    assert outputs.result == "STRING"
+
+
+def test_templating_node__function_call_value_access():
+    # GIVEN a templating node that accesses function call value
+    class TemplateNode(TemplatingNode[BaseState, str]):
+        template = "{{ func.value.name }}"
+        inputs = {"func": FunctionCall(name="test_function", arguments={"key": "value"})}
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN the function name is accessible
+    assert outputs.result == "test_function"
+
+
+def test_templating_node__function_call_type_access():
+    # GIVEN a templating node that accesses function call type
+    class TemplateNode(TemplatingNode[BaseState, str]):
+        template = "{{ func.type }}"
+        inputs = {"func": FunctionCall(name="test_function", arguments={"key": "value"})}
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN the function type is accessible
+    assert outputs.result == "FUNCTION_CALL"
+
+
+def test_templating_node__array_item_value_access():
+    # GIVEN a templating node that accesses array item value
+    class TemplateNode(TemplatingNode[BaseState, str]):
+        template = "{{ items[0].value }}"
+        inputs = {"items": ["apple"]}
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN the array item value is accessible
+    assert outputs.result == "apple"
+
+
+def test_templating_node__dict_value_access():
+    # GIVEN a templating node that accesses dict value
+    class TemplateNode(TemplatingNode[BaseState, Json]):
+        template = "{{ data.value }}"
+        inputs = {"data": {"name": "test", "score": 42}}
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN the dict returns itself as value
+    assert outputs.result == {"name": "test", "score": 42}
+
+
+def test_templating_node__list_value_access():
+    # GIVEN a templating node that accesses list value
+    class TemplateNode(TemplatingNode[BaseState, Json]):
+        template = "{{ items.value }}"
+        inputs = {"items": ["item1", "item2", "item3"]}
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN the list returns itself as value
+    assert outputs.result == ["item1", "item2", "item3"]
+
+
+def test_templating_node__nested_dict_access():
+    # GIVEN a templating node with nested dict access
+    class TemplateNode(TemplatingNode[BaseState, str]):
+        template = "{{ data.user.name }}"
+        inputs = {"data": {"user": {"name": "John Doe", "age": 30}, "status": "active"}}
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN nested properties are accessible
+    assert outputs.result == "John Doe"
+
+
+def test_templating_node__list_iteration_wrapper_access():
+    # GIVEN a templating node that iterates over list with wrapper access
+    class TemplateNode(TemplatingNode[BaseState, str]):
+        template = "{% for item in items %}{{ item.value }}{% if not loop.last %},{% endif %}{% endfor %}"
+        inputs = {"items": ["apple", "banana", "cherry"]}
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN list iteration with wrapper access works
+    assert outputs.result == "apple,banana,cherry"
+
+
+def test_templating_node__conditional_type_checking():
+    # GIVEN a templating node with conditional type checking
+    class TemplateNode(TemplatingNode[BaseState, str]):
+        template = "{% if input.type == 'STRING' %}{{ input.value }}{% else %}unknown{% endif %}"
+        inputs = {"input": "test string"}
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN conditional type checking works
+    assert outputs.result == "test string"

--- a/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
+++ b/src/vellum/workflows/nodes/core/templating_node/tests/test_templating_node.py
@@ -320,29 +320,51 @@ def test_api_error_templating_node():
 
 
 @pytest.mark.parametrize(
-    "template,inputs,expected_result,output_type",
+    "template,inputs,expected_result",
     [
         # String value access
-        ("{{ text_input.value }}", {"text_input": "hello world"}, "hello world", str),
+        ("{{ text_input.value }}", {"text_input": "hello world"}, "hello world"),
         # Function call value access
         (
             "{{ func.value.name }}",
             {"func": FunctionCall(name="test_function", arguments={"key": "value"})},
             "test_function",
-            str,
         ),
         # Array item value access
-        ("{{ items[0].value }}", {"items": ["apple"]}, "apple", str),
-        # Dict value access
-        ("{{ data.value }}", {"data": {"name": "test", "score": 42}}, {"name": "test", "score": 42}, Json),
-        # List value access
-        ("{{ items.value }}", {"items": ["item1", "item2", "item3"]}, ["item1", "item2", "item3"], Json),
+        ("{{ items[0].value }}", {"items": ["apple"]}, "apple"),
     ],
-    ids=["string_value", "function_call_value", "array_item_value", "dict_value", "list_value"],
+    ids=["string_value", "function_call_value", "array_item_value"],
 )
-def test_templating_node__value_access_patterns(template, inputs, expected_result, output_type):
+def test_templating_node__value_access_patterns_str(template, inputs, expected_result):
     # GIVEN a templating node that accesses wrapper value properties
-    class TemplateNode(TemplatingNode[BaseState, output_type]):
+    class TemplateNode(TemplatingNode[BaseState, str]):
+        pass
+
+    # Set template and inputs dynamically
+    TemplateNode.template = template
+    TemplateNode.inputs = inputs
+
+    # WHEN the node is run
+    node = TemplateNode()
+    outputs = node.run()
+
+    # THEN the value is accessible
+    assert outputs.result == expected_result
+
+
+@pytest.mark.parametrize(
+    "template,inputs,expected_result",
+    [
+        # Dict value access
+        ("{{ data.value }}", {"data": {"name": "test", "score": 42}}, {"name": "test", "score": 42}),
+        # List value access
+        ("{{ items.value }}", {"items": ["item1", "item2", "item3"]}, ["item1", "item2", "item3"]),
+    ],
+    ids=["dict_value", "list_value"],
+)
+def test_templating_node__value_access_patterns_json(template, inputs, expected_result):
+    # GIVEN a templating node that accesses wrapper value properties
+    class TemplateNode(TemplatingNode[BaseState, Json]):
         pass
 
     # Set template and inputs dynamically

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
@@ -6,9 +6,8 @@ from typing import Any, Optional, Tuple, Union
 
 from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
-from vellum.workflows.nodes.utils import cast_to_output_type
+from vellum.workflows.nodes.utils import cast_to_output_type, wrap_inputs_for_backward_compatibility
 from vellum.workflows.state.context import WorkflowContext
-from vellum.workflows.types.code_execution_node_wrappers import wrap_inputs_for_backward_compatibility
 from vellum.workflows.types.core import EntityInputsInterface
 
 

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
@@ -4,13 +4,11 @@ import sys
 import traceback
 from typing import Any, Optional, Tuple, Union
 
-from pydantic import BaseModel
-
 from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.utils import cast_to_output_type
 from vellum.workflows.state.context import WorkflowContext
-from vellum.workflows.types.code_execution_node_wrappers import ListWrapper, clean_for_dict_wrapper
+from vellum.workflows.types.code_execution_node_wrappers import wrap_inputs_for_backward_compatibility
 from vellum.workflows.types.core import EntityInputsInterface
 
 
@@ -51,23 +49,9 @@ def run_code_inline(
         print_line = f"{' '.join(str_args)}\n"
         log_buffer.write(print_line)
 
-    def wrap_value(value):
-        if isinstance(value, list):
-            return ListWrapper(
-                [
-                    # Convert VellumValue to dict with its fields
-                    (
-                        item.model_dump()
-                        if isinstance(item, BaseModel)
-                        else clean_for_dict_wrapper(item) if isinstance(item, (dict, list, str)) else item
-                    )
-                    for item in value
-                ]
-            )
-        return clean_for_dict_wrapper(value)
-
+    wrapped_inputs = wrap_inputs_for_backward_compatibility(inputs)
     exec_globals = {
-        "__arg__inputs": {name: wrap_value(value) for name, value in inputs.items()},
+        "__arg__inputs": wrapped_inputs,
         "__arg__out": None,
         "print": _inline_print,
     }

--- a/src/vellum/workflows/types/code_execution_node_wrappers.py
+++ b/src/vellum/workflows/types/code_execution_node_wrappers.py
@@ -1,7 +1,3 @@
-from typing import Any, Dict
-
-from pydantic import BaseModel
-
 from vellum.client.types.function_call import FunctionCall
 
 
@@ -103,23 +99,3 @@ def clean_for_dict_wrapper(obj):
         return FunctionCallWrapper(obj)
 
     return obj
-
-
-def wrap_inputs_for_backward_compatibility(inputs: Dict[str, Any]) -> Dict[str, Any]:
-    """Wrap inputs with backward-compatible wrapper classes for legacy .value and .type support."""
-
-    def _wrap_single_value(value: Any) -> Any:
-        if isinstance(value, list):
-            return ListWrapper(
-                [
-                    (
-                        item.model_dump()
-                        if isinstance(item, BaseModel)
-                        else clean_for_dict_wrapper(item) if isinstance(item, (dict, list, str)) else item
-                    )
-                    for item in value
-                ]
-            )
-        return clean_for_dict_wrapper(value)
-
-    return {name: _wrap_single_value(value) for name, value in inputs.items()}


### PR DESCRIPTION
### Issue

[APO-1072](https://linear.app/vellum/issue/APO-1072/templating-nodes-should-handle-legacy-value-and-type-references-like)

TemplatingNode broke after SDK-enabled workflows - can't access .value and .type properties on inputs anymore. Breaks workflows using Map node outputs like array[0].value.

### Fix

Add backward compatibility wrappers to TemplatingNode, same as CodeExecutionNode already has.

### Changes

  - Extract shared wrapper function to eliminate duplication between nodes
  - Wrap TemplatingNode inputs before template rendering
  - Refactor CodeExecutionNode to use shared function
  - Add test coverage for wrapper functionality
