### PR TITLE
[APO-1634] Add VellumIntegrationToolDefinition with placeholders

### DIFF
--- a/src/vellum/workflows/constants.py
+++ b/src/vellum/workflows/constants.py
@@ -1,4 +1,4 @@
-from enum import Enum, StrEnum
+from enum import Enum
 from typing import Any, cast
 
 
@@ -60,5 +60,5 @@ class AuthorizationType(Enum):
     API_KEY = "API_KEY"
 
 
-class VellumIntegrationProviderType(StrEnum):
+class VellumIntegrationProviderType(Enum):
     COMPOSIO = "COMPOSIO"

--- a/src/vellum/workflows/constants.py
+++ b/src/vellum/workflows/constants.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any, cast
 
 
@@ -58,3 +58,7 @@ class APIRequestMethod(Enum):
 class AuthorizationType(Enum):
     BEARER_TOKEN = "BEARER_TOKEN"
     API_KEY = "API_KEY"
+
+
+class VellumIntegrationProviderType(StrEnum):
+    COMPOSIO = "COMPOSIO"

--- a/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
@@ -45,7 +45,12 @@ from vellum.workflows.nodes.displayable.bases.base_prompt_node import BasePrompt
 from vellum.workflows.nodes.displayable.bases.utils import process_additional_prompt_outputs
 from vellum.workflows.outputs import BaseOutput
 from vellum.workflows.types import MergeBehavior
