### PR TITLE
Fix default parent class outputs

### DIFF
--- a/src/vellum/workflows/outputs/base.py
+++ b/src/vellum/workflows/outputs/base.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Dict, Generic, Iterator, Optional, Set, Tuple, Type, TypeVar, Union, cast
+from typing import Any, Dict, Generic, Iterator, Set, Tuple, Type, TypeVar, Union, cast
 from typing_extensions import dataclass_transform
 
 from pydantic import GetCoreSchemaHandler

--- a/src/vellum/workflows/outputs/base.py
+++ b/src/vellum/workflows/outputs/base.py
@@ -99,6 +99,10 @@ class BaseOutput(Generic[_Delta, _Accumulated]):
 
 @dataclass_transform(kw_only_default=True)
 class _BaseOutputsMeta(type):
+    def __new__(cls, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
+        dct["__parent_class__"] = type(None)
+        return super().__new__(cls, name, bases, dct)
+
     def __eq__(cls, other: Any) -> bool:
         """
         We need to include custom eq logic to prevent infinite loops during ipython reloading.

--- a/src/vellum/workflows/outputs/base.py
+++ b/src/vellum/workflows/outputs/base.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Generic, Iterator, Set, Tuple, Type, TypeVar, Union, cast
+from typing import Any, Dict, Generic, Iterator, Optional, Set, Tuple, Type, TypeVar, Union, cast
 from typing_extensions import dataclass_transform
 
 from pydantic import GetCoreSchemaHandler
@@ -190,7 +190,7 @@ class _BaseOutputsMeta(type):
 
 
 class BaseOutputs(metaclass=_BaseOutputsMeta):
-    __parent_class__: Type[BaseExecutable] = type(None)
+    __parent_class__: Union[Type[BaseExecutable], Type[None]] = type(None)
 
     def __init__(self, **kwargs: Any) -> None:
         declared_fields = {descriptor.name for descriptor in self.__class__}

--- a/src/vellum/workflows/outputs/base.py
+++ b/src/vellum/workflows/outputs/base.py
@@ -1,3 +1,4 @@
+from dataclasses import field
 import inspect
 from typing import Any, Dict, Generic, Iterator, Set, Tuple, Type, TypeVar, Union, cast
 from typing_extensions import dataclass_transform

--- a/src/vellum/workflows/outputs/base.py
+++ b/src/vellum/workflows/outputs/base.py
@@ -190,7 +190,7 @@ class _BaseOutputsMeta(type):
 
 
 class BaseOutputs(metaclass=_BaseOutputsMeta):
-    __parent_class__: Union[Type[BaseExecutable], Type[None]] = type(None)
+    __parent_class__: Type[BaseExecutable] = field(init=False)
 
     def __init__(self, **kwargs: Any) -> None:
         declared_fields = {descriptor.name for descriptor in self.__class__}

--- a/src/vellum/workflows/outputs/base.py
+++ b/src/vellum/workflows/outputs/base.py
@@ -124,6 +124,9 @@ class _BaseOutputsMeta(type):
         if self_outputs_class.__parent_class__ is None or other_outputs_class.__parent_class__ is None:
             return super().__eq__(other)
 
+        if self_outputs_class.__parent_class__ is type(None) or other_outputs_class.__parent_class__ is type(None):
+            return super().__eq__(other)
+
         return (
             self_outputs_class.__parent_class__.__qualname__ == other_outputs_class.__parent_class__.__qualname__
             and self_outputs_class.__parent_class__.__module__ == other_outputs_class.__parent_class__.__module__

--- a/src/vellum/workflows/outputs/base.py
+++ b/src/vellum/workflows/outputs/base.py
@@ -1,4 +1,3 @@
-from dataclasses import field
 import inspect
 from typing import Any, Generic, Iterator, Set, Tuple, Type, TypeVar, Union, cast
 from typing_extensions import dataclass_transform
@@ -187,7 +186,7 @@ class _BaseOutputsMeta(type):
 
 
 class BaseOutputs(metaclass=_BaseOutputsMeta):
-    __parent_class__: Type[BaseExecutable] = field(init=False)
+    __parent_class__: Type[BaseExecutable] = type(None)
 
     def __init__(self, **kwargs: Any) -> None:
         declared_fields = {descriptor.name for descriptor in self.__class__}


### PR DESCRIPTION
an issue while trying to start python workflow server

```bash
self_outputs_class.__parent_class__.__qualname__ == other_outputs_class.__parent_class__.__qualname__
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Field' object has no attribute '__qualname__'. Did you mean: '__set_name__'?
```