### PR TITLE
Add search engine abstraction with Brave Search support

### DIFF
--- a/src/vellum/workflows/nodes/displayable/web_search_node/engines/__init__.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/engines/__init__.py
@@ -1,0 +1,1 @@
+# Engine abstraction for WebSearchNode

--- a/src/vellum/workflows/nodes/displayable/web_search_node/engines/base.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/engines/base.py
@@ -1,0 +1,41 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+class SearchEngineBase(ABC):
+    """
+    Abstract base class for search engines used by WebSearchNode.
+
+    All search engines must implement the search method and return
+    a normalized response format compatible with WebSearchNode.Outputs.
+    """
+
+    @abstractmethod
+    def search(
+        self,
+        query: str,
+        api_key: str,
+        num_results: int,
+        location: Optional[str],
+        context: Any,
+    ) -> Dict[str, Any]:
+        """
+        Execute search and return normalized response.
+
+        Args:
+            query: The search query to execute
+            api_key: API authentication key
+            num_results: Number of search results to return
+            location: Optional geographic location filter
+            context: WorkflowContext for accessing vellum_client
+
+        Returns:
+            Dict containing:
+                - text: str - Formatted search result text
+                - urls: List[str] - List of result URLs
+                - results: List[Dict[str, Any]] - Raw search results
+
+        Raises:
+            NodeException: For validation, authentication, or API errors
+        """
+        pass

