### PR TITLE
Remove test delays from chatbot examples

### DIFF
--- a/examples/workflows/chatbot/chat.py
+++ b/examples/workflows/chatbot/chat.py
@@ -1,5 +1,3 @@
-import time
-
 from dotenv import load_dotenv
 
 from vellum.workflows.emitters.vellum_emitter import VellumEmitter
@@ -51,8 +49,6 @@ def main():
         previous_execution_id = current_execution_id
 
         iterations += 1
-
-        time.sleep(60)
 
 
 if __name__ == "__main__":

--- a/examples/workflows/chatbot/external_client.py
+++ b/examples/workflows/chatbot/external_client.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 from dotenv import load_dotenv
 
@@ -11,6 +10,7 @@ load_dotenv()
 client = Vellum(api_key=os.getenv("VELLUM_API_KEY"))
 workflow_deployment_name = "<workflow_deployment_name>"
 release_tag = "LATEST"
+
 
 def main():
     previous_execution_id = None
@@ -68,8 +68,6 @@ def main():
         previous_execution_id = current_execution_id
 
         iterations += 1
-
-        time.sleep(60)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The purpose of this PR is to remove artificial test delays from chatbot example scripts.

## Changes Made
- Remove `time.sleep(60)` calls from `chat.py` and `external_client.py` chatbot examples
- Remove unused `time` module imports

## Context
These 60-second delays were added during local testing of the RTA (Real-Time Analytics) fallback mechanism. They are no longer needed and were slowing down the example workflow execution unnecessarily.

## Testing
- Verified chatbot examples run without delays
- Confirmed conversation state resumption works correctly without artificial pauses

---
*This PR was created with Claude Code*