### PR TITLE
Fix Codegen of Generic Node Display Data

### DIFF
--- a/ee/codegen/python_file_merging/tests/fixtures/nodes/node_comments/generic_node.json
+++ b/ee/codegen/python_file_merging/tests/fixtures/nodes/node_comments/generic_node.json
@@ -17,6 +17,8 @@
     "comment": {
       "expanded": true,
       "value": "This is a comment"
-    }
+    },
+    "color": null,
+    "icon": null
   }
 }

--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -517,6 +517,12 @@ from ....nodes.tool_call_get_current_weather_node import GetCurrentWeatherNode
 class GetCurrentWeatherNodeDisplay(BaseNodeDisplay[GetCurrentWeatherNode]):
     label = "GetCurrentWeatherNode"
     node_id = UUID("21f29cac-da87-495f-bba1-093d423f4e46")
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=0, y=0),
+        comment=NodeDisplayComment(
+            value="\\n    A tool calling node that calls the get_current_weather function.\\n    "
+        ),
+    )
     attribute_ids_by_name = {
         "ml_model": UUID("44420e39-966f-4c59-bdf8-6365a61c5d2a"),
         "max_tool_calls": UUID("5c041b7d-732c-4773-a93a-32211f2af0b3"),
@@ -892,6 +898,12 @@ from ....nodes.tool_call_get_current_weather_node import GetCurrentWeatherNode
 class GetCurrentWeatherNodeDisplay(BaseNodeDisplay[GetCurrentWeatherNode]):
     label = "GetCurrentWeatherNode"
     node_id = UUID("21f29cac-da87-495f-bba1-093d423f4e46")
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=0, y=0),
+        comment=NodeDisplayComment(
+            value="\\n    A tool calling node that calls the get_current_weather function.\\n    "
+        ),
+    )
     attribute_ids_by_name = {
         "ml_model": UUID("44420e39-966f-4c59-bdf8-6365a61c5d2a"),
         "max_tool_calls": UUID("5c041b7d-732c-4773-a93a-32211f2af0b3"),

--- a/ee/codegen/src/__test__/generators/generic-node-display-data.test.ts
+++ b/ee/codegen/src/__test__/generators/generic-node-display-data.test.ts
@@ -1,0 +1,97 @@
+import { WorkflowContext } from "src/context";
+import { GenericNodeDisplayData } from "src/generators/generic-node-display-data";
+import { GenericNodeDisplayData as GenericNodeDisplayDataType } from "src/types/vellum";
+
+describe("GenericNodeDisplayData", () => {
+  let mockWorkflowContext: WorkflowContext;
+
+  beforeEach(() => {
+    mockWorkflowContext = {} as WorkflowContext;
+  });
+
+  describe("icon field generation", () => {
+    it("should include icon in generated code when icon is provided", () => {
+      const nodeDisplayData: GenericNodeDisplayDataType = {
+        position: { x: 0, y: 0 },
+        icon: "vellum:icon:star",
+      };
+
+      const generator = new GenericNodeDisplayData({
+        nodeDisplayData,
+        workflowContext: mockWorkflowContext,
+      });
+
+      const code = generator.toString();
+
+      expect(code).toContain('icon="vellum:icon:star"');
+    });
+
+    it("should not include icon in generated code when icon is undefined", () => {
+      const nodeDisplayData: GenericNodeDisplayDataType = {
+        position: { x: 0, y: 0 },
+      };
+
+      const generator = new GenericNodeDisplayData({
+        nodeDisplayData,
+        workflowContext: mockWorkflowContext,
+      });
+
+      const code = generator.toString();
+
+      expect(code).not.toContain("icon=");
+    });
+  });
+
+  describe("color field generation", () => {
+    it("should include color in generated code when color is provided", () => {
+      const nodeDisplayData: GenericNodeDisplayDataType = {
+        position: { x: 0, y: 0 },
+        color: "navy",
+      };
+
+      const generator = new GenericNodeDisplayData({
+        nodeDisplayData,
+        workflowContext: mockWorkflowContext,
+      });
+
+      const code = generator.toString();
+
+      expect(code).toContain('color="navy"');
+    });
+
+    it("should not include color in generated code when color is undefined", () => {
+      const nodeDisplayData: GenericNodeDisplayDataType = {
+        position: { x: 0, y: 0 },
+      };
+
+      const generator = new GenericNodeDisplayData({
+        nodeDisplayData,
+        workflowContext: mockWorkflowContext,
+      });
+
+      const code = generator.toString();
+
+      expect(code).not.toContain("color=");
+    });
+  });
+
+  describe("icon and color together", () => {
+    it("should include both icon and color in generated code when both are provided", () => {
+      const nodeDisplayData: GenericNodeDisplayDataType = {
+        position: { x: 0, y: 0 },
+        icon: "vellum:icon:cog",
+        color: "navy",
+      };
+
+      const generator = new GenericNodeDisplayData({
+        nodeDisplayData,
+        workflowContext: mockWorkflowContext,
+      });
+
+      const code = generator.toString();
+
+      expect(code).toContain('icon="vellum:icon:cog"');
+      expect(code).toContain('color="navy"');
+    });
+  });
+});

--- a/ee/codegen/src/__test__/generators/generic-node-display-data.test.ts
+++ b/ee/codegen/src/__test__/generators/generic-node-display-data.test.ts
@@ -75,6 +75,39 @@ describe("GenericNodeDisplayData", () => {
     });
   });
 
