### PR TITLE
[APO-1838] Add TypeScript codegen support for SlackTrigger workflows

### DIFF
--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -1101,5 +1101,59 @@ describe("Workflow", () => {
         `"ManualTrigger >> FirstNode >> SecondNode"`
       );
     });
+
+    it("should generate correct graph when workflow has a slack trigger", async () => {
+      const writer = new Writer();
+
+      const firstNode = genericNodeFactory({
+        id: "first-node",
+        label: "FirstNode",
+      });
+
+      const secondNode = genericNodeFactory({
+        id: "second-node",
+        label: "SecondNode",
+      });
+
+      const edges = edgesFactory([
+        [entrypointNode, firstNode],
+        [firstNode, secondNode],
+      ]);
+
+      const workflowContext = workflowContextFactory({
+        workflowRawData: {
+          nodes: [entrypointNode, firstNode, secondNode],
+          edges,
+        },
+        triggers: [
+          {
+            id: "trigger-1",
+            type: "SLACK_MESSAGE",
+            attributes: [],
+          },
+        ],
+      });
+
+      await Promise.all([
+        createNodeContext({
+          nodeData: firstNode,
+          workflowContext,
+        }),
+        createNodeContext({
+          nodeData: secondNode,
+          workflowContext,
+        }),
+      ]);
+
+      const graphAttribute = new GraphAttribute({
+        workflowContext,
+      });
+
+      graphAttribute.write(writer);
+
+      expect(writer.toString()).toMatchInlineSnapshot(
+        `"SlackTrigger >> FirstNode >> SecondNode"`
+      );
+    });
   });
 });

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/__snapshots__/trigger-attribute-workflow-reference.test.ts.snap
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/__snapshots__/trigger-attribute-workflow-reference.test.ts.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`TriggerAttributeWorkflowReference > should generate correct AST for SlackTrigger.message reference 1`] = `
+"SlackTrigger.message
+"
+`;
+
+exports[`TriggerAttributeWorkflowReference > should generate correct AST for SlackTrigger.user reference 1`] = `
+"SlackTrigger.user
+"
+`;
+
+exports[`TriggerAttributeWorkflowReference > should handle ManualTrigger reference 1`] = `
+"ManualTrigger.input
+"
+`;

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.test.ts
@@ -1,0 +1,120 @@
+import { Writer } from "@fern-api/python-ast/core/Writer";
+
+import { workflowContextFactory } from "src/__test__/helpers";
+import { WorkflowContext } from "src/context";
+import { TriggerAttributeWorkflowReference } from "src/generators/workflow-value-descriptor-reference/trigger-attribute-workflow-reference";
+import { WorkflowValueDescriptorReference } from "src/types/vellum";
+
+describe("TriggerAttributeWorkflowReference", () => {
+  let workflowContext: WorkflowContext;
+
+  beforeEach(() => {
+    workflowContext = workflowContextFactory({
+      triggers: [
+        {
+          id: "slack-trigger-id",
+          type: "SLACK_MESSAGE",
+          attributes: [
+            { id: "message-id", name: "message", type: "STRING" },
+            { id: "user-id", name: "user", type: "STRING" },
+            { id: "channel-id", name: "channel", type: "STRING" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("should generate correct AST for SlackTrigger.message reference", async () => {
+    const triggerAttributeReference: WorkflowValueDescriptorReference = {
+      type: "TRIGGER_ATTRIBUTE",
+      triggerId: "slack-trigger-id",
+      attributeId: "message-id",
+    };
+
+    const pointer = new TriggerAttributeWorkflowReference({
+      workflowContext,
+      nodeInputWorkflowReferencePointer: triggerAttributeReference,
+    });
+
+    const writer = new Writer();
+    pointer.write(writer);
+
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
+
+  it("should generate correct AST for SlackTrigger.user reference", async () => {
+    const triggerAttributeReference: WorkflowValueDescriptorReference = {
+      type: "TRIGGER_ATTRIBUTE",
+      triggerId: "slack-trigger-id",
+      attributeId: "user-id",
+    };
+
+    const pointer = new TriggerAttributeWorkflowReference({
+      workflowContext,
+      nodeInputWorkflowReferencePointer: triggerAttributeReference,
+    });
+
+    const writer = new Writer();
+    pointer.write(writer);
+
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
+
+  it("should return undefined for non-existent trigger", async () => {
+    const triggerAttributeReference: WorkflowValueDescriptorReference = {
+      type: "TRIGGER_ATTRIBUTE",
+      triggerId: "non-existent-trigger",
+      attributeId: "message-id",
+    };
+
+    const pointer = new TriggerAttributeWorkflowReference({
+      workflowContext,
+      nodeInputWorkflowReferencePointer: triggerAttributeReference,
+    });
+
+    expect(pointer.getAstNode()).toBeUndefined();
+  });
+
+  it("should return undefined for non-existent attribute", async () => {
+    const triggerAttributeReference: WorkflowValueDescriptorReference = {
+      type: "TRIGGER_ATTRIBUTE",
+      triggerId: "slack-trigger-id",
+      attributeId: "non-existent-attribute",
+    };
+
+    const pointer = new TriggerAttributeWorkflowReference({
+      workflowContext,
+      nodeInputWorkflowReferencePointer: triggerAttributeReference,
+    });
+
+    expect(pointer.getAstNode()).toBeUndefined();
+  });
+
+  it("should handle ManualTrigger reference", async () => {
+    const manualWorkflowContext = workflowContextFactory({
+      triggers: [
+        {
+          id: "manual-trigger-id",
+          type: "MANUAL",
+          attributes: [{ id: "input-id", name: "input", type: "STRING" }],
+        },
+      ],
+    });
+
+    const triggerAttributeReference: WorkflowValueDescriptorReference = {
+      type: "TRIGGER_ATTRIBUTE",
+      triggerId: "manual-trigger-id",
+      attributeId: "input-id",
+    };
+
+    const pointer = new TriggerAttributeWorkflowReference({
+      workflowContext: manualWorkflowContext,
+      nodeInputWorkflowReferencePointer: triggerAttributeReference,
+    });
+
+    const writer = new Writer();
+    pointer.write(writer);
+
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
+});

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.test.ts
@@ -15,9 +15,9 @@ describe("TriggerAttributeWorkflowReference", () => {
           id: "slack-trigger-id",
           type: "SLACK_MESSAGE",
           attributes: [
-            { id: "message-id", name: "message", type: "STRING" },
-            { id: "user-id", name: "user", type: "STRING" },
-            { id: "channel-id", name: "channel", type: "STRING" },
+            { id: "message-id", name: "message" },
+            { id: "user-id", name: "user" },
+            { id: "channel-id", name: "channel" },
           ],
         },
       ],
@@ -96,7 +96,7 @@ describe("TriggerAttributeWorkflowReference", () => {
         {
           id: "manual-trigger-id",
           type: "MANUAL",
-          attributes: [{ id: "input-id", name: "input", type: "STRING" }],
+          attributes: [{ id: "input-id", name: "input" }],
         },
       ],
     });

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -350,6 +350,11 @@ export class GraphAttribute extends AstNode {
           className: "ManualTrigger",
           modulePath: ["vellum", "workflows", "triggers", "manual"],
         };
+      case "SLACK_MESSAGE":
+        return {
+          className: "SlackTrigger",
+          modulePath: ["vellum", "workflows", "triggers", "slack"],
+        };
       default:
         return null;
     }

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.ts
@@ -1,0 +1,61 @@
+import { python } from "@fern-api/python-ast";
+import { AstNode } from "@fern-api/python-ast/core/AstNode";
+
+import { BaseNodeInputWorkflowReference } from "src/generators/workflow-value-descriptor-reference/BaseNodeInputWorkflowReference";
+import { TriggerAttributeWorkflowReference as TriggerAttributeWorkflowReferenceType } from "src/types/vellum";
+
+export class TriggerAttributeWorkflowReference extends BaseNodeInputWorkflowReference<TriggerAttributeWorkflowReferenceType> {
+  getAstNode(): AstNode | undefined {
+    const triggerAttributePointer = this.nodeInputWorkflowReferencePointer;
+
+    // Find the trigger in the workflow context
+    const trigger = this.workflowContext.triggers?.find(
+      (t) => t.id === triggerAttributePointer.triggerId
+    );
+
+    if (!trigger) {
+      return undefined;
+    }
+
+    // Find the attribute name from the trigger's attributes
+    const attribute = trigger.attributes.find(
+      (attr) => attr.id === triggerAttributePointer.attributeId
+    );
+
+    if (!attribute) {
+      return undefined;
+    }
+
+    // Get the trigger class information based on trigger type
+    const triggerClassInfo = this.getTriggerClassInfo(trigger.type);
+    if (!triggerClassInfo) {
+      return undefined;
+    }
+
+    // Generate: TriggerClassName.attributeName
+    return python.reference({
+      name: triggerClassInfo.className,
+      modulePath: triggerClassInfo.modulePath,
+      attribute: [attribute.name],
+    });
+  }
+
+  private getTriggerClassInfo(
+    triggerType: string
+  ): { className: string; modulePath: string[] } | null {
+    switch (triggerType) {
+      case "MANUAL":
+        return {
+          className: "ManualTrigger",
+          modulePath: ["vellum", "workflows", "triggers", "manual"],
+        };
+      case "SLACK_MESSAGE":
+        return {
+          className: "SlackTrigger",
+          modulePath: ["vellum", "workflows", "triggers", "slack"],
+        };
+      default:
+        return null;
+    }
+  }
+}

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-value-descriptor-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/workflow-value-descriptor-reference.ts
@@ -12,6 +12,7 @@ import { ConstantValueReference } from "src/generators/workflow-value-descriptor
 import { EnvironmentVariableWorkflowReference } from "src/generators/workflow-value-descriptor-reference/environment-variable-workflow-reference";
 import { ExecutionCounterWorkflowReference } from "src/generators/workflow-value-descriptor-reference/execution-counter-workflow-reference";
 import { NodeOutputWorkflowReference } from "src/generators/workflow-value-descriptor-reference/node-output-workflow-reference";
+import { TriggerAttributeWorkflowReference } from "src/generators/workflow-value-descriptor-reference/trigger-attribute-workflow-reference";
 import { VellumSecretWorkflowReference } from "src/generators/workflow-value-descriptor-reference/vellum-secret-workflow-reference";
 import { WorkflowInputReference } from "src/generators/workflow-value-descriptor-reference/workflow-input-reference";
 import {
@@ -118,6 +119,18 @@ export class WorkflowValueDescriptorReference extends AstNode {
           workflowContext: this.workflowContext,
           nodeInputWorkflowReferencePointer: workflowValueReferencePointer,
         });
+      case "TRIGGER_ATTRIBUTE": {
+        const reference = new TriggerAttributeWorkflowReference({
+          nodeContext: this.nodeContext,
+          workflowContext: this.workflowContext,
+          nodeInputWorkflowReferencePointer: workflowValueReferencePointer,
+        });
+        if (reference.getAstNode()) {
+          return reference;
+        } else {
+          return undefined;
+        }
+      }
       case "DICTIONARY_REFERENCE":
         return new DictionaryWorkflowReference({
           nodeContext: this.nodeContext,

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -103,6 +103,7 @@ import {
   SubworkflowNode,
   TemplatingNode,
   TernaryWorkflowExpression,
+  TriggerAttributeWorkflowReference,
   UnaryWorkflowExpression,
   VariablePromptTemplateBlock,
   VellumLogicalCondition,
@@ -831,6 +832,21 @@ export declare namespace ExecutionCounterWorkflowReferenceSerializer {
   }
 }
 
+export const TriggerAttributeWorkflowReferenceSerializer: ObjectSchema<
+  TriggerAttributeWorkflowReferenceSerializer.Raw,
+  Omit<TriggerAttributeWorkflowReference, "type">
+> = objectSchema({
+  triggerId: propertySchema("trigger_id", stringSchema()),
+  attributeId: propertySchema("attribute_id", stringSchema()),
+});
+
+export declare namespace TriggerAttributeWorkflowReferenceSerializer {
+  interface Raw {
+    trigger_id: string;
+    attribute_id: string;
+  }
+}
+
 export const DictionaryWorkflowReferenceEntrySerializer: ObjectSchema<
   DictionaryWorkflowReferenceEntrySerializer.Raw,
   Omit<DictionaryWorkflowReferenceEntry, "type">
@@ -888,6 +904,7 @@ export const WorkflowValueDescriptorSerializer: Schema<
   VELLUM_SECRET: VellumSecretWorkflowReferenceSerializer,
   ENVIRONMENT_VARIABLE: EnvironmentVariableWorkflowReferenceSerializer,
   EXECUTION_COUNTER: ExecutionCounterWorkflowReferenceSerializer,
+  TRIGGER_ATTRIBUTE: TriggerAttributeWorkflowReferenceSerializer,
   DICTIONARY_REFERENCE: DictionaryWorkflowReferenceSerializer,
   ARRAY_REFERENCE: ArrayWorkflowReferenceSerializer,
 });
@@ -904,6 +921,7 @@ export declare namespace WorkflowValueDescriptorSerializer {
     | VellumSecretWorkflowReferenceSerializer.Raw
     | EnvironmentVariableWorkflowReferenceSerializer.Raw
     | ExecutionCounterWorkflowReferenceSerializer.Raw
+    | TriggerAttributeWorkflowReferenceSerializer.Raw
     | DictionaryWorkflowReferenceSerializer.Raw
     | ArrayWorkflowReferenceSerializer.Raw;
 }

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -891,6 +891,12 @@ export interface ExecutionCounterWorkflowReference {
   nodeId: string;
 }
 
+export interface TriggerAttributeWorkflowReference {
+  type: "TRIGGER_ATTRIBUTE";
+  triggerId: string;
+  attributeId: string;
+}
+
 export interface DictionaryWorkflowReferenceEntry {
   id?: string; // TODO: Temporary supporting id key translation for input variable in blocks
   key: string;
@@ -920,6 +926,7 @@ export type WorkflowValueDescriptorReference =
   | VellumSecretWorkflowReference
   | EnvironmentVariableWorkflowReference
   | ExecutionCounterWorkflowReference
+  | TriggerAttributeWorkflowReference
   | DictionaryWorkflowReference
   | ArrayWorkflowReference;
 

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/__init__.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/__init__.py
@@ -1,0 +1,1 @@
+# Slack trigger workflow test

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/nodes/__init__.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/nodes/__init__.py
@@ -1,0 +1,1 @@
+# Nodes for slack trigger workflow test

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/nodes/process_message.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/nodes/process_message.py
@@ -1,0 +1,13 @@
+from vellum.workflows.nodes.bases.base import BaseNode
+
+
+class ProcessMessageNode(BaseNode):
+    """Process a Slack message."""
+
+    class Outputs(BaseNode.Outputs):
+        processed_message: str
+
+    def run(self) -> Outputs:
+        # In a real implementation, we would access SlackTrigger.Outputs.message here
+        # For now, just return a static message for testing
+        return self.Outputs(processed_message="Processed Slack message")

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/nodes/process_message.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/nodes/process_message.py
@@ -1,13 +1,12 @@
 from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.triggers.slack import SlackTrigger
 
 
 class ProcessMessageNode(BaseNode):
     """Process a Slack message."""
 
     class Outputs(BaseNode.Outputs):
-        processed_message: str
+        processed_message = SlackTrigger.message
 
     def run(self) -> Outputs:
-        # Access trigger attributes like: SlackTrigger.message, SlackTrigger.channel, etc.
-        # For this test, just return a static message
-        return self.Outputs(processed_message="Processed Slack message")
+        return self.Outputs()

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/nodes/process_message.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/nodes/process_message.py
@@ -8,6 +8,6 @@ class ProcessMessageNode(BaseNode):
         processed_message: str
 
     def run(self) -> Outputs:
-        # In a real implementation, we would access SlackTrigger.Outputs.message here
+        # In a real implementation, we would access SlackTrigger.Attributes.message here
         # For now, just return a static message for testing
         return self.Outputs(processed_message="Processed Slack message")

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/nodes/process_message.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/nodes/process_message.py
@@ -8,6 +8,6 @@ class ProcessMessageNode(BaseNode):
         processed_message: str
 
     def run(self) -> Outputs:
-        # In a real implementation, we would access SlackTrigger.Attributes.message here
-        # For now, just return a static message for testing
+        # Access trigger attributes like: SlackTrigger.message, SlackTrigger.channel, etc.
+        # For this test, just return a static message
         return self.Outputs(processed_message="Processed Slack message")

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/tests/__init__.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for slack trigger workflow

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/tests/test_workflow.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/tests/test_workflow.py
@@ -1,0 +1,53 @@
+"""Tests for SlackTrigger workflow."""
+
+from ..workflow import SlackTriggerWorkflow
+
+
+def test_slack_trigger_workflow__basic_execution():
+    """Test that SlackTrigger workflow can be instantiated and executed."""
+    # GIVEN a workflow with SlackTrigger
+    workflow = SlackTriggerWorkflow()
+
+    # WHEN we run the workflow
+    result = workflow.run()
+
+    # THEN it should execute successfully
+    assert result.name == "workflow.execution.fulfilled"
+    assert result.outputs.result == "Processed Slack message"
+
+
+def test_slack_trigger_workflow__has_trigger():
+    """Test that workflow has SlackTrigger in its graph."""
+    # GIVEN the SlackTrigger workflow
+    # WHEN we check its subgraphs
+    subgraphs = SlackTriggerWorkflow.get_subgraphs()
+
+    # THEN it should have trigger edges
+    has_trigger = False
+    for subgraph in subgraphs:
+        if list(subgraph.trigger_edges):
+            has_trigger = True
+            break
+
+    assert has_trigger, "Workflow should have trigger edges"
+
+
+def test_slack_trigger_workflow__serialization():
+    """Test that workflow with SlackTrigger can be serialized."""
+    from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+    # GIVEN the SlackTrigger workflow
+    # WHEN we serialize it
+    result = get_workflow_display(workflow_class=SlackTriggerWorkflow).serialize()
+
+    # THEN it should have triggers
+    assert "triggers" in result
+    assert len(result["triggers"]) == 1
+
+    # AND the trigger should be SLACK_MESSAGE type
+    trigger = result["triggers"][0]
+    assert trigger["type"] == "SLACK_MESSAGE"
+
+    # AND the trigger should have outputs
+    assert "outputs" in trigger
+    assert len(trigger["outputs"]) == 6  # All SlackTrigger output fields

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/tests/test_workflow.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/tests/test_workflow.py
@@ -1,5 +1,7 @@
 """Tests for SlackTrigger workflow."""
 
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
 from ..workflow import SlackTriggerWorkflow
 
 
@@ -32,8 +34,6 @@ def test_slack_trigger_workflow__has_trigger():
 
 def test_slack_trigger_workflow__serialization():
     """Test that workflow with SlackTrigger can be serialized."""
-    from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-
     # GIVEN the SlackTrigger workflow
     # WHEN we serialize it
     result = get_workflow_display(workflow_class=SlackTriggerWorkflow).serialize()
@@ -58,8 +58,6 @@ def test_slack_trigger_workflow__serialization():
 
 def test_slack_trigger_workflow__trigger_attribute_reference():
     """Test that nodes can reference trigger attributes."""
-    from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
-
     # GIVEN the SlackTrigger workflow
     # WHEN we serialize it
     result = get_workflow_display(workflow_class=SlackTriggerWorkflow).serialize()

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/tests/test_workflow.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/tests/test_workflow.py
@@ -48,6 +48,6 @@ def test_slack_trigger_workflow__serialization():
     trigger = result["triggers"][0]
     assert trigger["type"] == "SLACK_MESSAGE"
 
-    # AND the trigger should have outputs
-    assert "outputs" in trigger
-    assert len(trigger["outputs"]) == 6  # All SlackTrigger output fields
+    # AND the trigger should have attributes
+    assert "attributes" in trigger
+    assert len(trigger["attributes"]) == 6  # All SlackTrigger attribute fields

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/tests/test_workflow.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/tests/test_workflow.py
@@ -103,5 +103,5 @@ def test_slack_trigger_workflow__trigger_attribute_reference():
     value = processed_message_output["value"]
     assert isinstance(value, dict)
     assert value.get("type") == "TRIGGER_ATTRIBUTE"
-    assert "triggerId" in value
-    assert "attributeId" in value
+    assert "trigger_id" in value
+    assert "attribute_id" in value

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/tests/test_workflow.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/tests/test_workflow.py
@@ -42,12 +42,17 @@ def test_slack_trigger_workflow__serialization():
 
     # THEN it should have triggers
     assert "triggers" in result
-    assert len(result["triggers"]) == 1
+    triggers = result["triggers"]
+    assert isinstance(triggers, list)
+    assert len(triggers) == 1
 
     # AND the trigger should be SLACK_MESSAGE type
-    trigger = result["triggers"][0]
+    trigger = triggers[0]
+    assert isinstance(trigger, dict)
     assert trigger["type"] == "SLACK_MESSAGE"
 
     # AND the trigger should have attributes
     assert "attributes" in trigger
-    assert len(trigger["attributes"]) == 6  # All SlackTrigger attribute fields
+    attributes = trigger["attributes"]
+    assert isinstance(attributes, list)
+    assert len(attributes) == 6  # All SlackTrigger attribute fields

--- a/ee/codegen/tests/workflows/slack_trigger_workflow/workflow.py
+++ b/ee/codegen/tests/workflows/slack_trigger_workflow/workflow.py
@@ -1,0 +1,15 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.inputs.base import BaseInputs
+from vellum.workflows.state.base import BaseState
+from vellum.workflows.triggers.slack import SlackTrigger
+
+from .nodes.process_message import ProcessMessageNode
+
+
+class SlackTriggerWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+    """Example workflow triggered by Slack events."""
+
+    graph = SlackTrigger >> ProcessMessageNode
+
+    class Outputs(BaseWorkflow.Outputs):
+        result = ProcessMessageNode.Outputs.processed_message

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -355,8 +355,8 @@ def serialize_value(executable_id: UUID, display_context: "WorkflowDisplayContex
 
         return {
             "type": "TRIGGER_ATTRIBUTE",
-            "triggerId": str(trigger_id),
-            "attributeId": str(value.id),
+            "trigger_id": str(trigger_id),
+            "attribute_id": str(value.id),
         }
 
     if isinstance(value, list):

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -50,6 +50,7 @@ from vellum.workflows.references.execution_count import ExecutionCountReference
 from vellum.workflows.references.lazy import LazyReference
 from vellum.workflows.references.output import OutputReference
 from vellum.workflows.references.state_value import StateValueReference
+from vellum.workflows.references.trigger import TriggerAttributeReference
 from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.references.workflow_input import WorkflowInputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
@@ -345,6 +346,17 @@ def serialize_value(executable_id: UUID, display_context: "WorkflowDisplayContex
         return {
             "type": "EXECUTION_COUNTER",
             "node_id": str(node_class_display.node_id),
+        }
+
+    if isinstance(value, TriggerAttributeReference):
+        # Generate trigger ID using the same hash formula as in base_workflow_display.py
+        trigger_class = value.trigger_class
+        trigger_id = uuid4_from_hash(f"{trigger_class.__module__} | {trigger_class.__qualname__}")
+
+        return {
+            "type": "TRIGGER_ATTRIBUTE",
+            "triggerId": str(trigger_id),
+            "attributeId": str(value.id),
         }
 
     if isinstance(value, list):

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -25,7 +25,6 @@ from vellum.workflows.nodes.utils import get_unadorned_node, get_unadorned_port,
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference, WorkflowInputReference
 from vellum.workflows.state.encoder import DefaultStateEncoder
-from vellum.workflows.triggers.base import BaseTrigger
 from vellum.workflows.types.core import Json, JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.types.utils import get_original_base

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -25,6 +25,7 @@ from vellum.workflows.nodes.utils import get_unadorned_node, get_unadorned_port,
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference, WorkflowInputReference
 from vellum.workflows.state.encoder import DefaultStateEncoder
+from vellum.workflows.triggers.base import BaseTrigger
 from vellum.workflows.types.core import Json, JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.types.utils import get_original_base


### PR DESCRIPTION
The purpose of this PR is to add TypeScript codegen support for SlackTrigger workflows, including trigger type recognition, trigger attribute references (e.g., `SlackTrigger.message`), and serialization.

## Key Changes
- Added `SLACK_MESSAGE` trigger type mapping to generate `SlackTrigger` class references
- Implemented `TriggerAttributeWorkflowReference` class for generating AST nodes that reference trigger attributes
- Added `TriggerAttributeWorkflowReferenceSerializer` with proper snake_case conversion
- Updated `WorkflowValueDescriptorReference` union to include `TRIGGER_ATTRIBUTE` type
- Added Python serialization support for `TriggerAttributeReference` objects in `expressions.py`

## Test Coverage
- TypeScript: Graph generation, trigger attribute references, edge cases with snapshots
- Python: Workflow execution, serialization, trigger detection, attribute references
- All tests passing ✅

## Related
- Builds on APO-1833 (SlackTrigger base implementation)
- Part of Slack integration workflow support

🤖 Generated with [Claude Code](https://claude.com/claude-code)