### PR TITLE
Rename VellumIntegrationToolDefinition.integration to integration_name

### DIFF
--- a/ee/codegen/src/generators/nodes/generic-node.ts
+++ b/ee/codegen/src/generators/nodes/generic-node.ts
@@ -383,9 +383,9 @@ export class GenericNode extends BaseNode<GenericNodeType, GenericNodeContext> {
                       ),
                     }),
                     python.methodArgument({
-                      name: "integration",
+                      name: "integration_name",
                       value: python.TypeInstantiation.str(
-                        integrationTool.integration || "UNKNOWN"
+                        integrationTool.integration_name || "UNKNOWN"
                       ),
                     }),
                     python.methodArgument({

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -1015,7 +1015,7 @@ export type MCPServerFunctionArgs = {
 export type VellumIntegrationToolFunctionArgs = {
   type: "VELLUM_INTEGRATION";
   provider: string;
-  integration: string;
+  integration_name: string;
   name: string;
 } & NameDescription;
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_vellum_integration_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_vellum_integration_serialization.py
@@ -63,6 +63,6 @@ def test_serialize_workflow():
     function = functions_value[0]
     assert function["type"] == "VELLUM_INTEGRATION"
     assert function["provider"] == "COMPOSIO"  # VellumIntegrationProviderType.COMPOSIO
-    assert function["integration"] == "GITHUB"
+    assert function["integration_name"] == "GITHUB"
     assert function["name"] == "create_issue"
     assert function["description"] == "Create a new issue in a GitHub repository"

--- a/src/vellum/workflows/integrations/vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/vellum_integration_service.py
@@ -48,7 +48,7 @@ class VellumIntegrationService:
 
             return VellumIntegrationToolDetails(
                 provider=VellumIntegrationProviderType(response.provider),
-                integration=integration,
+                integration_name=integration,
                 name=response.name,
                 description=response.description,
                 parameters=response.input_parameters,

--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
@@ -275,7 +275,7 @@ class VellumIntegrationNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
         try:
             vellum_service = VellumIntegrationService()
             result = vellum_service.execute_tool(
-                integration=self.vellum_integration_tool.integration,
+                integration=self.vellum_integration_tool.integration_name,
                 provider=self.vellum_integration_tool.provider.value,
                 tool_name=self.vellum_integration_tool.name,
                 arguments=arguments,

--- a/src/vellum/workflows/types/definition.py
+++ b/src/vellum/workflows/types/definition.py
@@ -170,7 +170,7 @@ class VellumIntegrationToolDefinition(UniversalBaseModel):
 
     # Core identification
     provider: VellumIntegrationProviderType
-    integration: str  # "GITHUB", "SLACK", etc.
+    integration_name: str  # "GITHUB", "SLACK", etc.
     name: str  # Specific action like "GITHUB_CREATE_AN_ISSUE"
 
     # Required for tool base consistency

--- a/src/vellum/workflows/types/tests/test_definition.py
+++ b/src/vellum/workflows/types/tests/test_definition.py
@@ -155,14 +155,14 @@ def test_vellum_integration_tool_definition_creation():
     """Test that VellumIntegrationToolDefinition can be created with required fields."""
     vellum_tool = VellumIntegrationToolDefinition(
         provider=VellumIntegrationProviderType.COMPOSIO,
-        integration="GITHUB",
+        integration_name="GITHUB",
         name="create_issue",
         description="Create a new issue in a GitHub repository",
     )
 
     assert vellum_tool.type == "VELLUM_INTEGRATION"
     assert vellum_tool.provider == VellumIntegrationProviderType.COMPOSIO
-    assert vellum_tool.integration == "GITHUB"
+    assert vellum_tool.integration_name == "GITHUB"
     assert vellum_tool.name == "create_issue"
     assert vellum_tool.description == "Create a new issue in a GitHub repository"
 
@@ -171,13 +171,13 @@ def test_vellum_integration_tool_definition_with_different_provider():
     """Test VellumIntegrationToolDefinition with a different provider."""
     vellum_tool = VellumIntegrationToolDefinition(
         provider=VellumIntegrationProviderType.COMPOSIO,
-        integration="SLACK",
+        integration_name="SLACK",
         name="send_message",
         description="Send a message to a Slack channel",
     )
 
     assert vellum_tool.type == "VELLUM_INTEGRATION"
     assert vellum_tool.provider == VellumIntegrationProviderType.COMPOSIO
-    assert vellum_tool.integration == "SLACK"
+    assert vellum_tool.integration_name == "SLACK"
     assert vellum_tool.name == "send_message"
     assert vellum_tool.description == "Send a message to a Slack channel"

--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -335,7 +335,7 @@ def compile_vellum_integration_tool_definition(tool_def: VellumIntegrationToolDe
     try:
         service = VellumIntegrationService()
         tool_details = service.get_tool_definition(
-            integration=tool_def.integration,
+            integration=tool_def.integration_name,
             provider=tool_def.provider.value,
             tool_name=tool_def.name,
         )

--- a/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/tests/test_workflow.py
+++ b/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/tests/test_workflow.py
@@ -40,7 +40,7 @@ def _setup_mock_service(
         # Create proper VellumIntegrationToolDetails object from dict
         tool_details_obj = VellumIntegrationToolDetails(
             provider=VellumIntegrationProviderType.COMPOSIO,
-            integration="GITHUB",
+            integration_name="GITHUB",
             name=tool_details.get("name", "create_issue"),
             description=tool_details.get("description", "Mock description"),
             parameters=tool_details.get("input_parameters", {}),
@@ -239,7 +239,7 @@ def test_tool_definition_and_function_compilation():
     tool = github_create_issue_tool
     assert tool.type == "VELLUM_INTEGRATION"
     assert tool.provider.value == "COMPOSIO"
-    assert tool.integration == "GITHUB"
+    assert tool.integration_name == "GITHUB"
     assert tool.name == "create_issue"
     assert tool.description == "Create a new issue in a GitHub repository"
 
@@ -250,7 +250,7 @@ def test_tool_definition_and_function_compilation():
         # Create a proper VellumIntegrationToolDetails object
         mock_tool_details_obj = VellumIntegrationToolDetails(
             provider=VellumIntegrationProviderType.COMPOSIO,
-            integration="GITHUB",
+            integration_name="GITHUB",
             name="create_issue",
             description="Enhanced description from service",
             parameters={"type": "object", "properties": {"title": {"type": "string", "description": "Issue title"}}},

--- a/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/workflow.py
+++ b/tests/workflows/basic_tool_calling_node_with_vellum_integration_tool/workflow.py
@@ -16,7 +16,7 @@ class Inputs(BaseInputs):
 # Create a VellumIntegrationToolDefinition for testing
 github_create_issue_tool = VellumIntegrationToolDefinition(
     provider=VellumIntegrationProviderType.COMPOSIO,
-    integration="GITHUB",
+    integration_name="GITHUB",
     name="create_issue",
     description="Create a new issue in a GitHub repository",
 )


### PR DESCRIPTION
The purpose of this PR is to fix a field name mismatch between the Python SDK and frontend JSON format that was causing integration names to appear as 'UNKNOWN' in API requests.

## Changes Made
- Rename `integration` field to `integration_name` in `VellumIntegrationToolDefinition` model
- Update service layer and node utils to use the new field name
- Update TypeScript codegen types and generator to output correct field name
- Update all tests and fixtures to use `integration_name`

## Testing
- Updated unit tests and serialization tests
- Verified field naming consistency across Python SDK and TypeScript codegen

## Notes
The field was incorrectly named 'integration' which caused deserialization to fail when receiving 'integration_name' from the UI. When the field was missing, empty values were being interpreted as 'UNKNOWN' by the backend API.

---
*This PR was created with Claude Code*