### PR TITLE
[APO-1834] Add IntegrationTrigger base class

### DIFF
--- a/src/vellum/workflows/triggers/__init__.py
+++ b/src/vellum/workflows/triggers/__init__.py
@@ -1,4 +1,5 @@
 from vellum.workflows.triggers.base import BaseTrigger
+from vellum.workflows.triggers.integration import IntegrationTrigger
 from vellum.workflows.triggers.manual import ManualTrigger
 
-__all__ = ["BaseTrigger", "ManualTrigger"]
+__all__ = ["BaseTrigger", "IntegrationTrigger", "ManualTrigger"]

--- a/src/vellum/workflows/triggers/integration.py
+++ b/src/vellum/workflows/triggers/integration.py
@@ -1,0 +1,62 @@
+from abc import ABC
+from typing import ClassVar, Optional
+
+from vellum.workflows.outputs.base import BaseOutputs
+from vellum.workflows.triggers.base import BaseTrigger
+
+
+class IntegrationTrigger(BaseTrigger, ABC):
+    """
+    Base class for integration-based triggers (Slack, Email, etc.).
+
+    Integration triggers:
+    - Are initiated by external events (webhooks, API calls)
+    - Produce outputs that downstream nodes can reference
+    - Require configuration (auth, webhooks, etc.)
+
+    Examples:
+        # Define an integration trigger
+        class MyIntegrationTrigger(IntegrationTrigger):
+            class Outputs(IntegrationTrigger.Outputs):
+                data: str
+
+            @classmethod
+            def process_event(cls, event_data: dict):
+                return cls.Outputs(data=event_data.get("data", ""))
+
+        # Use in workflow
+        class MyWorkflow(BaseWorkflow):
+            graph = MyIntegrationTrigger >> ProcessNode
+
+    Note:
+        Unlike ManualTrigger, integration triggers provide structured outputs
+        that downstream nodes can reference directly via Outputs.
+    """
+
+    class Outputs(BaseOutputs):
+        """Base outputs for integration triggers."""
+
+        pass
+
+    # Configuration that can be set at runtime
+    config: ClassVar[Optional[dict]] = None
+
+    @classmethod
+    def process_event(cls, event_data: dict) -> "IntegrationTrigger.Outputs":
+        """
+        Process incoming webhook/event data and return trigger outputs.
+
+        This method should be implemented by subclasses to parse external
+        event payloads (e.g., Slack webhooks, email notifications) into
+        structured trigger outputs.
+
+        Args:
+            event_data: Raw event data from the external system
+
+        Returns:
+            Trigger outputs containing parsed event data
+
+        Raises:
+            NotImplementedError: If subclass doesn't implement this method
+        """
+        raise NotImplementedError(f"{cls.__name__} must implement process_event() method to handle external events")

--- a/src/vellum/workflows/triggers/tests/__init__.py
+++ b/src/vellum/workflows/triggers/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for workflow triggers

--- a/src/vellum/workflows/triggers/tests/test_integration.py
+++ b/src/vellum/workflows/triggers/tests/test_integration.py
@@ -1,0 +1,102 @@
+"""Tests for IntegrationTrigger base class."""
+
+import pytest
+
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.triggers.integration import IntegrationTrigger
+
+
+def test_integration_trigger__is_abstract():
+    """IntegrationTrigger cannot be instantiated directly (ABC)."""
+    # WHEN we try to call process_event on IntegrationTrigger directly
+    # THEN it raises NotImplementedError
+    with pytest.raises(NotImplementedError, match="must implement process_event"):
+        IntegrationTrigger.process_event({})
+
+
+def test_integration_trigger__outputs_class_exists():
+    """IntegrationTrigger has Outputs class."""
+    # GIVEN IntegrationTrigger
+    # THEN it has an Outputs class
+    assert hasattr(IntegrationTrigger, "Outputs")
+
+
+def test_integration_trigger__can_be_subclassed():
+    """IntegrationTrigger can be subclassed to create concrete triggers."""
+
+    # GIVEN a concrete implementation of IntegrationTrigger
+    class TestTrigger(IntegrationTrigger):
+        class Outputs(IntegrationTrigger.Outputs):
+            data: str
+
+        @classmethod
+        def process_event(cls, event_data: dict):
+            return cls.Outputs(data=event_data.get("data", ""))
+
+    # WHEN we process an event
+    result = TestTrigger.process_event({"data": "test"})
+
+    # THEN it returns the expected outputs
+    assert result.data == "test"
+
+
+def test_integration_trigger__graph_syntax():
+    """IntegrationTrigger can be used in graph syntax."""
+
+    # GIVEN a concrete trigger and a node
+    class TestTrigger(IntegrationTrigger):
+        class Outputs(IntegrationTrigger.Outputs):
+            value: str
+
+        @classmethod
+        def process_event(cls, event_data: dict):
+            return cls.Outputs(value=event_data.get("value", ""))
+
+    class TestNode(BaseNode):
+        pass
+
+    # WHEN we use trigger >> node syntax
+    graph = TestTrigger >> TestNode
+
+    # THEN a graph is created
+    assert graph is not None
+    assert len(list(graph.trigger_edges)) == 1
+    assert list(graph.trigger_edges)[0].trigger_class == TestTrigger
+    assert list(graph.trigger_edges)[0].to_node == TestNode
+
+
+def test_integration_trigger__multiple_entrypoints():
+    """IntegrationTrigger works with multiple entry points."""
+
+    # GIVEN a trigger and multiple nodes
+    class TestTrigger(IntegrationTrigger):
+        class Outputs(IntegrationTrigger.Outputs):
+            msg: str
+
+        @classmethod
+        def process_event(cls, event_data: dict):
+            return cls.Outputs(msg=event_data.get("msg", ""))
+
+    class NodeA(BaseNode):
+        pass
+
+    class NodeB(BaseNode):
+        pass
+
+    # WHEN we use trigger >> {nodes} syntax
+    graph = TestTrigger >> {NodeA, NodeB}
+
+    # THEN both nodes are entrypoints
+    trigger_edges = list(graph.trigger_edges)
+    assert len(trigger_edges) == 2
+    target_nodes = {edge.to_node for edge in trigger_edges}
+    assert target_nodes == {NodeA, NodeB}
+
+
+def test_integration_trigger__config_attribute():
+    """IntegrationTrigger has optional config attribute."""
+
+    # GIVEN IntegrationTrigger
+    # THEN it has a config class variable
+    assert hasattr(IntegrationTrigger, "config")
+    assert IntegrationTrigger.config is None


### PR DESCRIPTION
## Summary
Introduce `IntegrationTrigger` base class for integration-based workflow triggers (Slack, Email, GitHub, etc.).

This provides the foundation for all integration triggers and will be extended by APO-1833 (SlackTrigger implementation).

## Changes
- Add `IntegrationTrigger` abstract base class extending `BaseTrigger`
  - Support structured outputs that downstream nodes can reference
  - Add abstract `process_event()` method for parsing external webhooks
  - Include optional `config` ClassVar for runtime configuration
- Add 6 unit tests covering:
  - Abstract nature (cannot instantiate directly)
  - Subclassing capability
  - Graph syntax support (`IntegrationTrigger >> Node`)
  - Multiple entry points
  - Config attribute

## Test Plan
- [x] All 6 unit tests passing
- [x] Pre-commit hooks passing
- [x] Type checking passing

## Dependencies
None - this is a foundation PR

## Follow-up PRs
- APO-1833: SlackTrigger implementation (depends on this)
- Future: EmailTrigger, GitHubTrigger, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)