-from vellum.workflows.types.definition import ComposioToolDefinition, DeploymentDefinition, MCPServer
+from vellum.workflows.types.definition import (
+    ComposioToolDefinition,
+    DeploymentDefinition,
+    MCPServer,
+    VellumIntegrationToolDefinition,
+)
 from vellum.workflows.types.generics import StateType, is_workflow_class
 from vellum.workflows.utils.functions import (
     compile_composio_tool_definition,
@@ -145,6 +150,12 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
                     normalized_functions.append(compile_function_definition(function))
                 elif isinstance(function, ComposioToolDefinition):
                     normalized_functions.append(compile_composio_tool_definition(function))
+                elif isinstance(function, VellumIntegrationToolDefinition):
+                    # TODO: Implement compile_vellum_integration_tool_definition in APO-1636
+                    raise NotImplementedError(
+                        "VellumIntegrationToolDefinition support coming in APO-1636. "
+                        "This will be implemented when compile_vellum_integration_tool_definition is created."
+                    )
                 elif isinstance(function, MCPServer):
                     tool_definitions = compile_mcp_tool_definition(function)
                     for tool_def in tool_definitions:

--- a/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
@@ -151,9 +151,9 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
                 elif isinstance(function, ComposioToolDefinition):
                     normalized_functions.append(compile_composio_tool_definition(function))
                 elif isinstance(function, VellumIntegrationToolDefinition):
-                    # TODO: Implement compile_vellum_integration_tool_definition in APO-1636
+                    # TODO: Implement compile_vellum_integration_tool_definition
                     raise NotImplementedError(
-                        "VellumIntegrationToolDefinition support coming in APO-1636. "
+                        "VellumIntegrationToolDefinition support coming soon. "
                         "This will be implemented when compile_vellum_integration_tool_definition is created."
                     )
                 elif isinstance(function, MCPServer):

--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
@@ -29,7 +29,13 @@ from vellum.workflows.outputs.base import BaseOutput
 from vellum.workflows.ports.port import Port
 from vellum.workflows.state import BaseState
 from vellum.workflows.state.encoder import DefaultStateEncoder
-from vellum.workflows.types.core import EntityInputsInterface, MergeBehavior, Tool, ToolBase
+from vellum.workflows.types.core import (
+    EntityInputsInterface,
+    MergeBehavior,
+    Tool,
+    ToolBase,
+    VellumIntegrationToolDefinition,
+)
 from vellum.workflows.types.definition import ComposioToolDefinition, DeploymentDefinition, MCPServer, MCPToolDefinition
 from vellum.workflows.types.generics import is_workflow_class
 from vellum.workflows.utils.functions import compile_mcp_tool_definition, get_mcp_tool_name
@@ -295,7 +301,9 @@ def create_tool_prompt_node(
             and (
                 block["input_variable"]
                 if isinstance(block, dict)
-                else block.input_variable if isinstance(block, VariablePromptBlock) else None
+                else block.input_variable
+                if isinstance(block, VariablePromptBlock)
+                else None
             )
             == CHAT_HISTORY_VARIABLE
         )
@@ -533,5 +541,7 @@ def get_function_name(function: ToolBase) -> str:
     elif isinstance(function, ComposioToolDefinition):
         # model post init sets the name to the action if it's not set
         return function.name  # type: ignore[return-value]
+    elif isinstance(function, VellumIntegrationToolDefinition):
+        return function.tool_name
     else:
         return snake_case(function.__name__)

--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
@@ -550,6 +550,6 @@ def get_function_name(function: ToolBase) -> str:
         # model post init sets the name to the action if it's not set
         return function.name  # type: ignore[return-value]
     elif isinstance(function, VellumIntegrationToolDefinition):
-        return function.name  # type: ignore[return-value]
+        return function.name
     else:
         return snake_case(function.__name__)

--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
@@ -377,7 +377,6 @@ def create_router_node(
                 port = create_port_condition(function_name)
                 setattr(Ports, function_name, port)
             elif isinstance(function, VellumIntegrationToolDefinition):
-                # TODO: Full implementation
                 function_name = get_function_name(function)
                 port = create_port_condition(function_name)
                 setattr(Ports, function_name, port)
@@ -551,6 +550,6 @@ def get_function_name(function: ToolBase) -> str:
         # model post init sets the name to the action if it's not set
         return function.name  # type: ignore[return-value]
     elif isinstance(function, VellumIntegrationToolDefinition):
-        return function.tool_name
+        return function.name  # type: ignore[return-value]
     else:
         return snake_case(function.__name__)

--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
@@ -377,7 +377,7 @@ def create_router_node(
                 port = create_port_condition(function_name)
                 setattr(Ports, function_name, port)
             elif isinstance(function, VellumIntegrationToolDefinition):
-                # TODO: Full implementation in APO-1636
+                # TODO: Full implementation
                 function_name = get_function_name(function)
                 port = create_port_condition(function_name)
                 setattr(Ports, function_name, port)
@@ -456,9 +456,9 @@ def create_function_node(
         )
         return node
     elif isinstance(function, VellumIntegrationToolDefinition):
-        # TODO: Implement VellumIntegrationNode in APO-1636
+        # TODO: Implement VellumIntegrationNode
         raise NotImplementedError(
-            "VellumIntegrationToolDefinition support coming in APO-1636. "
+            "VellumIntegrationToolDefinition support coming soon. "
             "This will be implemented when the VellumIntegrationService is created."
         )
     elif is_workflow_class(function):

--- a/src/vellum/workflows/types/core.py
+++ b/src/vellum/workflows/types/core.py
@@ -13,7 +13,12 @@ from typing import (  # type: ignore[attr-defined]
 )
 
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
-from vellum.workflows.types.definition import ComposioToolDefinition, DeploymentDefinition, MCPServer
+from vellum.workflows.types.definition import (
+    ComposioToolDefinition,
+    DeploymentDefinition,
+    MCPServer,
+    VellumIntegrationToolDefinition,
+)
 
 if TYPE_CHECKING:
     from vellum.workflows.workflows.base import BaseWorkflow
@@ -51,5 +56,11 @@ class ConditionType(Enum):
 
 
 # Type alias for functions that can be called in tool calling nodes
-ToolBase = Union[Callable[..., Any], DeploymentDefinition, Type["BaseWorkflow"], ComposioToolDefinition]
+ToolBase = Union[
+    Callable[..., Any],
+    DeploymentDefinition,
+    Type["BaseWorkflow"],
+    ComposioToolDefinition,
+    VellumIntegrationToolDefinition,
+]
 Tool = Union[ToolBase, MCPServer]

--- a/src/vellum/workflows/types/definition.py
+++ b/src/vellum/workflows/types/definition.py
@@ -10,9 +10,8 @@ from vellum import Vellum
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
 from vellum.client.types.code_resource_definition import CodeResourceDefinition as ClientCodeResourceDefinition
 from vellum.client.types.vellum_variable import VellumVariable
-from vellum.workflows.constants import AuthorizationType
+from vellum.workflows.constants import AuthorizationType, VellumIntegrationProviderType
 from vellum.workflows.references.environment_variable import EnvironmentVariableReference
-from enum import StrEnum
 
 
 def serialize_type_encoder(obj: type) -> Dict[str, Any]:
@@ -166,10 +165,6 @@ class ComposioToolDefinition(UniversalBaseModel):
             self.name = self.action.lower()
 
 
-class VellumIntegrationProviderType(StrEnum):
-    COMPOSIO = "composio"
-
-
 class VellumIntegrationToolDefinition(UniversalBaseModel):
     type: Literal["INTEGRATION"] = "INTEGRATION"
 
@@ -177,6 +172,15 @@ class VellumIntegrationToolDefinition(UniversalBaseModel):
     provider: VellumIntegrationProviderType
     integration: str  # "GITHUB", "SLACK", etc.
     tool_name: str  # Specific action like "GITHUB_CREATE_AN_ISSUE"
+
+    # Fields for tool base consistency
+    description: str
+    name: str = ""
+
+    # copied from ComposioToolDefinition for convenience
+    def model_post_init(self, __context: Any):
+        if self.name == "":
+            self.name = self.tool_name.lower()
 
 
 class MCPServer(UniversalBaseModel):

--- a/src/vellum/workflows/types/definition.py
+++ b/src/vellum/workflows/types/definition.py
@@ -171,16 +171,10 @@ class VellumIntegrationToolDefinition(UniversalBaseModel):
     # Core identification
     provider: VellumIntegrationProviderType
     integration: str  # "GITHUB", "SLACK", etc.
-    tool_name: str  # Specific action like "GITHUB_CREATE_AN_ISSUE"
+    name: str  # Specific action like "GITHUB_CREATE_AN_ISSUE"
 
-    # Fields for tool base consistency
+    # Required for tool base consistency
     description: str
-    name: str = ""
-
-    # copied from ComposioToolDefinition for convenience
-    def model_post_init(self, __context: Any):
-        if self.name == "":
-            self.name = self.tool_name.lower()
 
 
 class MCPServer(UniversalBaseModel):

--- a/src/vellum/workflows/types/definition.py
+++ b/src/vellum/workflows/types/definition.py
@@ -12,6 +12,7 @@ from vellum.client.types.code_resource_definition import CodeResourceDefinition 
 from vellum.client.types.vellum_variable import VellumVariable
 from vellum.workflows.constants import AuthorizationType
 from vellum.workflows.references.environment_variable import EnvironmentVariableReference
+from enum import StrEnum
 
 
 def serialize_type_encoder(obj: type) -> Dict[str, Any]:
@@ -163,6 +164,19 @@ class ComposioToolDefinition(UniversalBaseModel):
     def model_post_init(self, __context: Any):
         if self.name == "":
             self.name = self.action.lower()
+
+
+class VellumIntegrationProviderType(StrEnum):
+    COMPOSIO = "composio"
+
+
+class VellumIntegrationToolDefinition(UniversalBaseModel):
+    type: Literal["INTEGRATION"] = "INTEGRATION"
+
+    # Core identification
+    provider: VellumIntegrationProviderType
+    integration: str  # "GITHUB", "SLACK", etc.
+    tool_name: str  # Specific action like "GITHUB_CREATE_AN_ISSUE"
 
 
 class MCPServer(UniversalBaseModel):

--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -10,7 +10,13 @@ from vellum import Vellum
 from vellum.client.types.function_definition import FunctionDefinition
 from vellum.workflows.integrations.composio_service import ComposioService
 from vellum.workflows.integrations.mcp_service import MCPService
-from vellum.workflows.types.definition import ComposioToolDefinition, DeploymentDefinition, MCPServer, MCPToolDefinition
+from vellum.workflows.types.definition import (
+    ComposioToolDefinition,
+    DeploymentDefinition,
+    MCPServer,
+    MCPToolDefinition,
+    VellumIntegrationToolDefinition,
+)
 from vellum.workflows.utils.vellum_variables import vellum_variable_type_to_openapi_type
 
 if TYPE_CHECKING:
@@ -310,6 +316,25 @@ def compile_composio_tool_definition(tool_def: ComposioToolDefinition) -> Functi
             description=tool_def.description,
             parameters={},
         )
+
+
+def compile_vellum_integration_tool_definition(tool_def: VellumIntegrationToolDefinition) -> FunctionDefinition:
+    """Compile a VellumIntegrationToolDefinition into a FunctionDefinition.
+
+    TODO: Implement in APO-1636 when VellumIntegrationService is created.
+
+    Args:
+        tool_def: The VellumIntegrationToolDefinition to compile
+
+    Returns:
+        FunctionDefinition with tool parameters and description
+    """
+    # TODO: Implement in APO-1636
+    # This will eventually use VellumIntegrationService to fetch tool details
+    raise NotImplementedError(
+        "VellumIntegrationToolDefinition compilation coming in APO-1636. "
+        "This will be implemented when the VellumIntegrationService is created."
+    )
 
 
 def use_tool_inputs(**inputs):

--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -321,7 +321,7 @@ def compile_composio_tool_definition(tool_def: ComposioToolDefinition) -> Functi
 def compile_vellum_integration_tool_definition(tool_def: VellumIntegrationToolDefinition) -> FunctionDefinition:
     """Compile a VellumIntegrationToolDefinition into a FunctionDefinition.
 
-    TODO: Implement in APO-1636 when VellumIntegrationService is created.
+    TODO: Implement when VellumIntegrationService is created.
 
     Args:
         tool_def: The VellumIntegrationToolDefinition to compile
@@ -329,10 +329,10 @@ def compile_vellum_integration_tool_definition(tool_def: VellumIntegrationToolDe
     Returns:
         FunctionDefinition with tool parameters and description
     """
-    # TODO: Implement in APO-1636
+    # TODO: Implement when VellumIntegrationService is available
     # This will eventually use VellumIntegrationService to fetch tool details
     raise NotImplementedError(
-        "VellumIntegrationToolDefinition compilation coming in APO-1636. "
+        "VellumIntegrationToolDefinition compilation coming soon. "
         "This will be implemented when the VellumIntegrationService is created."
     )
 


### PR DESCRIPTION
The purpose of this PR is to add VellumIntegrationToolDefinition type with placeholder implementations for future Vellum integration support.

## Changes Made
- Add VellumIntegrationToolDefinition class with provider, integration, and tool_name fields
- Add VellumIntegrationProviderType enum to constants
- Add NotImplementedError placeholders in inline_prompt_node and tool_calling_node for [APO-1636](https://linear.app/vellum/issue/APO-1636/implement-vellumintegrationservice)
- Create compile_vellum_integration_tool_definition function stub for future implementation

## Notes
- Full implementation will be completed in [APO-1636](https://linear.app/vellum/issue/APO-1636/implement-vellumintegrationservice)

---
*This PR was created with Claude Code*