### PR TITLE
Preserve NodeException error codes and raw_data in tool execution

### DIFF
--- a/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
@@ -261,6 +261,56 @@ def test_vellum_integration_service_execute_tool_structured_403_error(vellum_cli
     assert exc_info.value.raw_data["integration"]["provider"] == "COMPOSIO"
 
 
+def test_vellum_integration_service_execute_tool_structured_403_with_raw_data(vellum_client):
+    """Test structured 403 responses with raw_data (current backend format)"""
+    from vellum.client.core.api_error import ApiError
+    from vellum.workflows.errors.types import WorkflowErrorCode
+
+    mock_client = vellum_client
+    mock_client.integrations = mock.MagicMock()
+
+    # Mock current backend structure with raw_data
+    structured_error_body = {
+        "code": "INTEGRATION_CREDENTIALS_UNAVAILABLE",
+        "message": "You must authenticate with this integration before you can execute this tool.",
+        "raw_data": {
+            "integration": {
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "provider": "COMPOSIO",
+                "name": "GITHUB",
+            }
+        },
+    }
+
+    mock_client.integrations.execute_integration_tool.side_effect = ApiError(
+        status_code=403,
+        body=structured_error_body,
+    )
+
+    service = VellumIntegrationService(client=mock_client)
+
+    # WHEN we attempt to execute a tool without credentials
+    with pytest.raises(NodeException) as exc_info:
+        service.execute_tool(
+            integration="GITHUB",
+            provider="COMPOSIO",
+            tool_name="GITHUB_CREATE_AN_ISSUE",
+            arguments={"repo": "user/repo"},
+        )
+
+    # THEN it should raise NodeException with INTEGRATION_CREDENTIALS_UNAVAILABLE code
+    assert exc_info.value.code == WorkflowErrorCode.INTEGRATION_CREDENTIALS_UNAVAILABLE
+
+    # AND the error message should match the backend response
+    assert "You must authenticate with this integration" in exc_info.value.message
+
+    # AND raw_data should contain integration details nested under "integration" key
+    assert exc_info.value.raw_data is not None
+    assert exc_info.value.raw_data["integration"]["id"] == "550e8400-e29b-41d4-a716-446655440000"
+    assert exc_info.value.raw_data["integration"]["name"] == "GITHUB"
+    assert exc_info.value.raw_data["integration"]["provider"] == "COMPOSIO"
+
+
 def test_vellum_integration_service_execute_tool_legacy_403_error(vellum_client):
     """Test backward compatibility with legacy 403 responses (before PR #14857)"""
     from vellum.client.core.api_error import ApiError

--- a/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
@@ -217,51 +217,6 @@ def test_vellum_integration_service_multiple_tool_executions(vellum_client):
     assert mock_client.integrations.execute_integration_tool.call_count == 2
 
 
-def test_vellum_integration_service_execute_tool_structured_403_error(vellum_client):
-    """Test structured 403 responses with integration details (current backend format)"""
-    from vellum.client.core.api_error import ApiError
-    from vellum.workflows.errors.types import WorkflowErrorCode
-
-    # GIVEN a mock client configured to raise a structured 403 error
-    mock_client = vellum_client
-    mock_client.integrations = mock.MagicMock()
-
-    structured_error_body = {
-        "message": "You must authenticate with this integration before you can execute this tool.",
-        "integration": {
-            "id": "550e8400-e29b-41d4-a716-446655440000",
-            "provider": "COMPOSIO",
-            "name": "GITHUB",
-        },
-    }
-    mock_client.integrations.execute_integration_tool.side_effect = ApiError(
-        status_code=403,
-        body=structured_error_body,
-    )
-
-    # WHEN we attempt to execute a tool without credentials
-    service = VellumIntegrationService(client=mock_client)
-    with pytest.raises(NodeException) as exc_info:
-        service.execute_tool(
-            integration="GITHUB",
-            provider="COMPOSIO",
-            tool_name="GITHUB_CREATE_AN_ISSUE",
-            arguments={"repo": "user/repo"},
-        )
-
-    # THEN it should raise NodeException with INTEGRATION_CREDENTIALS_UNAVAILABLE code
-    assert exc_info.value.code == WorkflowErrorCode.INTEGRATION_CREDENTIALS_UNAVAILABLE
-
-    # AND the error message should match the backend response
-    assert "You must authenticate with this integration" in exc_info.value.message
-
-    # AND raw_data should contain integration details nested under "integration" key
-    assert exc_info.value.raw_data is not None
-    assert exc_info.value.raw_data["integration"]["id"] == "550e8400-e29b-41d4-a716-446655440000"
-    assert exc_info.value.raw_data["integration"]["name"] == "GITHUB"
-    assert exc_info.value.raw_data["integration"]["provider"] == "COMPOSIO"
-
-
 def test_vellum_integration_service_execute_tool_structured_403_with_raw_data(vellum_client):
     """Test structured 403 responses with raw_data (current backend format)"""
     from vellum.client.core.api_error import ApiError

--- a/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
@@ -217,24 +217,21 @@ def test_vellum_integration_service_multiple_tool_executions(vellum_client):
     assert mock_client.integrations.execute_integration_tool.call_count == 2
 
 
-def test_vellum_integration_service_execute_tool_structured_403_with_raw_data(vellum_client):
-    """Test structured 403 responses with raw_data (current backend format)"""
+def test_vellum_integration_service_execute_tool_structured_403_error(vellum_client):
+    """Test structured 403 responses with integration details (current backend format)"""
     from vellum.client.core.api_error import ApiError
     from vellum.workflows.errors.types import WorkflowErrorCode
 
-    # GIVEN a mock client configured to raise a structured 403 error with raw_data
+    # GIVEN a mock client configured to raise a structured 403 error
     mock_client = vellum_client
     mock_client.integrations = mock.MagicMock()
 
     structured_error_body = {
-        "code": "INTEGRATION_CREDENTIALS_UNAVAILABLE",
         "message": "You must authenticate with this integration before you can execute this tool.",
-        "raw_data": {
-            "integration": {
-                "id": "550e8400-e29b-41d4-a716-446655440000",
-                "provider": "COMPOSIO",
-                "name": "GITHUB",
-            }
+        "integration": {
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "provider": "COMPOSIO",
+            "name": "GITHUB",
         },
     }
     mock_client.integrations.execute_integration_tool.side_effect = ApiError(

--- a/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/tests/test_vellum_integration_service.py
@@ -12,6 +12,7 @@ from vellum.workflows.types.definition import VellumIntegrationToolDetails
 
 def test_vellum_integration_service_get_tool_definition_success(vellum_client):
     """Test that tool definitions are successfully retrieved from Vellum API"""
+    # GIVEN a mock client configured to return a tool definition
     mock_client = vellum_client
     tool_definition_response = ComponentsSchemasComposioToolDefinition(
         integration=ToolDefinitionIntegration(
@@ -33,7 +34,6 @@ def test_vellum_integration_service_get_tool_definition_success(vellum_client):
         },
         output_parameters={},
     )
-
     mock_client.integrations.retrieve_integration_tool_definition.return_value = tool_definition_response
 
     # WHEN we request a tool definition
@@ -66,6 +66,7 @@ def test_vellum_integration_service_get_tool_definition_success(vellum_client):
 
 def test_vellum_integration_service_get_tool_definition_api_error(vellum_client):
     """Test that API errors are properly handled when retrieving tool definitions"""
+    # GIVEN a mock client configured to raise an exception
     mock_client = vellum_client
     mock_client.integrations = mock.MagicMock()
     mock_client.integrations.retrieve_integration_tool_definition.side_effect = Exception("Tool not found")
@@ -87,6 +88,7 @@ def test_vellum_integration_service_get_tool_definition_api_error(vellum_client)
 
 def test_vellum_integration_service_execute_tool_success(vellum_client):
     """Test that tools are successfully executed via Vellum API"""
+    # GIVEN a mock client configured to return a successful response
     mock_client = vellum_client
     mock_client.integrations = mock.MagicMock()
 
@@ -96,7 +98,6 @@ def test_vellum_integration_service_execute_tool_success(vellum_client):
         "issue_id": 123,
         "issue_url": "https://github.com/user/repo/issues/123",
     }
-
     mock_client.integrations.execute_integration_tool.return_value = mock_response
 
     # WHEN we execute a tool with valid arguments
@@ -132,6 +133,7 @@ def test_vellum_integration_service_execute_tool_success(vellum_client):
 
 def test_vellum_integration_service_execute_tool_api_error(vellum_client):
     """Test that execution errors are properly handled"""
+    # GIVEN a mock client configured to raise an exception
     mock_client = vellum_client
     mock_client.integrations = mock.MagicMock()
     mock_client.integrations.execute_integration_tool.side_effect = Exception("Authentication failed")
@@ -154,12 +156,12 @@ def test_vellum_integration_service_execute_tool_api_error(vellum_client):
 
 def test_vellum_integration_service_execute_tool_empty_response(vellum_client):
     """Test that empty response data is handled gracefully"""
+    # GIVEN a mock client configured to return an empty response
     mock_client = vellum_client
     mock_client.integrations = mock.MagicMock()
 
     mock_response = mock.MagicMock()
     mock_response.data = {}
-
     mock_client.integrations.execute_integration_tool.return_value = mock_response
 
     # WHEN we execute a tool that returns empty data
@@ -180,6 +182,7 @@ def test_vellum_integration_service_execute_tool_empty_response(vellum_client):
 
 def test_vellum_integration_service_multiple_tool_executions(vellum_client):
     """Test that the service handles multiple sequential tool executions"""
+    # GIVEN a mock client configured to return different responses for multiple calls
     mock_client = vellum_client
     mock_client.integrations = mock.MagicMock()
 
@@ -214,62 +217,15 @@ def test_vellum_integration_service_multiple_tool_executions(vellum_client):
     assert mock_client.integrations.execute_integration_tool.call_count == 2
 
 
-def test_vellum_integration_service_execute_tool_structured_403_error(vellum_client):
-    """Test that structured 403 responses with integration details are properly parsed"""
-    from vellum.client.core.api_error import ApiError
-    from vellum.workflows.errors.types import WorkflowErrorCode
-
-    mock_client = vellum_client
-    mock_client.integrations = mock.MagicMock()
-
-    # Mock structured 403 response matching PR #14857 format
-    structured_error_body = {
-        "message": "You must authenticate with this integration before you can execute this tool.",
-        "integration": {
-            "id": "550e8400-e29b-41d4-a716-446655440000",
-            "provider": "COMPOSIO",
-            "name": "GITHUB",
-        },
-    }
-
-    mock_client.integrations.execute_integration_tool.side_effect = ApiError(
-        status_code=403,
-        body=structured_error_body,
-    )
-
-    service = VellumIntegrationService(client=mock_client)
-
-    # WHEN we attempt to execute a tool without credentials
-    with pytest.raises(NodeException) as exc_info:
-        service.execute_tool(
-            integration="GITHUB",
-            provider="COMPOSIO",
-            tool_name="GITHUB_CREATE_AN_ISSUE",
-            arguments={"repo": "user/repo"},
-        )
-
-    # THEN it should raise NodeException with INTEGRATION_CREDENTIALS_UNAVAILABLE code
-    assert exc_info.value.code == WorkflowErrorCode.INTEGRATION_CREDENTIALS_UNAVAILABLE
-
-    # AND the error message should match the backend response
-    assert "You must authenticate with this integration" in exc_info.value.message
-
-    # AND raw_data should contain integration details nested under "integration" key
-    assert exc_info.value.raw_data is not None
-    assert exc_info.value.raw_data["integration"]["id"] == "550e8400-e29b-41d4-a716-446655440000"
-    assert exc_info.value.raw_data["integration"]["name"] == "GITHUB"
-    assert exc_info.value.raw_data["integration"]["provider"] == "COMPOSIO"
-
-
 def test_vellum_integration_service_execute_tool_structured_403_with_raw_data(vellum_client):
     """Test structured 403 responses with raw_data (current backend format)"""
     from vellum.client.core.api_error import ApiError
     from vellum.workflows.errors.types import WorkflowErrorCode
 
+    # GIVEN a mock client configured to raise a structured 403 error with raw_data
     mock_client = vellum_client
     mock_client.integrations = mock.MagicMock()
 
-    # Mock current backend structure with raw_data
     structured_error_body = {
         "code": "INTEGRATION_CREDENTIALS_UNAVAILABLE",
         "message": "You must authenticate with this integration before you can execute this tool.",
@@ -281,15 +237,13 @@ def test_vellum_integration_service_execute_tool_structured_403_with_raw_data(ve
             }
         },
     }
-
     mock_client.integrations.execute_integration_tool.side_effect = ApiError(
         status_code=403,
         body=structured_error_body,
     )
 
-    service = VellumIntegrationService(client=mock_client)
-
     # WHEN we attempt to execute a tool without credentials
+    service = VellumIntegrationService(client=mock_client)
     with pytest.raises(NodeException) as exc_info:
         service.execute_tool(
             integration="GITHUB",
@@ -316,19 +270,18 @@ def test_vellum_integration_service_execute_tool_legacy_403_error(vellum_client)
     from vellum.client.core.api_error import ApiError
     from vellum.workflows.errors.types import WorkflowErrorCode
 
+    # GIVEN a mock client configured to raise a legacy 403 error
     mock_client = vellum_client
     mock_client.integrations = mock.MagicMock()
 
-    # Mock legacy 403 response format (just detail field)
     legacy_error_body = {"detail": "You do not have permission to execute this tool."}
-
     mock_client.integrations.execute_integration_tool.side_effect = ApiError(
         status_code=403,
         body=legacy_error_body,
     )
 
+    # WHEN we attempt to execute a tool that returns a legacy 403 error
     service = VellumIntegrationService(client=mock_client)
-
     with pytest.raises(NodeException) as exc_info:
         service.execute_tool(
             integration="GITHUB",

--- a/src/vellum/workflows/integrations/vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/vellum_integration_service.py
@@ -95,12 +95,25 @@ class VellumIntegrationService:
         except ApiError as e:
             # Handle structured 403 credential error responses
             if e.status_code == 403 and isinstance(e.body, dict):
-                # Check for current backend structure with integration directly in body
-                if "integration" in e.body and "message" in e.body:
+                # Check for new backend structure with raw_data
+                raw_data_from_backend = e.body.get("raw_data")
+                if raw_data_from_backend and "integration" in raw_data_from_backend:
+                    error_message = e.body.get(
+                        "message", "You must authenticate with this integration before you can execute this tool."
+                    )
+
+                    raise NodeException(
+                        message=error_message,
+                        code=WorkflowErrorCode.INTEGRATION_CREDENTIALS_UNAVAILABLE,
+                        raw_data=raw_data_from_backend,
+                    ) from e
+                # Fallback to original PR #14857 structure
+                elif "integration" in e.body and "message" in e.body:
                     integration_details = e.body["integration"]
                     error_message = e.body["message"]
 
-                    # Wrap integration details under "integration" key for consistency
+                    # Keep integration details nested under "integration" key to keep raw_data raw
+                    # and allow for future expansion
                     raw_data = {
                         "integration": integration_details,
                     }

--- a/src/vellum/workflows/integrations/vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/vellum_integration_service.py
@@ -95,17 +95,20 @@ class VellumIntegrationService:
         except ApiError as e:
             # Handle structured 403 credential error responses
             if e.status_code == 403 and isinstance(e.body, dict):
-                # Check for backend structure with raw_data
-                raw_data_from_backend = e.body.get("raw_data")
-                if raw_data_from_backend and "integration" in raw_data_from_backend:
-                    error_message = e.body.get(
-                        "message", "You must authenticate with this integration before you can execute this tool."
-                    )
+                # Check for current backend structure with integration directly in body
+                if "integration" in e.body and "message" in e.body:
+                    integration_details = e.body["integration"]
+                    error_message = e.body["message"]
+
+                    # Wrap integration details under "integration" key for consistency
+                    raw_data = {
+                        "integration": integration_details,
+                    }
 
                     raise NodeException(
                         message=error_message,
                         code=WorkflowErrorCode.INTEGRATION_CREDENTIALS_UNAVAILABLE,
-                        raw_data=raw_data_from_backend,
+                        raw_data=raw_data,
                     ) from e
                 else:
                     # Fallback for generic 403 responses

--- a/src/vellum/workflows/integrations/vellum_integration_service.py
+++ b/src/vellum/workflows/integrations/vellum_integration_service.py
@@ -95,7 +95,7 @@ class VellumIntegrationService:
         except ApiError as e:
             # Handle structured 403 credential error responses
             if e.status_code == 403 and isinstance(e.body, dict):
-                # Check for new backend structure with raw_data
+                # Check for backend structure with raw_data
                 raw_data_from_backend = e.body.get("raw_data")
                 if raw_data_from_backend and "integration" in raw_data_from_backend:
                     error_message = e.body.get(
@@ -106,22 +106,6 @@ class VellumIntegrationService:
                         message=error_message,
                         code=WorkflowErrorCode.INTEGRATION_CREDENTIALS_UNAVAILABLE,
                         raw_data=raw_data_from_backend,
-                    ) from e
-                # Fallback to original PR #14857 structure
-                elif "integration" in e.body and "message" in e.body:
-                    integration_details = e.body["integration"]
-                    error_message = e.body["message"]
-
-                    # Keep integration details nested under "integration" key to keep raw_data raw
-                    # and allow for future expansion
-                    raw_data = {
-                        "integration": integration_details,
-                    }
-
-                    raise NodeException(
-                        message=error_message,
-                        code=WorkflowErrorCode.INTEGRATION_CREDENTIALS_UNAVAILABLE,
-                        raw_data=raw_data,
                     ) from e
                 else:
                     # Fallback for generic 403 responses

--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
@@ -200,12 +200,20 @@ class FunctionNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
 
         try:
             result = self.function_definition(**arguments)
+        except NodeException as e:
+            # Preserve original error code and raw_data while adding context
+            function_name = self.function_definition.__name__
+            raise NodeException(
+                message=f"Error executing function '{function_name}': {e.message}",
+                code=e.code,
+                raw_data=e.raw_data,
+            ) from e
         except Exception as e:
             function_name = self.function_definition.__name__
             raise NodeException(
                 message=f"Error executing function '{function_name}': {str(e)}",
                 code=WorkflowErrorCode.NODE_EXECUTION,
-            )
+            ) from e
 
         # Add the result to the chat history
         self._add_function_result_to_chat_history(result, self.state)
@@ -231,11 +239,18 @@ class ComposioNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
                 )
             else:
                 result = composio_service.execute_tool(tool_name=self.composio_tool.action, arguments=arguments)
+        except NodeException as e:
+            # Preserve original error code and raw_data while adding context
+            raise NodeException(
+                message=f"Error executing Composio tool '{self.composio_tool.action}': {e.message}",
+                code=e.code,
+                raw_data=e.raw_data,
+            ) from e
         except Exception as e:
             raise NodeException(
                 message=f"Error executing Composio tool '{self.composio_tool.action}': {str(e)}",
                 code=WorkflowErrorCode.NODE_EXECUTION,
-            )
+            ) from e
 
         # Add result to chat history
         self._add_function_result_to_chat_history(result, self.state)