--- a/src/vellum/workflows/nodes/displayable/web_search_node/engines/brave.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/engines/brave.py
@@ -1,0 +1,178 @@
+import logging
+from typing import Any, Dict, Optional
+
+from requests import Request, RequestException, Session
+from requests.exceptions import JSONDecodeError
+
+from vellum.workflows.errors.types import WorkflowErrorCode
+from vellum.workflows.exceptions import NodeException
+
+from .base import SearchEngineBase
+
+logger = logging.getLogger(__name__)
+
+
+class BraveEngine(SearchEngineBase):
+    """
+    Brave Search API engine implementation.
+
+    Uses Brave's independent search index.
+    """
+
+    def search(
+        self,
+        query: str,
+        api_key: str,
+        num_results: int,
+        location: Optional[str],
+        context: Any,
+    ) -> Dict[str, Any]:
+        """Execute search via Brave Search API and return normalized response."""
+        params = {
+            "q": query,
+            "count": num_results,  # Brave uses "count" vs SerpAPI's "num"
+        }
+
+        # Convert location to country code for Brave API
+        if location:
+            params["country"] = self._location_to_country_code(location)
+
+        # Brave uses header authentication vs SerpAPI's query param
+        headers = {
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip",
+            "X-Subscription-Token": api_key,  # Header-based auth
+        }
+
+        # Include Vellum User-Agent
+        client_headers = context.vellum_client._client_wrapper.get_headers()
+        headers["User-Agent"] = client_headers.get("User-Agent")
+
+        try:
+            prepped = Request(
+                method="GET", url="https://api.search.brave.com/res/v1/web/search", params=params, headers=headers
+            ).prepare()
+        except Exception as e:
+            logger.exception("Failed to prepare Brave API request")
+            raise NodeException(f"Failed to prepare HTTP request: {e}", code=WorkflowErrorCode.PROVIDER_ERROR) from e
+
+        try:
+            with Session() as session:
+                response = session.send(prepped, timeout=30)
+        except RequestException as e:
+            logger.exception("Brave API request failed")
+            raise NodeException(f"HTTP request failed: {e}", code=WorkflowErrorCode.PROVIDER_ERROR) from e
+
+        if response.status_code == 401:
+            logger.error("Brave API authentication failed")
+            raise NodeException("Invalid API key", code=WorkflowErrorCode.INVALID_INPUTS)
+        elif response.status_code == 429:
+            logger.warning("Brave API rate limit exceeded")
+            raise NodeException("Rate limit exceeded", code=WorkflowErrorCode.PROVIDER_ERROR)
+        elif response.status_code >= 400:
+            logger.error(f"Brave API returned error status: {response.status_code}")
+            raise NodeException(f"Brave API error: HTTP {response.status_code}", code=WorkflowErrorCode.PROVIDER_ERROR)
+
+        try:
+            json_response = response.json()
+        except JSONDecodeError as e:
+            logger.exception("Failed to parse Brave API response as JSON")
+            raise NodeException(
+                f"Invalid JSON response from Brave API: {e}", code=WorkflowErrorCode.PROVIDER_ERROR
+            ) from e
+
+        # Brave doesn't use an "error" field like SerpAPI, but check for API errors
+        if "error" in json_response:
+            error_msg = json_response["error"]
+            logger.error(f"Brave API returned error: {error_msg}")
+            raise NodeException(f"Brave API error: {error_msg}", code=WorkflowErrorCode.PROVIDER_ERROR)
+
+        return self._normalize_brave_response(json_response)
+
+    def _normalize_brave_response(self, json_response: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Normalize Brave API response to SerpAPI-compatible format.
+
+        Args:
+            json_response: Raw Brave API response
+
+        Returns:
+            Normalized response with text, urls, and results fields compatible with SerpAPI
+        """
+        # Brave API structure: {"web": {"results": [...]}}
+        web_results = json_response.get("web", {}).get("results", [])
+
+        text_results = []
+        urls = []
+        normalized_results = []
+
+        for result in web_results:
+            title = result.get("title", "")
+            description = result.get("description", "")  # Brave uses "description" vs SerpAPI's "snippet"
+            url = result.get("url", "")  # Brave uses "url" vs SerpAPI's "link"
+
+            # Convert to SerpAPI format for consistency
+            normalized_result = {
+                "title": title,
+                "snippet": description,  # Map description → snippet
+                "link": url,  # Map url → link
+            }
+
+            normalized_results.append(normalized_result)
+
+            # Build text output same as SerpAPI
+            if title and description:
+                text_results.append(f"{title}: {description}")
+            elif title:
+                text_results.append(title)
+            elif description:
+                text_results.append(description)
+
+            if url:
+                urls.append(url)
+
+        return {
+            "text": "\n\n".join(text_results),
+            "urls": urls,
+            "results": normalized_results,  # Return normalized format for consistency
+        }
+
+    def _location_to_country_code(self, location: str) -> str:
+        """
+        Convert location string to country code for Brave API.
+
+        Args:
+            location: Location string (e.g., "New York, NY", "United States")
+
+        Returns:
+            Country code (e.g., "us", "uk", "ca")
+        """
+        # Simple mapping - can be expanded based on requirements
+        location_lower = location.lower().strip()
+
+        # Check longer/more specific terms first to avoid false matches
+        # Australia variations (check before US to avoid "us" in "australia")
+        if any(term in location_lower for term in ["australia", "sydney", "melbourne"]):
+            return "au"
+        # Germany variations (check before US to avoid "us" in "deutschland")
+        elif any(term in location_lower for term in ["germany", "deutschland", "berlin"]):
+            return "de"
+        # United States variations
+        elif (
+            any(term in location_lower for term in ["united states", "usa", "new york", "california", "texas"])
+            or location_lower == "us"
+        ):
+            return "us"
+        # United Kingdom variations
+        elif any(term in location_lower for term in ["united kingdom", "uk", "england", "london"]):
+            return "uk"
+        # Canada variations
+        elif any(term in location_lower for term in ["canada", "toronto", "vancouver"]):
+            return "ca"
+        # France variations
+        elif any(term in location_lower for term in ["france", "paris"]):
+            return "fr"
+        # Default to US if unable to determine
+        else:
+            logger.warning(f"Unable to determine country code for location: {location}, defaulting to 'us'")
+            return "us"

--- a/src/vellum/workflows/nodes/displayable/web_search_node/engines/factory.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/engines/factory.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Type
 
 from .base import SearchEngineBase
+from .brave import BraveEngine
 from .serpapi import SerpAPIEngine
 
 
@@ -14,6 +15,7 @@ class SearchEngineFactory:
 
     _engines: Dict[str, Type[SearchEngineBase]] = {
         "serpapi": SerpAPIEngine,
+        "brave": BraveEngine,
     }
 
     @classmethod

--- a/src/vellum/workflows/nodes/displayable/web_search_node/engines/factory.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/engines/factory.py
@@ -1,0 +1,54 @@
+from typing import Dict, List, Type
+
+from .base import SearchEngineBase
+from .serpapi import SerpAPIEngine
+
+
+class SearchEngineFactory:
+    """
+    Factory for creating search engine instances.
+
+    Manages the registry of available search engines and provides
+    a clean interface for engine instantiation.
+    """
+
+    _engines: Dict[str, Type[SearchEngineBase]] = {
+        "serpapi": SerpAPIEngine,
+    }
+
+    @classmethod
+    def create_engine(cls, engine_name: str) -> SearchEngineBase:
+        """
+        Create a search engine instance by name.
+
+        Args:
+            engine_name: Name of the engine to create (e.g., "serpapi")
+
+        Returns:
+            SearchEngineBase instance
+
+        Raises:
+            ValueError: If engine_name is not supported
+        """
+        if engine_name not in cls._engines:
+            available_engines = list(cls._engines.keys())
+            raise ValueError(f"Unsupported search engine: {engine_name}. " f"Available engines: {available_engines}")
+
+        engine_class = cls._engines[engine_name]
+        return engine_class()
+
+    @classmethod
+    def get_available_engines(cls) -> List[str]:
+        """Get list of available engine names."""
+        return list(cls._engines.keys())
+
+    @classmethod
+    def register_engine(cls, engine_name: str, engine_class: Type[SearchEngineBase]) -> None:
+        """
+        Register a new search engine.
+
+        Args:
+            engine_name: Unique name for the engine
+            engine_class: Engine class that implements SearchEngineBase
+        """
+        cls._engines[engine_name] = engine_class

--- a/src/vellum/workflows/nodes/displayable/web_search_node/engines/serpapi.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/engines/serpapi.py
@@ -1,0 +1,117 @@
+import logging
+from typing import Any, Dict, Optional
+
+from requests import Request, RequestException, Session
+from requests.exceptions import JSONDecodeError
+
+from vellum.workflows.errors.types import WorkflowErrorCode
+from vellum.workflows.exceptions import NodeException
+
+from .base import SearchEngineBase
+
+logger = logging.getLogger(__name__)
+
+
+class SerpAPIEngine(SearchEngineBase):
+    """
+    SerpAPI search engine implementation.
+
+    Uses Google search via SerpAPI service.
+    """
+
+    def search(
+        self,
+        query: str,
+        api_key: str,
+        num_results: int,
+        location: Optional[str],
+        context: Any,
+    ) -> Dict[str, Any]:
+        """Execute search via SerpAPI and return normalized response."""
+        params = {
+            "q": query,
+            "api_key": api_key,
+            "num": num_results,
+            "engine": "google",
+        }
+
+        if location:
+            params["location"] = location
+
+        headers = {}
+        client_headers = context.vellum_client._client_wrapper.get_headers()
+        headers["User-Agent"] = client_headers.get("User-Agent")
+
+        try:
+            prepped = Request(method="GET", url="https://serpapi.com/search", params=params, headers=headers).prepare()
+        except Exception as e:
+            logger.exception("Failed to prepare SerpAPI request")
+            raise NodeException(f"Failed to prepare HTTP request: {e}", code=WorkflowErrorCode.PROVIDER_ERROR) from e
+
+        try:
+            with Session() as session:
+                response = session.send(prepped, timeout=30)
+        except RequestException as e:
+            logger.exception("SerpAPI request failed")
+            raise NodeException(f"HTTP request failed: {e}", code=WorkflowErrorCode.PROVIDER_ERROR) from e
+
+        if response.status_code == 401:
+            logger.error("SerpAPI authentication failed")
+            raise NodeException("Invalid API key", code=WorkflowErrorCode.INVALID_INPUTS)
+        elif response.status_code == 429:
+            logger.warning("SerpAPI rate limit exceeded")
+            raise NodeException("Rate limit exceeded", code=WorkflowErrorCode.PROVIDER_ERROR)
+        elif response.status_code >= 400:
+            logger.error(f"SerpAPI returned error status: {response.status_code}")
+            raise NodeException(f"SerpAPI error: HTTP {response.status_code}", code=WorkflowErrorCode.PROVIDER_ERROR)
+
+        try:
+            json_response = response.json()
+        except JSONDecodeError as e:
+            logger.exception("Failed to parse SerpAPI response as JSON")
+            raise NodeException(
+                f"Invalid JSON response from SerpAPI: {e}", code=WorkflowErrorCode.PROVIDER_ERROR
+            ) from e
+
+        if "error" in json_response:
+            error_msg = json_response["error"]
+            logger.error(f"SerpAPI returned error: {error_msg}")
+            raise NodeException(f"SerpAPI error: {error_msg}", code=WorkflowErrorCode.PROVIDER_ERROR)
+
+        return self._normalize_response(json_response)
+
+    def _normalize_response(self, json_response: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Normalize SerpAPI response to standard format.
+
+        Args:
+            json_response: Raw SerpAPI response
+
+        Returns:
+            Normalized response with text, urls, and results fields
+        """
+        organic_results = json_response.get("organic_results", [])
+
+        text_results = []
+        urls = []
+
+        for result in organic_results:
+            title = result.get("title", "")
+            snippet = result.get("snippet", "")
+            link = result.get("link", "")
+
+            if title and snippet:
+                text_results.append(f"{title}: {snippet}")
+            elif title:
+                text_results.append(title)
+            elif snippet:
+                text_results.append(snippet)
+
+            if link:
+                urls.append(link)
+
+        return {
+            "text": "\n\n".join(text_results),
+            "urls": urls,
+            "results": organic_results,
+        }

--- a/src/vellum/workflows/nodes/displayable/web_search_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/node.py
@@ -1,24 +1,23 @@
 import logging
 from typing import Any, ClassVar, Dict, List, Optional
 
-from requests import Request, RequestException, Session
-from requests.exceptions import JSONDecodeError
-
 from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.outputs import BaseOutputs
 from vellum.workflows.types.generics import StateType
 
+from .engines.factory import SearchEngineFactory
+
 logger = logging.getLogger(__name__)
 
 
 class WebSearchNode(BaseNode[StateType]):
     """
-    Used to perform web search using SerpAPI.
+    Used to perform web search using configurable search engines.
 
     query: str - The search query to execute
-    api_key: str - SerpAPI authentication key
+    api_key: str - Search engine authentication key
     num_results: int - Number of search results to return (default: 10)
     location: Optional[str] - Geographic location filter for search
     """
@@ -34,7 +33,7 @@ class WebSearchNode(BaseNode[StateType]):
 
         text: str - Concatenated search result snippets with titles
         urls: List[str] - List of URLs from search results
-        results: List[Dict[str, Any]] - Raw search results from SerpAPI
+        results: List[Dict[str, Any]] - Raw search results from search engine
         """
 
         text: str
@@ -55,79 +54,22 @@ class WebSearchNode(BaseNode[StateType]):
             raise NodeException("num_results must be a positive integer", code=WorkflowErrorCode.INVALID_INPUTS)
 
     def run(self) -> Outputs:
-        """Run the WebSearchNode to perform web search via SerpAPI."""
+        """Run the WebSearchNode to perform web search via search engine."""
         self._validate()
 
-        api_key_value = self.api_key
+        # Use SerpAPI engine for Phase 1 - maintains exact same functionality
+        search_engine = SearchEngineFactory.create_engine("serpapi")
 
-        params = {
-            "q": self.query,
-            "api_key": api_key_value,
-            "num": self.num_results,
-            "engine": "google",
-        }
+        result = search_engine.search(
+            query=self.query,
+            api_key=self.api_key,
+            num_results=self.num_results,
+            location=self.location,
+            context=self._context,
+        )
 
-        if self.location:
-            params["location"] = self.location
-
-        headers = {}
-        client_headers = self._context.vellum_client._client_wrapper.get_headers()
-        headers["User-Agent"] = client_headers.get("User-Agent")
-
-        try:
-            prepped = Request(method="GET", url="https://serpapi.com/search", params=params, headers=headers).prepare()
-        except Exception as e:
-            logger.exception("Failed to prepare SerpAPI request")
-            raise NodeException(f"Failed to prepare HTTP request: {e}", code=WorkflowErrorCode.PROVIDER_ERROR) from e
-
-        try:
-            with Session() as session:
-                response = session.send(prepped, timeout=30)
-        except RequestException as e:
-            logger.exception("SerpAPI request failed")
-            raise NodeException(f"HTTP request failed: {e}", code=WorkflowErrorCode.PROVIDER_ERROR) from e
-
-        if response.status_code == 401:
-            logger.error("SerpAPI authentication failed")
-            raise NodeException("Invalid API key", code=WorkflowErrorCode.INVALID_INPUTS)
-        elif response.status_code == 429:
-            logger.warning("SerpAPI rate limit exceeded")
-            raise NodeException("Rate limit exceeded", code=WorkflowErrorCode.PROVIDER_ERROR)
-        elif response.status_code >= 400:
-            logger.error(f"SerpAPI returned error status: {response.status_code}")
-            raise NodeException(f"SerpAPI error: HTTP {response.status_code}", code=WorkflowErrorCode.PROVIDER_ERROR)
-
-        try:
-            json_response = response.json()
-        except JSONDecodeError as e:
-            logger.exception("Failed to parse SerpAPI response as JSON")
-            raise NodeException(
-                f"Invalid JSON response from SerpAPI: {e}", code=WorkflowErrorCode.PROVIDER_ERROR
-            ) from e
-
-        if "error" in json_response:
-            error_msg = json_response["error"]
-            logger.error(f"SerpAPI returned error: {error_msg}")
-            raise NodeException(f"SerpAPI error: {error_msg}", code=WorkflowErrorCode.PROVIDER_ERROR)
-
-        organic_results = json_response.get("organic_results", [])
-
-        text_results = []
-        urls = []
-
-        for result in organic_results:
-            title = result.get("title", "")
-            snippet = result.get("snippet", "")
-            link = result.get("link", "")
-
-            if title and snippet:
-                text_results.append(f"{title}: {snippet}")
-            elif title:
-                text_results.append(title)
-            elif snippet:
-                text_results.append(snippet)
-
-            if link:
-                urls.append(link)
-
-        return self.Outputs(text="\n\n".join(text_results), urls=urls, results=organic_results)
+        return self.Outputs(
+            text=result["text"],
+            urls=result["urls"],
+            results=result["results"],
+        )

--- a/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/__init__.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/__init__.py
@@ -1,0 +1,1 @@
+# Engine tests

--- a/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/test_brave.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/test_brave.py
@@ -1,0 +1,371 @@
+import pytest
+from unittest.mock import MagicMock
+
+import requests
+
+from vellum.workflows.errors.types import WorkflowErrorCode
+from vellum.workflows.exceptions import NodeException
+
+from ...engines.brave import BraveEngine
+
+
+@pytest.fixture
+def vellum_context():
+    """Mock WorkflowContext with vellum_client."""
+    context = MagicMock()
+    context.vellum_client._client_wrapper.get_headers.return_value = {"User-Agent": "vellum-python-sdk/1.0.0"}
+    return context
+
+
+@pytest.fixture
+def brave_engine():
+    """Create BraveEngine instance."""
+    return BraveEngine()
+
+
+def test_successful_search_with_results(brave_engine, vellum_context, requests_mock):
+    """Test successful Brave API search with typical web results."""
+    # GIVEN a mock Brave API response with web results
+    mock_response = {
+        "web": {
+            "results": [
+                {
+                    "title": "First Result",
+                    "description": "This is the first search result description",
+                    "url": "https://example1.com",
+                },
+                {
+                    "title": "Second Result",
+                    "description": "This is the second search result description",
+                    "url": "https://example2.com",
+                },
+                {
+                    "title": "Third Result",
+                    "description": "This is the third search result description",
+                    "url": "https://example3.com",
+                },
+            ]
+        }
+    }
+
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", json=mock_response)
+
+    # WHEN we search with the engine
+    result = brave_engine.search(
+        query="test query",
+        api_key="test_api_key",
+        num_results=3,
+        location=None,
+        context=vellum_context,
+    )
+
+    # THEN the text output should be properly formatted
+    expected_text = (
+        "First Result: This is the first search result description\n\n"
+        "Second Result: This is the second search result description\n\n"
+        "Third Result: This is the third search result description"
+    )
+    assert result["text"] == expected_text
+
+    # AND URLs should be extracted correctly
+    assert result["urls"] == ["https://example1.com", "https://example2.com", "https://example3.com"]
+
+    # AND results should be normalized to SerpAPI format
+    expected_results = [
+        {
+            "title": "First Result",
+            "snippet": "This is the first search result description",  # description → snippet
+            "link": "https://example1.com",  # url → link
+        },
+        {
+            "title": "Second Result",
+            "snippet": "This is the second search result description",
+            "link": "https://example2.com",
+        },
+        {
+            "title": "Third Result",
+            "snippet": "This is the third search result description",
+            "link": "https://example3.com",
+        },
+    ]
+    assert result["results"] == expected_results
+
+    # AND the request should have the correct parameters
+    assert requests_mock.last_request.qs == {
+        "q": ["test query"],
+        "count": ["3"],  # Brave uses "count" vs SerpAPI's "num"
+    }
+
+
+def test_search_with_location_parameter(brave_engine, vellum_context, requests_mock):
+    """Test that location parameter is converted to country code for Brave API."""
+    # GIVEN a location parameter is set
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", json={"web": {"results": []}})
+
+    # WHEN we search with location
+    brave_engine.search(
+        query="test query",
+        api_key="test_api_key",
+        num_results=10,
+        location="New York, NY",
+        context=vellum_context,
+    )
+
+    # THEN the country parameter should be included (converted from location)
+    assert "country" in requests_mock.last_request.qs
+    assert requests_mock.last_request.qs["country"][0] == "us"
+
+
+def test_header_authentication(brave_engine, vellum_context, requests_mock):
+    """Test that Brave API uses header-based authentication."""
+    # GIVEN a successful request
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", json={"web": {"results": []}})
+
+    # WHEN we search
+    brave_engine.search(
+        query="test query",
+        api_key="test_brave_key",
+        num_results=10,
+        location=None,
+        context=vellum_context,
+    )
+
+    # THEN the X-Subscription-Token header should be set
+    assert requests_mock.last_request.headers["X-Subscription-Token"] == "test_brave_key"
+    # AND Accept headers should be set
+    assert requests_mock.last_request.headers["Accept"] == "application/json"
+    assert requests_mock.last_request.headers["Accept-Encoding"] == "gzip"
+
+
+def test_authentication_error_401(brave_engine, vellum_context, requests_mock):
+    """Test 401 authentication error raises NodeException with INVALID_INPUTS."""
+    # GIVEN Brave API returns a 401 authentication error
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", status_code=401)
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        brave_engine.search(
+            query="test query",
+            api_key="invalid_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise the appropriate error
+    assert exc_info.value.code == WorkflowErrorCode.INVALID_INPUTS
+    assert "Invalid API key" in str(exc_info.value)
+
+
+def test_rate_limit_error_429(brave_engine, vellum_context, requests_mock):
+    """Test 429 rate limit error raises NodeException with PROVIDER_ERROR."""
+    # GIVEN Brave API returns a 429 rate limit error
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", status_code=429)
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        brave_engine.search(
+            query="test query",
+            api_key="test_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise the appropriate error
+    assert exc_info.value.code == WorkflowErrorCode.PROVIDER_ERROR
+    assert "Rate limit exceeded" in str(exc_info.value)
+
+
+def test_server_error_500(brave_engine, vellum_context, requests_mock):
+    """Test 500+ server errors raise NodeException with PROVIDER_ERROR."""
+    # GIVEN Brave API returns a 500 server error
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", status_code=500)
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        brave_engine.search(
+            query="test query",
+            api_key="test_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise the appropriate error
+    assert exc_info.value.code == WorkflowErrorCode.PROVIDER_ERROR
+    assert "Brave API error: HTTP 500" in str(exc_info.value)
+
+
+def test_invalid_json_response(brave_engine, vellum_context, requests_mock):
+    """Test non-JSON response raises appropriate NodeException."""
+    # GIVEN Brave API returns non-JSON content
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", text="Not JSON")
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        brave_engine.search(
+            query="test query",
+            api_key="test_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise the appropriate error
+    assert exc_info.value.code == WorkflowErrorCode.PROVIDER_ERROR
+    assert "Invalid JSON response from Brave API" in str(exc_info.value)
+
+
+def test_brave_api_error_in_response(brave_engine, vellum_context, requests_mock):
+    """Test Brave API error field in response raises NodeException."""
+    # GIVEN Brave API returns an error in the response body
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", json={"error": "Invalid search parameters"})
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        brave_engine.search(
+            query="test query",
+            api_key="test_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise the appropriate error
+    assert exc_info.value.code == WorkflowErrorCode.PROVIDER_ERROR
+    assert "Invalid search parameters" in str(exc_info.value)
+
+
+def test_empty_web_results(brave_engine, vellum_context, requests_mock):
+    """Test handling of empty search results."""
+    # GIVEN Brave API returns no web results
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", json={"web": {"results": []}})
+
+    # WHEN we search
+    result = brave_engine.search(
+        query="test query",
+        api_key="test_key",
+        num_results=10,
+        location=None,
+        context=vellum_context,
+    )
+
+    # THEN all outputs should be empty
+    assert result["text"] == ""
+    assert result["urls"] == []
+    assert result["results"] == []
+
+
+def test_missing_web_section(brave_engine, vellum_context, requests_mock):
+    """Test handling when web section is missing from response."""
+    # GIVEN Brave API returns response without web section
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", json={})
+
+    # WHEN we search
+    result = brave_engine.search(
+        query="test query",
+        api_key="test_key",
+        num_results=10,
+        location=None,
+        context=vellum_context,
+    )
+
+    # THEN all outputs should be empty
+    assert result["text"] == ""
+    assert result["urls"] == []
+    assert result["results"] == []
+
+
+def test_missing_fields_in_results(brave_engine, vellum_context, requests_mock):
+    """Test handling of missing title, description, or url fields."""
+    # GIVEN Brave API returns results with missing fields
+    mock_response = {
+        "web": {
+            "results": [
+                {
+                    "title": "Only Title",
+                    # Missing description and url
+                },
+                {
+                    "description": "Only description, no title or url"
+                    # Missing title and url
+                },
+                {
+                    "title": "Title with URL",
+                    "url": "https://example.com",
+                    # Missing description
+                },
+                {
+                    # All fields missing
+                },
+            ]
+        }
+    }
+
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", json=mock_response)
+
+    # WHEN we search
+    result = brave_engine.search(
+        query="test query",
+        api_key="test_key",
+        num_results=10,
+        location=None,
+        context=vellum_context,
+    )
+
+    # THEN text should handle missing fields gracefully
+    expected_text = "Only Title\n\n" "Only description, no title or url\n\n" "Title with URL"
+    assert result["text"] == expected_text
+
+    # AND URLs should only include valid links
+    assert result["urls"] == ["https://example.com"]
+
+    # AND results should be normalized with empty values for missing fields
+    expected_results = [
+        {"title": "Only Title", "snippet": "", "link": ""},
+        {"title": "", "snippet": "Only description, no title or url", "link": ""},
+        {"title": "Title with URL", "snippet": "", "link": "https://example.com"},
+        {"title": "", "snippet": "", "link": ""},
+    ]
+    assert result["results"] == expected_results
+
+
+def test_request_timeout_handling(brave_engine, vellum_context, requests_mock):
+    """Test network timeout raises appropriate error."""
+    # GIVEN a network timeout occurs
+    requests_mock.get(
+        "https://api.search.brave.com/res/v1/web/search", exc=requests.exceptions.Timeout("Connection timed out")
+    )
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        brave_engine.search(
+            query="test query",
+            api_key="test_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise a provider error
+    assert exc_info.value.code == WorkflowErrorCode.PROVIDER_ERROR
+    assert "HTTP request failed" in str(exc_info.value)
+
+
+def test_user_agent_header_included(brave_engine, vellum_context, requests_mock):
+    """Test that User-Agent header from vellum_client is included."""
+    # GIVEN a successful request
+    requests_mock.get("https://api.search.brave.com/res/v1/web/search", json={"web": {"results": []}})
+
+    # WHEN we search
+    brave_engine.search(
+        query="test query",
+        api_key="test_key",
+        num_results=10,
+        location=None,
+        context=vellum_context,
+    )
+
+    # THEN the User-Agent header should be included
+    assert requests_mock.last_request.headers["User-Agent"] == "vellum-python-sdk/1.0.0"

--- a/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/test_brave_location.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/test_brave_location.py
@@ -1,0 +1,133 @@
+import pytest
+
+from ...engines.brave import BraveEngine
+
+
+@pytest.fixture
+def brave_engine():
+    """Create BraveEngine instance."""
+    return BraveEngine()
+
+
+def test_location_to_country_code_us_variations(brave_engine):
+    """Test US location variations are converted to 'us'."""
+    us_locations = [
+        "United States",
+        "USA",
+        "US",
+        "New York, NY",
+        "California",
+        "Texas",
+        "new york, ny",  # case insensitive
+        "UNITED STATES",
+    ]
+
+    for location in us_locations:
+        result = brave_engine._location_to_country_code(location)
+        assert result == "us", f"Failed for location: {location}"
+
+
+def test_location_to_country_code_uk_variations(brave_engine):
+    """Test UK location variations are converted to 'uk'."""
+    uk_locations = [
+        "United Kingdom",
+        "UK",
+        "England",
+        "London",
+        "united kingdom",  # case insensitive
+        "LONDON",
+    ]
+
+    for location in uk_locations:
+        result = brave_engine._location_to_country_code(location)
+        assert result == "uk", f"Failed for location: {location}"
+
+
+def test_location_to_country_code_canada_variations(brave_engine):
+    """Test Canada location variations are converted to 'ca'."""
+    canada_locations = [
+        "Canada",
+        "Toronto",
+        "Vancouver",
+        "canada",  # case insensitive
+        "TORONTO",
+    ]
+
+    for location in canada_locations:
+        result = brave_engine._location_to_country_code(location)
+        assert result == "ca", f"Failed for location: {location}"
+
+
+def test_location_to_country_code_australia_variations(brave_engine):
+    """Test Australia location variations are converted to 'au'."""
+    australia_locations = [
+        "Australia",
+        "Sydney",
+        "Melbourne",
+        "australia",  # case insensitive
+        "SYDNEY",
+    ]
+
+    for location in australia_locations:
+        result = brave_engine._location_to_country_code(location)
+        assert result == "au", f"Failed for location: {location}"
+
+
+def test_location_to_country_code_germany_variations(brave_engine):
+    """Test Germany location variations are converted to 'de'."""
+    germany_locations = [
+        "Germany",
+        "Deutschland",
+        "Berlin",
+        "germany",  # case insensitive
+        "BERLIN",
+    ]
+
+    for location in germany_locations:
+        result = brave_engine._location_to_country_code(location)
+        assert result == "de", f"Failed for location: {location}"
+
+
+def test_location_to_country_code_france_variations(brave_engine):
+    """Test France location variations are converted to 'fr'."""
+    france_locations = [
+        "France",
+        "Paris",
+        "france",  # case insensitive
+        "PARIS",
+    ]
+
+    for location in france_locations:
+        result = brave_engine._location_to_country_code(location)
+        assert result == "fr", f"Failed for location: {location}"
+
+
+def test_location_to_country_code_unknown_defaults_to_us(brave_engine):
+    """Test unknown locations default to 'us'."""
+    unknown_locations = [
+        "Mars",
+        "Unknown Place",
+        "Atlantis",
+        "",  # empty string
+        "123456",  # numeric
+    ]
+
+    for location in unknown_locations:
+        result = brave_engine._location_to_country_code(location)
+        assert result == "us", f"Failed to default to 'us' for location: {location}"
+
+
+def test_location_to_country_code_mixed_case_and_whitespace(brave_engine):
+    """Test location conversion handles mixed case and whitespace."""
+    test_cases = [
+        ("  New York, NY  ", "us"),
+        ("  LONDON  ", "uk"),
+        (" toronto ", "ca"),
+        ("Sydney, Australia", "au"),
+        ("Berlin, Germany", "de"),
+        ("Paris, France", "fr"),
+    ]
+
+    for location, expected in test_cases:
+        result = brave_engine._location_to_country_code(location)
+        assert result == expected, f"Failed for location: '{location}', expected '{expected}', got '{result}'"

--- a/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/test_factory.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/test_factory.py
@@ -1,0 +1,57 @@
+import pytest
+
+from ...engines.base import SearchEngineBase
+from ...engines.factory import SearchEngineFactory
+from ...engines.serpapi import SerpAPIEngine
+
+
+def test_create_serpapi_engine():
+    """Test creating SerpAPI engine via factory."""
+    # WHEN we create a SerpAPI engine
+    engine = SearchEngineFactory.create_engine("serpapi")
+
+    # THEN it should be the correct type
+    assert isinstance(engine, SerpAPIEngine)
+    assert isinstance(engine, SearchEngineBase)
+
+
+def test_create_invalid_engine():
+    """Test creating invalid engine raises ValueError."""
+    # WHEN we try to create an unsupported engine
+    with pytest.raises(ValueError) as exc_info:
+        SearchEngineFactory.create_engine("unsupported_engine")
+
+    # THEN it should raise an appropriate error
+    assert "Unsupported search engine: unsupported_engine" in str(exc_info.value)
+    assert "Available engines: ['serpapi']" in str(exc_info.value)
+
+
+def test_get_available_engines():
+    """Test getting list of available engines."""
+    # WHEN we get available engines
+    engines = SearchEngineFactory.get_available_engines()
+
+    # THEN it should return the correct list
+    assert engines == ["serpapi"]
+
+
+def test_register_new_engine():
+    """Test registering a new engine dynamically."""
+
+    # GIVEN a mock engine class
+    class MockEngine(SearchEngineBase):
+        def search(self, query, api_key, num_results, location, context):
+            return {"text": "mock", "urls": [], "results": []}
+
+    # WHEN we register a new engine
+    SearchEngineFactory.register_engine("mock", MockEngine)
+
+    # THEN it should be available
+    assert "mock" in SearchEngineFactory.get_available_engines()
+
+    # AND we should be able to create it
+    engine = SearchEngineFactory.create_engine("mock")
+    assert isinstance(engine, MockEngine)
+
+    # Clean up
+    del SearchEngineFactory._engines["mock"]

--- a/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/test_factory.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/test_factory.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ...engines.base import SearchEngineBase
+from ...engines.brave import BraveEngine
 from ...engines.factory import SearchEngineFactory
 from ...engines.serpapi import SerpAPIEngine
 
@@ -23,7 +24,19 @@ def test_create_invalid_engine():
 
     # THEN it should raise an appropriate error
     assert "Unsupported search engine: unsupported_engine" in str(exc_info.value)
-    assert "Available engines: ['serpapi']" in str(exc_info.value)
+    assert "Available engines:" in str(exc_info.value)
+    assert "serpapi" in str(exc_info.value)
+    assert "brave" in str(exc_info.value)
+
+
+def test_create_brave_engine():
+    """Test creating Brave engine via factory."""
+    # WHEN we create a Brave engine
+    engine = SearchEngineFactory.create_engine("brave")
+
+    # THEN it should be the correct type
+    assert isinstance(engine, BraveEngine)
+    assert isinstance(engine, SearchEngineBase)
 
 
 def test_get_available_engines():
@@ -32,7 +45,7 @@ def test_get_available_engines():
     engines = SearchEngineFactory.get_available_engines()
 
     # THEN it should return the correct list
-    assert engines == ["serpapi"]
+    assert set(engines) == {"serpapi", "brave"}
 
 
 def test_register_new_engine():

--- a/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/test_serpapi.py
+++ b/src/vellum/workflows/nodes/displayable/web_search_node/tests/engines/test_serpapi.py
@@ -1,0 +1,304 @@
+import pytest
+from unittest.mock import MagicMock
+
+import requests
+
+from vellum.workflows.errors.types import WorkflowErrorCode
+from vellum.workflows.exceptions import NodeException
+
+from ...engines.serpapi import SerpAPIEngine
+
+
+@pytest.fixture
+def vellum_context():
+    """Mock WorkflowContext with vellum_client."""
+    context = MagicMock()
+    context.vellum_client._client_wrapper.get_headers.return_value = {"User-Agent": "vellum-python-sdk/1.0.0"}
+    return context
+
+
+@pytest.fixture
+def serpapi_engine():
+    """Create SerpAPIEngine instance."""
+    return SerpAPIEngine()
+
+
+def test_successful_search_with_results(serpapi_engine, vellum_context, requests_mock):
+    """Test successful SerpAPI search with typical organic results."""
+    # GIVEN a mock SerpAPI response with organic results
+    mock_response = {
+        "organic_results": [
+            {
+                "title": "First Result",
+                "snippet": "This is the first search result snippet",
+                "link": "https://example1.com",
+                "position": 1,
+            },
+            {
+                "title": "Second Result",
+                "snippet": "This is the second search result snippet",
+                "link": "https://example2.com",
+                "position": 2,
+            },
+            {
+                "title": "Third Result",
+                "snippet": "This is the third search result snippet",
+                "link": "https://example3.com",
+                "position": 3,
+            },
+        ]
+    }
+
+    requests_mock.get("https://serpapi.com/search", json=mock_response)
+
+    # WHEN we search with the engine
+    result = serpapi_engine.search(
+        query="test query",
+        api_key="test_api_key",
+        num_results=3,
+        location=None,
+        context=vellum_context,
+    )
+
+    # THEN the text output should be properly formatted
+    expected_text = (
+        "First Result: This is the first search result snippet\n\n"
+        "Second Result: This is the second search result snippet\n\n"
+        "Third Result: This is the third search result snippet"
+    )
+    assert result["text"] == expected_text
+
+    # AND URLs should be extracted correctly
+    assert result["urls"] == ["https://example1.com", "https://example2.com", "https://example3.com"]
+
+    # AND raw results should be preserved
+    assert result["results"] == mock_response["organic_results"]
+
+    # AND the request should have the correct parameters
+    assert requests_mock.last_request.qs == {
+        "q": ["test query"],
+        "api_key": ["test_api_key"],
+        "num": ["3"],
+        "engine": ["google"],
+    }
+
+
+def test_search_with_location_parameter(serpapi_engine, vellum_context, requests_mock):
+    """Test that location parameter is properly passed to SerpAPI."""
+    # GIVEN a location parameter is set
+    requests_mock.get("https://serpapi.com/search", json={"organic_results": []})
+
+    # WHEN we search with location
+    serpapi_engine.search(
+        query="test query",
+        api_key="test_api_key",
+        num_results=10,
+        location="New York, NY",
+        context=vellum_context,
+    )
+
+    # THEN the location parameter should be included
+    assert "location" in requests_mock.last_request.qs
+    assert requests_mock.last_request.qs["location"][0].lower() == "new york, ny"
+
+
+def test_authentication_error_401(serpapi_engine, vellum_context, requests_mock):
+    """Test 401 authentication error raises NodeException with INVALID_INPUTS."""
+    # GIVEN SerpAPI returns a 401 authentication error
+    requests_mock.get("https://serpapi.com/search", status_code=401)
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        serpapi_engine.search(
+            query="test query",
+            api_key="invalid_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise the appropriate error
+    assert exc_info.value.code == WorkflowErrorCode.INVALID_INPUTS
+    assert "Invalid API key" in str(exc_info.value)
+
+
+def test_rate_limit_error_429(serpapi_engine, vellum_context, requests_mock):
+    """Test 429 rate limit error raises NodeException with PROVIDER_ERROR."""
+    # GIVEN SerpAPI returns a 429 rate limit error
+    requests_mock.get("https://serpapi.com/search", status_code=429)
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        serpapi_engine.search(
+            query="test query",
+            api_key="test_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise the appropriate error
+    assert exc_info.value.code == WorkflowErrorCode.PROVIDER_ERROR
+    assert "Rate limit exceeded" in str(exc_info.value)
+
+
+def test_server_error_500(serpapi_engine, vellum_context, requests_mock):
+    """Test 500+ server errors raise NodeException with PROVIDER_ERROR."""
+    # GIVEN SerpAPI returns a 500 server error
+    requests_mock.get("https://serpapi.com/search", status_code=500)
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        serpapi_engine.search(
+            query="test query",
+            api_key="test_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise the appropriate error
+    assert exc_info.value.code == WorkflowErrorCode.PROVIDER_ERROR
+    assert "SerpAPI error: HTTP 500" in str(exc_info.value)
+
+
+def test_invalid_json_response(serpapi_engine, vellum_context, requests_mock):
+    """Test non-JSON response raises appropriate NodeException."""
+    # GIVEN SerpAPI returns non-JSON content
+    requests_mock.get("https://serpapi.com/search", text="Not JSON")
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        serpapi_engine.search(
+            query="test query",
+            api_key="test_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise the appropriate error
+    assert exc_info.value.code == WorkflowErrorCode.PROVIDER_ERROR
+    assert "Invalid JSON response" in str(exc_info.value)
+
+
+def test_serpapi_error_in_response(serpapi_engine, vellum_context, requests_mock):
+    """Test SerpAPI error field in response raises NodeException."""
+    # GIVEN SerpAPI returns an error in the response body
+    requests_mock.get("https://serpapi.com/search", json={"error": "Invalid search parameters"})
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        serpapi_engine.search(
+            query="test query",
+            api_key="test_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise the appropriate error
+    assert exc_info.value.code == WorkflowErrorCode.PROVIDER_ERROR
+    assert "Invalid search parameters" in str(exc_info.value)
+
+
+def test_empty_organic_results(serpapi_engine, vellum_context, requests_mock):
+    """Test handling of empty search results."""
+    # GIVEN SerpAPI returns no organic results
+    requests_mock.get("https://serpapi.com/search", json={"organic_results": []})
+
+    # WHEN we search
+    result = serpapi_engine.search(
+        query="test query",
+        api_key="test_key",
+        num_results=10,
+        location=None,
+        context=vellum_context,
+    )
+
+    # THEN all outputs should be empty
+    assert result["text"] == ""
+    assert result["urls"] == []
+    assert result["results"] == []
+
+
+def test_missing_fields_in_results(serpapi_engine, vellum_context, requests_mock):
+    """Test handling of missing title, snippet, or link fields."""
+    # GIVEN SerpAPI returns results with missing fields
+    mock_response = {
+        "organic_results": [
+            {
+                "title": "Only Title",
+                # Missing snippet and link
+            },
+            {
+                "snippet": "Only snippet, no title or link"
+                # Missing title and link
+            },
+            {
+                "title": "Title with link",
+                "link": "https://example.com",
+                # Missing snippet
+            },
+            {
+                # All fields missing - should be skipped
+                "position": 4
+            },
+        ]
+    }
+
+    requests_mock.get("https://serpapi.com/search", json=mock_response)
+
+    # WHEN we search
+    result = serpapi_engine.search(
+        query="test query",
+        api_key="test_key",
+        num_results=10,
+        location=None,
+        context=vellum_context,
+    )
+
+    # THEN text should handle missing fields gracefully
+    expected_text = "Only Title\n\n" "Only snippet, no title or link\n\n" "Title with link"
+    assert result["text"] == expected_text
+
+    # AND URLs should only include valid links
+    assert result["urls"] == ["https://example.com"]
+
+
+def test_request_timeout_handling(serpapi_engine, vellum_context, requests_mock):
+    """Test network timeout raises appropriate error."""
+    # GIVEN a network timeout occurs
+    requests_mock.get("https://serpapi.com/search", exc=requests.exceptions.Timeout("Connection timed out"))
+
+    # WHEN we search
+    with pytest.raises(NodeException) as exc_info:
+        serpapi_engine.search(
+            query="test query",
+            api_key="test_key",
+            num_results=10,
+            location=None,
+            context=vellum_context,
+        )
+
+    # THEN it should raise a provider error
+    assert exc_info.value.code == WorkflowErrorCode.PROVIDER_ERROR
+    assert "HTTP request failed" in str(exc_info.value)
+
+
+def test_user_agent_header_included(serpapi_engine, vellum_context, requests_mock):
+    """Test that User-Agent header from vellum_client is included."""
+    # GIVEN a successful request
+    requests_mock.get("https://serpapi.com/search", json={"organic_results": []})
+
+    # WHEN we search
+    serpapi_engine.search(
+        query="test query",
+        api_key="test_key",
+        num_results=10,
+        location=None,
+        context=vellum_context,
+    )
+
+    # THEN the User-Agent header should be included
+    assert requests_mock.last_request.headers["User-Agent"] == "vellum-python-sdk/1.0.0"


### PR DESCRIPTION
[Ticket](https://linear.app/vellum/issue/APO-1432/add-search-engine-abstraction-with-brave-search-support-for)

 ## Summary
  Implements search engine abstraction for WebSearchNode with Brave Search as second engine option alongside existing
  SerpAPI support.

 ## Changes
  - **Engine Abstraction**: Extract SerpAPI logic into modular engine system with `SearchEngineBase` interface
  - **BraveEngine**: Complete Brave Search API integration with header-based authentication
  - **Response Normalization**: Convert between different API formats for consistent output
  - **Location Mapping**: Intelligent location-to-country-code conversion for Brave API requirements


## Technical Details
  ### Engine Abstraction
  - `SearchEngineBase`: Abstract interface for all search engines
  - `SearchEngineFactory`: Factory pattern for engine instantiation
  - Maintains exact same WebSearchNode behavior (hardcoded to SerpAPI for now)

  ### Brave API Integration
  - Uses `https://api.search.brave.com/res/v1/web/search`
  - Header authentication with `X-Subscription-Token`
  - Converts Brave format (`description`, `url`) to SerpAPI format (`snippet`, `link`)
  - Maps locations to country codes (US, UK, CA, AU, DE, FR)
