### PR TITLE
Remove redundant example code

### DIFF
--- a/examples/workflows/trust_center_q_a/README.md
+++ b/examples/workflows/trust_center_q_a/README.md
@@ -1,0 +1,39 @@
+# Trust Center Q&A Workflow
+
+A Vellum workflow example that demonstrates how to build a question-answering system using chat history and search results.
+
+## Overview
+
+This workflow processes user questions by:
+1. Extracting the most recent message from chat history
+2. Performing search operations to find relevant information
+3. Formatting search results and generating answers
+4. Outputting structured responses including search results, questions, and answers
+
+## Features
+
+- **Zero-config monitoring**: Automatically displays monitoring URLs for workflow execution
+- **Local SDK integration**: Uses Vellum's local SDK for development and testing
+- **Structured outputs**: Provides search results, user questions, and generated answers
+- **Real-time monitoring**: View workflow execution details in the Vellum dashboard
+
+## Requirements
+
+- Python 3.9+
+- Vellum API key (`VELLUM_API_KEY` environment variable)
+
+## Quick Start
+
+1. **Set your API key:**
+   ```bash
+   export VELLUM_API_KEY="your-api-key"
+   ```
+
+2. **Run the demo:**
+   ```bash
+   python -m trust_center_q_a.external
+   ```
+
+3. **View results:**
+   - The script will output workflow results to the console
+   - A monitoring URL will be displayed for viewing execution details in Vellum

--- a/examples/workflows/trust_center_q_a/display/workflow.py
+++ b/examples/workflows/trust_center_q_a/display/workflow.py
@@ -3,12 +3,13 @@ from uuid import UUID
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
     EntrypointDisplay,
+    WorkflowDisplayData,
+    WorkflowDisplayDataViewport,
     WorkflowInputsDisplay,
     WorkflowMetaDisplay,
     WorkflowOutputDisplay,
 )
 from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
-from vellum_ee.workflows.display.vellum import WorkflowDisplayData, WorkflowDisplayDataViewport
 from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 from ..inputs import Inputs

--- a/examples/workflows/trust_center_q_a/external.py
+++ b/examples/workflows/trust_center_q_a/external.py
@@ -1,68 +1,20 @@
-#!/usr/bin/env python3
-"""
-Trust Center Q&A Local Demo Runner (Zero-Config Monitoring)
-
-This script runs the `trust_center_q_a` example workflow using Vellum's local SDK code
-and prints a Monitoring URL so you can view the execution in Vellum.
-
-Soon this monitoring url feature will be available in the SDK for all workflow executions!
-
-Requirements:
-- Set VELLUM_API_KEY in your environment
-- Python 3.9+
-
-Usage:
-    export VELLUM_API_KEY="your-api-key"
-    python3 external.py
-"""
-import importlib
-import os
 import sys
 import time
-
-# Ensure local repo src and ee are on sys.path so we pick up local SDK code
-CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-REPO_ROOT = os.path.abspath(os.path.join(CURRENT_DIR, "../../.."))
-SRC_DIR = os.path.join(REPO_ROOT, "src")
-EE_DIR = os.path.join(REPO_ROOT, "ee")
-EXAMPLES_WORKFLOWS_DIR = os.path.join(REPO_ROOT, "examples", "workflows")
-for path in [SRC_DIR, EE_DIR, EXAMPLES_WORKFLOWS_DIR]:
-    if path not in sys.path:
-        sys.path.insert(0, path)
-
-# Patch `vellum_ee.workflows.display.vellum` to include display data classes from `display.base`
-# without removing existing exports like NodeInput/NodeInputValuePointer.
-try:
-    base_mod = importlib.import_module("vellum_ee.workflows.display.base")
-    vellum_mod = importlib.import_module("vellum_ee.workflows.display.vellum")
-    setattr(vellum_mod, "WorkflowDisplayData", base_mod.WorkflowDisplayData)
-    setattr(vellum_mod, "WorkflowDisplayDataViewport", base_mod.WorkflowDisplayDataViewport)
-    sys.modules["vellum_ee.workflows.display.vellum"] = vellum_mod
-except Exception:
-    pass
-
-from trust_center_q_a.inputs import Inputs
-from trust_center_q_a.workflow import Workflow  # type: ignore
 
 from vellum.client.types import ChatMessage
 from vellum.workflows.emitters.vellum_emitter import VellumEmitter  # local SDK emitter
 
-print("🎯 Trust Center Q&A Local Demo (Zero-Config Monitoring)")
+from .inputs import Inputs
+from .workflow import Workflow
+
+print("Trust Center Q&A Local Demo (Zero-Config Monitoring)")
 print("=" * 50)
 
-# In this local demo, we:
-# 1. Use local SDK modules via sys.path
-# 2. Patch display module compatibility for the example
-# 3. Instantiate the Trust Center Q&A workflow
-# 4. Attach the local VellumEmitter for monitoring
-# 5. Provide a sample user question as chat_history
-# 6. Print the Monitoring URL derived from the workflow context
-
-print("\n📋 Creating Trust Center Q&A workflow...")
+print("\nCreating Trust Center Q&A workflow...")
 # Explicitly pass the local VellumEmitter instance so the workflow uses it
 workflow = Workflow(emitters=[VellumEmitter()])
 
-print("\n🏃 Running Trust Center Q&A workflow...")
+print("\nRunning Trust Center Q&A workflow...")
 print("   (Monitoring URL will be printed automatically if enabled)")
 
 # Minimal required inputs for this workflow
@@ -72,7 +24,7 @@ inputs = Inputs(chat_history=[ChatMessage(role="USER", text=sample_question)])
 # Run the workflow - monitoring URL will be automatically printed!
 result = workflow.run(inputs=inputs)
 
-print(f"\n✅ Workflow completed! \n")
+print(f"\nWorkflow completed! \n")
 
 
 span_id = str(getattr(result, "span_id", ""))
@@ -99,4 +51,4 @@ if span_id:
 else:
     print("   No span_id available to construct monitoring URL.\n")
 
-print("\n🎉 Trust Center Q&A demo complete!")
+print("\nTrust Center Q&A demo complete!")


### PR DESCRIPTION
this example still use search node which regular user will not have those documents to search, ticketed
<img width="1437" height="427" alt="Screenshot 2025-08-25 at 9 01 49 PM" src="https://github.com/user-attachments/assets/a803c3af-8098-4d6b-bb78-e200be916653" />