@@ -254,11 +269,18 @@ class MCPNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
         try:
             mcp_service = MCPService()
             result = mcp_service.execute_tool(tool_def=self.mcp_tool, arguments=arguments)
+        except NodeException as e:
+            # Preserve original error code and raw_data while adding context
+            raise NodeException(
+                message=f"Error executing MCP tool '{self.mcp_tool.name}': {e.message}",
+                code=e.code,
+                raw_data=e.raw_data,
+            ) from e
         except Exception as e:
             raise NodeException(
                 message=f"Error executing MCP tool '{self.mcp_tool.name}': {str(e)}",
                 code=WorkflowErrorCode.NODE_EXECUTION,
-            )
+            ) from e
 
         # Add result to chat history
         self._add_function_result_to_chat_history(result, self.state)

--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
@@ -200,14 +200,6 @@ class FunctionNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
 
         try:
             result = self.function_definition(**arguments)
-        except NodeException as e:
-            # Preserve original error code and raw_data while adding context
-            function_name = self.function_definition.__name__
-            raise NodeException(
-                message=f"Error executing function '{function_name}': {e.message}",
-                code=e.code,
-                raw_data=e.raw_data,
-            ) from e
         except Exception as e:
             function_name = self.function_definition.__name__
             raise NodeException(
@@ -239,13 +231,6 @@ class ComposioNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
                 )
             else:
                 result = composio_service.execute_tool(tool_name=self.composio_tool.action, arguments=arguments)
