### PR TITLE
[APO-1354] Fix None type codegen for unresolved workflow references

### DIFF
--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/environment-variable-workflow-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/environment-variable-workflow-reference.ts
@@ -11,7 +11,35 @@ export class EnvironmentVariableWorkflowReference extends BaseNodeInputWorkflowR
       this.nodeInputWorkflowReferencePointer.environmentVariable;
 
     if (isNil(environmentVariable)) {
-      return python.TypeInstantiation.none();
+      // Return a LazyReference with error message instead of None to provide better error context
+      return python.instantiateClass({
+        classReference: python.reference({
+          name: "LazyReference",
+          modulePath: [
+            ...this.workflowContext.sdkModulePathNames.WORKFLOWS_MODULE_PATH,
+            "references",
+          ],
+        }),
+        arguments_: [
+          python.methodArgument({
+            value: python.lambda({
+              body: python.instantiateClass({
+                classReference: python.reference({
+                  name: "ValueError",
+                  modulePath: [],
+                }),
+                arguments_: [
+                  python.methodArgument({
+                    value: python.TypeInstantiation.str(
+                      "Unresolved environment variable reference: name is undefined"
+                    ),
+                  }),
+                ],
+              }),
+            }),
+          }),
+        ],
+      });
     }
     return python.instantiateClass({
       classReference: python.reference({

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/vellum-secret-workflow-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/vellum-secret-workflow-reference.ts
@@ -11,7 +11,35 @@ export class VellumSecretWorkflowReference extends BaseNodeInputWorkflowReferenc
       this.nodeInputWorkflowReferencePointer.vellumSecretName;
 
     if (isNil(vellumSecretName)) {
-      return python.TypeInstantiation.none();
+      // Return a LazyReference with error message instead of None to provide better error context
+      return python.instantiateClass({
+        classReference: python.reference({
+          name: "LazyReference",
+          modulePath: [
+            ...this.workflowContext.sdkModulePathNames.WORKFLOWS_MODULE_PATH,
+            "references",
+          ],
+        }),
+        arguments_: [
+          python.methodArgument({
+            value: python.lambda({
+              body: python.instantiateClass({
+                classReference: python.reference({
+                  name: "ValueError",
+                  modulePath: [],
+                }),
+                arguments_: [
+                  python.methodArgument({
+                    value: python.TypeInstantiation.str(
+                      "Unresolved Vellum secret reference: name is undefined"
+                    ),
+                  }),
+                ],
+              }),
+            }),
+          }),
+        ],
+      });
     }
     return python.instantiateClass({
       classReference: python.reference({

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-input-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-input-reference.ts
@@ -20,7 +20,35 @@ export class WorkflowInputReference extends BaseNodeInputWorkflowReference<Workf
           `Could not find input variable context with id ${workflowInputReference.inputVariableId}`
         )
       );
-      return python.TypeInstantiation.none();
+      // Return a LazyReference with error message instead of None to provide better error context
+      return python.instantiateClass({
+        classReference: python.reference({
+          name: "LazyReference",
+          modulePath: [
+            ...this.workflowContext.sdkModulePathNames.WORKFLOWS_MODULE_PATH,
+            "references",
+          ],
+        }),
+        arguments_: [
+          python.methodArgument({
+            value: python.lambda({
+              body: python.instantiateClass({
+                classReference: python.reference({
+                  name: "ValueError",
+                  modulePath: [],
+                }),
+                arguments_: [
+                  python.methodArgument({
+                    value: python.TypeInstantiation.str(
+                      `Unresolved input variable reference: id=${workflowInputReference.inputVariableId}`
+                    ),
+                  }),
+                ],
+              }),
+            }),
+          }),
+        ],
+      });
     }
     return python.reference({
       name: inputVariableContext.definition.name,

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-state-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-state-reference.ts
@@ -22,7 +22,35 @@ export class WorkflowStateReference extends BaseNodeInputWorkflowReference<Workf
           "WARNING"
         )
       );
-      return python.TypeInstantiation.none();
+      // Return a LazyReference with error message instead of None to provide better error context
+      return python.instantiateClass({
+        classReference: python.reference({
+          name: "LazyReference",
+          modulePath: [
+            ...this.workflowContext.sdkModulePathNames.WORKFLOWS_MODULE_PATH,
+            "references",
+          ],
+        }),
+        arguments_: [
+          python.methodArgument({
+            value: python.lambda({
+              body: python.instantiateClass({
+                classReference: python.reference({
+                  name: "ValueError",
+                  modulePath: [],
+                }),
+                arguments_: [
+                  python.methodArgument({
+                    value: python.TypeInstantiation.str(
+                      `Unresolved state variable reference: id=${workflowStateReference.stateVariableId}`
+                    ),
+                  }),
+                ],
+              }),
+            }),
+          }),
+        ],
+      });
     }
     return python.reference({
       name: stateVariableContext.definition.name,


### PR DESCRIPTION
The purpose of this PR is to fix codegen producing `None` types when workflow references cannot be resolved.

## Context
Resolves [APO-1354](https://linear.app/vellum/issue/APO-1354/codegen-of-unexpected-graph-producing-a-none-type) where unresolved workflow references were generating invalid Python code with literal `None` values instead of proper error handling.

## Changes Made
- Replace `python.TypeInstantiation.none()` with `LazyReference` containing `ValueError` for better error handling
- Updated 4 reference generator files to throw descriptive errors instead of returning `None`:
  - `environment-variable-workflow-reference.ts` - for unresolved environment variables
  - `vellum-secret-workflow-reference.ts` - for unresolved Vellum secrets  
  - `workflow-input-reference.ts` - for unresolved input variables
  - `workflow-state-reference.ts` - for unresolved state variables

## Notes
This prevents broken workflow code generation in the sandbox when references can't be resolved, providing users with clear error messages instead of cryptic `None` type errors.

---
*This PR was created with Claude Code*