### PR TITLE
[APO-1693] Add Vellum Integration support for tool calling nodes

### DIFF
--- a/src/vellum/workflows/emitters/vellum_emitter.py
+++ b/src/vellum/workflows/emitters/vellum_emitter.py
@@ -126,7 +126,10 @@ class VellumEmitter(BaseWorkflowEmitter):
             return
 
         client = self._context.vellum_client
-        request_options = RequestOptions(timeout_in_seconds=self._timeout, max_retries=self._max_retries)
+        if self._timeout is not None:
+            request_options = RequestOptions(timeout_in_seconds=int(self._timeout), max_retries=self._max_retries)
+        else:
+            request_options = RequestOptions(max_retries=self._max_retries)
 
         client.events.create(
             # The API accepts a ClientWorkflowEvent but our SDK emits an SDKWorkflowEvent. These shapes are

--- a/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
@@ -57,6 +57,7 @@ from vellum.workflows.utils.functions import (
     compile_function_definition,
     compile_inline_workflow_function_definition,
     compile_mcp_tool_definition,
+    compile_vellum_integration_tool_definition,
     compile_workflow_deployment_function_definition,
     get_mcp_tool_name,
 )
@@ -151,11 +152,7 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
                 elif isinstance(function, ComposioToolDefinition):
                     normalized_functions.append(compile_composio_tool_definition(function))
                 elif isinstance(function, VellumIntegrationToolDefinition):
-                    # TODO: Implement compile_vellum_integration_tool_definition
-                    raise NotImplementedError(
-                        "VellumIntegrationToolDefinition support coming soon. "
-                        "This will be implemented when compile_vellum_integration_tool_definition is created."
-                    )
+                    normalized_functions.append(compile_vellum_integration_tool_definition(function))
                 elif isinstance(function, MCPServer):
                     tool_definitions = compile_mcp_tool_definition(function)
                     for tool_def in tool_definitions:

--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -10,6 +10,7 @@ from vellum import Vellum
 from vellum.client.types.function_definition import FunctionDefinition
 from vellum.workflows.integrations.composio_service import ComposioService
 from vellum.workflows.integrations.mcp_service import MCPService
+from vellum.workflows.integrations.vellum_integration_service import VellumIntegrationService
 from vellum.workflows.types.definition import (
     ComposioToolDefinition,
     DeploymentDefinition,
@@ -333,8 +334,6 @@ def compile_vellum_integration_tool_definition(tool_def: VellumIntegrationToolDe
         FunctionDefinition with tool parameters and description
     """
     try:
-        from vellum.workflows.integrations.vellum_integration_service import VellumIntegrationService
-
         service = VellumIntegrationService()
         tool_details = service.get_tool_definition(
             integration=tool_def.integration, provider=tool_def.provider.value, tool_name=tool_def.name

--- a/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/__init__.py
+++ b/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/__init__.py
@@ -1,0 +1,1 @@
+# Test directory for basic tool calling node with vellum integration tool

--- a/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/tests/__init__.py
+++ b/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for basic tool calling node with vellum integration tool

--- a/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/tests/test_workflow.py
+++ b/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/tests/test_workflow.py
@@ -1,6 +1,6 @@
 from unittest import mock
 from uuid import uuid4
-from typing import Iterator, List, cast
+from typing import Iterator, cast
 
 from vellum.client.types.execute_prompt_event import ExecutePromptEvent
 from vellum.client.types.fulfilled_execute_prompt_event import FulfilledExecutePromptEvent
@@ -9,7 +9,6 @@ from vellum.client.types.function_call_chat_message_content import FunctionCallC
 from vellum.client.types.function_call_vellum_value import FunctionCallVellumValue
 from vellum.client.types.function_definition import FunctionDefinition
 from vellum.client.types.initiated_execute_prompt_event import InitiatedExecutePromptEvent
-from vellum.client.types.prompt_output import PromptOutput
 from vellum.client.types.string_vellum_value import StringVellumValue
 
 from tests.workflows.basic_tool_calling_node_with_vellum_integration_tool.workflow import (
@@ -19,23 +18,49 @@ from tests.workflows.basic_tool_calling_node_with_vellum_integration_tool.workfl
 )
 
 
-def test_run_workflow__happy_path(vellum_adhoc_prompt_client, vellum_client, mock_uuid4_generator):
-    """
-    Test that the VellumIntegrationToolCallingNode workflow returns the expected outputs
-    when successfully executing a Vellum Integration tool.
-    """
+def _setup_mock_service(
+    mock_service_class,
+    mock_service_class_utils,
+    tool_details=None,
+    execute_result=None,
+    get_tool_error=None,
+    execute_error=None,
+):
+    """Helper to set up VellumIntegrationService mocks."""
+    mock_service_instance = mock.Mock()
 
-    # Mock VellumIntegrationService
+    if get_tool_error:
+        mock_service_instance.get_tool_definition.side_effect = get_tool_error
+    elif tool_details:
+        mock_service_instance.get_tool_definition.return_value = tool_details
+
+    if execute_error:
+        mock_service_instance.execute_tool.side_effect = execute_error
+    elif execute_result:
+        mock_service_instance.execute_tool.return_value = execute_result
+
+    mock_service_class.return_value = mock_service_instance
+    mock_service_class_utils.return_value = mock_service_instance
+    return mock_service_instance
+
+
+def _generate_events(outputs, execution_id=None):
+    """Helper to generate ExecutePromptEvents."""
+    if execution_id is None:
+        execution_id = str(uuid4())
+
+    return [
+        InitiatedExecutePromptEvent(execution_id=execution_id),
+        FulfilledExecutePromptEvent(execution_id=execution_id, outputs=outputs),
+    ]
+
+
+def test_run_workflow__happy_path(vellum_adhoc_prompt_client, vellum_client, mock_uuid4_generator):
+    """Test successful tool execution with full workflow verification."""
     mock_vellum_result = {
-        "issue": {
-            "id": 123,
-            "title": "Test Issue",
-            "body": "This is a test issue created via Vellum Integration",
-            "url": "https://github.com/owner/repo/issues/123",
-        }
+        "issue": {"id": 123, "title": "Test Issue", "url": "https://github.com/owner/repo/issues/123"}
     }
 
-    # Mock tool details for hydration
     mock_tool_details = {
         "name": "create_issue",
         "description": "Create a new issue in a GitHub repository",
@@ -54,19 +79,18 @@ def test_run_workflow__happy_path(vellum_adhoc_prompt_client, vellum_client, moc
     with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class, mock.patch(
         "vellum.workflows.nodes.displayable.tool_calling_node.utils.VellumIntegrationService"
     ) as mock_service_class_utils:
-        mock_service_instance = mock.Mock()
-        mock_service_instance.execute_tool.return_value = mock_vellum_result
-        mock_service_instance.get_tool_definition.return_value = mock_tool_details
-        mock_service_class.return_value = mock_service_instance
-        mock_service_class_utils.return_value = mock_service_instance
+
+        mock_service_instance = _setup_mock_service(
+            mock_service_class,
+            mock_service_class_utils,
+            tool_details=mock_tool_details,
+            execute_result=mock_vellum_result,
+        )
 
         def generate_prompt_events(*_args, **_kwargs) -> Iterator[ExecutePromptEvent]:
-            execution_id = str(uuid4())
-
             call_count = vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.call_count
-            expected_outputs: List[PromptOutput]
             if call_count == 1:
-                expected_outputs = [
+                outputs = [
                     FunctionCallVellumValue(
                         value=FunctionCall(
                             arguments={
@@ -77,75 +101,41 @@ def test_run_workflow__happy_path(vellum_adhoc_prompt_client, vellum_client, moc
                             },
                             id="call_vellum_integration_create_issue",
                             name="create_issue",
-                            state="FULFILLED",
-                        ),
-                    ),
-                ]
-            else:
-                expected_outputs = [
-                    StringVellumValue(
-                        value=(
-                            "I've successfully created the GitHub issue. "
-                            "You can view it at: https://github.com/owner/repo/issues/123"
                         )
                     )
                 ]
+            else:
+                outputs = [
+                    StringVellumValue(
+                        value="I've successfully created the GitHub issue. "
+                        "You can view it at: https://github.com/owner/repo/issues/123"
+                    )
+                ]
 
-            events: List[ExecutePromptEvent] = [
-                InitiatedExecutePromptEvent(execution_id=execution_id),
-                FulfilledExecutePromptEvent(
-                    execution_id=execution_id,
-                    outputs=expected_outputs,
-                ),
-            ]
-            yield from events
+            yield from _generate_events(outputs)
 
-        # Set up the mock to return our events
         vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_prompt_events
-
-        # GIVEN a Vellum Integration tool calling workflow
         workflow = BasicToolCallingNodeWithVellumIntegrationToolWorkflow()
 
-        # WHEN the workflow is executed
         terminal_event = workflow.run(
-            Inputs(query=("Create an issue in the test-owner/test-repo repository about authentication bug"))
+            Inputs(query="Create an issue in the test-owner/test-repo repository about authentication bug")
         )
 
-        # Then assert
         assert terminal_event.name == "workflow.execution.fulfilled"
-        assert terminal_event.outputs.text == (
-            "I've successfully created the GitHub issue. You can view it at: https://github.com/owner/repo/issues/123"
-        )
-
-        # AND the chat history contains the function call and result
+        assert "successfully created" in terminal_event.outputs.text
         assert len(terminal_event.outputs.chat_history) == 3
 
-        # Function call message
+        # Verify function call message
         function_call_msg = terminal_event.outputs.chat_history[0]
         assert function_call_msg.role == "ASSISTANT"
-        assert function_call_msg.content is not None
-        assert function_call_msg.content.type == "FUNCTION_CALL"
-
-        # Cast to the specific type to help mypy
         function_content = cast(FunctionCallChatMessageContent, function_call_msg.content)
         assert function_content.value.name == "create_issue"
 
-        # Function result message
-        function_result_msg = terminal_event.outputs.chat_history[1]
-        assert function_result_msg.role == "FUNCTION"
-        assert function_result_msg.content is not None
-        assert function_result_msg.content.type == "STRING"
-        # The result should be the JSON serialized version of mock_vellum_result
-        assert mock_vellum_result["issue"]["id"] == 123
+        # Verify function result and final messages
+        assert terminal_event.outputs.chat_history[1].role == "FUNCTION"
+        assert terminal_event.outputs.chat_history[2].role == "ASSISTANT"
 
-        # Final assistant message
-        final_msg = terminal_event.outputs.chat_history[2]
-        assert final_msg.role == "ASSISTANT"
-        assert final_msg.text is not None
-        assert "successfully created" in final_msg.text
-
-        # THEN the VellumIntegrationService was called correctly
-        assert mock_service_class.call_count >= 1  # Called for hydration and execution
+        # Verify service was called correctly
         mock_service_instance.execute_tool.assert_called_once_with(
             integration="GITHUB",
             provider="COMPOSIO",
@@ -159,66 +149,40 @@ def test_run_workflow__happy_path(vellum_adhoc_prompt_client, vellum_client, moc
         )
 
 
-def test_run_workflow__service_error_uses_fallback(vellum_adhoc_prompt_client):
-    """
-    Test that the workflow properly handles VellumIntegrationService errors by using fallback compilation.
-    """
-
+def test_run_workflow__error_handling_and_fallback(vellum_adhoc_prompt_client):
+    """Test service errors use fallback and execution errors are properly raised."""
+    # Test fallback when service unavailable
     with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class, mock.patch(
         "vellum.workflows.nodes.displayable.tool_calling_node.utils.VellumIntegrationService"
     ) as mock_service_class_utils:
-        # Mock service to raise an exception during compilation (get_tool_definition)
-        mock_service_instance = mock.Mock()
-        mock_service_instance.get_tool_definition.side_effect = Exception("Service unavailable")
-        mock_service_instance.execute_tool.return_value = {"success": True}
-        mock_service_class.return_value = mock_service_instance
-        mock_service_class_utils.return_value = mock_service_instance
 
-        def generate_prompt_events(*_args, **_kwargs) -> Iterator[ExecutePromptEvent]:
-            execution_id = str(uuid4())
-            expected_outputs = [StringVellumValue(value="No function call needed")]
+        _setup_mock_service(
+            mock_service_class, mock_service_class_utils, get_tool_error=Exception("Service unavailable")
+        )
 
-            events: List[ExecutePromptEvent] = [
-                InitiatedExecutePromptEvent(execution_id=execution_id),
-                FulfilledExecutePromptEvent(
-                    execution_id=execution_id,
-                    outputs=expected_outputs,
-                ),
-            ]
-            yield from events
+        def generate_fallback_events(*_args, **_kwargs):
+            yield from _generate_events([StringVellumValue(value="No function call needed")])
 
-        vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_prompt_events
-
-        # GIVEN a workflow
+        vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_fallback_events
         workflow = BasicToolCallingNodeWithVellumIntegrationToolWorkflow()
 
-        # WHEN the workflow runs (should not fail due to fallback)
         terminal_event = workflow.run(Inputs(query="What can you help me with?"))
-
-        # THEN the workflow should succeed with fallback
         assert terminal_event.name == "workflow.execution.fulfilled"
 
-        # AND the prompt call should still include our function with fallback parameters
+        # Verify fallback function definition
         call_args = vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.call_args_list[0]
         functions = call_args.kwargs["functions"]
-
         assert len(functions) == 1
         function_def = functions[0]
-        assert isinstance(function_def, FunctionDefinition)
         assert function_def.name == "create_issue"
-        assert function_def.description == "Create a new issue in a GitHub repository"
-        # Should have empty parameters due to fallback
-        assert function_def.parameters == {}
+        assert function_def.parameters == {}  # Empty due to fallback
 
 
 def test_run_workflow__tool_execution_error(vellum_adhoc_prompt_client):
-    """
-    Test that VellumIntegrationNode properly handles and re-raises exceptions from VellumIntegrationService.
-    """
-
+    """Test tool execution errors are properly handled and re-raised."""
     mock_tool_details = {
         "name": "create_issue",
-        "description": "Create a new issue in a GitHub repository",
+        "description": "Create a new issue",
         "parameters": {},
         "provider": "COMPOSIO",
     }
@@ -226,71 +190,83 @@ def test_run_workflow__tool_execution_error(vellum_adhoc_prompt_client):
     with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class, mock.patch(
         "vellum.workflows.nodes.displayable.tool_calling_node.utils.VellumIntegrationService"
     ) as mock_service_class_utils:
-        mock_service_instance = mock.Mock()
-        mock_service_instance.get_tool_definition.return_value = mock_tool_details
-        # Simulate an API error during execution
-        mock_service_instance.execute_tool.side_effect = Exception("API rate limit exceeded")
-        mock_service_class.return_value = mock_service_instance
-        mock_service_class_utils.return_value = mock_service_instance
 
-        def generate_prompt_events(*_args, **_kwargs) -> Iterator[ExecutePromptEvent]:
-            execution_id = str(uuid4())
-            expected_outputs = [
+        _setup_mock_service(
+            mock_service_class,
+            mock_service_class_utils,
+            tool_details=mock_tool_details,
+            execute_error=Exception("API rate limit exceeded"),
+        )
+
+        def generate_error_events(*_args, **_kwargs):
+            outputs = [
                 FunctionCallVellumValue(
                     value=FunctionCall(
                         arguments={"owner": "test-owner", "repo": "test-repo", "title": "Test Issue"},
                         id="call_vellum_error_test",
                         name="create_issue",
-                        state="FULFILLED",
-                    ),
-                ),
+                    )
+                )
             ]
+            yield from _generate_events(outputs)
 
-            events: List[ExecutePromptEvent] = [
-                InitiatedExecutePromptEvent(execution_id=execution_id),
-                FulfilledExecutePromptEvent(
-                    execution_id=execution_id,
-                    outputs=expected_outputs,
-                ),
-            ]
-            yield from events
-
-        vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_prompt_events
-
-        # GIVEN a workflow and VellumIntegrationService that will fail during execution
+        vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_error_events
         workflow = BasicToolCallingNodeWithVellumIntegrationToolWorkflow()
 
-        # WHEN the workflow is executed
         terminal_event = workflow.run(Inputs(query="Create a test issue"))
 
-        # THEN the workflow should be rejected with the original error context
         assert terminal_event.name == "workflow.execution.rejected"
         assert "Error executing Vellum Integration tool 'create_issue'" in str(terminal_event.error.message)
         assert "API rate limit exceeded" in str(terminal_event.error.message)
 
 
-def test_tool_definition_properties():
-    """
-    Test that the VellumIntegrationToolDefinition has the correct properties.
-    """
-
-    # GIVEN a VellumIntegrationToolDefinition
+def test_tool_definition_and_function_compilation():
+    """Test tool properties and function compilation with both success and failure scenarios."""
+    # Test basic tool properties
     tool = github_create_issue_tool
-
-    # WHEN we access its properties
-    # THEN they should be as expected
     assert tool.type == "INTEGRATION"
     assert tool.provider.value == "COMPOSIO"
     assert tool.integration == "GITHUB"
     assert tool.name == "create_issue"
     assert tool.description == "Create a new issue in a GitHub repository"
 
+    from vellum.workflows.utils.functions import compile_vellum_integration_tool_definition
 
-def test_workflow_prompt_structure_includes_vellum_integration_tool_as_function(vellum_adhoc_prompt_client):
-    """
-    Test that the workflow properly includes the VellumIntegrationToolDefinition as a function in the prompt calls.
-    """
+    # Test successful compilation
+    mock_tool_details = {
+        "name": "create_issue",
+        "description": "Enhanced description from service",
+        "parameters": {"type": "object", "properties": {"title": {"type": "string", "description": "Issue title"}}},
+        "provider": "COMPOSIO",
+    }
 
+    with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class:
+        mock_service_instance = mock.Mock()
+        mock_service_instance.get_tool_definition.return_value = mock_tool_details
+        mock_service_class.return_value = mock_service_instance
+
+        result = compile_vellum_integration_tool_definition(tool)
+        assert result.name == "create_issue"
+        assert result.description == "Enhanced description from service"
+        assert "title" in result.parameters["properties"]
+        mock_service_instance.get_tool_definition.assert_called_once_with(
+            integration="GITHUB", provider="COMPOSIO", tool_name="create_issue"
+        )
+
+    # Test fallback on service failure
+    with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class:
+        mock_service_instance = mock.Mock()
+        mock_service_instance.get_tool_definition.side_effect = Exception("Service down")
+        mock_service_class.return_value = mock_service_instance
+
+        result = compile_vellum_integration_tool_definition(tool)
+        assert result.name == "create_issue"
+        assert result.description == "Create a new issue in a GitHub repository"
+        assert result.parameters == {}
+
+
+def test_workflow_prompt_structure_with_function_definition(vellum_adhoc_prompt_client):
+    """Test workflow includes VellumIntegrationToolDefinition correctly in prompt calls."""
     mock_tool_details = {
         "name": "create_issue",
         "description": "Create a new issue in a GitHub repository",
@@ -307,33 +283,16 @@ def test_workflow_prompt_structure_includes_vellum_integration_tool_as_function(
     with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class, mock.patch(
         "vellum.workflows.nodes.displayable.tool_calling_node.utils.VellumIntegrationService"
     ) as mock_service_class_utils:
-        mock_service_instance = mock.Mock()
-        mock_service_instance.get_tool_definition.return_value = mock_tool_details
-        mock_service_class.return_value = mock_service_instance
-        mock_service_class_utils.return_value = mock_service_instance
 
-        def generate_prompt_events(*_args, **_kwargs) -> Iterator[ExecutePromptEvent]:
-            execution_id = str(uuid4())
-            expected_outputs = [StringVellumValue(value="No function call needed")]
+        _setup_mock_service(mock_service_class, mock_service_class_utils, tool_details=mock_tool_details)
 
-            events: List[ExecutePromptEvent] = [
-                InitiatedExecutePromptEvent(execution_id=execution_id),
-                FulfilledExecutePromptEvent(
-                    execution_id=execution_id,
-                    outputs=expected_outputs,
-                ),
-            ]
-            yield from events
+        def generate_events(*_args, **_kwargs):
+            yield from _generate_events([StringVellumValue(value="No function call needed")])
 
-        vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_prompt_events
-
-        # GIVEN a workflow
+        vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_events
         workflow = BasicToolCallingNodeWithVellumIntegrationToolWorkflow()
-
-        # WHEN the workflow runs
         workflow.run(Inputs(query="What can you help me with?"))
 
-        # THEN the prompt call should include our VellumIntegrationToolDefinition as a function
         call_args = vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.call_args_list[0]
         functions = call_args.kwargs["functions"]
 
@@ -344,66 +303,3 @@ def test_workflow_prompt_structure_includes_vellum_integration_tool_as_function(
         assert function_def.description == "Create a new issue in a GitHub repository"
         assert "title" in function_def.parameters["properties"]
         assert "body" in function_def.parameters["properties"]
-
-
-def test_compile_function_with_successful_service_call():
-    """
-    Test that the compile_vellum_integration_tool_definition function works with a successful service call.
-    """
-    from vellum.workflows.utils.functions import compile_vellum_integration_tool_definition
-
-    mock_tool_details = {
-        "name": "create_issue",
-        "description": "Enhanced description from service",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "title": {"type": "string", "description": "Issue title"},
-            },
-        },
-        "provider": "COMPOSIO",
-    }
-
-    with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class:
-        mock_service_instance = mock.Mock()
-        mock_service_instance.get_tool_definition.return_value = mock_tool_details
-        mock_service_class.return_value = mock_service_instance
-
-        # GIVEN a VellumIntegrationToolDefinition
-        tool = github_create_issue_tool
-
-        # WHEN we compile it
-        result = compile_vellum_integration_tool_definition(tool)
-
-        # THEN it should return the enhanced definition from the service
-        assert result.name == "create_issue"
-        assert result.description == "Enhanced description from service"
-        assert "title" in result.parameters["properties"]
-
-        # AND the service should have been called with correct parameters
-        mock_service_instance.get_tool_definition.assert_called_once_with(
-            integration="GITHUB", provider="COMPOSIO", tool_name="create_issue"
-        )
-
-
-def test_compile_function_with_service_failure_uses_fallback():
-    """
-    Test that the compile_vellum_integration_tool_definition function uses fallback when service fails.
-    """
-    from vellum.workflows.utils.functions import compile_vellum_integration_tool_definition
-
-    with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class:
-        mock_service_instance = mock.Mock()
-        mock_service_instance.get_tool_definition.side_effect = Exception("Service down")
-        mock_service_class.return_value = mock_service_instance
-
-        # GIVEN a VellumIntegrationToolDefinition
-        tool = github_create_issue_tool
-
-        # WHEN we compile it and the service fails
-        result = compile_vellum_integration_tool_definition(tool)
-
-        # THEN it should return the fallback definition with basic information
-        assert result.name == "create_issue"
-        assert result.description == "Create a new issue in a GitHub repository"  # From tool definition
-        assert result.parameters == {}  # Empty fallback parameters

--- a/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/tests/test_workflow.py
+++ b/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/tests/test_workflow.py
@@ -1,6 +1,6 @@
 from unittest import mock
 from uuid import uuid4
-from typing import Iterator, cast
+from typing import Iterator, List, Union, cast
 
 from vellum.client.types.execute_prompt_event import ExecutePromptEvent
 from vellum.client.types.fulfilled_execute_prompt_event import FulfilledExecutePromptEvent
@@ -90,7 +90,7 @@ def test_run_workflow__happy_path(vellum_adhoc_prompt_client, vellum_client, moc
         def generate_prompt_events(*_args, **_kwargs) -> Iterator[ExecutePromptEvent]:
             call_count = vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.call_count
             if call_count == 1:
-                outputs = [
+                outputs: List[Union[FunctionCallVellumValue, StringVellumValue]] = [
                     FunctionCallVellumValue(
                         value=FunctionCall(
                             arguments={
@@ -248,7 +248,8 @@ def test_tool_definition_and_function_compilation():
         result = compile_vellum_integration_tool_definition(tool)
         assert result.name == "create_issue"
         assert result.description == "Enhanced description from service"
-        assert "title" in result.parameters["properties"]
+        assert result.parameters is not None and "properties" in result.parameters
+        assert result.parameters["properties"] is not None and "title" in result.parameters["properties"]
         mock_service_instance.get_tool_definition.assert_called_once_with(
             integration="GITHUB", provider="COMPOSIO", tool_name="create_issue"
         )
@@ -301,5 +302,6 @@ def test_workflow_prompt_structure_with_function_definition(vellum_adhoc_prompt_
         assert isinstance(function_def, FunctionDefinition)
         assert function_def.name == "create_issue"
         assert function_def.description == "Create a new issue in a GitHub repository"
-        assert "title" in function_def.parameters["properties"]
-        assert "body" in function_def.parameters["properties"]
+        assert function_def.parameters is not None and "properties" in function_def.parameters
+        assert function_def.parameters["properties"] is not None and "title" in function_def.parameters["properties"]
+        assert function_def.parameters["properties"] is not None and "body" in function_def.parameters["properties"]

--- a/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/tests/test_workflow.py
+++ b/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/tests/test_workflow.py
@@ -1,0 +1,409 @@
+from unittest import mock
+from uuid import uuid4
+from typing import Iterator, List, cast
+
+from vellum.client.types.execute_prompt_event import ExecutePromptEvent
+from vellum.client.types.fulfilled_execute_prompt_event import FulfilledExecutePromptEvent
+from vellum.client.types.function_call import FunctionCall
+from vellum.client.types.function_call_chat_message_content import FunctionCallChatMessageContent
+from vellum.client.types.function_call_vellum_value import FunctionCallVellumValue
+from vellum.client.types.function_definition import FunctionDefinition
+from vellum.client.types.initiated_execute_prompt_event import InitiatedExecutePromptEvent
+from vellum.client.types.prompt_output import PromptOutput
+from vellum.client.types.string_vellum_value import StringVellumValue
+
+from tests.workflows.basic_tool_calling_node_with_vellum_integration_tool.workflow import (
+    BasicToolCallingNodeWithVellumIntegrationToolWorkflow,
+    Inputs,
+    github_create_issue_tool,
+)
+
+
+def test_run_workflow__happy_path(vellum_adhoc_prompt_client, vellum_client, mock_uuid4_generator):
+    """
+    Test that the VellumIntegrationToolCallingNode workflow returns the expected outputs
+    when successfully executing a Vellum Integration tool.
+    """
+
+    # Mock VellumIntegrationService
+    mock_vellum_result = {
+        "issue": {
+            "id": 123,
+            "title": "Test Issue",
+            "body": "This is a test issue created via Vellum Integration",
+            "url": "https://github.com/owner/repo/issues/123",
+        }
+    }
+
+    # Mock tool details for hydration
+    mock_tool_details = {
+        "name": "create_issue",
+        "description": "Create a new issue in a GitHub repository",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "owner": {"type": "string", "description": "Repository owner"},
+                "repo": {"type": "string", "description": "Repository name"},
+                "title": {"type": "string", "description": "Issue title"},
+                "body": {"type": "string", "description": "Issue body"},
+            },
+        },
+        "provider": "COMPOSIO",
+    }
+
+    with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class, mock.patch(
+        "vellum.workflows.nodes.displayable.tool_calling_node.utils.VellumIntegrationService"
+    ) as mock_service_class_utils:
+        mock_service_instance = mock.Mock()
+        mock_service_instance.execute_tool.return_value = mock_vellum_result
+        mock_service_instance.get_tool_definition.return_value = mock_tool_details
+        mock_service_class.return_value = mock_service_instance
+        mock_service_class_utils.return_value = mock_service_instance
+
+        def generate_prompt_events(*_args, **_kwargs) -> Iterator[ExecutePromptEvent]:
+            execution_id = str(uuid4())
+
+            call_count = vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.call_count
+            expected_outputs: List[PromptOutput]
+            if call_count == 1:
+                expected_outputs = [
+                    FunctionCallVellumValue(
+                        value=FunctionCall(
+                            arguments={
+                                "owner": "test-owner",
+                                "repo": "test-repo",
+                                "title": "Bug in authentication",
+                                "body": "There seems to be an issue with login functionality",
+                            },
+                            id="call_vellum_integration_create_issue",
+                            name="create_issue",
+                            state="FULFILLED",
+                        ),
+                    ),
+                ]
+            else:
+                expected_outputs = [
+                    StringVellumValue(
+                        value=(
+                            "I've successfully created the GitHub issue. "
+                            "You can view it at: https://github.com/owner/repo/issues/123"
+                        )
+                    )
+                ]
+
+            events: List[ExecutePromptEvent] = [
+                InitiatedExecutePromptEvent(execution_id=execution_id),
+                FulfilledExecutePromptEvent(
+                    execution_id=execution_id,
+                    outputs=expected_outputs,
+                ),
+            ]
+            yield from events
+
+        # Set up the mock to return our events
+        vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_prompt_events
+
+        # GIVEN a Vellum Integration tool calling workflow
+        workflow = BasicToolCallingNodeWithVellumIntegrationToolWorkflow()
+
+        # WHEN the workflow is executed
+        terminal_event = workflow.run(
+            Inputs(query=("Create an issue in the test-owner/test-repo repository about authentication bug"))
+        )
+
+        # Then assert
+        assert terminal_event.name == "workflow.execution.fulfilled"
+        assert terminal_event.outputs.text == (
+            "I've successfully created the GitHub issue. You can view it at: https://github.com/owner/repo/issues/123"
+        )
+
+        # AND the chat history contains the function call and result
+        assert len(terminal_event.outputs.chat_history) == 3
+
+        # Function call message
+        function_call_msg = terminal_event.outputs.chat_history[0]
+        assert function_call_msg.role == "ASSISTANT"
+        assert function_call_msg.content is not None
+        assert function_call_msg.content.type == "FUNCTION_CALL"
+
+        # Cast to the specific type to help mypy
+        function_content = cast(FunctionCallChatMessageContent, function_call_msg.content)
+        assert function_content.value.name == "create_issue"
+
+        # Function result message
+        function_result_msg = terminal_event.outputs.chat_history[1]
+        assert function_result_msg.role == "FUNCTION"
+        assert function_result_msg.content is not None
+        assert function_result_msg.content.type == "STRING"
+        # The result should be the JSON serialized version of mock_vellum_result
+        assert mock_vellum_result["issue"]["id"] == 123
+
+        # Final assistant message
+        final_msg = terminal_event.outputs.chat_history[2]
+        assert final_msg.role == "ASSISTANT"
+        assert final_msg.text is not None
+        assert "successfully created" in final_msg.text
+
+        # THEN the VellumIntegrationService was called correctly
+        assert mock_service_class.call_count >= 1  # Called for hydration and execution
+        mock_service_instance.execute_tool.assert_called_once_with(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="create_issue",
+            arguments={
+                "owner": "test-owner",
+                "repo": "test-repo",
+                "title": "Bug in authentication",
+                "body": "There seems to be an issue with login functionality",
+            },
+        )
+
+
+def test_run_workflow__service_error_uses_fallback(vellum_adhoc_prompt_client):
+    """
+    Test that the workflow properly handles VellumIntegrationService errors by using fallback compilation.
+    """
+
+    with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class, mock.patch(
+        "vellum.workflows.nodes.displayable.tool_calling_node.utils.VellumIntegrationService"
+    ) as mock_service_class_utils:
+        # Mock service to raise an exception during compilation (get_tool_definition)
+        mock_service_instance = mock.Mock()
+        mock_service_instance.get_tool_definition.side_effect = Exception("Service unavailable")
+        mock_service_instance.execute_tool.return_value = {"success": True}
+        mock_service_class.return_value = mock_service_instance
+        mock_service_class_utils.return_value = mock_service_instance
+
+        def generate_prompt_events(*_args, **_kwargs) -> Iterator[ExecutePromptEvent]:
+            execution_id = str(uuid4())
+            expected_outputs = [StringVellumValue(value="No function call needed")]
+
+            events: List[ExecutePromptEvent] = [
+                InitiatedExecutePromptEvent(execution_id=execution_id),
+                FulfilledExecutePromptEvent(
+                    execution_id=execution_id,
+                    outputs=expected_outputs,
+                ),
+            ]
+            yield from events
+
+        vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_prompt_events
+
+        # GIVEN a workflow
+        workflow = BasicToolCallingNodeWithVellumIntegrationToolWorkflow()
+
+        # WHEN the workflow runs (should not fail due to fallback)
+        terminal_event = workflow.run(Inputs(query="What can you help me with?"))
+
+        # THEN the workflow should succeed with fallback
+        assert terminal_event.name == "workflow.execution.fulfilled"
+
+        # AND the prompt call should still include our function with fallback parameters
+        call_args = vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.call_args_list[0]
+        functions = call_args.kwargs["functions"]
+
+        assert len(functions) == 1
+        function_def = functions[0]
+        assert isinstance(function_def, FunctionDefinition)
+        assert function_def.name == "create_issue"
+        assert function_def.description == "Create a new issue in a GitHub repository"
+        # Should have empty parameters due to fallback
+        assert function_def.parameters == {}
+
+
+def test_run_workflow__tool_execution_error(vellum_adhoc_prompt_client):
+    """
+    Test that VellumIntegrationNode properly handles and re-raises exceptions from VellumIntegrationService.
+    """
+
+    mock_tool_details = {
+        "name": "create_issue",
+        "description": "Create a new issue in a GitHub repository",
+        "parameters": {},
+        "provider": "COMPOSIO",
+    }
+
+    with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class, mock.patch(
+        "vellum.workflows.nodes.displayable.tool_calling_node.utils.VellumIntegrationService"
+    ) as mock_service_class_utils:
+        mock_service_instance = mock.Mock()
+        mock_service_instance.get_tool_definition.return_value = mock_tool_details
+        # Simulate an API error during execution
+        mock_service_instance.execute_tool.side_effect = Exception("API rate limit exceeded")
+        mock_service_class.return_value = mock_service_instance
+        mock_service_class_utils.return_value = mock_service_instance
+
+        def generate_prompt_events(*_args, **_kwargs) -> Iterator[ExecutePromptEvent]:
+            execution_id = str(uuid4())
+            expected_outputs = [
+                FunctionCallVellumValue(
+                    value=FunctionCall(
+                        arguments={"owner": "test-owner", "repo": "test-repo", "title": "Test Issue"},
+                        id="call_vellum_error_test",
+                        name="create_issue",
+                        state="FULFILLED",
+                    ),
+                ),
+            ]
+
+            events: List[ExecutePromptEvent] = [
+                InitiatedExecutePromptEvent(execution_id=execution_id),
+                FulfilledExecutePromptEvent(
+                    execution_id=execution_id,
+                    outputs=expected_outputs,
+                ),
+            ]
+            yield from events
+
+        vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_prompt_events
+
+        # GIVEN a workflow and VellumIntegrationService that will fail during execution
+        workflow = BasicToolCallingNodeWithVellumIntegrationToolWorkflow()
+
+        # WHEN the workflow is executed
+        terminal_event = workflow.run(Inputs(query="Create a test issue"))
+
+        # THEN the workflow should be rejected with the original error context
+        assert terminal_event.name == "workflow.execution.rejected"
+        assert "Error executing Vellum Integration tool 'create_issue'" in str(terminal_event.error.message)
+        assert "API rate limit exceeded" in str(terminal_event.error.message)
+
+
+def test_tool_definition_properties():
+    """
+    Test that the VellumIntegrationToolDefinition has the correct properties.
+    """
+
+    # GIVEN a VellumIntegrationToolDefinition
+    tool = github_create_issue_tool
+
+    # WHEN we access its properties
+    # THEN they should be as expected
+    assert tool.type == "INTEGRATION"
+    assert tool.provider.value == "COMPOSIO"
+    assert tool.integration == "GITHUB"
+    assert tool.name == "create_issue"
+    assert tool.description == "Create a new issue in a GitHub repository"
+
+
+def test_workflow_prompt_structure_includes_vellum_integration_tool_as_function(vellum_adhoc_prompt_client):
+    """
+    Test that the workflow properly includes the VellumIntegrationToolDefinition as a function in the prompt calls.
+    """
+
+    mock_tool_details = {
+        "name": "create_issue",
+        "description": "Create a new issue in a GitHub repository",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Issue title"},
+                "body": {"type": "string", "description": "Issue body"},
+            },
+        },
+        "provider": "COMPOSIO",
+    }
+
+    with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class, mock.patch(
+        "vellum.workflows.nodes.displayable.tool_calling_node.utils.VellumIntegrationService"
+    ) as mock_service_class_utils:
+        mock_service_instance = mock.Mock()
+        mock_service_instance.get_tool_definition.return_value = mock_tool_details
+        mock_service_class.return_value = mock_service_instance
+        mock_service_class_utils.return_value = mock_service_instance
+
+        def generate_prompt_events(*_args, **_kwargs) -> Iterator[ExecutePromptEvent]:
+            execution_id = str(uuid4())
+            expected_outputs = [StringVellumValue(value="No function call needed")]
+
+            events: List[ExecutePromptEvent] = [
+                InitiatedExecutePromptEvent(execution_id=execution_id),
+                FulfilledExecutePromptEvent(
+                    execution_id=execution_id,
+                    outputs=expected_outputs,
+                ),
+            ]
+            yield from events
+
+        vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.side_effect = generate_prompt_events
+
+        # GIVEN a workflow
+        workflow = BasicToolCallingNodeWithVellumIntegrationToolWorkflow()
+
+        # WHEN the workflow runs
+        workflow.run(Inputs(query="What can you help me with?"))
+
+        # THEN the prompt call should include our VellumIntegrationToolDefinition as a function
+        call_args = vellum_adhoc_prompt_client.adhoc_execute_prompt_stream.call_args_list[0]
+        functions = call_args.kwargs["functions"]
+
+        assert len(functions) == 1
+        function_def = functions[0]
+        assert isinstance(function_def, FunctionDefinition)
+        assert function_def.name == "create_issue"
+        assert function_def.description == "Create a new issue in a GitHub repository"
+        assert "title" in function_def.parameters["properties"]
+        assert "body" in function_def.parameters["properties"]
+
+
+def test_compile_function_with_successful_service_call():
+    """
+    Test that the compile_vellum_integration_tool_definition function works with a successful service call.
+    """
+    from vellum.workflows.utils.functions import compile_vellum_integration_tool_definition
+
+    mock_tool_details = {
+        "name": "create_issue",
+        "description": "Enhanced description from service",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Issue title"},
+            },
+        },
+        "provider": "COMPOSIO",
+    }
+
+    with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class:
+        mock_service_instance = mock.Mock()
+        mock_service_instance.get_tool_definition.return_value = mock_tool_details
+        mock_service_class.return_value = mock_service_instance
+
+        # GIVEN a VellumIntegrationToolDefinition
+        tool = github_create_issue_tool
+
+        # WHEN we compile it
+        result = compile_vellum_integration_tool_definition(tool)
+
+        # THEN it should return the enhanced definition from the service
+        assert result.name == "create_issue"
+        assert result.description == "Enhanced description from service"
+        assert "title" in result.parameters["properties"]
+
+        # AND the service should have been called with correct parameters
+        mock_service_instance.get_tool_definition.assert_called_once_with(
+            integration="GITHUB", provider="COMPOSIO", tool_name="create_issue"
+        )
+
+
+def test_compile_function_with_service_failure_uses_fallback():
+    """
+    Test that the compile_vellum_integration_tool_definition function uses fallback when service fails.
+    """
+    from vellum.workflows.utils.functions import compile_vellum_integration_tool_definition
+
+    with mock.patch("vellum.workflows.utils.functions.VellumIntegrationService") as mock_service_class:
+        mock_service_instance = mock.Mock()
+        mock_service_instance.get_tool_definition.side_effect = Exception("Service down")
+        mock_service_class.return_value = mock_service_instance
+
+        # GIVEN a VellumIntegrationToolDefinition
+        tool = github_create_issue_tool
+
+        # WHEN we compile it and the service fails
+        result = compile_vellum_integration_tool_definition(tool)
+
+        # THEN it should return the fallback definition with basic information
+        assert result.name == "create_issue"
+        assert result.description == "Create a new issue in a GitHub repository"  # From tool definition
+        assert result.parameters == {}  # Empty fallback parameters

--- a/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/workflow.py
+++ b/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/workflow.py
@@ -1,0 +1,75 @@
+from vellum.client.types.chat_message_prompt_block import ChatMessagePromptBlock
+from vellum.client.types.plain_text_prompt_block import PlainTextPromptBlock
+from vellum.client.types.rich_text_prompt_block import RichTextPromptBlock
+from vellum.client.types.variable_prompt_block import VariablePromptBlock
+from vellum.workflows.constants import VellumIntegrationProviderType
+from vellum.workflows.nodes.displayable.tool_calling_node import ToolCallingNode
+from vellum.workflows.state.base import BaseState
+from vellum.workflows.types.definition import VellumIntegrationToolDefinition
+from vellum.workflows.workflows.base import BaseInputs, BaseWorkflow
+
+
+class Inputs(BaseInputs):
+    query: str
+
+
+# Create a VellumIntegrationToolDefinition for testing
+github_create_issue_tool = VellumIntegrationToolDefinition(
+    provider=VellumIntegrationProviderType.COMPOSIO,
+    integration="GITHUB",
+    name="create_issue",
+    description="Create a new issue in a GitHub repository",
+)
+
+
+class VellumIntegrationToolCallingNode(ToolCallingNode):
+    """
+    A tool calling node that uses a Vellum Integration tool to create GitHub issues.
+    """
+
+    ml_model = "gpt-4o-mini"
+    blocks = [
+        ChatMessagePromptBlock(
+            chat_role="SYSTEM",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        PlainTextPromptBlock(
+                            text=(
+                                "You are a helpful assistant that can create GitHub issues. "
+                                "When asked to create an issue, use the provided tool."
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        ChatMessagePromptBlock(
+            chat_role="USER",
+            blocks=[
+                RichTextPromptBlock(
+                    blocks=[
+                        VariablePromptBlock(
+                            input_variable="question",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    ]
+    functions = [github_create_issue_tool]
+    prompt_inputs = {
+        "question": Inputs.query,
+    }
+
+
+class BasicToolCallingNodeWithVellumIntegrationToolWorkflow(BaseWorkflow[Inputs, BaseState]):
+    """
+    A workflow that uses the VellumIntegrationToolCallingNode.
+    """
+
+    graph = VellumIntegrationToolCallingNode
+
+    class Outputs(BaseWorkflow.Outputs):
+        text = VellumIntegrationToolCallingNode.Outputs.text
+        chat_history = VellumIntegrationToolCallingNode.Outputs.chat_history


### PR DESCRIPTION
The purpose of this PR is to add support for Vellum Integration tools in tool calling nodes, enabling workflow nodes to interact with external Vellum integrations.

## Changes Made
- Updated tool calling node utilities to handle Vellum Integration tool definitions
- Enhanced function utilities to properly process integration-based tools
- Modified inline prompt node to support integration tool contexts
- Added integration test demonstrating Vellum Integration tool usage in workflows

## Testing
- Added integration test workflow demonstrating Vellum Integration tool functionality
- Manual testing of tool calling with integration tools

---
*This PR was created with Claude Code*