-        except NodeException as e:
-            # Preserve original error code and raw_data while adding context
-            raise NodeException(
-                message=f"Error executing Composio tool '{self.composio_tool.action}': {e.message}",
-                code=e.code,
-                raw_data=e.raw_data,
-            ) from e
         except Exception as e:
             raise NodeException(
                 message=f"Error executing Composio tool '{self.composio_tool.action}': {str(e)}",
@@ -269,13 +254,6 @@ class MCPNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
         try:
             mcp_service = MCPService()
             result = mcp_service.execute_tool(tool_def=self.mcp_tool, arguments=arguments)
-        except NodeException as e:
-            # Preserve original error code and raw_data while adding context
-            raise NodeException(
-                message=f"Error executing MCP tool '{self.mcp_tool.name}': {e.message}",
-                code=e.code,
-                raw_data=e.raw_data,
-            ) from e
         except Exception as e:
             raise NodeException(
                 message=f"Error executing MCP tool '{self.mcp_tool.name}': {str(e)}",

--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
@@ -200,12 +200,20 @@ class FunctionNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
 
         try:
             result = self.function_definition(**arguments)
+        except NodeException as e:
+            # Preserve original error code and raw_data while adding context
+            function_name = self.function_definition.__name__
+            raise NodeException(
+                message=f"Error executing function '{function_name}': {e.message}",
+                code=e.code,
+                raw_data=e.raw_data,
+            ) from e
         except Exception as e:
             function_name = self.function_definition.__name__
             raise NodeException(
                 message=f"Error executing function '{function_name}': {str(e)}",
                 code=WorkflowErrorCode.NODE_EXECUTION,
-            )
+            ) from e
 
         # Add the result to the chat history
         self._add_function_result_to_chat_history(result, self.state)
@@ -231,11 +239,18 @@ class ComposioNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
                 )
             else:
                 result = composio_service.execute_tool(tool_name=self.composio_tool.action, arguments=arguments)