+  describe("z_index field generation", () => {
+    it("should include z_index in generated code when z_index is provided", () => {
+      const nodeDisplayData: GenericNodeDisplayDataType = {
+        position: { x: 0, y: 0 },
+        z_index: 5,
+      };
+
+      const generator = new GenericNodeDisplayData({
+        nodeDisplayData,
+        workflowContext: mockWorkflowContext,
+      });
+
+      const code = generator.toString();
+
+      expect(code).toContain("z_index=5");
+    });
+
+    it("should not include z_index in generated code when z_index is undefined", () => {
+      const nodeDisplayData: GenericNodeDisplayDataType = {
+        position: { x: 0, y: 0 },
+      };
+
+      const generator = new GenericNodeDisplayData({
+        nodeDisplayData,
+        workflowContext: mockWorkflowContext,
+      });
+
+      const code = generator.toString();
+
+      expect(code).not.toContain("z_index=");
+    });
+  });
+
   describe("icon and color together", () => {
     it("should include both icon and color in generated code when both are provided", () => {
       const nodeDisplayData: GenericNodeDisplayDataType = {
@@ -92,6 +125,36 @@ describe("GenericNodeDisplayData", () => {
 
       expect(code).toContain('icon="vellum:icon:cog"');
       expect(code).toContain('color="navy"');
+    });
+  });
+
+  describe("empty display data", () => {
+    it("should return empty string when no display data is provided", () => {
+      const generator = new GenericNodeDisplayData({
+        nodeDisplayData: undefined,
+        workflowContext: mockWorkflowContext,
+      });
+
+      const code = generator.toString();
+
+      expect(code).toBe("");
+    });
+
+    it("should return empty string when only null/undefined fields are provided", () => {
+      const nodeDisplayData: GenericNodeDisplayDataType = {
+        icon: null,
+        color: null,
+        // position and z_index undefined, should not generate any content
+      };
+
+      const generator = new GenericNodeDisplayData({
+        nodeDisplayData,
+        workflowContext: mockWorkflowContext,
+      });
+
+      const code = generator.toString();
+
+      expect(code).toBe("");
     });
   });
 });

--- a/ee/codegen/src/__test__/nodes/generic-node-display-data-integration.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-node-display-data-integration.test.ts
@@ -94,4 +94,46 @@ describe("GenericNode DisplayData Integration", () => {
     expect(result).not.toContain("icon=");
     expect(result).not.toContain("color=");
   });
+
+  it("should generate display data with z_index when provided in serialized JSON", async () => {
+    const nodeData = createGenericNodeWithDisplayData({
+      position: { x: 25, y: 50 },
+      z_index: 10,
+    });
+
+    const nodeContext = (await createNodeContext({
+      workflowContext,
+      nodeData,
+    })) as GenericNodeContext;
+
+    const node = new GenericNode({
+      workflowContext,
+      nodeContext,
+    });
+
+    node.getNodeDisplayFile().write(writer);
+    const result = await writer.toStringFormatted();
+
+    expect(result).toContain("z_index=10");
+  });
+
+  it("should not generate display_data field when no display data is provided", async () => {
+    const nodeData = createGenericNodeWithDisplayData(undefined);
+
+    const nodeContext = (await createNodeContext({
+      workflowContext,
+      nodeData,
+    })) as GenericNodeContext;
+
+    const node = new GenericNode({
+      workflowContext,
+      nodeContext,
+    });
+
+    node.getNodeDisplayFile().write(writer);
+    const result = await writer.toStringFormatted();
+
+    // Should not contain any display_data field at all
+    expect(result).not.toContain("display_data=");
+  });
 });

