### PR TITLE
Add mcp tool description field

### DIFF
--- a/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_tool_calling_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/tests/test_tool_calling_node.py
@@ -191,6 +191,7 @@ def test_serialize_node__tool_calling_node__mcp_server_api_key():
                     {
                         "type": "MCP_SERVER",
                         "name": "my-mcp-server",
+                        "description": "",
                         "url": "https://my-mcp-server.com",
                         "authorization_type": "API_KEY",
                         "bearer_token_value": None,
@@ -243,6 +244,7 @@ def test_serialize_node__tool_calling_node__mcp_server_no_authorization():
                     {
                         "type": "MCP_SERVER",
                         "name": "my-mcp-server",
+                        "description": "",
                         "url": "https://my-mcp-server.com",
                         "authorization_type": None,
                         "bearer_token_value": None,

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_mcp_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_mcp_serialization.py
@@ -52,6 +52,7 @@ def test_serialize_workflow():
                     {
                         "type": "MCP_SERVER",
                         "name": "github",
+                        "description": "",
                         "url": "https://api.githubcopilot.com/mcp/",
                         "authorization_type": "BEARER_TOKEN",
                         "bearer_token_value": "GITHUB_PERSONAL_ACCESS_TOKEN",

--- a/src/vellum/workflows/types/definition.py
+++ b/src/vellum/workflows/types/definition.py
@@ -121,6 +121,7 @@ class ComposioToolDefinition(UniversalBaseModel):
 class MCPServer(UniversalBaseModel):
     type: Literal["MCP_SERVER"] = "MCP_SERVER"
     name: str
+    description: str = ""  # We don't use this field, its for compatibility with UI
     url: str
     authorization_type: Optional[AuthorizationType] = None
     bearer_token_value: Optional[Union[str, EnvironmentVariableReference]] = None


### PR DESCRIPTION
frontend tool type uses both name and description, though description is nullable, I think we could set it as a placeholder?