+        except NodeException as e:
+            # Preserve original error code and raw_data while adding context
+            raise NodeException(
+                message=f"Error executing Composio tool '{self.composio_tool.action}': {e.message}",
+                code=e.code,
+                raw_data=e.raw_data,
+            ) from e
         except Exception as e:
             raise NodeException(
                 message=f"Error executing Composio tool '{self.composio_tool.action}': {str(e)}",
                 code=WorkflowErrorCode.NODE_EXECUTION,
-            )
+            ) from e
 
         # Add result to chat history
         self._add_function_result_to_chat_history(result, self.state)
@@ -254,11 +269,18 @@ class MCPNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
         try:
             mcp_service = MCPService()
             result = mcp_service.execute_tool(tool_def=self.mcp_tool, arguments=arguments)
+        except NodeException as e:
+            # Preserve original error code and raw_data while adding context
+            raise NodeException(
+                message=f"Error executing MCP tool '{self.mcp_tool.name}': {e.message}",
+                code=e.code,
+                raw_data=e.raw_data,
+            ) from e
         except Exception as e:
             raise NodeException(
                 message=f"Error executing MCP tool '{self.mcp_tool.name}': {str(e)}",
                 code=WorkflowErrorCode.NODE_EXECUTION,
-            )
+            ) from e
 
         # Add result to chat history
         self._add_function_result_to_chat_history(result, self.state)
