### PR TITLE
Remove null function name test

### DIFF
--- a/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/tool-calling-node.test.ts.snap
@@ -175,17 +175,6 @@ class CasingTestNode(ToolCallingNode):
 "
 `;
 
-exports[`ToolCallingNode > function name casing > skips null/empty function names 1`] = `
-"from .valid_function import validFunction
-
-from vellum.workflows.nodes.displayable.tool_calling_node import ToolCallingNode
-
-
-class NullTestNode(ToolCallingNode):
-    functions = [validFunction]
-"
-`;
-
 exports[`ToolCallingNode > function ordering > should preserve order: code-exec, workflow 1`] = `
 "from .add_numbers import add_numbers
 from .subtract_workflow.workflow import SubtractWorkflow

--- a/ee/codegen/src/__test__/nodes/tool-calling-node.test.ts
+++ b/ee/codegen/src/__test__/nodes/tool-calling-node.test.ts
@@ -819,45 +819,5 @@ describe("ToolCallingNode", () => {
 
       expect(output).toMatchSnapshot();
     });
-
-    it("skips null/empty function names", async () => {
-      const functions = [
-        {
-          type: "CODE_EXECUTION",
-          name: "validFunction",
-          src: "def validFunction(): pass",
-        },
-        { type: "CODE_EXECUTION", name: null, src: "def unnamed(): pass" },
-        { type: "CODE_EXECUTION", name: "", src: "def empty(): pass" },
-      ];
-
-      const functionsAttribute = nodeAttributeFactory(
-        "functions-attr-id",
-        "functions",
-        {
-          type: "CONSTANT_VALUE",
-          value: { type: "JSON", value: functions },
-        }
-      );
-
-      const nodeData = toolCallingNodeFactory({
-        nodePorts: [nodePortFactory({ id: "port-id" })],
-        nodeAttributes: [functionsAttribute],
-        label: "NullTestNode",
-      });
-
-      const nodeContext = (await createNodeContext({
-        workflowContext,
-        nodeData,
-      })) as GenericNodeContext;
-      const node = new GenericNode({ workflowContext, nodeContext });
-
-      expect(() => {
-        node.getNodeFile().write(writer);
-      }).not.toThrow();
-
-      const output = await writer.toStringFormatted();
-      expect(output).toMatchSnapshot();
-    });
   });
 });

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -99,18 +99,16 @@ export class GenericNode extends BaseNode<GenericNodeType, GenericNodeContext> {
               switch (f.type) {
                 case "CODE_EXECUTION": {
                   codeExecutionFunctions.push(f as FunctionArgs);
-                  if (f.name) {
-                    const snakeName = toPythonSafeSnakeCase(f.name);
-                    // Use toValidPythonIdentifier to ensure the name is safe for Python references
-                    // but preserve original casing when possible (see APO-1372)
-                    const safeName = toValidPythonIdentifier(f.name);
-                    functionReferences.push(
-                      python.reference({
-                        name: safeName, // Use safe Python identifier that preserves original casing
-                        modulePath: [`.${snakeName}`], // Import from snake_case module
-                      })
-                    );
-                  }
+                  const snakeName = toPythonSafeSnakeCase(f.name);
+                  // Use toValidPythonIdentifier to ensure the name is safe for Python references
+                  // but preserve original casing when possible (see APO-1372)
+                  const safeName = toValidPythonIdentifier(f.name);
+                  functionReferences.push(
+                    python.reference({
+                      name: safeName, // Use safe Python identifier that preserves original casing
+                      modulePath: [`.${snakeName}`], // Import from snake_case module
+                    })
+                  );
                   break;
                 }
                 case "INLINE_WORKFLOW": {


### PR DESCRIPTION
this is now blocking another PR since we add back the if else f.name check but I think empty/null name should be catch in sdk or frontend since in codegen all function has name as required