--- a/ee/codegen/src/__test__/nodes/generic-node-display-data-integration.test.ts
+++ b/ee/codegen/src/__test__/nodes/generic-node-display-data-integration.test.ts
@@ -1,0 +1,97 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { beforeEach } from "vitest";
+
+import { workflowContextFactory } from "src/__test__/helpers";
+import { inputVariableContextFactory } from "src/__test__/helpers/input-variable-context-factory";
+import { createNodeContext, WorkflowContext } from "src/context";
+import { GenericNodeContext } from "src/context/node-context/generic-node";
+import { GenericNode } from "src/generators/nodes/generic-node";
+import {
+  GenericNode as GenericNodeType,
+  GenericNodeDisplayData,
+} from "src/types/vellum";
+
+describe("GenericNode DisplayData Integration", () => {
+  let workflowContext: WorkflowContext;
+  let writer: Writer;
+
+  beforeEach(() => {
+    workflowContext = workflowContextFactory({ strict: false });
+    writer = new Writer();
+
+    workflowContext.addInputVariableContext(
+      inputVariableContextFactory({
+        inputVariableData: {
+          id: "input-1",
+          key: "count",
+          type: "NUMBER",
+        },
+        workflowContext,
+      })
+    );
+  });
+
+  // Helper function to create a minimal generic node with display data
+  const createGenericNodeWithDisplayData = (
+    displayData: GenericNodeDisplayData | undefined
+  ): GenericNodeType => ({
+    id: "test-node-id",
+    label: "TestDisplayNode",
+    type: "GENERIC",
+    displayData,
+    base: {
+      module: ["vellum", "workflows", "nodes", "bases", "base"],
+      name: "BaseNode",
+    },
+    trigger: { id: "trigger-1", mergeBehavior: "AWAIT_ALL" },
+    ports: [{ id: "port-1", name: "default", type: "DEFAULT" }],
+    attributes: [],
+    outputs: [],
+  });
+
+  it("should generate display data with icon and color when provided in serialized JSON", async () => {
+    const nodeData = createGenericNodeWithDisplayData({
+      position: { x: 100, y: 200 },
+      icon: "vellum:icon:star",
+      color: "navy",
+    });
+
+    const nodeContext = (await createNodeContext({
+      workflowContext,
+      nodeData,
+    })) as GenericNodeContext;
+
+    const node = new GenericNode({
+      workflowContext,
+      nodeContext,
+    });
+
+    node.getNodeDisplayFile().write(writer);
+    const result = await writer.toStringFormatted();
+
+    expect(result).toContain('icon="vellum:icon:star"');
+    expect(result).toContain('color="navy"');
+  });
+
+  it("should not include icon and color when not provided in serialized JSON", async () => {
+    const nodeData = createGenericNodeWithDisplayData({
+      position: { x: 50, y: 75 },
+    });
+
+    const nodeContext = (await createNodeContext({
+      workflowContext,
+      nodeData,
+    })) as GenericNodeContext;
+
+    const node = new GenericNode({
+      workflowContext,
+      nodeContext,
+    });
+
+    node.getNodeDisplayFile().write(writer);
+    const result = await writer.toStringFormatted();
+
+    expect(result).not.toContain("icon=");
+    expect(result).not.toContain("color=");
+  });
+});