@@ -283,11 +305,18 @@ class VellumIntegrationNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
                 tool_name=self.vellum_integration_tool.name,
                 arguments=arguments,
             )
+        except NodeException as e:
+            # Preserve original error code and raw_data while adding context
+            raise NodeException(
+                message=f"Error executing Vellum Integration tool '{self.vellum_integration_tool.name}': {e.message}",
+                code=e.code,
+                raw_data=e.raw_data,
+            ) from e
         except Exception as e:
             raise NodeException(
                 message=f"Error executing Vellum Integration tool '{self.vellum_integration_tool.name}': {str(e)}",
                 code=WorkflowErrorCode.NODE_EXECUTION,
-            )
+            ) from e
 
         # Add result to chat history
         self._add_function_result_to_chat_history(result, self.state)

--- a/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py
@@ -205,7 +205,7 @@ class FunctionNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
             raise NodeException(
                 message=f"Error executing function '{function_name}': {str(e)}",
                 code=WorkflowErrorCode.NODE_EXECUTION,
-            ) from e
+            )
 
         # Add the result to the chat history
         self._add_function_result_to_chat_history(result, self.state)
@@ -235,7 +235,7 @@ class ComposioNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
             raise NodeException(
                 message=f"Error executing Composio tool '{self.composio_tool.action}': {str(e)}",
                 code=WorkflowErrorCode.NODE_EXECUTION,
-            ) from e
+            )
 
         # Add result to chat history
         self._add_function_result_to_chat_history(result, self.state)
