### PR TITLE
Fix default trace id

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,7 @@ from pytest_mock import MockerFixture
 import requests_mock
 
 from vellum.client.environment import VellumEnvironment
-from vellum.workflows.context import monitoring_context_store
+from vellum.workflows.context import clear_execution_context
 from vellum.workflows.logging import load_logger
 
 
@@ -20,12 +20,12 @@ from vellum.workflows.logging import load_logger
 def clear_monitoring_context():
     """Clear the global monitoring context store between tests to prevent collisions."""
     # Clear before test
-    monitoring_context_store.clear_context()
+    clear_execution_context()
 
     yield
 
     # Clear after test
-    monitoring_context_store.clear_context()
+    clear_execution_context()
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/src/vellum/workflows/state/context.py
+++ b/src/vellum/workflows/state/context.py
@@ -41,6 +41,7 @@ class WorkflowContext:
 
         if self._execution_context.parent_context is None:
             self._execution_context.parent_context = ExternalParentContext(span_id=uuid4())
+            self._execution_context.trace_id = uuid4()
             # Propagate the updated context back to the global execution context
             set_execution_context(self._execution_context)
 

--- a/src/vellum/workflows/state/context.py
+++ b/src/vellum/workflows/state/context.py
@@ -1,6 +1,6 @@
 from functools import cached_property
 from queue import Queue
-from uuid import uuid4
+from uuid import UUID, uuid4
 from typing import TYPE_CHECKING, Dict, List, Optional, Type
 
 from vellum import Vellum, __version__
@@ -41,7 +41,9 @@ class WorkflowContext:
 
         if self._execution_context.parent_context is None:
             self._execution_context.parent_context = ExternalParentContext(span_id=uuid4())
-            self._execution_context.trace_id = uuid4()
+            # Only generate a new trace_id if one wasn't explicitly provided (i.e., if it's the default zero UUID)
+            if self._execution_context.trace_id == UUID("00000000-0000-0000-0000-000000000000"):
+                self._execution_context.trace_id = uuid4()
             # Propagate the updated context back to the global execution context
             set_execution_context(self._execution_context)
 

--- a/tests/workflows/trivial/tests/test_workflow.py
+++ b/tests/workflows/trivial/tests/test_workflow.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from tests.workflows.trivial.workflow import TrivialWorkflow
 
 
@@ -18,6 +20,9 @@ def test_stream_workflow__happy_path():
     assert events[0].name == "workflow.execution.initiated"
 
     assert events[1].name == "workflow.execution.fulfilled"
+
+    assert events[0].trace_id != UUID("00000000-0000-0000-0000-000000000000")
+    assert events[0].trace_id == events[1].trace_id
 
     for event in events:
         assert event.span_id == stream.span_id


### PR DESCRIPTION
# Fix external workflow trace ID defaulting to zeros

## Summary
Fixes the issue where external workflow trace IDs were defaulting to "00000000-0000-0000-0000-000000000000" instead of proper UUIDs.

**Root Cause**: The `execution_context()` function was using `int(prev_context.trace_id)` to determine when to preserve vs. generate trace IDs, but this logic didn't properly handle the relationship between nested contexts and fresh contexts.

**Solution**: Updated the trace ID logic to:
1. Use `parent_context` presence as the primary indicator for nested contexts
2. Preserve existing trace_id when in nested contexts (and trace_id is not zero)
3. Allow explicit trace_id when starting fresh contexts
4. Generate new UUID as fallback

## Review & Testing Checklist for Human
- [ ] **Test external workflow execution end-to-end** - Verify that external workflows now generate proper UUID trace IDs instead of zeros
- [ ] **Verify nested context behavior** - Test that trace IDs are preserved correctly when contexts are nested (e.g., subworkflows, node executions)
- [ ] **Check conditional logic edge cases** - Review the 3-condition logic in `execution_context()` for potential edge cases or unintended behavior
- [ ] **Run the originally failing tests** - Confirm that the 4 tests mentioned in CI (test_context_trace_and_parent, inline_prompt_node tests, etc.) now pass consistently

### Notes
- The fix addresses both the symptom (zero trace IDs) and ensures proper trace ID propagation in nested contexts
- Only minimal test changes were made - main validation comes from existing test suite passing
- CI tests are now passing, but end-to-end external workflow testing is recommended

---
**Link to Devin run**: https://app.devin.ai/sessions/0d8fa169a5774d218abd6599a4fcfd39  
**Requested by**: @vincent0426 (vincent@vellum.ai)