--- a/ee/codegen/src/generators/generic-node-display-data.ts
+++ b/ee/codegen/src/generators/generic-node-display-data.ts
@@ -1,0 +1,143 @@
+import { python } from "@fern-api/python-ast";
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+import { Writer } from "@fern-api/python-ast/core/Writer";
+import { isNil } from "lodash";
+
+import { VELLUM_WORKFLOW_EDITOR_TYPES_PATH } from "src/constants";
+import { WorkflowContext } from "src/context";
+import { GenericNodeDisplayData as GenericNodeDisplayDataType } from "src/types/vellum";
+import { isNilOrEmpty } from "src/utils/typing";
+
+export namespace GenericNodeDisplayData {
+  export interface Args {
+    workflowContext: WorkflowContext;
+    nodeDisplayData: GenericNodeDisplayDataType | undefined;
+  }
+}
+
+export class GenericNodeDisplayData extends AstNode {
+  private readonly sourceNodeDisplayData:
+    | GenericNodeDisplayDataType
+    | undefined;
+  private readonly nodeDisplayData: AstNode;
+  private readonly workflowContext: WorkflowContext;
+
+  public constructor({
+    nodeDisplayData,
+    workflowContext,
+  }: GenericNodeDisplayData.Args) {
+    super();
+    this.sourceNodeDisplayData = nodeDisplayData;
+    this.workflowContext = workflowContext;
+    this.nodeDisplayData = this.generateNodeDisplayData();
+  }
+
+  private generateNodeDisplayData(): python.ClassInstantiation {
+    const args: python.MethodArgument[] = [];
+
+    args.push(
+      python.methodArgument({
+        name: "position",
+        value: python.instantiateClass({
+          classReference: python.reference({
+            name: "NodeDisplayPosition",
+            modulePath: VELLUM_WORKFLOW_EDITOR_TYPES_PATH,
+          }),
+          arguments_: [
+            python.methodArgument({
+              name: "x",
+              value: python.TypeInstantiation.float(
+                this.sourceNodeDisplayData?.position?.x ?? 0
+              ),
+            }),
+            python.methodArgument({
+              name: "y",
+              value: python.TypeInstantiation.float(
+                this.sourceNodeDisplayData?.position?.y ?? 0
+              ),
+            }),
+          ],
+        }),
+      })
+    );
+
+    if (!isNil(this.sourceNodeDisplayData?.icon)) {
+      args.push(
+        python.methodArgument({
+          name: "icon",
+          value: python.TypeInstantiation.str(this.sourceNodeDisplayData.icon),
+        })
+      );
+    }
+
+    if (!isNil(this.sourceNodeDisplayData?.color)) {
+      args.push(
+        python.methodArgument({
+          name: "color",
+          value: python.TypeInstantiation.str(this.sourceNodeDisplayData.color),
+        })
+      );
+    }
+
+    const commentArg = this.generateCommentArg();
+    if (commentArg) {
+      args.push(commentArg);
+    }
+
+    const clazz = python.instantiateClass({
+      classReference: python.reference({
+        name: "GenericNodeDisplayData",
+        modulePath: VELLUM_WORKFLOW_EDITOR_TYPES_PATH,
+      }),
+      arguments_: args,
+    });
+    this.inheritReferences(clazz);
+    return clazz;
+  }
+
+  private generateCommentArg(): python.MethodArgument | undefined {
+    if (!this.sourceNodeDisplayData?.comment) {
+      return undefined;
+    }
+
+    const commentArgs: python.MethodArgument[] = [];
+    const { expanded, value } = this.sourceNodeDisplayData.comment;
+
+    if (expanded) {
+      commentArgs.push(
+        python.methodArgument({
+          name: "expanded",
+          value: python.TypeInstantiation.bool(expanded),
+        })
+      );
+    }
+
+    if (value) {
+      commentArgs.push(
+        python.methodArgument({
+          name: "value",
+          value: python.TypeInstantiation.str(value),
+        })
+      );
+    }
+
+    if (isNilOrEmpty(commentArgs)) {
+      return undefined;
+    }
+
+    return python.methodArgument({
+      name: "comment",
+      value: python.instantiateClass({
+        classReference: python.reference({
+          name: "NodeDisplayComment",
+          modulePath: VELLUM_WORKFLOW_EDITOR_TYPES_PATH,
+        }),
+        arguments_: commentArgs,
+      }),
+    });
+  }
+
+  public write(writer: Writer) {
+    this.nodeDisplayData.write(writer);
+  }
+}

--- a/ee/codegen/src/generators/node-display-data.ts
+++ b/ee/codegen/src/generators/node-display-data.ts
@@ -1,6 +1,7 @@
 import { python } from "@fern-api/python-ast";
 import { AstNode } from "@fern-api/python-ast/core/AstNode";
 import { Writer } from "@fern-api/python-ast/core/Writer";
+import { isNil } from "lodash";
 
 import { VELLUM_WORKFLOW_EDITOR_TYPES_PATH } from "src/constants";
 import { WorkflowContext } from "src/context";
@@ -58,10 +59,7 @@ export class NodeDisplayData extends AstNode {
       })
     );
 
