### PR TITLE
[APO-1833] Add SlackTrigger base implementation and serialization

### DIFF
--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 class WorkflowTriggerType(Enum):
     MANUAL = "MANUAL"
+    SLACK_MESSAGE = "SLACK_MESSAGE"
 
 
 def get_trigger_type_mapping() -> Dict[Type["BaseTrigger"], WorkflowTriggerType]:
@@ -29,9 +30,11 @@ def get_trigger_type_mapping() -> Dict[Type["BaseTrigger"], WorkflowTriggerType]
         Dictionary mapping trigger classes to their enum types
     """
     from vellum.workflows.triggers.manual import ManualTrigger
+    from vellum.workflows.triggers.slack import SlackTrigger
 
     return {
         ManualTrigger: WorkflowTriggerType.MANUAL,
+        SlackTrigger: WorkflowTriggerType.SLACK_MESSAGE,
     }
 
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_slack_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_slack_trigger_serialization.py
@@ -1,0 +1,135 @@
+"""Tests for serialization of workflows with SlackTrigger."""
+
+from typing import cast
+
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.inputs.base import BaseInputs
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.state.base import BaseState
+from vellum.workflows.triggers.slack import SlackTrigger
+from vellum.workflows.types.core import JsonArray, JsonObject
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+
+class Inputs(BaseInputs):
+    input: str
+
+
+class SimpleNode(BaseNode):
+    class Outputs(BaseNode.Outputs):
+        output = Inputs.input
+
+
+def create_workflow(trigger=None):
+    """Factory for creating test workflows."""
+
+    class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
+        graph = trigger >> SimpleNode if trigger else SimpleNode
+
+        class Outputs(BaseWorkflow.Outputs):
+            output = SimpleNode.Outputs.output
+
+    return TestWorkflow
+
+
+def serialize(workflow_class) -> JsonObject:
+    """Helper to serialize a workflow."""
+    return get_workflow_display(workflow_class=workflow_class).serialize()
+
+
+def test_slack_trigger_serialization():
+    """Workflow with SlackTrigger serializes with triggers field and outputs."""
+    result = serialize(create_workflow(SlackTrigger))
+    triggers = cast(JsonArray, result["triggers"])
+
+    assert len(triggers) == 1
+    trigger = cast(JsonObject, triggers[0])
+
+    assert trigger["type"] == "SLACK_MESSAGE"
+    assert "id" in trigger
+    assert "attributes" in trigger
+    assert trigger["attributes"] == []
+
+    # Check that outputs are included
+    assert "outputs" in trigger
+    outputs = cast(JsonArray, trigger["outputs"])
+    assert len(outputs) == 6  # message, channel, user, timestamp, thread_ts, event_type
+
+    # Verify output structure
+    output_names = {cast(JsonObject, output)["name"] for output in outputs}
+    assert output_names == {"message", "channel", "user", "timestamp", "thread_ts", "event_type"}
+
+    # Verify output types (all should be STRING for SlackTrigger)
+    for output in outputs:
+        output_obj = cast(JsonObject, output)
+        assert output_obj["type"] == "STRING"
+
+
+def test_slack_trigger_multiple_entrypoints():
+    """SlackTrigger with multiple entrypoints."""
+
+    class NodeA(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output = Inputs.input
+
+    class NodeB(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output = Inputs.input
+
+    class MultiWorkflow(BaseWorkflow[Inputs, BaseState]):
+        graph = SlackTrigger >> {NodeA, NodeB}
+
+        class Outputs(BaseWorkflow.Outputs):
+            output_a = NodeA.Outputs.output
+            output_b = NodeB.Outputs.output
+
+    result = serialize(MultiWorkflow)
+    triggers = cast(JsonArray, result["triggers"])
+    workflow_data = cast(JsonObject, result["workflow_raw_data"])
+    nodes = cast(JsonArray, workflow_data["nodes"])
+
+    assert len(triggers) == 1
+    trigger = cast(JsonObject, triggers[0])
+    assert trigger["type"] == "SLACK_MESSAGE"
+    assert "outputs" in trigger
+    assert len([n for n in nodes if cast(JsonObject, n)["type"] == "GENERIC"]) >= 2
+
+
+def test_serialized_slack_workflow_structure():
+    """Verify complete structure of serialized workflow with SlackTrigger."""
+    result = serialize(create_workflow(SlackTrigger))
+    workflow_raw_data = cast(JsonObject, result["workflow_raw_data"])
+    definition = cast(JsonObject, workflow_raw_data["definition"])
+
+    assert result.keys() == {
+        "workflow_raw_data",
+        "input_variables",
+        "state_variables",
+        "output_variables",
+        "triggers",
+    }
+    assert workflow_raw_data.keys() == {"nodes", "edges", "display_data", "definition", "output_values"}
+    assert definition["name"] == "TestWorkflow"
+
+
+def test_slack_trigger_outputs_correct_fields():
+    """Verify SlackTrigger outputs contain all expected fields."""
+    result = serialize(create_workflow(SlackTrigger))
+    triggers = cast(JsonArray, result["triggers"])
+    trigger = cast(JsonObject, triggers[0])
+    outputs = cast(JsonArray, trigger["outputs"])
+
+    # Convert to dict for easy lookup
+    outputs_dict = {cast(JsonObject, o)["name"]: cast(JsonObject, o) for o in outputs}
+
+    # Verify all required fields
+    assert "message" in outputs_dict
+    assert "channel" in outputs_dict
+    assert "user" in outputs_dict
+    assert "timestamp" in outputs_dict
+    assert "thread_ts" in outputs_dict
+    assert "event_type" in outputs_dict
+
+    # All should be STRING type
+    for field_name in ["message", "channel", "user", "timestamp", "thread_ts", "event_type"]:
+        assert outputs_dict[field_name]["type"] == "STRING"

--- a/src/vellum/workflows/triggers/__init__.py
+++ b/src/vellum/workflows/triggers/__init__.py
@@ -1,4 +1,6 @@
 from vellum.workflows.triggers.base import BaseTrigger
+from vellum.workflows.triggers.integration import IntegrationTrigger
 from vellum.workflows.triggers.manual import ManualTrigger
+from vellum.workflows.triggers.slack import SlackTrigger
 
-__all__ = ["BaseTrigger", "ManualTrigger"]
+__all__ = ["BaseTrigger", "IntegrationTrigger", "ManualTrigger", "SlackTrigger"]

--- a/src/vellum/workflows/triggers/integration.py
+++ b/src/vellum/workflows/triggers/integration.py
@@ -1,0 +1,62 @@
+from abc import ABC
+from typing import ClassVar, Optional
+
+from vellum.workflows.outputs.base import BaseOutputs
+from vellum.workflows.triggers.base import BaseTrigger
+
+
+class IntegrationTrigger(BaseTrigger, ABC):
+    """
+    Base class for integration-based triggers (Slack, Email, etc.).
+
+    Integration triggers:
+    - Are initiated by external events (webhooks, API calls)
+    - Produce outputs that downstream nodes can reference
+    - Require configuration (auth, webhooks, etc.)
+
+    Examples:
+        # Define an integration trigger
+        class MyIntegrationTrigger(IntegrationTrigger):
+            class Outputs(IntegrationTrigger.Outputs):
+                data: str
+
+            @classmethod
+            def process_event(cls, event_data: dict):
+                return cls.Outputs(data=event_data.get("data", ""))
+
+        # Use in workflow
+        class MyWorkflow(BaseWorkflow):
+            graph = MyIntegrationTrigger >> ProcessNode
+
+    Note:
+        Unlike ManualTrigger, integration triggers provide structured outputs
+        that downstream nodes can reference directly via Outputs.
+    """
+
+    class Outputs(BaseOutputs):
+        """Base outputs for integration triggers."""
+
+        pass
+
+    # Configuration that can be set at runtime
+    config: ClassVar[Optional[dict]] = None
+
+    @classmethod
+    def process_event(cls, event_data: dict) -> "IntegrationTrigger.Outputs":
+        """
+        Process incoming webhook/event data and return trigger outputs.
+
+        This method should be implemented by subclasses to parse external
+        event payloads (e.g., Slack webhooks, email notifications) into
+        structured trigger outputs.
+
+        Args:
+            event_data: Raw event data from the external system
+
+        Returns:
+            Trigger outputs containing parsed event data
+
+        Raises:
+            NotImplementedError: If subclass doesn't implement this method
+        """
+        raise NotImplementedError(f"{cls.__name__} must implement process_event() method to handle external events")

--- a/src/vellum/workflows/triggers/slack.py
+++ b/src/vellum/workflows/triggers/slack.py
@@ -1,0 +1,104 @@
+from typing import Optional
+
+from vellum.workflows.triggers.integration import IntegrationTrigger
+
+
+class SlackTrigger(IntegrationTrigger):
+    """
+    Trigger for Slack events (messages, mentions, reactions, etc.).
+
+    SlackTrigger enables workflows to be initiated from Slack events such as
+    messages in channels, direct messages, app mentions, or reactions. The trigger
+    parses Slack webhook payloads and provides structured outputs that downstream
+    nodes can reference.
+
+    Examples:
+        Basic Slack message trigger:
+            >>> class MyWorkflow(BaseWorkflow):
+            ...     graph = SlackTrigger >> ProcessMessageNode
+
+        Access trigger outputs in nodes:
+            >>> class ProcessMessageNode(BaseNode):
+            ...     class Outputs(BaseNode.Outputs):
+            ...         response = SlackTrigger.Outputs.message
+
+        Multiple entry points:
+            >>> class MyWorkflow(BaseWorkflow):
+            ...     graph = {
+            ...         SlackTrigger >> ProcessSlackNode,
+            ...         ManualTrigger >> ProcessManualNode,
+            ...     }
+
+    Outputs:
+        message: str
+            The message text from Slack
+        channel: str
+            Slack channel ID where message was sent
+        user: str
+            User ID who sent the message
+        timestamp: str
+            Message timestamp (ts field from Slack)
+        thread_ts: Optional[str]
+            Thread timestamp if message is in a thread, None otherwise
+        event_type: str
+            Type of Slack event (e.g., "message", "app_mention")
+
+    Note:
+        The trigger expects Slack Event API webhook payloads. For details on
+        the payload structure, see: https://api.slack.com/apis/connections/events-api
+    """
+
+    class Outputs(IntegrationTrigger.Outputs):
+        message: str
+        channel: str
+        user: str
+        timestamp: str
+        thread_ts: Optional[str]
+        event_type: str
+
+    @classmethod
+    def process_event(cls, event_data: dict) -> "SlackTrigger.Outputs":
+        """
+        Parse Slack webhook payload into trigger outputs.
+
+        Args:
+            event_data: Slack event payload from webhook. Expected structure:
+                {
+                    "event": {
+                        "type": "message",
+                        "text": "Hello world",
+                        "channel": "C123456",
+                        "user": "U123456",
+                        "ts": "1234567890.123456",
+                        "thread_ts": "1234567890.123456"  # optional
+                    }
+                }
+
+        Returns:
+            SlackTrigger.Outputs with parsed data from the Slack event
+
+        Examples:
+            >>> slack_payload = {
+            ...     "event": {
+            ...         "type": "message",
+            ...         "text": "Hello!",
+            ...         "channel": "C123",
+            ...         "user": "U456",
+            ...         "ts": "1234567890.123456"
+            ...     }
+            ... }
+            >>> outputs = SlackTrigger.process_event(slack_payload)
+            >>> outputs.message
+            'Hello!'
+        """
+        # Extract from Slack's event structure
+        event = event_data.get("event", {})
+
+        return cls.Outputs(
+            message=event.get("text", ""),
+            channel=event.get("channel", ""),
+            user=event.get("user", ""),
+            timestamp=event.get("ts", ""),
+            thread_ts=event.get("thread_ts"),
+            event_type=event.get("type", "message"),
+        )

--- a/src/vellum/workflows/triggers/tests/__init__.py
+++ b/src/vellum/workflows/triggers/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for workflow triggers

--- a/src/vellum/workflows/triggers/tests/test_integration.py
+++ b/src/vellum/workflows/triggers/tests/test_integration.py
@@ -1,0 +1,102 @@
+"""Tests for IntegrationTrigger base class."""
+
+import pytest
+
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.triggers.integration import IntegrationTrigger
+
+
+def test_integration_trigger__is_abstract():
+    """IntegrationTrigger cannot be instantiated directly (ABC)."""
+    # WHEN we try to call process_event on IntegrationTrigger directly
+    # THEN it raises NotImplementedError
+    with pytest.raises(NotImplementedError, match="must implement process_event"):
+        IntegrationTrigger.process_event({})
+
+
+def test_integration_trigger__outputs_class_exists():
+    """IntegrationTrigger has Outputs class."""
+    # GIVEN IntegrationTrigger
+    # THEN it has an Outputs class
+    assert hasattr(IntegrationTrigger, "Outputs")
+
+
+def test_integration_trigger__can_be_subclassed():
+    """IntegrationTrigger can be subclassed to create concrete triggers."""
+
+    # GIVEN a concrete implementation of IntegrationTrigger
+    class TestTrigger(IntegrationTrigger):
+        class Outputs(IntegrationTrigger.Outputs):
+            data: str
+
+        @classmethod
+        def process_event(cls, event_data: dict):
+            return cls.Outputs(data=event_data.get("data", ""))
+
+    # WHEN we process an event
+    result = TestTrigger.process_event({"data": "test"})
+
+    # THEN it returns the expected outputs
+    assert result.data == "test"
+
+
+def test_integration_trigger__graph_syntax():
+    """IntegrationTrigger can be used in graph syntax."""
+
+    # GIVEN a concrete trigger and a node
+    class TestTrigger(IntegrationTrigger):
+        class Outputs(IntegrationTrigger.Outputs):
+            value: str
+
+        @classmethod
+        def process_event(cls, event_data: dict):
+            return cls.Outputs(value=event_data.get("value", ""))
+
+    class TestNode(BaseNode):
+        pass
+
+    # WHEN we use trigger >> node syntax
+    graph = TestTrigger >> TestNode
+
+    # THEN a graph is created
+    assert graph is not None
+    assert len(list(graph.trigger_edges)) == 1
+    assert list(graph.trigger_edges)[0].trigger_class == TestTrigger
+    assert list(graph.trigger_edges)[0].to_node == TestNode
+
+
+def test_integration_trigger__multiple_entrypoints():
+    """IntegrationTrigger works with multiple entry points."""
+
+    # GIVEN a trigger and multiple nodes
+    class TestTrigger(IntegrationTrigger):
+        class Outputs(IntegrationTrigger.Outputs):
+            msg: str
+
+        @classmethod
+        def process_event(cls, event_data: dict):
+            return cls.Outputs(msg=event_data.get("msg", ""))
+
+    class NodeA(BaseNode):
+        pass
+
+    class NodeB(BaseNode):
+        pass
+
+    # WHEN we use trigger >> {nodes} syntax
+    graph = TestTrigger >> {NodeA, NodeB}
+
+    # THEN both nodes are entrypoints
+    trigger_edges = list(graph.trigger_edges)
+    assert len(trigger_edges) == 2
+    target_nodes = {edge.to_node for edge in trigger_edges}
+    assert target_nodes == {NodeA, NodeB}
+
+
+def test_integration_trigger__config_attribute():
+    """IntegrationTrigger has optional config attribute."""
+
+    # GIVEN IntegrationTrigger
+    # THEN it has a config class variable
+    assert hasattr(IntegrationTrigger, "config")
+    assert IntegrationTrigger.config is None

--- a/src/vellum/workflows/triggers/tests/test_slack.py
+++ b/src/vellum/workflows/triggers/tests/test_slack.py
@@ -1,0 +1,164 @@
+"""Tests for SlackTrigger."""
+
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.triggers.slack import SlackTrigger
+
+
+def test_slack_trigger__process_event__basic():
+    """SlackTrigger.process_event parses Slack payload correctly."""
+    # GIVEN a Slack event payload
+    slack_payload = {
+        "event": {
+            "type": "message",
+            "text": "Hello world!",
+            "channel": "C123456",
+            "user": "U123456",
+            "ts": "1234567890.123456",
+        }
+    }
+
+    # WHEN we process the event
+    outputs = SlackTrigger.process_event(slack_payload)
+
+    # THEN outputs contain the correct data
+    assert outputs.message == "Hello world!"
+    assert outputs.channel == "C123456"
+    assert outputs.user == "U123456"
+    assert outputs.timestamp == "1234567890.123456"
+    assert outputs.thread_ts is None
+    assert outputs.event_type == "message"
+
+
+def test_slack_trigger__process_event__with_thread():
+    """SlackTrigger.process_event handles threaded messages."""
+    # GIVEN a Slack event payload with thread_ts
+    slack_payload = {
+        "event": {
+            "type": "message",
+            "text": "Reply in thread",
+            "channel": "C123456",
+            "user": "U123456",
+            "ts": "1234567891.123456",
+            "thread_ts": "1234567890.123456",
+        }
+    }
+
+    # WHEN we process the event
+    outputs = SlackTrigger.process_event(slack_payload)
+
+    # THEN thread_ts is populated
+    assert outputs.thread_ts == "1234567890.123456"
+
+
+def test_slack_trigger__process_event__empty_payload():
+    """SlackTrigger.process_event handles empty payload gracefully."""
+    # GIVEN an empty payload
+    slack_payload = {}
+
+    # WHEN we process the event
+    outputs = SlackTrigger.process_event(slack_payload)
+
+    # THEN it returns empty strings for required fields
+    assert outputs.message == ""
+    assert outputs.channel == ""
+    assert outputs.user == ""
+    assert outputs.timestamp == ""
+    assert outputs.thread_ts is None
+    assert outputs.event_type == "message"  # default value
+
+
+def test_slack_trigger__process_event__app_mention():
+    """SlackTrigger.process_event handles app_mention events."""
+    # GIVEN an app_mention event
+    slack_payload = {
+        "event": {
+            "type": "app_mention",
+            "text": "<@U0LAN0Z89> is it everything a river should be?",
+            "channel": "C123456",
+            "user": "U123456",
+            "ts": "1234567890.123456",
+        }
+    }
+
+    # WHEN we process the event
+    outputs = SlackTrigger.process_event(slack_payload)
+
+    # THEN event_type is app_mention
+    assert outputs.event_type == "app_mention"
+    assert outputs.message == "<@U0LAN0Z89> is it everything a river should be?"
+
+
+def test_slack_trigger__outputs_class():
+    """SlackTrigger.Outputs has correct fields."""
+    # GIVEN SlackTrigger.Outputs
+    # THEN it has all expected fields
+    assert hasattr(SlackTrigger.Outputs, "__annotations__")
+    annotations = SlackTrigger.Outputs.__annotations__
+    assert "message" in annotations
+    assert "channel" in annotations
+    assert "user" in annotations
+    assert "timestamp" in annotations
+    assert "thread_ts" in annotations
+    assert "event_type" in annotations
+
+
+def test_slack_trigger__graph_syntax():
+    """SlackTrigger can be used in graph syntax."""
+
+    # GIVEN a node
+    class TestNode(BaseNode):
+        pass
+
+    # WHEN we use SlackTrigger >> Node syntax
+    graph = SlackTrigger >> TestNode
+
+    # THEN a graph is created with trigger edge
+    assert graph is not None
+    trigger_edges = list(graph.trigger_edges)
+    assert len(trigger_edges) == 1
+    assert trigger_edges[0].trigger_class == SlackTrigger
+    assert trigger_edges[0].to_node == TestNode
+
+
+def test_slack_trigger__multiple_entrypoints():
+    """SlackTrigger works with multiple entry points."""
+
+    # GIVEN multiple nodes
+    class NodeA(BaseNode):
+        pass
+
+    class NodeB(BaseNode):
+        pass
+
+    # WHEN we use SlackTrigger >> {NodeA, NodeB} syntax
+    graph = SlackTrigger >> {NodeA, NodeB}
+
+    # THEN both nodes have trigger edges
+    trigger_edges = list(graph.trigger_edges)
+    assert len(trigger_edges) == 2
+    target_nodes = {edge.to_node for edge in trigger_edges}
+    assert target_nodes == {NodeA, NodeB}
+
+
+def test_slack_trigger__trigger_then_graph():
+    """SlackTrigger works with trigger >> node >> node syntax."""
+
+    # GIVEN two nodes
+    class StartNode(BaseNode):
+        pass
+
+    class EndNode(BaseNode):
+        pass
+
+    # WHEN we create SlackTrigger >> StartNode >> EndNode
+    graph = SlackTrigger >> StartNode >> EndNode
+
+    # THEN the graph has one trigger edge and one regular edge
+    trigger_edges = list(graph.trigger_edges)
+    assert len(trigger_edges) == 1
+    assert trigger_edges[0].trigger_class == SlackTrigger
+    assert trigger_edges[0].to_node == StartNode
+
+    edges = list(graph.edges)
+    assert len(edges) == 1
+    assert edges[0].to_node == EndNode


### PR DESCRIPTION
Implement SlackTrigger as the first integration trigger for workflows:

Core Implementation:
- Add IntegrationTrigger base class for all integration triggers
- Implement SlackTrigger with outputs: message, channel, user, timestamp, thread_ts, event_type
- Support graph syntax: SlackTrigger >> Node
- Add process_event() method to parse Slack webhook payloads

Serialization:
- Add SLACK_MESSAGE to WorkflowTriggerType enum
- Implement _serialize_trigger_outputs() for integration trigger outputs
- Update trigger type mapping to include SlackTrigger
- Serialize trigger outputs in workflow JSON

Testing:
- Add unit tests for IntegrationTrigger and SlackTrigger (14 tests)
- Add serialization tests for SlackTrigger workflows (4 tests)
- All 18 tests passing

This enables workflows to be defined with SlackTrigger and sets the foundation for runtime execution support (APO-1836) and codegen (APO-1840).

🤖 Generated with [Claude Code](https://claude.com/claude-code)