### PR TITLE
[APO-1636] Add VellumIntegrationService for native Vellum integration tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tsconfig.tsbuildinfo
 .idea
 .DS_Store
 htmlcov/
+CLAUDE.md

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -786,7 +786,7 @@ export class GenericNode extends BaseNode<GenericNodeType, GenericNodeContext> {
   }
 
   private getFunction(f: FunctionArgs): FunctionArgs {
-    const inputs = f.definition?.inputs;
+    const inputs = f.definition?.parameters;
     if (!f.definition || !inputs) {
       return f;
     }

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -786,7 +786,6 @@ export class GenericNode extends BaseNode<GenericNodeType, GenericNodeContext> {
   }
 
   private getFunction(f: FunctionArgs): FunctionArgs {
-    // @ts-expect-error - FunctionDefinition type doesn't include inputs field but runtime data does
     const inputs = f.definition?.inputs;
     if (!f.definition || !inputs) {
       return f;

--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -786,7 +786,8 @@ export class GenericNode extends BaseNode<GenericNodeType, GenericNodeContext> {
   }
 
   private getFunction(f: FunctionArgs): FunctionArgs {
-    const inputs = f.definition?.parameters;
+    // @ts-expect-error - FunctionDefinition type doesn't include inputs field but runtime data does
+    const inputs = f.definition?.inputs;
     if (!f.definition || !inputs) {
       return f;
     }

--- a/src/vellum/workflows/integrations/__init__.py
+++ b/src/vellum/workflows/integrations/__init__.py
@@ -1,0 +1,5 @@
+from .composio_service import ComposioService
+from .mcp_service import MCPService
+from .vellum_integration_service import VellumIntegrationService
+
+__all__ = ["ComposioService", "MCPService", "VellumIntegrationService"]

--- a/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
@@ -5,205 +5,209 @@ from vellum.workflows.exceptions import NodeException
 from vellum.workflows.integrations.vellum_integration_service import VellumIntegrationService
 
 
-class TestVellumIntegrationService:
-    """Test suite for VellumIntegrationService."""
+@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+def test_vellum_integration_service_get_tool_definition_success(mock_create_client):
+    """Test that tool definitions are successfully retrieved from Vellum API"""
+    # GIVEN a mock Vellum client configured to return a tool definition
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
 
-    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-    def test_get_tool_definition_success(self, mock_create_client):
-        """Test successful retrieval of tool definition."""
-        # Setup
-        mock_client = MagicMock()
-        mock_create_client.return_value = mock_client
+    mock_response = MagicMock()
+    mock_response.name = "GITHUB_CREATE_AN_ISSUE"
+    mock_response.description = "Create a new issue in a GitHub repository"
+    mock_response.parameters = {
+        "type": "object",
+        "properties": {
+            "repo": {"type": "string", "description": "Repository name"},
+            "title": {"type": "string", "description": "Issue title"},
+            "body": {"type": "string", "description": "Issue body"},
+        },
+        "required": ["repo", "title"],
+    }
+    mock_response.provider = "COMPOSIO"
 
-        mock_response = MagicMock()
-        mock_response.name = "GITHUB_CREATE_AN_ISSUE"
-        mock_response.description = "Create a new issue in a GitHub repository"
-        mock_response.parameters = {
-            "type": "object",
-            "properties": {
-                "repo": {"type": "string", "description": "Repository name"},
-                "title": {"type": "string", "description": "Issue title"},
-                "body": {"type": "string", "description": "Issue body"},
-            },
-            "required": ["repo", "title"],
-        }
-        mock_response.provider = "COMPOSIO"
+    mock_client.integrations.retrieve_integration_tool_definition.return_value = mock_response
 
-        mock_client.integrations.retrieve_integration_tool_definition.return_value = mock_response
+    # WHEN we request a tool definition
+    service = VellumIntegrationService()
+    result = service.get_tool_definition(
+        integration="GITHUB",
+        provider="COMPOSIO",
+        tool_name="GITHUB_CREATE_AN_ISSUE",
+    )
 
-        service = VellumIntegrationService()
+    # THEN the tool definition should be returned with all expected fields
+    assert result["name"] == "GITHUB_CREATE_AN_ISSUE"
+    assert result["description"] == "Create a new issue in a GitHub repository"
+    assert result["provider"] == "COMPOSIO"
+    assert "properties" in result["parameters"]
+    assert "repo" in result["parameters"]["properties"]
 
-        # Execute
-        result = service.get_tool_definition(
+    # AND the API should have been called with the correct parameters
+    mock_client.integrations.retrieve_integration_tool_definition.assert_called_once_with(
+        integration="GITHUB",
+        provider="COMPOSIO",
+        tool_name="GITHUB_CREATE_AN_ISSUE",
+    )
+
+
+@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+def test_vellum_integration_service_get_tool_definition_api_error(mock_create_client):
+    """Test that API errors are properly handled when retrieving tool definitions"""
+    # GIVEN a mock client that raises an exception when retrieving tool definitions
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
+
+    mock_client.integrations.retrieve_integration_tool_definition.side_effect = Exception("Tool not found")
+
+    # WHEN we attempt to get a tool definition for an invalid tool
+    service = VellumIntegrationService()
+
+    # THEN it should raise a NodeException with appropriate error message
+    with pytest.raises(NodeException) as exc_info:
+        service.get_tool_definition(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="INVALID_TOOL",
+        )
+
+    assert "Failed to retrieve tool definition" in str(exc_info.value)
+    assert "Tool not found" in str(exc_info.value)
+
+
+@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+def test_vellum_integration_service_execute_tool_success(mock_create_client):
+    """Test that tools are successfully executed via Vellum API"""
+    # GIVEN a mock client configured to return successful execution results
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
+
+    mock_response = MagicMock()
+    mock_response.data = {
+        "success": True,
+        "issue_id": 123,
+        "issue_url": "https://github.com/user/repo/issues/123",
+    }
+
+    mock_client.integrations.execute_integration_tool.return_value = mock_response
+
+    # WHEN we execute a tool with valid arguments
+    service = VellumIntegrationService()
+    result = service.execute_tool(
+        integration="GITHUB",
+        provider="COMPOSIO",
+        tool_name="GITHUB_CREATE_AN_ISSUE",
+        arguments={
+            "repo": "user/repo",
+            "title": "Test Issue",
+            "body": "Test body",
+        },
+    )
+
+    # THEN the execution result should contain expected data
+    assert result["success"] is True
+    assert result["issue_id"] == 123
+    assert result["issue_url"] == "https://github.com/user/repo/issues/123"
+
+    # AND the API should have been called with correct parameters
+    mock_client.integrations.execute_integration_tool.assert_called_once_with(
+        integration="GITHUB",
+        provider="COMPOSIO",
+        tool_name="GITHUB_CREATE_AN_ISSUE",
+        arguments={
+            "repo": "user/repo",
+            "title": "Test Issue",
+            "body": "Test body",
+        },
+    )
+
+
+@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+def test_vellum_integration_service_execute_tool_api_error(mock_create_client):
+    """Test that execution errors are properly handled"""
+    # GIVEN a mock client that raises an exception during tool execution
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
+
+    mock_client.integrations.execute_integration_tool.side_effect = Exception("Authentication failed")
+
+    # WHEN we attempt to execute a tool that encounters an error
+    service = VellumIntegrationService()
+
+    # THEN it should raise a NodeException with appropriate error message
+    with pytest.raises(NodeException) as exc_info:
+        service.execute_tool(
             integration="GITHUB",
             provider="COMPOSIO",
             tool_name="GITHUB_CREATE_AN_ISSUE",
+            arguments={"repo": "user/repo"},
         )
 
-        # Assert
-        assert result["name"] == "GITHUB_CREATE_AN_ISSUE"
-        assert result["description"] == "Create a new issue in a GitHub repository"
-        assert result["provider"] == "COMPOSIO"
-        assert "properties" in result["parameters"]
-        assert "repo" in result["parameters"]["properties"]
+    assert "Failed to execute tool" in str(exc_info.value)
+    assert "Authentication failed" in str(exc_info.value)
 
-        mock_client.integrations.retrieve_integration_tool_definition.assert_called_once_with(
-            integration="GITHUB",
-            provider="COMPOSIO",
-            tool_name="GITHUB_CREATE_AN_ISSUE",
-        )
 
-    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-    def test_get_tool_definition_failure(self, mock_create_client):
-        """Test handling of errors when retrieving tool definition."""
-        # Setup
-        mock_client = MagicMock()
-        mock_create_client.return_value = mock_client
+@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+def test_vellum_integration_service_execute_tool_empty_response(mock_create_client):
+    """Test that empty response data is handled gracefully"""
+    # GIVEN a mock client that returns an empty response
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
 
-        mock_client.integrations.retrieve_integration_tool_definition.side_effect = Exception("Tool not found")
+    mock_response = MagicMock()
+    mock_response.data = {}
 
-        service = VellumIntegrationService()
+    mock_client.integrations.execute_integration_tool.return_value = mock_response
 
-        # Execute & Assert
-        with pytest.raises(NodeException) as exc_info:
-            service.get_tool_definition(
-                integration="GITHUB",
-                provider="COMPOSIO",
-                tool_name="INVALID_TOOL",
-            )
+    # WHEN we execute a tool that returns empty data
+    service = VellumIntegrationService()
+    result = service.execute_tool(
+        integration="SLACK",
+        provider="COMPOSIO",
+        tool_name="SLACK_SEND_MESSAGE",
+        arguments={
+            "channel": "#general",
+            "message": "Hello, world!",
+        },
+    )
 
-        assert "Failed to retrieve tool definition" in str(exc_info.value)
-        assert "Tool not found" in str(exc_info.value)
+    # THEN an empty dictionary should be returned without errors
+    assert result == {}
 
-    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-    def test_execute_tool_success(self, mock_create_client):
-        """Test successful tool execution."""
-        # Setup
-        mock_client = MagicMock()
-        mock_create_client.return_value = mock_client
 
-        mock_response = MagicMock()
-        mock_response.data = {
-            "success": True,
-            "issue_id": 123,
-            "issue_url": "https://github.com/user/repo/issues/123",
-        }
+@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+def test_vellum_integration_service_multiple_tool_executions(mock_create_client):
+    """Test that the service handles multiple sequential tool executions"""
+    # GIVEN a mock client configured to return different responses for each call
+    mock_client = MagicMock()
+    mock_create_client.return_value = mock_client
 
-        mock_client.integrations.execute_integration_tool.return_value = mock_response
+    responses = [
+        MagicMock(data={"result": "first"}),
+        MagicMock(data={"result": "second"}),
+    ]
+    mock_client.integrations.execute_integration_tool.side_effect = responses
 
-        service = VellumIntegrationService()
+    # WHEN we execute multiple tools in sequence
+    service = VellumIntegrationService()
 
-        # Execute
-        result = service.execute_tool(
-            integration="GITHUB",
-            provider="COMPOSIO",
-            tool_name="GITHUB_CREATE_AN_ISSUE",
-            arguments={
-                "repo": "user/repo",
-                "title": "Test Issue",
-                "body": "Test body",
-            },
-        )
+    result1 = service.execute_tool(
+        integration="GITHUB",
+        provider="COMPOSIO",
+        tool_name="TOOL_1",
+        arguments={"arg": "val1"},
+    )
 
-        # Assert
-        assert result["success"] is True
-        assert result["issue_id"] == 123
-        assert result["issue_url"] == "https://github.com/user/repo/issues/123"
+    result2 = service.execute_tool(
+        integration="SLACK",
+        provider="COMPOSIO",
+        tool_name="TOOL_2",
+        arguments={"arg": "val2"},
+    )
 
-        mock_client.integrations.execute_integration_tool.assert_called_once_with(
-            integration="GITHUB",
-            provider="COMPOSIO",
-            tool_name="GITHUB_CREATE_AN_ISSUE",
-            arguments={
-                "repo": "user/repo",
-                "title": "Test Issue",
-                "body": "Test body",
-            },
-        )
+    # THEN each tool execution should return its respective result
+    assert result1["result"] == "first"
+    assert result2["result"] == "second"
 
-    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-    def test_execute_tool_failure(self, mock_create_client):
-        """Test handling of errors during tool execution."""
-        # Setup
-        mock_client = MagicMock()
-        mock_create_client.return_value = mock_client
-
-        mock_client.integrations.execute_integration_tool.side_effect = Exception("Authentication failed")
-
-        service = VellumIntegrationService()
-
-        # Execute & Assert
-        with pytest.raises(NodeException) as exc_info:
-            service.execute_tool(
-                integration="GITHUB",
-                provider="COMPOSIO",
-                tool_name="GITHUB_CREATE_AN_ISSUE",
-                arguments={"repo": "user/repo"},
-            )
-
-        assert "Failed to execute tool" in str(exc_info.value)
-        assert "Authentication failed" in str(exc_info.value)
-
-    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-    def test_execute_tool_empty_response_data(self, mock_create_client):
-        """Test handling of empty response data from tool execution."""
-        # Setup
-        mock_client = MagicMock()
-        mock_create_client.return_value = mock_client
-
-        mock_response = MagicMock()
-        mock_response.data = {}
-
-        mock_client.integrations.execute_integration_tool.return_value = mock_response
-
-        service = VellumIntegrationService()
-
-        # Execute
-        result = service.execute_tool(
-            integration="SLACK",
-            provider="COMPOSIO",
-            tool_name="SLACK_SEND_MESSAGE",
-            arguments={
-                "channel": "#general",
-                "message": "Hello, world!",
-            },
-        )
-
-        # Assert
-        assert result == {}
-
-    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-    def test_multiple_tool_executions(self, mock_create_client):
-        """Test that the service can handle multiple tool executions."""
-        # Setup
-        mock_client = MagicMock()
-        mock_create_client.return_value = mock_client
-
-        service = VellumIntegrationService()
-
-        # Mock different responses for different tools
-        responses = [
-            MagicMock(data={"result": "first"}),
-            MagicMock(data={"result": "second"}),
-        ]
-        mock_client.integrations.execute_integration_tool.side_effect = responses
-
-        # Execute
-        result1 = service.execute_tool(
-            integration="GITHUB",
-            provider="COMPOSIO",
-            tool_name="TOOL_1",
-            arguments={"arg": "val1"},
-        )
-
-        result2 = service.execute_tool(
-            integration="SLACK",
-            provider="COMPOSIO",
-            tool_name="TOOL_2",
-            arguments={"arg": "val2"},
-        )
-
-        # Assert
-        assert result1["result"] == "first"
-        assert result2["result"] == "second"
-        assert mock_client.integrations.execute_integration_tool.call_count == 2
+    # AND the API should have been called twice
+    assert mock_client.integrations.execute_integration_tool.call_count == 2

--- a/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
@@ -1,0 +1,209 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from vellum.workflows.exceptions import NodeException
+from vellum.workflows.integrations.vellum_integration_service import VellumIntegrationService
+
+
+class TestVellumIntegrationService:
+    """Test suite for VellumIntegrationService."""
+
+    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+    def test_get_tool_definition_success(self, mock_create_client):
+        """Test successful retrieval of tool definition."""
+        # Setup
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.name = "GITHUB_CREATE_AN_ISSUE"
+        mock_response.description = "Create a new issue in a GitHub repository"
+        mock_response.parameters = {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "Repository name"},
+                "title": {"type": "string", "description": "Issue title"},
+                "body": {"type": "string", "description": "Issue body"},
+            },
+            "required": ["repo", "title"],
+        }
+        mock_response.provider = "COMPOSIO"
+
+        mock_client.integrations.retrieve_integration_tool_definition.return_value = mock_response
+
+        service = VellumIntegrationService()
+
+        # Execute
+        result = service.get_tool_definition(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="GITHUB_CREATE_AN_ISSUE",
+        )
+
+        # Assert
+        assert result["name"] == "GITHUB_CREATE_AN_ISSUE"
+        assert result["description"] == "Create a new issue in a GitHub repository"
+        assert result["provider"] == "COMPOSIO"
+        assert "properties" in result["parameters"]
+        assert "repo" in result["parameters"]["properties"]
+
+        mock_client.integrations.retrieve_integration_tool_definition.assert_called_once_with(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="GITHUB_CREATE_AN_ISSUE",
+        )
+
+    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+    def test_get_tool_definition_failure(self, mock_create_client):
+        """Test handling of errors when retrieving tool definition."""
+        # Setup
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        mock_client.integrations.retrieve_integration_tool_definition.side_effect = Exception("Tool not found")
+
+        service = VellumIntegrationService()
+
+        # Execute & Assert
+        with pytest.raises(NodeException) as exc_info:
+            service.get_tool_definition(
+                integration="GITHUB",
+                provider="COMPOSIO",
+                tool_name="INVALID_TOOL",
+            )
+
+        assert "Failed to retrieve tool definition" in str(exc_info.value)
+        assert "Tool not found" in str(exc_info.value)
+
+    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+    def test_execute_tool_success(self, mock_create_client):
+        """Test successful tool execution."""
+        # Setup
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.data = {
+            "success": True,
+            "issue_id": 123,
+            "issue_url": "https://github.com/user/repo/issues/123",
+        }
+
+        mock_client.integrations.execute_integration_tool.return_value = mock_response
+
+        service = VellumIntegrationService()
+
+        # Execute
+        result = service.execute_tool(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="GITHUB_CREATE_AN_ISSUE",
+            arguments={
+                "repo": "user/repo",
+                "title": "Test Issue",
+                "body": "Test body",
+            },
+        )
+
+        # Assert
+        assert result["success"] is True
+        assert result["issue_id"] == 123
+        assert result["issue_url"] == "https://github.com/user/repo/issues/123"
+
+        mock_client.integrations.execute_integration_tool.assert_called_once_with(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="GITHUB_CREATE_AN_ISSUE",
+            arguments={
+                "repo": "user/repo",
+                "title": "Test Issue",
+                "body": "Test body",
+            },
+        )
+
+    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+    def test_execute_tool_failure(self, mock_create_client):
+        """Test handling of errors during tool execution."""
+        # Setup
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        mock_client.integrations.execute_integration_tool.side_effect = Exception("Authentication failed")
+
+        service = VellumIntegrationService()
+
+        # Execute & Assert
+        with pytest.raises(NodeException) as exc_info:
+            service.execute_tool(
+                integration="GITHUB",
+                provider="COMPOSIO",
+                tool_name="GITHUB_CREATE_AN_ISSUE",
+                arguments={"repo": "user/repo"},
+            )
+
+        assert "Failed to execute tool" in str(exc_info.value)
+        assert "Authentication failed" in str(exc_info.value)
+
+    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+    def test_execute_tool_empty_response_data(self, mock_create_client):
+        """Test handling of empty response data from tool execution."""
+        # Setup
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.data = {}
+
+        mock_client.integrations.execute_integration_tool.return_value = mock_response
+
+        service = VellumIntegrationService()
+
+        # Execute
+        result = service.execute_tool(
+            integration="SLACK",
+            provider="COMPOSIO",
+            tool_name="SLACK_SEND_MESSAGE",
+            arguments={
+                "channel": "#general",
+                "message": "Hello, world!",
+            },
+        )
+
+        # Assert
+        assert result == {}
+
+    @patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
+    def test_multiple_tool_executions(self, mock_create_client):
+        """Test that the service can handle multiple tool executions."""
+        # Setup
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        service = VellumIntegrationService()
+
+        # Mock different responses for different tools
+        responses = [
+            MagicMock(data={"result": "first"}),
+            MagicMock(data={"result": "second"}),
+        ]
+        mock_client.integrations.execute_integration_tool.side_effect = responses
+
+        # Execute
+        result1 = service.execute_tool(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="TOOL_1",
+            arguments={"arg": "val1"},
+        )
+
+        result2 = service.execute_tool(
+            integration="SLACK",
+            provider="COMPOSIO",
+            tool_name="TOOL_2",
+            arguments={"arg": "val2"},
+        )
+
+        # Assert
+        assert result1["result"] == "first"
+        assert result2["result"] == "second"
+        assert mock_client.integrations.execute_integration_tool.call_count == 2

--- a/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
@@ -1,213 +1,225 @@
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 from vellum.workflows.exceptions import NodeException
 from vellum.workflows.integrations.vellum_integration_service import VellumIntegrationService
 
 
-@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-def test_vellum_integration_service_get_tool_definition_success(mock_create_client):
+def test_vellum_integration_service_get_tool_definition_success():
     """Test that tool definitions are successfully retrieved from Vellum API"""
-    # GIVEN a mock Vellum client configured to return a tool definition
-    mock_client = MagicMock()
-    mock_create_client.return_value = mock_client
+    with mock.patch(
+        "vellum.workflows.integrations.vellum_integration_service.create_vellum_client"
+    ) as mock_create_client:
+        # GIVEN a mock Vellum client configured to return a tool definition
+        mock_client = mock.MagicMock()
+        mock_create_client.return_value = mock_client
 
-    mock_response = MagicMock()
-    mock_response.name = "GITHUB_CREATE_AN_ISSUE"
-    mock_response.description = "Create a new issue in a GitHub repository"
-    mock_response.parameters = {
-        "type": "object",
-        "properties": {
-            "repo": {"type": "string", "description": "Repository name"},
-            "title": {"type": "string", "description": "Issue title"},
-            "body": {"type": "string", "description": "Issue body"},
-        },
-        "required": ["repo", "title"],
-    }
-    mock_response.provider = "COMPOSIO"
+        mock_response = mock.MagicMock()
+        mock_response.name = "GITHUB_CREATE_AN_ISSUE"
+        mock_response.description = "Create a new issue in a GitHub repository"
+        mock_response.parameters = {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "Repository name"},
+                "title": {"type": "string", "description": "Issue title"},
+                "body": {"type": "string", "description": "Issue body"},
+            },
+            "required": ["repo", "title"],
+        }
+        mock_response.provider = "COMPOSIO"
 
-    mock_client.integrations.retrieve_integration_tool_definition.return_value = mock_response
+        mock_client.integrations.retrieve_integration_tool_definition.return_value = mock_response
 
-    # WHEN we request a tool definition
-    service = VellumIntegrationService()
-    result = service.get_tool_definition(
-        integration="GITHUB",
-        provider="COMPOSIO",
-        tool_name="GITHUB_CREATE_AN_ISSUE",
-    )
-
-    # THEN the tool definition should be returned with all expected fields
-    assert result["name"] == "GITHUB_CREATE_AN_ISSUE"
-    assert result["description"] == "Create a new issue in a GitHub repository"
-    assert result["provider"] == "COMPOSIO"
-    assert "properties" in result["parameters"]
-    assert "repo" in result["parameters"]["properties"]
-
-    # AND the API should have been called with the correct parameters
-    mock_client.integrations.retrieve_integration_tool_definition.assert_called_once_with(
-        integration="GITHUB",
-        provider="COMPOSIO",
-        tool_name="GITHUB_CREATE_AN_ISSUE",
-    )
-
-
-@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-def test_vellum_integration_service_get_tool_definition_api_error(mock_create_client):
-    """Test that API errors are properly handled when retrieving tool definitions"""
-    # GIVEN a mock client that raises an exception when retrieving tool definitions
-    mock_client = MagicMock()
-    mock_create_client.return_value = mock_client
-
-    mock_client.integrations.retrieve_integration_tool_definition.side_effect = Exception("Tool not found")
-
-    # WHEN we attempt to get a tool definition for an invalid tool
-    service = VellumIntegrationService()
-
-    # THEN it should raise a NodeException with appropriate error message
-    with pytest.raises(NodeException) as exc_info:
-        service.get_tool_definition(
-            integration="GITHUB",
-            provider="COMPOSIO",
-            tool_name="INVALID_TOOL",
-        )
-
-    assert "Failed to retrieve tool definition" in str(exc_info.value)
-    assert "Tool not found" in str(exc_info.value)
-
-
-@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-def test_vellum_integration_service_execute_tool_success(mock_create_client):
-    """Test that tools are successfully executed via Vellum API"""
-    # GIVEN a mock client configured to return successful execution results
-    mock_client = MagicMock()
-    mock_create_client.return_value = mock_client
-
-    mock_response = MagicMock()
-    mock_response.data = {
-        "success": True,
-        "issue_id": 123,
-        "issue_url": "https://github.com/user/repo/issues/123",
-    }
-
-    mock_client.integrations.execute_integration_tool.return_value = mock_response
-
-    # WHEN we execute a tool with valid arguments
-    service = VellumIntegrationService()
-    result = service.execute_tool(
-        integration="GITHUB",
-        provider="COMPOSIO",
-        tool_name="GITHUB_CREATE_AN_ISSUE",
-        arguments={
-            "repo": "user/repo",
-            "title": "Test Issue",
-            "body": "Test body",
-        },
-    )
-
-    # THEN the execution result should contain expected data
-    assert result["success"] is True
-    assert result["issue_id"] == 123
-    assert result["issue_url"] == "https://github.com/user/repo/issues/123"
-
-    # AND the API should have been called with correct parameters
-    mock_client.integrations.execute_integration_tool.assert_called_once_with(
-        integration="GITHUB",
-        provider="COMPOSIO",
-        tool_name="GITHUB_CREATE_AN_ISSUE",
-        arguments={
-            "repo": "user/repo",
-            "title": "Test Issue",
-            "body": "Test body",
-        },
-    )
-
-
-@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-def test_vellum_integration_service_execute_tool_api_error(mock_create_client):
-    """Test that execution errors are properly handled"""
-    # GIVEN a mock client that raises an exception during tool execution
-    mock_client = MagicMock()
-    mock_create_client.return_value = mock_client
-
-    mock_client.integrations.execute_integration_tool.side_effect = Exception("Authentication failed")
-
-    # WHEN we attempt to execute a tool that encounters an error
-    service = VellumIntegrationService()
-
-    # THEN it should raise a NodeException with appropriate error message
-    with pytest.raises(NodeException) as exc_info:
-        service.execute_tool(
+        # WHEN we request a tool definition
+        service = VellumIntegrationService()
+        result = service.get_tool_definition(
             integration="GITHUB",
             provider="COMPOSIO",
             tool_name="GITHUB_CREATE_AN_ISSUE",
-            arguments={"repo": "user/repo"},
         )
 
-    assert "Failed to execute tool" in str(exc_info.value)
-    assert "Authentication failed" in str(exc_info.value)
+        # THEN the tool definition should be returned with all expected fields
+        assert result["name"] == "GITHUB_CREATE_AN_ISSUE"
+        assert result["description"] == "Create a new issue in a GitHub repository"
+        assert result["provider"] == "COMPOSIO"
+        assert "properties" in result["parameters"]
+        assert "repo" in result["parameters"]["properties"]
+
+        # AND the API should have been called with the correct parameters
+        mock_client.integrations.retrieve_integration_tool_definition.assert_called_once_with(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="GITHUB_CREATE_AN_ISSUE",
+        )
 
 
-@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-def test_vellum_integration_service_execute_tool_empty_response(mock_create_client):
+def test_vellum_integration_service_get_tool_definition_api_error():
+    """Test that API errors are properly handled when retrieving tool definitions"""
+    with mock.patch(
+        "vellum.workflows.integrations.vellum_integration_service.create_vellum_client"
+    ) as mock_create_client:
+        # GIVEN a mock client that raises an exception when retrieving tool definitions
+        mock_client = mock.MagicMock()
+        mock_create_client.return_value = mock_client
+
+        mock_client.integrations.retrieve_integration_tool_definition.side_effect = Exception("Tool not found")
+
+        # WHEN we attempt to get a tool definition for an invalid tool
+        service = VellumIntegrationService()
+
+        # THEN it should raise a NodeException with appropriate error message
+        with pytest.raises(NodeException) as exc_info:
+            service.get_tool_definition(
+                integration="GITHUB",
+                provider="COMPOSIO",
+                tool_name="INVALID_TOOL",
+            )
+
+        assert "Failed to retrieve tool definition" in str(exc_info.value)
+        assert "Tool not found" in str(exc_info.value)
+
+
+def test_vellum_integration_service_execute_tool_success():
+    """Test that tools are successfully executed via Vellum API"""
+    with mock.patch(
+        "vellum.workflows.integrations.vellum_integration_service.create_vellum_client"
+    ) as mock_create_client:
+        # GIVEN a mock client configured to return successful execution results
+        mock_client = mock.MagicMock()
+        mock_create_client.return_value = mock_client
+
+        mock_response = mock.MagicMock()
+        mock_response.data = {
+            "success": True,
+            "issue_id": 123,
+            "issue_url": "https://github.com/user/repo/issues/123",
+        }
+
+        mock_client.integrations.execute_integration_tool.return_value = mock_response
+
+        # WHEN we execute a tool with valid arguments
+        service = VellumIntegrationService()
+        result = service.execute_tool(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="GITHUB_CREATE_AN_ISSUE",
+            arguments={
+                "repo": "user/repo",
+                "title": "Test Issue",
+                "body": "Test body",
+            },
+        )
+
+        # THEN the execution result should contain expected data
+        assert result["success"] is True
+        assert result["issue_id"] == 123
+        assert result["issue_url"] == "https://github.com/user/repo/issues/123"
+
+        # AND the API should have been called with correct parameters
+        mock_client.integrations.execute_integration_tool.assert_called_once_with(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="GITHUB_CREATE_AN_ISSUE",
+            arguments={
+                "repo": "user/repo",
+                "title": "Test Issue",
+                "body": "Test body",
+            },
+        )
+
+
+def test_vellum_integration_service_execute_tool_api_error():
+    """Test that execution errors are properly handled"""
+    with mock.patch(
+        "vellum.workflows.integrations.vellum_integration_service.create_vellum_client"
+    ) as mock_create_client:
+        # GIVEN a mock client that raises an exception during tool execution
+        mock_client = mock.MagicMock()
+        mock_create_client.return_value = mock_client
+
+        mock_client.integrations.execute_integration_tool.side_effect = Exception("Authentication failed")
+
+        # WHEN we attempt to execute a tool that encounters an error
+        service = VellumIntegrationService()
+
+        # THEN it should raise a NodeException with appropriate error message
+        with pytest.raises(NodeException) as exc_info:
+            service.execute_tool(
+                integration="GITHUB",
+                provider="COMPOSIO",
+                tool_name="GITHUB_CREATE_AN_ISSUE",
+                arguments={"repo": "user/repo"},
+            )
+
+        assert "Failed to execute tool" in str(exc_info.value)
+        assert "Authentication failed" in str(exc_info.value)
+
+
+def test_vellum_integration_service_execute_tool_empty_response():
     """Test that empty response data is handled gracefully"""
-    # GIVEN a mock client that returns an empty response
-    mock_client = MagicMock()
-    mock_create_client.return_value = mock_client
+    with mock.patch(
+        "vellum.workflows.integrations.vellum_integration_service.create_vellum_client"
+    ) as mock_create_client:
+        # GIVEN a mock client that returns an empty response
+        mock_client = mock.MagicMock()
+        mock_create_client.return_value = mock_client
 
-    mock_response = MagicMock()
-    mock_response.data = {}
+        mock_response = mock.MagicMock()
+        mock_response.data = {}
 
-    mock_client.integrations.execute_integration_tool.return_value = mock_response
+        mock_client.integrations.execute_integration_tool.return_value = mock_response
 
-    # WHEN we execute a tool that returns empty data
-    service = VellumIntegrationService()
-    result = service.execute_tool(
-        integration="SLACK",
-        provider="COMPOSIO",
-        tool_name="SLACK_SEND_MESSAGE",
-        arguments={
-            "channel": "#general",
-            "message": "Hello, world!",
-        },
-    )
+        # WHEN we execute a tool that returns empty data
+        service = VellumIntegrationService()
+        result = service.execute_tool(
+            integration="SLACK",
+            provider="COMPOSIO",
+            tool_name="SLACK_SEND_MESSAGE",
+            arguments={
+                "channel": "#general",
+                "message": "Hello, world!",
+            },
+        )
 
-    # THEN an empty dictionary should be returned without errors
-    assert result == {}
+        # THEN an empty dictionary should be returned without errors
+        assert result == {}
 
 
-@patch("vellum.workflows.integrations.vellum_integration_service.create_vellum_client")
-def test_vellum_integration_service_multiple_tool_executions(mock_create_client):
+def test_vellum_integration_service_multiple_tool_executions():
     """Test that the service handles multiple sequential tool executions"""
-    # GIVEN a mock client configured to return different responses for each call
-    mock_client = MagicMock()
-    mock_create_client.return_value = mock_client
+    with mock.patch(
+        "vellum.workflows.integrations.vellum_integration_service.create_vellum_client"
+    ) as mock_create_client:
+        # GIVEN a mock client configured to return different responses for each call
+        mock_client = mock.MagicMock()
+        mock_create_client.return_value = mock_client
 
-    responses = [
-        MagicMock(data={"result": "first"}),
-        MagicMock(data={"result": "second"}),
-    ]
-    mock_client.integrations.execute_integration_tool.side_effect = responses
+        responses = [
+            mock.MagicMock(data={"result": "first"}),
+            mock.MagicMock(data={"result": "second"}),
+        ]
+        mock_client.integrations.execute_integration_tool.side_effect = responses
 
-    # WHEN we execute multiple tools in sequence
-    service = VellumIntegrationService()
+        # WHEN we execute multiple tools in sequence
+        service = VellumIntegrationService()
 
-    result1 = service.execute_tool(
-        integration="GITHUB",
-        provider="COMPOSIO",
-        tool_name="TOOL_1",
-        arguments={"arg": "val1"},
-    )
+        result1 = service.execute_tool(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="TOOL_1",
+            arguments={"arg": "val1"},
+        )
 
-    result2 = service.execute_tool(
-        integration="SLACK",
-        provider="COMPOSIO",
-        tool_name="TOOL_2",
-        arguments={"arg": "val2"},
-    )
+        result2 = service.execute_tool(
+            integration="SLACK",
+            provider="COMPOSIO",
+            tool_name="TOOL_2",
+            arguments={"arg": "val2"},
+        )
 
-    # THEN each tool execution should return its respective result
-    assert result1["result"] == "first"
-    assert result2["result"] == "second"
+        # THEN each tool execution should return its respective result
+        assert result1["result"] == "first"
+        assert result2["result"] == "second"
 
-    # AND the API should have been called twice
-    assert mock_client.integrations.execute_integration_tool.call_count == 2
+        # AND the API should have been called twice
+        assert mock_client.integrations.execute_integration_tool.call_count == 2

--- a/src/vellum/workflows/integrations/vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/vellum_integration_service.py
@@ -1,0 +1,96 @@
+from typing import Any, Dict
+
+from vellum.workflows.errors.types import WorkflowErrorCode
+from vellum.workflows.exceptions import NodeException
+from vellum.workflows.vellum_client import create_vellum_client
+
+
+class VellumIntegrationService:
+    """Vellum Integration Service for retrieving tool definitions and executing tools.
+
+    This service uses the native Vellum client SDK to interact with Vellum's integration
+    endpoints, providing functionality similar to ComposioService but using Vellum's
+    own integration infrastructure.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the VellumIntegrationService with a Vellum client."""
+        self._client = create_vellum_client()
+
+    def get_tool_definition(
+        self,
+        integration: str,
+        provider: str,
+        tool_name: str,
+    ) -> Dict[str, Any]:
+        """Retrieve a tool definition from Vellum integrations.
+
+        Args:
+            integration: The integration name (e.g., "GITHUB", "SLACK")
+            provider: The integration provider name (e.g., "COMPOSIO")
+            tool_name: The tool's unique name as specified by the provider
+
+        Returns:
+            Dict containing the tool definition with name, description, and parameters
+
+        Raises:
+            NodeException: If the tool definition cannot be retrieved
+        """
+        try:
+            response = self._client.integrations.retrieve_integration_tool_definition(
+                integration=integration,
+                provider=provider,
+                tool_name=tool_name,
+            )
+
+            # Convert the response to a dict format matching what's expected
+            return {
+                "name": response.name,
+                "description": response.description,
+                "parameters": response.parameters,
+                "provider": response.provider,
+            }
+        except Exception as e:
+            error_message = f"Failed to retrieve tool definition for {tool_name}: {str(e)}"
+            raise NodeException(
+                message=error_message,
+                code=WorkflowErrorCode.INVALID_OUTPUTS,
+            ) from e
+
+    def execute_tool(
+        self,
+        integration: str,
+        provider: str,
+        tool_name: str,
+        arguments: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Execute a tool through Vellum integrations.
+
+        Args:
+            integration: The integration name (e.g., "GITHUB", "SLACK")
+            provider: The integration provider name (e.g., "COMPOSIO")
+            tool_name: The tool's unique name as specified by the provider
+            arguments: Arguments to pass to the tool
+
+        Returns:
+            Dict containing the execution result data
+
+        Raises:
+            NodeException: If the tool execution fails
+        """
+        try:
+            response = self._client.integrations.execute_integration_tool(
+                integration=integration,
+                provider=provider,
+                tool_name=tool_name,
+                arguments=arguments,
+            )
+
+            # Return the data from the response
+            return response.data
+        except Exception as e:
+            error_message = f"Failed to execute tool {tool_name}: {str(e)}"
+            raise NodeException(
+                message=error_message,
+                code=WorkflowErrorCode.INVALID_OUTPUTS,
+            ) from e


### PR DESCRIPTION
The purpose of this PR is to create a service that uses Vellum's native integration endpoints for tool execution.

## Changes Made
- Add VellumIntegrationService class that uses native Vellum client SDK endpoints
- Implement get_tool_definition() and execute_tool() methods
- Add comprehensive unit tests

## Testing
- Unit tests added for all service methods
- Tests cover success cases, error handling, and edge cases
- All tests passing

---
*This PR was created with Claude Code*