-    if (
-      this.sourceNodeDisplayData?.z_index !== undefined &&
-      this.sourceNodeDisplayData?.z_index !== null
-    ) {
+    if (!isNil(this.sourceNodeDisplayData?.z_index)) {
       args.push(
         python.methodArgument({
           name: "z_index",
@@ -72,10 +70,7 @@ export class NodeDisplayData extends AstNode {
       );
     }
 
-    if (
-      this.sourceNodeDisplayData?.width !== undefined &&
-      this.sourceNodeDisplayData?.width !== null
-    ) {
+    if (!isNil(this.sourceNodeDisplayData?.width)) {
       args.push(
         python.methodArgument({
           name: "width",
@@ -84,10 +79,7 @@ export class NodeDisplayData extends AstNode {
       );
     }
 
-    if (
-      this.sourceNodeDisplayData?.height !== undefined &&
-      this.sourceNodeDisplayData?.height !== null
-    ) {
+    if (!isNil(this.sourceNodeDisplayData?.height)) {
       args.push(
         python.methodArgument({
           name: "height",
@@ -98,10 +90,7 @@ export class NodeDisplayData extends AstNode {
       );
     }
 
-    if (
-      this.sourceNodeDisplayData?.icon !== undefined &&
-      this.sourceNodeDisplayData?.icon !== null
-    ) {
+    if (!isNil(this.sourceNodeDisplayData?.icon)) {
       args.push(
         python.methodArgument({
           name: "icon",
@@ -110,10 +99,7 @@ export class NodeDisplayData extends AstNode {
       );
     }
 
-    if (
-      this.sourceNodeDisplayData?.color !== undefined &&
-      this.sourceNodeDisplayData?.color !== null
-    ) {
+    if (!isNil(this.sourceNodeDisplayData?.color)) {
       args.push(
         python.methodArgument({
           name: "color",

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -629,13 +629,16 @@ export class GenericNode extends BaseNode<GenericNodeType, GenericNodeContext> {
   getNodeDisplayClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
 
-    // Add display data with our custom GenericNodeDisplayData generator
-    statements.push(
-      python.field({
-        name: "display_data",
-        initializer: this.generateGenericNodeDisplayData(),
-      })
-    );
+    // Add display data with our custom GenericNodeDisplayData generator only if it has content
+    const displayDataGenerator = this.generateGenericNodeDisplayData();
+    if (displayDataGenerator.hasContent()) {
+      statements.push(
+        python.field({
+          name: "display_data",
+          initializer: displayDataGenerator,
+        })
+      );
+    }
 
     return statements;
   }

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -19,6 +19,7 @@ import { GenericNodeContext } from "src/context/node-context/generic-node";
 import { PromptBlock as PromptBlockType } from "src/generators/base-prompt-block";
 import { NodeDefinitionGenerationError } from "src/generators/errors";
 import { FunctionFile } from "src/generators/function-file";
+import { GenericNodeDisplayData } from "src/generators/generic-node-display-data";
 import { InitFile } from "src/generators/init-file";
 import { NodeOutputs } from "src/generators/node-outputs";
 import { BaseNode } from "src/generators/nodes/bases/base";
@@ -68,6 +69,13 @@ export class GenericNode extends BaseNode<GenericNodeType, GenericNodeContext> {
     super(args);
 
     this.nodeAttributes = this.generateNodeAttributes();
+  }
+
+  private generateGenericNodeDisplayData() {
+    return new GenericNodeDisplayData({
+      workflowContext: this.workflowContext,
+      nodeDisplayData: this.nodeData.displayData,
+    });
   }
 
   private generateNodeAttributes(): AstNode[] {
@@ -620,6 +628,15 @@ export class GenericNode extends BaseNode<GenericNodeType, GenericNodeContext> {
 
   getNodeDisplayClassBodyStatements(): AstNode[] {
     const statements: AstNode[] = [];
+
+    // Add display data with our custom GenericNodeDisplayData generator
+    statements.push(
+      python.field({
+        name: "display_data",
+        initializer: this.generateGenericNodeDisplayData(),
+      })
+    );
+
     return statements;
   }
 

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -657,6 +657,8 @@ export const NodeDisplayDataSerializer: ObjectSchema<
   width: numberSchema().optional(),
   height: numberSchema().optional(),
   comment: NodeDisplayCommentSerializer.optional(),
+  color: stringSchema().optional().nullable(),
+  icon: stringSchema().optional().nullable(),
 });
 
 export declare namespace NodeDisplayDataSerializer {
@@ -666,6 +668,8 @@ export declare namespace NodeDisplayDataSerializer {
     width?: number | null;
     height?: number | null;
     comment?: NodeDisplayCommentSerializer.Raw | null;
+    color?: string | null;
+    icon?: string | null;
   }
 }
 
@@ -2095,12 +2099,16 @@ export const GenericNodeDisplayDataSerializer: ObjectSchema<
 > = objectSchema({
   position: NodeDisplayPositionSerializer.optional(),
   comment: NodeDisplayCommentSerializer.optional(),
+  color: stringSchema().optional().nullable(),
+  icon: stringSchema().optional().nullable(),
 });
 
 export declare namespace GenericNodeDisplayDataSerializer {
   interface Raw {
     position?: NodeDisplayPositionSerializer.Raw | null;
     comment?: NodeDisplayCommentSerializer.Raw | null;
+    color?: string | null;
+    icon?: string | null;
   }
 }
 
@@ -2129,12 +2137,7 @@ export declare namespace GenericNodeSerializer {
     id: string;
     label: string;
     base: CodeResourceDefinitionSerializer.Raw;
-    display_data?: {
-      position?: {
-        x: number;
-        y: number;
-      } | null;
-    } | null;
+    display_data?: GenericNodeDisplayDataSerializer.Raw | null;
     definition?: CodeResourceDefinitionSerializer.Raw | null;
     trigger: NodeTriggerSerializer.Raw;
     ports: NodePortSerializer.Raw[];

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -657,8 +657,8 @@ export const NodeDisplayDataSerializer: ObjectSchema<
   width: numberSchema().optional(),
   height: numberSchema().optional(),
   comment: NodeDisplayCommentSerializer.optional(),
-  color: stringSchema().optional().nullable(),
-  icon: stringSchema().optional().nullable(),
+  color: stringSchema().nullable().optional(),
+  icon: stringSchema().nullable().optional(),
 });
 
 export declare namespace NodeDisplayDataSerializer {
@@ -2093,19 +2093,21 @@ export declare namespace ErrorNodeSerializer {
   }
 }
 
-export const GenericNodeDisplayDataSerializer: ObjectSchema<
+export const GenericNodeDisplayDataSerializer = objectSchema({
+  position: NodeDisplayPositionSerializer.optional(),
+  z_index: numberSchema().optional(),
+  comment: NodeDisplayCommentSerializer.optional(),
+  color: stringSchema().nullable().optional(),
+  icon: stringSchema().nullable().optional(),
+}) as ObjectSchema<
   GenericNodeDisplayDataSerializer.Raw,
   GenericNodeDisplayData
-> = objectSchema({
-  position: NodeDisplayPositionSerializer.optional(),
-  comment: NodeDisplayCommentSerializer.optional(),
-  color: stringSchema().optional().nullable(),
-  icon: stringSchema().optional().nullable(),
-});
+>;
 
 export declare namespace GenericNodeDisplayDataSerializer {
   interface Raw {
     position?: NodeDisplayPositionSerializer.Raw | null;
+    z_index?: number | null;
     comment?: NodeDisplayCommentSerializer.Raw | null;
     color?: string | null;
     icon?: string | null;

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -183,8 +183,8 @@ export interface NodeDisplayData {
   width?: number;
   height?: number;
   comment?: NodeDisplayComment;
-  icon?: string;
-  color?: string;
+  icon?: string | null;
+  color?: string | null;
 }
 
 export interface WorkflowEdgeDisplayData {
@@ -717,6 +717,8 @@ export interface ErrorNode extends BaseDisplayableWorkflowNode {
 export interface GenericNodeDisplayData {
   position?: { x: number; y: number };
   comment?: NodeDisplayComment;
+  color?: string | null;
+  icon?: string | null;
 }
 
 export interface NodeOutput {

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -716,6 +716,7 @@ export interface ErrorNode extends BaseDisplayableWorkflowNode {
 
 export interface GenericNodeDisplayData {
   position?: { x: number; y: number };
+  z_index?: number;
   comment?: NodeDisplayComment;
   color?: string | null;
   icon?: string | null;


### PR DESCRIPTION
Generic Nodes have a different JSON schema for their display data as compared to legacy node types. As such, they need their own display data codegen class (unless I'm missing something).

The root bug I'm trying to fix is that codegen isn't including color/icon for Custom Nodes.