### PR TITLE
[codegen] add file types to `WorkflowSandboxInput` union type

### DIFF
--- a/ee/codegen/package-lock.json
+++ b/ee/codegen/package-lock.json
@@ -13,7 +13,7 @@
         "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
         "lodash": "^4.17.21",
         "uuid": "^11.0.3",
-        "vellum-ai": "1.2.1"
+        "vellum-ai": "1.2.4"
       },
       "devDependencies": {
         "@octokit/auth-app": "^7.1.3",
@@ -6189,9 +6189,9 @@
       "dev": true
     },
     "node_modules/vellum-ai": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-1.2.1.tgz",
-      "integrity": "sha512-s+aDzNlkrTLCkPQAGISUGAEkKeUpcG8Zjzxhh0dEuafG3LPvdv1MGsCoyoj+KMyVHl8bu2RKrYR4nCDjOsnz8A==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-1.2.4.tgz",
+      "integrity": "sha512-XVLFG+cquXVmDrcBWkv38HMe2KIxI36bzeXXMQ9EGLIZH38w+bUcAqzeH368feHZ9HekhpgnwZkRHE7YoHToOQ==",
       "dependencies": {
         "cdktf": "^0.20.5",
         "constructs": "10.3.0",
@@ -10665,9 +10665,9 @@
       "dev": true
     },
     "vellum-ai": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-1.2.1.tgz",
-      "integrity": "sha512-s+aDzNlkrTLCkPQAGISUGAEkKeUpcG8Zjzxhh0dEuafG3LPvdv1MGsCoyoj+KMyVHl8bu2RKrYR4nCDjOsnz8A==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/vellum-ai/-/vellum-ai-1.2.4.tgz",
+      "integrity": "sha512-XVLFG+cquXVmDrcBWkv38HMe2KIxI36bzeXXMQ9EGLIZH38w+bUcAqzeH368feHZ9HekhpgnwZkRHE7YoHToOQ==",
       "requires": {
         "cdktf": "^0.20.5",
         "constructs": "10.3.0",

--- a/ee/codegen/package.json
+++ b/ee/codegen/package.json
@@ -36,7 +36,7 @@
     "@fern-fern/generator-exec-sdk": "file:./stubs/generator-exec-sdk",
     "lodash": "^4.17.21",
     "uuid": "^11.0.3",
-    "vellum-ai": "1.2.1"
+    "vellum-ai": "1.2.4"
   },
   "devDependencies": {
     "@octokit/auth-app": "^7.1.3",

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -5,10 +5,13 @@ import {
   LogicalOperator,
 } from "vellum-ai/api";
 import {
+  AudioInputRequest,
   ChatHistoryInput,
   ChatMessageRequest,
   ChatMessageRole,
+  DocumentInputRequest,
   FunctionDefinition,
+  ImageInputRequest,
   JsonInput,
   NumberInput,
   PromptBlockState,
@@ -19,6 +22,7 @@ import {
   VellumValue,
   VellumVariable,
   VellumVariableType,
+  VideoInputRequest,
 } from "vellum-ai/api/types";
 
 export enum WorkflowNodeType {
@@ -800,7 +804,11 @@ type WorkflowSandboxInput =
   | StringInput
   | JsonInput
   | ChatHistoryInput
-  | NumberInput;
+  | NumberInput
+  | AudioInputRequest
+  | VideoInputRequest
+  | ImageInputRequest
+  | DocumentInputRequest;
 export type WorkflowSandboxInputs = WorkflowSandboxInput[];
 
 export interface UnaryWorkflowExpression {


### PR DESCRIPTION
1. Bump `vellum-ai` dependency to gain access to the new file input types
2. Add file types to the `WorkflowSandboxInput` union type. AFAICT, this is mostly a cosmetic change since our logic already uses the polymorphic `VellumValue` and just passes the raw value through to codegen