### PR TITLE
Fix ManualTrigger serialization to match Django backend schema

### DIFF
--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -480,8 +480,7 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
             trigger_class.__name__,
         ]
         trigger_target_identifiers = sorted(
-            f"{edge.to_node.__module__}.{edge.to_node.__name__}"
-            for edge in trigger_edges
+            f"{edge.to_node.__module__}.{edge.to_node.__name__}" for edge in trigger_edges
         )
         trigger_identifier_parts.extend(trigger_target_identifiers)
 

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -473,9 +473,7 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
             )
 
         # Return as a list with a single trigger object matching Django schema
-        trigger_id = uuid4_from_hash(
-            f"{trigger_class.__module__} | {trigger_class.__qualname__}"
-        )
+        trigger_id = uuid4_from_hash(f"{trigger_class.__module__} | {trigger_class.__qualname__}")
 
         return cast(
             JsonArray,

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -6,7 +6,7 @@ import inspect
 import json
 import logging
 import os
-from uuid import UUID, uuid4
+from uuid import UUID
 from typing import Any, Dict, ForwardRef, Generic, List, Optional, Tuple, Type, TypeVar, Union, cast, get_args
 
 from vellum.client import Vellum as VellumClient
@@ -473,11 +473,25 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
             )
 
         # Return as a list with a single trigger object matching Django schema
+        trigger_identifier_parts: List[str] = [
+            str(self.workflow_id),
+            "trigger",
+            trigger_class.__module__,
+            trigger_class.__name__,
+        ]
+        trigger_target_identifiers = sorted(
+            f"{edge.to_node.__module__}.{edge.to_node.__name__}"
+            for edge in trigger_edges
+        )
+        trigger_identifier_parts.extend(trigger_target_identifiers)
+
+        trigger_id = uuid4_from_hash("|".join(trigger_identifier_parts))
+
         return cast(
             JsonArray,
             [
                 {
-                    "id": str(uuid4()),
+                    "id": str(trigger_id),
                     "type": trigger_type.value,
                     "attributes": [],
                 }

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -477,12 +477,8 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
             str(self.workflow_id),
             "trigger",
             trigger_class.__module__,
-            trigger_class.__name__,
+            trigger_class.__qualname__,
         ]
-        trigger_target_identifiers = sorted(
-            f"{edge.to_node.__module__}.{edge.to_node.__name__}" for edge in trigger_edges
-        )
-        trigger_identifier_parts.extend(trigger_target_identifiers)
 
         trigger_id = uuid4_from_hash("|".join(trigger_identifier_parts))
 

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -473,14 +473,9 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
             )
 
         # Return as a list with a single trigger object matching Django schema
-        trigger_identifier_parts: List[str] = [
-            str(self.workflow_id),
-            "trigger",
-            trigger_class.__module__,
-            trigger_class.__qualname__,
-        ]
-
-        trigger_id = uuid4_from_hash("|".join(trigger_identifier_parts))
+        trigger_id = uuid4_from_hash(
+            f"{trigger_class.__module__} | {trigger_class.__qualname__}"
+        )
 
         return cast(
             JsonArray,


### PR DESCRIPTION
The purpose of this PR is to fix the ManualTrigger serialization structure to align with the Django backend schema expectations.

## Changes Made
- Move `triggers` field from inside `workflow_raw_data` to top level of serialized output
- Change field name from `trigger` (singular) to `triggers` (plural)
- Return triggers as a list instead of a single object
- Update trigger object structure: add `id` (UUID) and `attributes` fields, remove `definition` field
- Update all tests to validate new schema structure
- Remove unused DeepDiff import from tests

## Testing
- All 5 existing tests updated and passing
- Tests now validate: `id` field presence, `type` field, `attributes` field, and absence of `definition` field
- Verified triggers appear at top level, not inside `workflow_raw_data`

## Notes
This addresses all blocking feedback from dvargas92495 on PR #2695:
- Triggers now at top level and plural (matching `WorkflowVersionExecConfig.triggers`)
- Trigger structure matches Django `BaseTrigger` dataclass (`id`, `type`, `attributes`)
- Ready for integration with Django backend

---
*This PR was created with Claude Code*