@@ -258,7 +258,7 @@ class MCPNode(BaseNode[ToolCallingState], FunctionCallNodeMixin):
             raise NodeException(
                 message=f"Error executing MCP tool '{self.mcp_tool.name}': {str(e)}",
                 code=WorkflowErrorCode.NODE_EXECUTION,
-            ) from e
+            )
 
         # Add result to chat history
         self._add_function_result_to_chat_history(result, self.state)


### PR DESCRIPTION
The purpose of this PR is to fix error propagation for integration credential failures by preserving NodeException error codes and raw_data through the tool execution stack. Supports changes in the vellum repo for displaying the error and helping users authenticate when necessary.

## Demo
https://www.loom.com/share/f4cf359fcc4a4415b2cafeccd1a5c971?sid=e5612114-7358-4e48-a2ba-2adac7cf6ade

## Changes Made
- Add explicit NodeException handler in `VellumIntegrationNode` to preserve error codes and `raw_data` instead of converting all exceptions to `NODE_EXECUTION`
- Update `VellumIntegrationService` to parse backend's `raw_data` structure for integration credential errors
- Add test coverage for new backend response structure with `raw_data` field

## Context
This fixes an issue where `INTEGRATION_CREDENTIALS_UNAVAILABLE` errors were being converted to generic `NODE_EXECUTION` errors, preventing the frontend from displaying integration-specific authentication modals. The fix ensures error codes and raw_data (containing integration ID, name, provider) are preserved through the entire error propagation chain.

---
*This PR was created with Claude Code*