### PR TITLE
[APO-1833] Add SlackTrigger implementation and serialization

### DIFF
--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 class WorkflowTriggerType(Enum):
     MANUAL = "MANUAL"
+    SLACK_MESSAGE = "SLACK_MESSAGE"
 
 
 def get_trigger_type_mapping() -> Dict[Type["BaseTrigger"], WorkflowTriggerType]:
@@ -29,9 +30,11 @@ def get_trigger_type_mapping() -> Dict[Type["BaseTrigger"], WorkflowTriggerType]
         Dictionary mapping trigger classes to their enum types
     """
     from vellum.workflows.triggers.manual import ManualTrigger
+    from vellum.workflows.triggers.slack import SlackTrigger
 
     return {
         ManualTrigger: WorkflowTriggerType.MANUAL,
+        SlackTrigger: WorkflowTriggerType.SLACK_MESSAGE,
     }
 
 

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_slack_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_slack_trigger_serialization.py
@@ -1,9 +1,11 @@
 """Tests for serialization of workflows with SlackTrigger."""
 
-try:  # Python 3.9 compatibility
+import sys
+
+if sys.version_info >= (3, 10):
     from typing import TypeGuard
-except ImportError:  # pragma: no cover - fallback for older runtimes
-    from typing_extensions import TypeGuard  # type: ignore[assignment]
+else:
+    from typing_extensions import TypeGuard
 
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.inputs.base import BaseInputs

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_slack_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_slack_trigger_serialization.py
@@ -1,0 +1,135 @@
+"""Tests for serialization of workflows with SlackTrigger."""
+
+from typing import cast
+
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.inputs.base import BaseInputs
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.state.base import BaseState
+from vellum.workflows.triggers.slack import SlackTrigger
+from vellum.workflows.types.core import JsonArray, JsonObject
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+
+class Inputs(BaseInputs):
+    input: str
+
+
+class SimpleNode(BaseNode):
+    class Outputs(BaseNode.Outputs):
+        output = Inputs.input
+
+
+def create_workflow(trigger=None):
+    """Factory for creating test workflows."""
+
+    class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
+        graph = trigger >> SimpleNode if trigger else SimpleNode
+
+        class Outputs(BaseWorkflow.Outputs):
+            output = SimpleNode.Outputs.output
+
+    return TestWorkflow
+
+
+def serialize(workflow_class) -> JsonObject:
+    """Helper to serialize a workflow."""
+    return get_workflow_display(workflow_class=workflow_class).serialize()
+
+
+def test_slack_trigger_serialization():
+    """Workflow with SlackTrigger serializes with triggers field and outputs."""
+    result = serialize(create_workflow(SlackTrigger))
+    triggers = cast(JsonArray, result["triggers"])
+
+    assert len(triggers) == 1
+    trigger = cast(JsonObject, triggers[0])
+
+    assert trigger["type"] == "SLACK_MESSAGE"
+    assert "id" in trigger
+    assert "attributes" in trigger
+    assert trigger["attributes"] == []
+
+    # Check that outputs are included
+    assert "outputs" in trigger
+    outputs = cast(JsonArray, trigger["outputs"])
+    assert len(outputs) == 6  # message, channel, user, timestamp, thread_ts, event_type
+
+    # Verify output structure
+    output_names = {cast(JsonObject, output)["name"] for output in outputs}
+    assert output_names == {"message", "channel", "user", "timestamp", "thread_ts", "event_type"}
+
+    # Verify output types (all should be STRING for SlackTrigger)
+    for output in outputs:
+        output_obj = cast(JsonObject, output)
+        assert output_obj["type"] == "STRING"
+
+
+def test_slack_trigger_multiple_entrypoints():
+    """SlackTrigger with multiple entrypoints."""
+
+    class NodeA(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output = Inputs.input
+
+    class NodeB(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            output = Inputs.input
+
+    class MultiWorkflow(BaseWorkflow[Inputs, BaseState]):
+        graph = SlackTrigger >> {NodeA, NodeB}
+
+        class Outputs(BaseWorkflow.Outputs):
+            output_a = NodeA.Outputs.output
+            output_b = NodeB.Outputs.output
+
+    result = serialize(MultiWorkflow)
+    triggers = cast(JsonArray, result["triggers"])
+    workflow_data = cast(JsonObject, result["workflow_raw_data"])
+    nodes = cast(JsonArray, workflow_data["nodes"])
+
+    assert len(triggers) == 1
+    trigger = cast(JsonObject, triggers[0])
+    assert trigger["type"] == "SLACK_MESSAGE"
+    assert "outputs" in trigger
+    assert len([n for n in nodes if cast(JsonObject, n)["type"] == "GENERIC"]) >= 2
+
+
+def test_serialized_slack_workflow_structure():
+    """Verify complete structure of serialized workflow with SlackTrigger."""
+    result = serialize(create_workflow(SlackTrigger))
+    workflow_raw_data = cast(JsonObject, result["workflow_raw_data"])
+    definition = cast(JsonObject, workflow_raw_data["definition"])
+
+    assert result.keys() == {
+        "workflow_raw_data",
+        "input_variables",
+        "state_variables",
+        "output_variables",
+        "triggers",
+    }
+    assert workflow_raw_data.keys() == {"nodes", "edges", "display_data", "definition", "output_values"}
+    assert definition["name"] == "TestWorkflow"
+
+
+def test_slack_trigger_outputs_correct_fields():
+    """Verify SlackTrigger outputs contain all expected fields."""
+    result = serialize(create_workflow(SlackTrigger))
+    triggers = cast(JsonArray, result["triggers"])
+    trigger = cast(JsonObject, triggers[0])
+    outputs = cast(JsonArray, trigger["outputs"])
+
+    # Convert to dict for easy lookup
+    outputs_dict = {cast(JsonObject, o)["name"]: cast(JsonObject, o) for o in outputs}
+
+    # Verify all required fields
+    assert "message" in outputs_dict
+    assert "channel" in outputs_dict
+    assert "user" in outputs_dict
+    assert "timestamp" in outputs_dict
+    assert "thread_ts" in outputs_dict
+    assert "event_type" in outputs_dict
+
+    # All should be STRING type
+    for field_name in ["message", "channel", "user", "timestamp", "thread_ts", "event_type"]:
+        assert outputs_dict[field_name]["type"] == "STRING"

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_slack_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_slack_trigger_serialization.py
@@ -1,13 +1,13 @@
 """Tests for serialization of workflows with SlackTrigger."""
 
-from typing import assert_type
+from typing import TypeGuard
 
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.state.base import BaseState
 from vellum.workflows.triggers.slack import SlackTrigger
-from vellum.workflows.types.core import JsonArray, JsonObject
+from vellum.workflows.types.core import Json, JsonArray, JsonObject
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 
@@ -20,7 +20,19 @@ class SimpleNode(BaseNode):
         output = Inputs.input
 
 
-def test_slack_trigger_serialization():
+def is_json_array(value: Json) -> TypeGuard[JsonArray]:
+    return isinstance(value, list)
+
+
+def is_json_object(value: Json) -> TypeGuard[JsonObject]:
+    return isinstance(value, dict)
+
+
+def is_json_str(value: Json) -> TypeGuard[str]:
+    return isinstance(value, str)
+
+
+def test_slack_trigger_serialization() -> None:
     """Workflow with SlackTrigger serializes with triggers field."""
 
     class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
@@ -30,20 +42,27 @@ def test_slack_trigger_serialization():
             output = SimpleNode.Outputs.output
 
     result = get_workflow_display(workflow_class=TestWorkflow).serialize()
-    triggers = result["triggers"]
-    assert_type(triggers, JsonArray)
+
+    triggers_value = result["triggers"]
+    assert is_json_array(triggers_value)
+    triggers = triggers_value
 
     assert len(triggers) == 1
-    trigger = triggers[0]
-    assert_type(trigger, JsonObject)
+    trigger_value = triggers[0]
+    assert is_json_object(trigger_value)
+    trigger = trigger_value
 
-    assert trigger["type"] == "SLACK_MESSAGE"
+    trigger_type_value = trigger["type"]
+    assert is_json_str(trigger_type_value)
+    assert trigger_type_value == "SLACK_MESSAGE"
+
     assert "id" in trigger
-    assert "attributes" in trigger
-    assert trigger["attributes"] == []
+    attributes_value = trigger["attributes"]
+    assert is_json_array(attributes_value)
+    assert attributes_value == []
 
 
-def test_slack_trigger_multiple_entrypoints():
+def test_slack_trigger_multiple_entrypoints() -> None:
     """SlackTrigger with multiple entrypoints."""
 
     class NodeA(BaseNode):
@@ -62,25 +81,41 @@ def test_slack_trigger_multiple_entrypoints():
             output_b = NodeB.Outputs.output
 
     result = get_workflow_display(workflow_class=MultiWorkflow).serialize()
-    triggers = result["triggers"]
-    assert_type(triggers, JsonArray)
 
-    workflow_data = result["workflow_raw_data"]
-    assert_type(workflow_data, JsonObject)
+    triggers_value = result["triggers"]
+    assert is_json_array(triggers_value)
+    triggers = triggers_value
 
-    nodes = workflow_data["nodes"]
-    assert_type(nodes, JsonArray)
+    workflow_data_value = result["workflow_raw_data"]
+    assert is_json_object(workflow_data_value)
+    workflow_data = workflow_data_value
+
+    nodes_value = workflow_data["nodes"]
+    assert is_json_array(nodes_value)
+    nodes = nodes_value
 
     assert len(triggers) == 1
-    trigger = triggers[0]
-    assert_type(trigger, JsonObject)
-    assert trigger["type"] == "SLACK_MESSAGE"
+    trigger_value = triggers[0]
+    assert is_json_object(trigger_value)
+    trigger = trigger_value
 
-    generic_nodes = [n for n in nodes if assert_type(n, JsonObject)["type"] == "GENERIC"]
+    trigger_type_value = trigger["type"]
+    assert is_json_str(trigger_type_value)
+    assert trigger_type_value == "SLACK_MESSAGE"
+
+    generic_nodes = []
+    for node in nodes:
+        assert is_json_object(node)
+        node_type_value = node.get("type")
+        assert node_type_value is not None
+        assert is_json_str(node_type_value)
+        if node_type_value == "GENERIC":
+            generic_nodes.append(node)
+
     assert len(generic_nodes) >= 2
 
 
-def test_serialized_slack_workflow_structure():
+def test_serialized_slack_workflow_structure() -> None:
     """Verify complete structure of serialized workflow with SlackTrigger."""
 
     class TestWorkflow(BaseWorkflow[Inputs, BaseState]):
@@ -90,18 +125,31 @@ def test_serialized_slack_workflow_structure():
             output = SimpleNode.Outputs.output
 
     result = get_workflow_display(workflow_class=TestWorkflow).serialize()
-    workflow_raw_data = result["workflow_raw_data"]
-    assert_type(workflow_raw_data, JsonObject)
 
-    definition = workflow_raw_data["definition"]
-    assert_type(definition, JsonObject)
+    workflow_raw_data_value = result["workflow_raw_data"]
+    assert is_json_object(workflow_raw_data_value)
+    workflow_raw_data = workflow_raw_data_value
 
-    assert result.keys() == {
+    definition_value = workflow_raw_data["definition"]
+    assert is_json_object(definition_value)
+    definition = definition_value
+
+    assert set(result.keys()) == {
         "workflow_raw_data",
         "input_variables",
         "state_variables",
         "output_variables",
         "triggers",
     }
-    assert workflow_raw_data.keys() == {"nodes", "edges", "display_data", "definition", "output_values"}
-    assert definition["name"] == "TestWorkflow"
+
+    assert set(workflow_raw_data.keys()) == {
+        "nodes",
+        "edges",
+        "display_data",
+        "definition",
+        "output_values",
+    }
+
+    definition_name = definition["name"]
+    assert is_json_str(definition_name)
+    assert definition_name == "TestWorkflow"

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_slack_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_slack_trigger_serialization.py
@@ -1,6 +1,9 @@
 """Tests for serialization of workflows with SlackTrigger."""
 
-from typing import TypeGuard
+try:  # Python 3.9 compatibility
+    from typing import TypeGuard
+except ImportError:  # pragma: no cover - fallback for older runtimes
+    from typing_extensions import TypeGuard  # type: ignore[assignment]
 
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.inputs.base import BaseInputs

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -26,6 +26,7 @@ from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference, WorkflowInputReference
 from vellum.workflows.state.encoder import DefaultStateEncoder
 from vellum.workflows.triggers.base import BaseTrigger
+from vellum.workflows.triggers.integration import IntegrationTrigger
 from vellum.workflows.types.core import Json, JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.types.utils import get_original_base
@@ -446,8 +447,6 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
         Returns:
             JsonArray with output definitions, or None if trigger has no outputs
         """
-        from vellum.workflows.triggers.integration import IntegrationTrigger
-
         # Only integration triggers have outputs
         if not issubclass(trigger_class, IntegrationTrigger):
             return None

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -25,8 +25,6 @@ from vellum.workflows.nodes.utils import get_unadorned_node, get_unadorned_port,
 from vellum.workflows.ports import Port
 from vellum.workflows.references import OutputReference, WorkflowInputReference
 from vellum.workflows.state.encoder import DefaultStateEncoder
-from vellum.workflows.triggers.base import BaseTrigger
-from vellum.workflows.triggers.integration import IntegrationTrigger
 from vellum.workflows.types.core import Json, JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.types.utils import get_original_base
@@ -437,60 +435,13 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
 
         return result
 
-    def _serialize_trigger_outputs(self, trigger_class: Type["BaseTrigger"]) -> Optional[JsonArray]:
-        """
-        Serialize trigger outputs for integration triggers.
-
-        Args:
-            trigger_class: The trigger class to serialize outputs for
-
-        Returns:
-            JsonArray with output definitions, or None if trigger has no outputs
-        """
-        # Only integration triggers have outputs
-        if not issubclass(trigger_class, IntegrationTrigger):
-            return None
-
-        # Check if trigger has class-level annotations (top-level attributes)
-        if not hasattr(trigger_class, "__annotations__"):
-            return None
-
-        # Serialize each output field from top-level attributes
-        outputs: JsonArray = []
-        for field_name, field_type in trigger_class.__annotations__.items():
-            # Skip private/protected attributes
-            if field_name.startswith("_"):
-                continue
-
-            # Map Python types to workflow output types
-            type_str = "STRING"  # Default
-            if "int" in str(field_type).lower():
-                type_str = "NUMBER"
-            elif "bool" in str(field_type).lower():
-                type_str = "BOOLEAN"
-            elif "dict" in str(field_type).lower() or "json" in str(field_type).lower():
-                type_str = "JSON"
-
-            outputs.append(
-                cast(
-                    JsonObject,
-                    {
-                        "name": field_name,
-                        "type": type_str,
-                    },
-                )
-            )
-
-        return outputs if outputs else None
-
     def _serialize_workflow_trigger(self) -> Optional[JsonArray]:
         """
         Serialize workflow-level trigger information.
 
         Returns:
             JsonArray with trigger data if a trigger is present, None otherwise.
-            Each trigger in the array has: id (UUID), type (str), attributes (list),
-            and optionally outputs (for integration triggers)
+            Each trigger in the array has: id (UUID), type (str), attributes (list)
         """
         # Get all trigger edges from the workflow's subgraphs
         trigger_edges = []
@@ -524,18 +475,11 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
         # Return as a list with a single trigger object matching Django schema
         trigger_id = uuid4_from_hash(f"{trigger_class.__module__} | {trigger_class.__qualname__}")
 
-        # Serialize trigger outputs for integration triggers
-        outputs = self._serialize_trigger_outputs(trigger_class)
-
         trigger_data: JsonObject = {
             "id": str(trigger_id),
             "type": trigger_type.value,
             "attributes": [],
         }
-
-        # Add outputs if present (for integration triggers)
-        if outputs:
-            trigger_data["outputs"] = outputs
 
         return cast(JsonArray, [trigger_data])
 

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -29,6 +29,7 @@ from vellum.workflows.types.core import Json, JsonArray, JsonObject
 from vellum.workflows.types.generics import WorkflowType
 from vellum.workflows.types.utils import get_original_base
 from vellum.workflows.utils.uuids import uuid4_from_hash
+from vellum.workflows.utils.vellum_variables import primitive_type_to_vellum_variable_type
 from vellum.workflows.vellum_client import create_vellum_client
 from vellum_ee.workflows.display.base import (
     EdgeDisplay,
@@ -475,6 +476,7 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
         # Return as a list with a single trigger object matching Django schema
         trigger_id = uuid4_from_hash(f"{trigger_class.__module__} | {trigger_class.__qualname__}")
 
+        # Serialize trigger attributes like node outputs
         attribute_references = trigger_class.attribute_references().values()
         trigger_attributes: JsonArray = cast(
             JsonArray,
@@ -484,6 +486,7 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
                     {
                         "id": str(reference.id),
                         "name": reference.name,
+                        "type": primitive_type_to_vellum_variable_type(reference),
                         "value": None,
                     },
                 )

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -475,10 +475,26 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
         # Return as a list with a single trigger object matching Django schema
         trigger_id = uuid4_from_hash(f"{trigger_class.__module__} | {trigger_class.__qualname__}")
 
+        attribute_references = trigger_class.attribute_references().values()
+        trigger_attributes: JsonArray = cast(
+            JsonArray,
+            [
+                cast(
+                    JsonObject,
+                    {
+                        "id": str(reference.id),
+                        "name": reference.name,
+                        "value": None,
+                    },
+                )
+                for reference in sorted(attribute_references, key=lambda ref: ref.name)
+            ],
+        )
+
         trigger_data: JsonObject = {
             "id": str(trigger_id),
             "type": trigger_type.value,
-            "attributes": [],
+            "attributes": trigger_attributes,
         }
 
         return cast(JsonArray, [trigger_data])

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -452,17 +452,17 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
         if not issubclass(trigger_class, IntegrationTrigger):
             return None
 
-        # Check if trigger has Outputs class with annotations
-        if not hasattr(trigger_class, "Outputs"):
+        # Check if trigger has class-level annotations (top-level attributes)
+        if not hasattr(trigger_class, "__annotations__"):
             return None
 
-        outputs_class = trigger_class.Outputs
-        if not hasattr(outputs_class, "__annotations__"):
-            return None
-
-        # Serialize each output field
+        # Serialize each output field from top-level attributes
         outputs: JsonArray = []
-        for field_name, field_type in outputs_class.__annotations__.items():
+        for field_name, field_type in trigger_class.__annotations__.items():
+            # Skip private/protected attributes
+            if field_name.startswith("_"):
+                continue
+
             # Map Python types to workflow output types
             type_str = "STRING"  # Default
             if "int" in str(field_type).lower():

--- a/src/vellum/workflows/references/__init__.py
+++ b/src/vellum/workflows/references/__init__.py
@@ -4,6 +4,7 @@ from .lazy import LazyReference
 from .node import NodeReference
 from .output import OutputReference
 from .state_value import StateValueReference
+from .trigger import TriggerAttributeReference
 from .vellum_secret import VellumSecretReference
 from .workflow_input import WorkflowInputReference
 
@@ -14,6 +15,7 @@ __all__ = [
     "NodeReference",
     "OutputReference",
     "StateValueReference",
+    "TriggerAttributeReference",
     "VellumSecretReference",
     "WorkflowInputReference",
 ]

--- a/src/vellum/workflows/references/trigger.py
+++ b/src/vellum/workflows/references/trigger.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from uuid import UUID, uuid4
+from uuid import UUID
 from typing import TYPE_CHECKING, Any, Generic, Optional, Tuple, Type, TypeVar, cast
 
 from pydantic import GetCoreSchemaHandler
@@ -43,7 +43,11 @@ class TriggerAttributeReference(BaseDescriptor[_T], Generic[_T]):
         attribute_id = attribute_ids.get(self.name)
         if isinstance(attribute_id, UUID):
             return attribute_id
-        return uuid4()
+
+        raise RuntimeError(
+            "Trigger attribute identifiers must be generated at class creation time. "
+            f"Attribute '{self.name}' is not registered on {self._trigger_class.__qualname__}."
+        )
 
     def resolve(self, state: BaseState) -> _T:
         trigger_attributes = getattr(state.meta, "trigger_attributes", {})

--- a/src/vellum/workflows/references/trigger.py
+++ b/src/vellum/workflows/references/trigger.py
@@ -1,0 +1,79 @@
+"""Descriptor for referring to trigger attributes in workflow graphs."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+from typing import TYPE_CHECKING, Any, Generic, Optional, Tuple, Type, TypeVar, cast
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
+from vellum.workflows.descriptors.base import BaseDescriptor
+from vellum.workflows.errors.types import WorkflowErrorCode
+from vellum.workflows.exceptions import NodeException
+
+if TYPE_CHECKING:
+    from vellum.workflows.state.base import BaseState
+    from vellum.workflows.triggers.base import BaseTrigger
+
+_T = TypeVar("_T")
+
+
+class TriggerAttributeReference(BaseDescriptor[_T], Generic[_T]):
+    """Reference to a trigger attribute defined via type annotations."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        types: Tuple[Type[_T], ...],
+        instance: Optional[_T],
+        trigger_class: Type[BaseTrigger],
+    ) -> None:
+        super().__init__(name=name, types=types, instance=instance)
+        self._trigger_class = trigger_class
+
+    @property
+    def trigger_class(self) -> Type[BaseTrigger]:
+        return self._trigger_class
+
+    @property
+    def id(self) -> UUID:
+        attribute_ids = getattr(self._trigger_class, "__trigger_attribute_ids__", {})
+        attribute_id = attribute_ids.get(self.name)
+        if isinstance(attribute_id, UUID):
+            return attribute_id
+        return uuid4()
+
+    def resolve(self, state: BaseState) -> _T:
+        trigger_attributes = getattr(state.meta, "trigger_attributes", {})
+        if self in trigger_attributes:
+            return cast(_T, trigger_attributes[self])
+
+        if state.meta.parent:
+            return self.resolve(state.meta.parent)
+
+        if type(None) in self.types:
+            return cast(_T, None)
+
+        raise NodeException(
+            message=f"Missing trigger attribute '{self.name}' for {self._trigger_class.__name__}",
+            code=WorkflowErrorCode.INVALID_INPUTS,
+        )
+
+    def __repr__(self) -> str:
+        return f"{self._trigger_class.__qualname__}.{self.name}"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TriggerAttributeReference):
+            return False
+        return super().__eq__(other) and self._trigger_class == other._trigger_class
+
+    def __hash__(self) -> int:
+        return hash((self._trigger_class, self._name))
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Type[Any], handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.is_instance_schema(cls)

--- a/src/vellum/workflows/triggers/__init__.py
+++ b/src/vellum/workflows/triggers/__init__.py
@@ -1,5 +1,6 @@
 from vellum.workflows.triggers.base import BaseTrigger
 from vellum.workflows.triggers.integration import IntegrationTrigger
 from vellum.workflows.triggers.manual import ManualTrigger
+from vellum.workflows.triggers.slack import SlackTrigger
 
-__all__ = ["BaseTrigger", "IntegrationTrigger", "ManualTrigger"]
+__all__ = ["BaseTrigger", "IntegrationTrigger", "ManualTrigger", "SlackTrigger"]

--- a/src/vellum/workflows/triggers/base.py
+++ b/src/vellum/workflows/triggers/base.py
@@ -26,7 +26,7 @@ def _is_annotated(cls: Type, name: str) -> bool:
 class BaseTriggerMeta(ABCMeta):
     def __new__(mcs, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
         cls = super().__new__(mcs, name, bases, dct)
-        trigger_cls = cast("Type[BaseTrigger]", cls)
+        trigger_cls = cast(Type["BaseTrigger"], cls)
 
         attribute_ids: Dict[str, Any] = {}
         for base in bases:
@@ -56,6 +56,7 @@ class BaseTriggerMeta(ABCMeta):
     """
 
     def __getattribute__(cls, name: str) -> Any:
+        trigger_cls = cast(Type["BaseTrigger"], cls)
         if name.startswith("_"):
             return super().__getattribute__(name)
 
@@ -90,7 +91,7 @@ class BaseTriggerMeta(ABCMeta):
                 return base_cache[name]
 
         types = infer_types(cls, name)
-        reference = TriggerAttributeReference(name=name, types=types, instance=attribute, trigger_class=cls)
+        reference = TriggerAttributeReference(name=name, types=types, instance=attribute, trigger_class=trigger_cls)
         cache[name] = reference
         cls.__trigger_attribute_cache__ = cache
         return reference
@@ -136,7 +137,7 @@ class BaseTriggerMeta(ABCMeta):
         from vellum.workflows.nodes.bases.base import BaseNode as BaseNodeClass
 
         # Cast cls to the proper type for TriggerEdge
-        trigger_cls = cast("Type[BaseTrigger]", cls)
+        trigger_cls = cast(Type["BaseTrigger"], cls)
 
         if isinstance(other, set):
             # Trigger >> {NodeA, NodeB}

--- a/src/vellum/workflows/triggers/base.py
+++ b/src/vellum/workflows/triggers/base.py
@@ -1,17 +1,120 @@
 from abc import ABC, ABCMeta
-from typing import TYPE_CHECKING, Any, Type, cast
+import inspect
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Tuple, Type, cast
 
 if TYPE_CHECKING:
     from vellum.workflows.graph.graph import Graph, GraphTarget
+    from vellum.workflows.state.base import BaseState
+
+from vellum.workflows.references.trigger import TriggerAttributeReference
+from vellum.workflows.types.utils import get_class_attr_names, infer_types
+from vellum.workflows.utils.uuids import uuid4_from_hash
+
+
+def _is_annotated(cls: Type, name: str) -> bool:
+    annotations = getattr(cls, "__annotations__", {})
+    if name in annotations:
+        return True
+
+    for base in cls.__bases__:
+        if _is_annotated(base, name):
+            return True
+
+    return False
 
 
 class BaseTriggerMeta(ABCMeta):
+    def __new__(mcs, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
+        cls = super().__new__(mcs, name, bases, dct)
+        trigger_cls = cast("Type[BaseTrigger]", cls)
+
+        attribute_ids: Dict[str, Any] = {}
+        for base in bases:
+            base_ids = getattr(base, "__trigger_attribute_ids__", None)
+            if isinstance(base_ids, dict):
+                attribute_ids.update(base_ids)
+
+        annotations = getattr(trigger_cls, "__annotations__", {})
+        for attr_name in annotations:
+            if attr_name.startswith("_"):
+                continue
+            if attr_name in trigger_cls.__dict__:
+                continue
+            attribute_ids[attr_name] = uuid4_from_hash(
+                f"{trigger_cls.__module__}|{trigger_cls.__qualname__}|{attr_name}"
+            )
+
+        trigger_cls.__trigger_attribute_ids__ = attribute_ids
+        trigger_cls.__trigger_attribute_cache__ = {}
+        return trigger_cls
+
     """
     Metaclass for BaseTrigger that enables class-level >> operator.
 
     This allows triggers to be used at the class level, similar to nodes:
         ManualTrigger >> MyNode  # Class-level, no instantiation
     """
+
+    def __getattribute__(cls, name: str) -> Any:
+        if name.startswith("_"):
+            return super().__getattribute__(name)
+
+        try:
+            attribute = super().__getattribute__(name)
+        except AttributeError as exc:
+            if _is_annotated(cls, name):
+                attribute = None
+            else:
+                raise exc
+
+        if inspect.isroutine(attribute) or isinstance(attribute, (property, classmethod, staticmethod)):
+            return attribute
+
+        if isinstance(attribute, TriggerAttributeReference):
+            return attribute
+
+        if name in cls.__dict__:
+            return attribute
+
+        if not _is_annotated(cls, name):
+            return attribute
+
+        cache = getattr(cls, "__trigger_attribute_cache__", {})
+        if name in cache:
+            return cache[name]
+
+        for base in cls.__mro__[1:]:
+            base_cache = getattr(base, "__trigger_attribute_cache__", None)
+            if base_cache and name in base_cache:
+                cache[name] = base_cache[name]
+                return base_cache[name]
+
+        types = infer_types(cls, name)
+        reference = TriggerAttributeReference(name=name, types=types, instance=attribute, trigger_class=cls)
+        cache[name] = reference
+        cls.__trigger_attribute_cache__ = cache
+        return reference
+
+    def __iter__(cls) -> Iterator[TriggerAttributeReference]:
+        cache = getattr(cls, "__trigger_attribute_cache__", {})
+        seen: Dict[str, TriggerAttributeReference] = dict(cache)
+
+        for base in cls.__mro__[1:]:
+            base_cache = getattr(base, "__trigger_attribute_cache__", None)
+            if not base_cache:
+                continue
+            for key, value in base_cache.items():
+                seen.setdefault(key, value)
+
+        for attr_name in get_class_attr_names(cls):
+            if attr_name in seen:
+                yield seen[attr_name]
+                continue
+
+            attr_value = getattr(cls, attr_name)
+            if isinstance(attr_value, TriggerAttributeReference):
+                seen[attr_name] = attr_value
+                yield attr_value
 
     def __rshift__(cls, other: "GraphTarget") -> "Graph":  # type: ignore[misc]
         """
@@ -122,4 +225,32 @@ class BaseTrigger(ABC, metaclass=BaseTriggerMeta):
         Like nodes, triggers work at the class level only. Do not instantiate triggers.
     """
 
-    pass
+    __trigger_attribute_ids__: Dict[str, Any]
+    __trigger_attribute_cache__: Dict[str, "TriggerAttributeReference[Any]"]
+
+    @classmethod
+    def attribute_references(cls) -> Dict[str, "TriggerAttributeReference[Any]"]:
+        """Return class-level trigger attribute descriptors keyed by attribute name."""
+
+        return {reference.name: reference for reference in cls}
+
+    def to_trigger_attribute_values(self) -> Dict["TriggerAttributeReference[Any]", Any]:
+        """Materialize attribute descriptor/value pairs for this trigger instance."""
+
+        attribute_values: Dict["TriggerAttributeReference[Any]", Any] = {}
+        for reference in type(self):
+            if hasattr(self, reference.name):
+                attribute_values[reference] = getattr(self, reference.name)
+            elif type(None) in reference.types:
+                attribute_values[reference] = None
+            else:
+                raise AttributeError(
+                    f"{type(self).__name__} did not populate required trigger attribute '{reference.name}'"
+                )
+
+        return attribute_values
+
+    def bind_to_state(self, state: "BaseState") -> None:
+        """Persist this trigger's attribute values onto the provided state."""
+
+        state.meta.trigger_attributes.update(self.to_trigger_attribute_values())

--- a/src/vellum/workflows/triggers/integration.py
+++ b/src/vellum/workflows/triggers/integration.py
@@ -18,11 +18,9 @@ class IntegrationTrigger(BaseTrigger, ABC):
         class MyIntegrationTrigger(IntegrationTrigger):
             data: str
 
-            @classmethod
-            def process_event(cls, event_data: dict):
-                trigger = cls()
-                trigger.data = event_data.get("data", "")
-                return trigger
+            def __init__(self, event_data: dict):
+                super().__init__(event_data)
+                self.data = event_data.get("data", "")
 
         # Use in workflow
         class MyWorkflow(BaseWorkflow):
@@ -41,22 +39,27 @@ class IntegrationTrigger(BaseTrigger, ABC):
     # Configuration that can be set at runtime
     config: ClassVar[Optional[dict]] = None
 
-    @classmethod
-    def process_event(cls, event_data: dict) -> "IntegrationTrigger":
+    def __init__(self, event_data: dict):
         """
-        Process incoming webhook/event data and return trigger instance.
+        Initialize trigger with event data from external system.
 
-        This method should be implemented by subclasses to parse external
-        event payloads (e.g., Slack webhooks, email notifications) into
-        a trigger instance with populated attributes.
+        Subclasses should override this method to parse external
+        event payloads (e.g., Slack webhooks, email notifications) and
+        populate trigger attributes.
 
         Args:
             event_data: Raw event data from the external system
 
-        Returns:
-            Trigger instance with attributes populated from parsed event data
-
-        Raises:
-            NotImplementedError: If subclass doesn't implement this method
+        Examples:
+            >>> class MyTrigger(IntegrationTrigger):
+            ...     data: str
+            ...
+            ...     def __init__(self, event_data: dict):
+            ...         super().__init__(event_data)
+            ...         self.data = event_data.get("data", "")
+            >>>
+            >>> trigger = MyTrigger({"data": "hello"})
+            >>> trigger.data
+            'hello'
         """
-        raise NotImplementedError(f"{cls.__name__} must implement process_event() method to handle external events")
+        self._event_data = event_data

--- a/src/vellum/workflows/triggers/integration.py
+++ b/src/vellum/workflows/triggers/integration.py
@@ -1,7 +1,6 @@
 from abc import ABC
 from typing import ClassVar, Optional
 
-from vellum.workflows.outputs.base import BaseOutputs
 from vellum.workflows.triggers.base import BaseTrigger
 
 
@@ -11,50 +10,51 @@ class IntegrationTrigger(BaseTrigger, ABC):
 
     Integration triggers:
     - Are initiated by external events (webhooks, API calls)
-    - Produce outputs that downstream nodes can reference
+    - Produce attributes that downstream nodes can reference
     - Require configuration (auth, webhooks, etc.)
 
     Examples:
         # Define an integration trigger
         class MyIntegrationTrigger(IntegrationTrigger):
-            class Outputs(IntegrationTrigger.Outputs):
-                data: str
+            data: str
 
             @classmethod
             def process_event(cls, event_data: dict):
-                return cls.Outputs(data=event_data.get("data", ""))
+                trigger = cls()
+                trigger.data = event_data.get("data", "")
+                return trigger
 
         # Use in workflow
         class MyWorkflow(BaseWorkflow):
             graph = MyIntegrationTrigger >> ProcessNode
 
+        # Reference trigger attributes in nodes
+        class ProcessNode(BaseNode):
+            class Outputs(BaseNode.Outputs):
+                result = MyIntegrationTrigger.data
+
     Note:
-        Unlike ManualTrigger, integration triggers provide structured outputs
-        that downstream nodes can reference directly via Outputs.
+        Unlike ManualTrigger, integration triggers provide structured attributes
+        that downstream nodes can reference directly.
     """
-
-    class Outputs(BaseOutputs):
-        """Base outputs for integration triggers."""
-
-        pass
 
     # Configuration that can be set at runtime
     config: ClassVar[Optional[dict]] = None
 
     @classmethod
-    def process_event(cls, event_data: dict) -> "IntegrationTrigger.Outputs":
+    def process_event(cls, event_data: dict) -> "IntegrationTrigger":
         """
-        Process incoming webhook/event data and return trigger outputs.
+        Process incoming webhook/event data and return trigger instance.
 
         This method should be implemented by subclasses to parse external
         event payloads (e.g., Slack webhooks, email notifications) into
-        structured trigger outputs.
+        a trigger instance with populated attributes.
 
         Args:
             event_data: Raw event data from the external system
 
         Returns:
-            Trigger outputs containing parsed event data
+            Trigger instance with attributes populated from parsed event data
 
         Raises:
             NotImplementedError: If subclass doesn't implement this method

--- a/src/vellum/workflows/triggers/integration.py
+++ b/src/vellum/workflows/triggers/integration.py
@@ -59,7 +59,9 @@ class IntegrationTrigger(BaseTrigger, ABC):
             ...         self.data = event_data.get("data", "")
             >>>
             >>> trigger = MyTrigger({"data": "hello"})
-            >>> trigger.data
+            >>> state = workflow.get_default_state()
+            >>> trigger.bind_to_state(state)
+            >>> MyTrigger.data.resolve(state)
             'hello'
         """
         self._event_data = event_data

--- a/src/vellum/workflows/triggers/integration.py
+++ b/src/vellum/workflows/triggers/integration.py
@@ -18,9 +18,11 @@ class IntegrationTrigger(BaseTrigger, ABC):
         class MyIntegrationTrigger(IntegrationTrigger):
             data: str
 
-            def __init__(self, event_data: dict):
-                super().__init__(event_data)
-                self.data = event_data.get("data", "")
+            @classmethod
+            def process_event(cls, event_data: dict):
+                trigger = cls()
+                trigger.data = event_data.get("data", "")
+                return trigger
 
         # Use in workflow
         class MyWorkflow(BaseWorkflow):
@@ -39,27 +41,22 @@ class IntegrationTrigger(BaseTrigger, ABC):
     # Configuration that can be set at runtime
     config: ClassVar[Optional[dict]] = None
 
-    def __init__(self, event_data: dict):
+    @classmethod
+    def process_event(cls, event_data: dict) -> "IntegrationTrigger":
         """
-        Initialize trigger with event data from external system.
+        Process incoming webhook/event data and return trigger instance.
 
-        Subclasses should override this method to parse external
-        event payloads (e.g., Slack webhooks, email notifications) and
-        populate trigger attributes.
+        This method should be implemented by subclasses to parse external
+        event payloads (e.g., Slack webhooks, email notifications) into
+        a trigger instance with populated attributes.
 
         Args:
             event_data: Raw event data from the external system
 
-        Examples:
-            >>> class MyTrigger(IntegrationTrigger):
-            ...     data: str
-            ...
-            ...     def __init__(self, event_data: dict):
-            ...         super().__init__(event_data)
-            ...         self.data = event_data.get("data", "")
-            >>>
-            >>> trigger = MyTrigger({"data": "hello"})
-            >>> trigger.data
-            'hello'
+        Returns:
+            Trigger instance with attributes populated from parsed event data
+
+        Raises:
+            NotImplementedError: If subclass doesn't implement this method
         """
-        self._event_data = event_data
+        raise NotImplementedError(f"{cls.__name__} must implement process_event() method to handle external events")

--- a/src/vellum/workflows/triggers/slack.py
+++ b/src/vellum/workflows/triggers/slack.py
@@ -55,10 +55,9 @@ class SlackTrigger(IntegrationTrigger):
     thread_ts: Optional[str]
     event_type: str
 
-    @classmethod
-    def process_event(cls, event_data: dict) -> "SlackTrigger":
+    def __init__(self, event_data: dict):
         """
-        Parse Slack webhook payload into trigger instance.
+        Initialize SlackTrigger with Slack webhook payload.
 
         Args:
             event_data: Slack event payload from webhook. Expected structure:
@@ -73,9 +72,6 @@ class SlackTrigger(IntegrationTrigger):
                     }
                 }
 
-        Returns:
-            SlackTrigger instance with parsed data from the Slack event
-
         Examples:
             >>> slack_payload = {
             ...     "event": {
@@ -86,20 +82,20 @@ class SlackTrigger(IntegrationTrigger):
             ...         "ts": "1234567890.123456"
             ...     }
             ... }
-            >>> trigger = SlackTrigger.process_event(slack_payload)
+            >>> trigger = SlackTrigger(slack_payload)
             >>> trigger.message
             'Hello!'
         """
+        # Call parent init
+        super().__init__(event_data)
+
         # Extract from Slack's event structure
         event = event_data.get("event", {})
 
-        # Create trigger instance and populate attributes
-        trigger = cls()
-        trigger.message = event.get("text", "")
-        trigger.channel = event.get("channel", "")
-        trigger.user = event.get("user", "")
-        trigger.timestamp = event.get("ts", "")
-        trigger.thread_ts = event.get("thread_ts")
-        trigger.event_type = event.get("type", "message")
-
-        return trigger
+        # Populate trigger attributes
+        self.message = event.get("text", "")
+        self.channel = event.get("channel", "")
+        self.user = event.get("user", "")
+        self.timestamp = event.get("ts", "")
+        self.thread_ts = event.get("thread_ts")
+        self.event_type = event.get("type", "message")

--- a/src/vellum/workflows/triggers/slack.py
+++ b/src/vellum/workflows/triggers/slack.py
@@ -55,9 +55,10 @@ class SlackTrigger(IntegrationTrigger):
     thread_ts: Optional[str]
     event_type: str
 
-    def __init__(self, event_data: dict):
+    @classmethod
+    def process_event(cls, event_data: dict) -> "SlackTrigger":
         """
-        Initialize SlackTrigger with Slack webhook payload.
+        Parse Slack webhook payload into trigger instance.
 
         Args:
             event_data: Slack event payload from webhook. Expected structure:
@@ -72,6 +73,9 @@ class SlackTrigger(IntegrationTrigger):
                     }
                 }
 
+        Returns:
+            SlackTrigger instance with parsed data from the Slack event
+
         Examples:
             >>> slack_payload = {
             ...     "event": {
@@ -82,20 +86,20 @@ class SlackTrigger(IntegrationTrigger):
             ...         "ts": "1234567890.123456"
             ...     }
             ... }
-            >>> trigger = SlackTrigger(slack_payload)
+            >>> trigger = SlackTrigger.process_event(slack_payload)
             >>> trigger.message
             'Hello!'
         """
-        # Call parent init
-        super().__init__(event_data)
-
         # Extract from Slack's event structure
         event = event_data.get("event", {})
 
-        # Populate trigger attributes
-        self.message = event.get("text", "")
-        self.channel = event.get("channel", "")
-        self.user = event.get("user", "")
-        self.timestamp = event.get("ts", "")
-        self.thread_ts = event.get("thread_ts")
-        self.event_type = event.get("type", "message")
+        # Create trigger instance and populate attributes
+        trigger = cls()
+        trigger.message = event.get("text", "")
+        trigger.channel = event.get("channel", "")
+        trigger.user = event.get("user", "")
+        trigger.timestamp = event.get("ts", "")
+        trigger.thread_ts = event.get("thread_ts")
+        trigger.event_type = event.get("type", "message")
+
+        return trigger

--- a/src/vellum/workflows/triggers/slack.py
+++ b/src/vellum/workflows/triggers/slack.py
@@ -1,0 +1,104 @@
+from typing import Optional
+
+from vellum.workflows.triggers.integration import IntegrationTrigger
+
+
+class SlackTrigger(IntegrationTrigger):
+    """
+    Trigger for Slack events (messages, mentions, reactions, etc.).
+
+    SlackTrigger enables workflows to be initiated from Slack events such as
+    messages in channels, direct messages, app mentions, or reactions. The trigger
+    parses Slack webhook payloads and provides structured outputs that downstream
+    nodes can reference.
+
+    Examples:
+        Basic Slack message trigger:
+            >>> class MyWorkflow(BaseWorkflow):
+            ...     graph = SlackTrigger >> ProcessMessageNode
+
+        Access trigger outputs in nodes:
+            >>> class ProcessMessageNode(BaseNode):
+            ...     class Outputs(BaseNode.Outputs):
+            ...         response = SlackTrigger.Outputs.message
+
+        Multiple entry points:
+            >>> class MyWorkflow(BaseWorkflow):
+            ...     graph = {
+            ...         SlackTrigger >> ProcessSlackNode,
+            ...         ManualTrigger >> ProcessManualNode,
+            ...     }
+
+    Outputs:
+        message: str
+            The message text from Slack
+        channel: str
+            Slack channel ID where message was sent
+        user: str
+            User ID who sent the message
+        timestamp: str
+            Message timestamp (ts field from Slack)
+        thread_ts: Optional[str]
+            Thread timestamp if message is in a thread, None otherwise
+        event_type: str
+            Type of Slack event (e.g., "message", "app_mention")
+
+    Note:
+        The trigger expects Slack Event API webhook payloads. For details on
+        the payload structure, see: https://api.slack.com/apis/connections/events-api
+    """
+
+    class Outputs(IntegrationTrigger.Outputs):
+        message: str
+        channel: str
+        user: str
+        timestamp: str
+        thread_ts: Optional[str]
+        event_type: str
+
+    @classmethod
+    def process_event(cls, event_data: dict) -> "SlackTrigger.Outputs":
+        """
+        Parse Slack webhook payload into trigger outputs.
+
+        Args:
+            event_data: Slack event payload from webhook. Expected structure:
+                {
+                    "event": {
+                        "type": "message",
+                        "text": "Hello world",
+                        "channel": "C123456",
+                        "user": "U123456",
+                        "ts": "1234567890.123456",
+                        "thread_ts": "1234567890.123456"  # optional
+                    }
+                }
+
+        Returns:
+            SlackTrigger.Outputs with parsed data from the Slack event
+
+        Examples:
+            >>> slack_payload = {
+            ...     "event": {
+            ...         "type": "message",
+            ...         "text": "Hello!",
+            ...         "channel": "C123",
+            ...         "user": "U456",
+            ...         "ts": "1234567890.123456"
+            ...     }
+            ... }
+            >>> outputs = SlackTrigger.process_event(slack_payload)
+            >>> outputs.message
+            'Hello!'
+        """
+        # Extract from Slack's event structure
+        event = event_data.get("event", {})
+
+        return cls.Outputs(
+            message=event.get("text", ""),
+            channel=event.get("channel", ""),
+            user=event.get("user", ""),
+            timestamp=event.get("ts", ""),
+            thread_ts=event.get("thread_ts"),
+            event_type=event.get("type", "message"),
+        )

--- a/src/vellum/workflows/triggers/tests/test_integration.py
+++ b/src/vellum/workflows/triggers/tests/test_integration.py
@@ -1,16 +1,17 @@
 """Tests for IntegrationTrigger base class."""
 
+import pytest
+
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.triggers.integration import IntegrationTrigger
 
 
-def test_integration_trigger__can_be_instantiated_as_base():
-    """IntegrationTrigger can be instantiated as a base class."""
-    # WHEN we instantiate IntegrationTrigger directly
-    trigger = IntegrationTrigger({"test": "data"})
-
-    # THEN it creates an instance with event data stored
-    assert trigger._event_data == {"test": "data"}
+def test_integration_trigger__is_abstract():
+    """IntegrationTrigger cannot be instantiated directly (ABC)."""
+    # WHEN we try to call process_event on IntegrationTrigger directly
+    # THEN it raises NotImplementedError
+    with pytest.raises(NotImplementedError, match="must implement process_event"):
+        IntegrationTrigger.process_event({})
 
 
 def test_integration_trigger__can_be_instantiated():
@@ -31,12 +32,14 @@ def test_integration_trigger__can_be_subclassed():
     class TestTrigger(IntegrationTrigger):
         data: str
 
-        def __init__(self, event_data: dict):
-            super().__init__(event_data)
-            self.data = event_data.get("data", "")
+        @classmethod
+        def process_event(cls, event_data: dict):
+            trigger = cls()
+            trigger.data = event_data.get("data", "")
+            return trigger
 
-    # WHEN we create a trigger instance
-    result = TestTrigger({"data": "test"})
+    # WHEN we process an event
+    result = TestTrigger.process_event({"data": "test"})
 
     # THEN it returns the expected trigger instance with populated attributes
     assert result.data == "test"
@@ -49,9 +52,11 @@ def test_integration_trigger__graph_syntax():
     class TestTrigger(IntegrationTrigger):
         value: str
 
-        def __init__(self, event_data: dict):
-            super().__init__(event_data)
-            self.value = event_data.get("value", "")
+        @classmethod
+        def process_event(cls, event_data: dict):
+            trigger = cls()
+            trigger.value = event_data.get("value", "")
+            return trigger
 
     class TestNode(BaseNode):
         pass
@@ -73,9 +78,11 @@ def test_integration_trigger__multiple_entrypoints():
     class TestTrigger(IntegrationTrigger):
         msg: str
 
-        def __init__(self, event_data: dict):
-            super().__init__(event_data)
-            self.msg = event_data.get("msg", "")
+        @classmethod
+        def process_event(cls, event_data: dict):
+            trigger = cls()
+            trigger.msg = event_data.get("msg", "")
+            return trigger
 
     class NodeA(BaseNode):
         pass

--- a/src/vellum/workflows/triggers/tests/test_integration.py
+++ b/src/vellum/workflows/triggers/tests/test_integration.py
@@ -14,11 +14,15 @@ def test_integration_trigger__is_abstract():
         IntegrationTrigger.process_event({})
 
 
-def test_integration_trigger__outputs_class_exists():
-    """IntegrationTrigger has Outputs class."""
-    # GIVEN IntegrationTrigger
-    # THEN it has an Outputs class
-    assert hasattr(IntegrationTrigger, "Outputs")
+def test_integration_trigger__can_be_instantiated():
+    """IntegrationTrigger can be instantiated for testing."""
+
+    # GIVEN IntegrationTrigger with concrete implementation
+    class TestTrigger(IntegrationTrigger):
+        pass
+
+    # THEN it can be instantiated (even though base is ABC, concrete subclasses work)
+    assert TestTrigger is not None
 
 
 def test_integration_trigger__can_be_subclassed():
@@ -26,17 +30,18 @@ def test_integration_trigger__can_be_subclassed():
 
     # GIVEN a concrete implementation of IntegrationTrigger
     class TestTrigger(IntegrationTrigger):
-        class Outputs(IntegrationTrigger.Outputs):
-            data: str
+        data: str
 
         @classmethod
         def process_event(cls, event_data: dict):
-            return cls.Outputs(data=event_data.get("data", ""))
+            trigger = cls()
+            trigger.data = event_data.get("data", "")
+            return trigger
 
     # WHEN we process an event
     result = TestTrigger.process_event({"data": "test"})
 
-    # THEN it returns the expected outputs
+    # THEN it returns the expected trigger instance with populated attributes
     assert result.data == "test"
 
 
@@ -45,12 +50,13 @@ def test_integration_trigger__graph_syntax():
 
     # GIVEN a concrete trigger and a node
     class TestTrigger(IntegrationTrigger):
-        class Outputs(IntegrationTrigger.Outputs):
-            value: str
+        value: str
 
         @classmethod
         def process_event(cls, event_data: dict):
-            return cls.Outputs(value=event_data.get("value", ""))
+            trigger = cls()
+            trigger.value = event_data.get("value", "")
+            return trigger
 
     class TestNode(BaseNode):
         pass
@@ -70,12 +76,13 @@ def test_integration_trigger__multiple_entrypoints():
 
     # GIVEN a trigger and multiple nodes
     class TestTrigger(IntegrationTrigger):
-        class Outputs(IntegrationTrigger.Outputs):
-            msg: str
+        msg: str
 
         @classmethod
         def process_event(cls, event_data: dict):
-            return cls.Outputs(msg=event_data.get("msg", ""))
+            trigger = cls()
+            trigger.msg = event_data.get("msg", "")
+            return trigger
 
     class NodeA(BaseNode):
         pass

--- a/src/vellum/workflows/triggers/tests/test_integration.py
+++ b/src/vellum/workflows/triggers/tests/test_integration.py
@@ -1,17 +1,16 @@
 """Tests for IntegrationTrigger base class."""
 
-import pytest
-
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.triggers.integration import IntegrationTrigger
 
 
-def test_integration_trigger__is_abstract():
-    """IntegrationTrigger cannot be instantiated directly (ABC)."""
-    # WHEN we try to call process_event on IntegrationTrigger directly
-    # THEN it raises NotImplementedError
-    with pytest.raises(NotImplementedError, match="must implement process_event"):
-        IntegrationTrigger.process_event({})
+def test_integration_trigger__can_be_instantiated_as_base():
+    """IntegrationTrigger can be instantiated as a base class."""
+    # WHEN we instantiate IntegrationTrigger directly
+    trigger = IntegrationTrigger({"test": "data"})
+
+    # THEN it creates an instance with event data stored
+    assert trigger._event_data == {"test": "data"}
 
 
 def test_integration_trigger__can_be_instantiated():
@@ -32,14 +31,12 @@ def test_integration_trigger__can_be_subclassed():
     class TestTrigger(IntegrationTrigger):
         data: str
 
-        @classmethod
-        def process_event(cls, event_data: dict):
-            trigger = cls()
-            trigger.data = event_data.get("data", "")
-            return trigger
+        def __init__(self, event_data: dict):
+            super().__init__(event_data)
+            self.data = event_data.get("data", "")
 
-    # WHEN we process an event
-    result = TestTrigger.process_event({"data": "test"})
+    # WHEN we create a trigger instance
+    result = TestTrigger({"data": "test"})
 
     # THEN it returns the expected trigger instance with populated attributes
     assert result.data == "test"
@@ -52,11 +49,9 @@ def test_integration_trigger__graph_syntax():
     class TestTrigger(IntegrationTrigger):
         value: str
 
-        @classmethod
-        def process_event(cls, event_data: dict):
-            trigger = cls()
-            trigger.value = event_data.get("value", "")
-            return trigger
+        def __init__(self, event_data: dict):
+            super().__init__(event_data)
+            self.value = event_data.get("value", "")
 
     class TestNode(BaseNode):
         pass
@@ -78,11 +73,9 @@ def test_integration_trigger__multiple_entrypoints():
     class TestTrigger(IntegrationTrigger):
         msg: str
 
-        @classmethod
-        def process_event(cls, event_data: dict):
-            trigger = cls()
-            trigger.msg = event_data.get("msg", "")
-            return trigger
+        def __init__(self, event_data: dict):
+            super().__init__(event_data)
+            self.msg = event_data.get("msg", "")
 
     class NodeA(BaseNode):
         pass

--- a/src/vellum/workflows/triggers/tests/test_slack.py
+++ b/src/vellum/workflows/triggers/tests/test_slack.py
@@ -4,8 +4,8 @@ from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.triggers.slack import SlackTrigger
 
 
-def test_slack_trigger__process_event__basic():
-    """SlackTrigger.process_event parses Slack payload correctly."""
+def test_slack_trigger__basic():
+    """SlackTrigger parses Slack payload correctly."""
     # GIVEN a Slack event payload
     slack_payload = {
         "event": {
@@ -17,8 +17,8 @@ def test_slack_trigger__process_event__basic():
         }
     }
 
-    # WHEN we process the event
-    trigger = SlackTrigger.process_event(slack_payload)
+    # WHEN we create a trigger instance
+    trigger = SlackTrigger(slack_payload)
 
     # THEN trigger attributes contain the correct data
     assert trigger.message == "Hello world!"
@@ -29,8 +29,8 @@ def test_slack_trigger__process_event__basic():
     assert trigger.event_type == "message"
 
 
-def test_slack_trigger__process_event__with_thread():
-    """SlackTrigger.process_event handles threaded messages."""
+def test_slack_trigger__with_thread():
+    """SlackTrigger handles threaded messages."""
     # GIVEN a Slack event payload with thread_ts
     slack_payload = {
         "event": {
@@ -43,20 +43,20 @@ def test_slack_trigger__process_event__with_thread():
         }
     }
 
-    # WHEN we process the event
-    trigger = SlackTrigger.process_event(slack_payload)
+    # WHEN we create a trigger instance
+    trigger = SlackTrigger(slack_payload)
 
     # THEN thread_ts is populated
     assert trigger.thread_ts == "1234567890.123456"
 
 
-def test_slack_trigger__process_event__empty_payload():
-    """SlackTrigger.process_event handles empty payload gracefully."""
+def test_slack_trigger__empty_payload():
+    """SlackTrigger handles empty payload gracefully."""
     # GIVEN an empty payload
     slack_payload: dict[str, str] = {}
 
-    # WHEN we process the event
-    trigger = SlackTrigger.process_event(slack_payload)
+    # WHEN we create a trigger instance
+    trigger = SlackTrigger(slack_payload)
 
     # THEN it returns empty strings for required fields
     assert trigger.message == ""
@@ -67,8 +67,8 @@ def test_slack_trigger__process_event__empty_payload():
     assert trigger.event_type == "message"  # default value
 
 
-def test_slack_trigger__process_event__app_mention():
-    """SlackTrigger.process_event handles app_mention events."""
+def test_slack_trigger__app_mention():
+    """SlackTrigger handles app_mention events."""
     # GIVEN an app_mention event
     slack_payload = {
         "event": {
@@ -80,8 +80,8 @@ def test_slack_trigger__process_event__app_mention():
         }
     }
 
-    # WHEN we process the event
-    trigger = SlackTrigger.process_event(slack_payload)
+    # WHEN we create a trigger instance
+    trigger = SlackTrigger(slack_payload)
 
     # THEN event_type is app_mention
     assert trigger.event_type == "app_mention"

--- a/src/vellum/workflows/triggers/tests/test_slack.py
+++ b/src/vellum/workflows/triggers/tests/test_slack.py
@@ -5,7 +5,7 @@ from vellum.workflows.triggers.slack import SlackTrigger
 
 
 def test_slack_trigger__process_event__basic():
-    """SlackTrigger.process_event parses Slack payload correctly."""
+    """SlackTrigger parses Slack payload correctly."""
     # GIVEN a Slack event payload
     slack_payload = {
         "event": {
@@ -17,8 +17,8 @@ def test_slack_trigger__process_event__basic():
         }
     }
 
-    # WHEN we process the event
-    trigger = SlackTrigger.process_event(slack_payload)
+    # WHEN we create a trigger instance
+    trigger = SlackTrigger(slack_payload)
 
     # THEN trigger attributes contain the correct data
     assert trigger.message == "Hello world!"
@@ -30,7 +30,7 @@ def test_slack_trigger__process_event__basic():
 
 
 def test_slack_trigger__process_event__with_thread():
-    """SlackTrigger.process_event handles threaded messages."""
+    """SlackTrigger handles threaded messages."""
     # GIVEN a Slack event payload with thread_ts
     slack_payload = {
         "event": {
@@ -43,20 +43,20 @@ def test_slack_trigger__process_event__with_thread():
         }
     }
 
-    # WHEN we process the event
-    trigger = SlackTrigger.process_event(slack_payload)
+    # WHEN we create a trigger instance
+    trigger = SlackTrigger(slack_payload)
 
     # THEN thread_ts is populated
     assert trigger.thread_ts == "1234567890.123456"
 
 
 def test_slack_trigger__process_event__empty_payload():
-    """SlackTrigger.process_event handles empty payload gracefully."""
+    """SlackTrigger handles empty payload gracefully."""
     # GIVEN an empty payload
     slack_payload: dict[str, str] = {}
 
-    # WHEN we process the event
-    trigger = SlackTrigger.process_event(slack_payload)
+    # WHEN we create a trigger instance
+    trigger = SlackTrigger(slack_payload)
 
     # THEN it returns empty strings for required fields
     assert trigger.message == ""
@@ -68,7 +68,7 @@ def test_slack_trigger__process_event__empty_payload():
 
 
 def test_slack_trigger__process_event__app_mention():
-    """SlackTrigger.process_event handles app_mention events."""
+    """SlackTrigger handles app_mention events."""
     # GIVEN an app_mention event
     slack_payload = {
         "event": {
@@ -80,8 +80,8 @@ def test_slack_trigger__process_event__app_mention():
         }
     }
 
-    # WHEN we process the event
-    trigger = SlackTrigger.process_event(slack_payload)
+    # WHEN we create a trigger instance
+    trigger = SlackTrigger(slack_payload)
 
     # THEN event_type is app_mention
     assert trigger.event_type == "app_mention"

--- a/src/vellum/workflows/triggers/tests/test_slack.py
+++ b/src/vellum/workflows/triggers/tests/test_slack.py
@@ -53,7 +53,7 @@ def test_slack_trigger__process_event__with_thread():
 def test_slack_trigger__process_event__empty_payload():
     """SlackTrigger.process_event handles empty payload gracefully."""
     # GIVEN an empty payload
-    slack_payload = {}
+    slack_payload: dict[str, str] = {}
 
     # WHEN we process the event
     outputs = SlackTrigger.process_event(slack_payload)

--- a/src/vellum/workflows/triggers/tests/test_slack.py
+++ b/src/vellum/workflows/triggers/tests/test_slack.py
@@ -18,15 +18,15 @@ def test_slack_trigger__process_event__basic():
     }
 
     # WHEN we process the event
-    outputs = SlackTrigger.process_event(slack_payload)
+    trigger = SlackTrigger.process_event(slack_payload)
 
-    # THEN outputs contain the correct data
-    assert outputs.message == "Hello world!"
-    assert outputs.channel == "C123456"
-    assert outputs.user == "U123456"
-    assert outputs.timestamp == "1234567890.123456"
-    assert outputs.thread_ts is None
-    assert outputs.event_type == "message"
+    # THEN trigger attributes contain the correct data
+    assert trigger.message == "Hello world!"
+    assert trigger.channel == "C123456"
+    assert trigger.user == "U123456"
+    assert trigger.timestamp == "1234567890.123456"
+    assert trigger.thread_ts is None
+    assert trigger.event_type == "message"
 
 
 def test_slack_trigger__process_event__with_thread():
@@ -44,10 +44,10 @@ def test_slack_trigger__process_event__with_thread():
     }
 
     # WHEN we process the event
-    outputs = SlackTrigger.process_event(slack_payload)
+    trigger = SlackTrigger.process_event(slack_payload)
 
     # THEN thread_ts is populated
-    assert outputs.thread_ts == "1234567890.123456"
+    assert trigger.thread_ts == "1234567890.123456"
 
 
 def test_slack_trigger__process_event__empty_payload():
@@ -56,15 +56,15 @@ def test_slack_trigger__process_event__empty_payload():
     slack_payload: dict[str, str] = {}
 
     # WHEN we process the event
-    outputs = SlackTrigger.process_event(slack_payload)
+    trigger = SlackTrigger.process_event(slack_payload)
 
     # THEN it returns empty strings for required fields
-    assert outputs.message == ""
-    assert outputs.channel == ""
-    assert outputs.user == ""
-    assert outputs.timestamp == ""
-    assert outputs.thread_ts is None
-    assert outputs.event_type == "message"  # default value
+    assert trigger.message == ""
+    assert trigger.channel == ""
+    assert trigger.user == ""
+    assert trigger.timestamp == ""
+    assert trigger.thread_ts is None
+    assert trigger.event_type == "message"  # default value
 
 
 def test_slack_trigger__process_event__app_mention():
@@ -81,19 +81,19 @@ def test_slack_trigger__process_event__app_mention():
     }
 
     # WHEN we process the event
-    outputs = SlackTrigger.process_event(slack_payload)
+    trigger = SlackTrigger.process_event(slack_payload)
 
     # THEN event_type is app_mention
-    assert outputs.event_type == "app_mention"
-    assert outputs.message == "<@U0LAN0Z89> is it everything a river should be?"
+    assert trigger.event_type == "app_mention"
+    assert trigger.message == "<@U0LAN0Z89> is it everything a river should be?"
 
 
-def test_slack_trigger__outputs_class():
-    """SlackTrigger.Outputs has correct fields."""
-    # GIVEN SlackTrigger.Outputs
-    # THEN it has all expected fields
-    assert hasattr(SlackTrigger.Outputs, "__annotations__")
-    annotations = SlackTrigger.Outputs.__annotations__
+def test_slack_trigger__attributes():
+    """SlackTrigger has correct attributes."""
+    # GIVEN SlackTrigger class
+    # THEN it has all expected fields as top-level attributes
+    assert hasattr(SlackTrigger, "__annotations__")
+    annotations = SlackTrigger.__annotations__
     assert "message" in annotations
     assert "channel" in annotations
     assert "user" in annotations

--- a/src/vellum/workflows/triggers/tests/test_slack.py
+++ b/src/vellum/workflows/triggers/tests/test_slack.py
@@ -5,7 +5,7 @@ from vellum.workflows.triggers.slack import SlackTrigger
 
 
 def test_slack_trigger__process_event__basic():
-    """SlackTrigger parses Slack payload correctly."""
+    """SlackTrigger.process_event parses Slack payload correctly."""
     # GIVEN a Slack event payload
     slack_payload = {
         "event": {
@@ -17,8 +17,8 @@ def test_slack_trigger__process_event__basic():
         }
     }
 
-    # WHEN we create a trigger instance
-    trigger = SlackTrigger(slack_payload)
+    # WHEN we process the event
+    trigger = SlackTrigger.process_event(slack_payload)
 
     # THEN trigger attributes contain the correct data
     assert trigger.message == "Hello world!"
@@ -30,7 +30,7 @@ def test_slack_trigger__process_event__basic():
 
 
 def test_slack_trigger__process_event__with_thread():
-    """SlackTrigger handles threaded messages."""
+    """SlackTrigger.process_event handles threaded messages."""
     # GIVEN a Slack event payload with thread_ts
     slack_payload = {
         "event": {
@@ -43,20 +43,20 @@ def test_slack_trigger__process_event__with_thread():
         }
     }
 
-    # WHEN we create a trigger instance
-    trigger = SlackTrigger(slack_payload)
+    # WHEN we process the event
+    trigger = SlackTrigger.process_event(slack_payload)
 
     # THEN thread_ts is populated
     assert trigger.thread_ts == "1234567890.123456"
 
 
 def test_slack_trigger__process_event__empty_payload():
-    """SlackTrigger handles empty payload gracefully."""
+    """SlackTrigger.process_event handles empty payload gracefully."""
     # GIVEN an empty payload
     slack_payload: dict[str, str] = {}
 
-    # WHEN we create a trigger instance
-    trigger = SlackTrigger(slack_payload)
+    # WHEN we process the event
+    trigger = SlackTrigger.process_event(slack_payload)
 
     # THEN it returns empty strings for required fields
     assert trigger.message == ""
@@ -68,7 +68,7 @@ def test_slack_trigger__process_event__empty_payload():
 
 
 def test_slack_trigger__process_event__app_mention():
-    """SlackTrigger handles app_mention events."""
+    """SlackTrigger.process_event handles app_mention events."""
     # GIVEN an app_mention event
     slack_payload = {
         "event": {
@@ -80,8 +80,8 @@ def test_slack_trigger__process_event__app_mention():
         }
     }
 
-    # WHEN we create a trigger instance
-    trigger = SlackTrigger(slack_payload)
+    # WHEN we process the event
+    trigger = SlackTrigger.process_event(slack_payload)
 
     # THEN event_type is app_mention
     assert trigger.event_type == "app_mention"

--- a/src/vellum/workflows/triggers/tests/test_slack.py
+++ b/src/vellum/workflows/triggers/tests/test_slack.py
@@ -1,5 +1,7 @@
 """Tests for SlackTrigger."""
 
+from typing import cast
+
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.references.trigger import TriggerAttributeReference
 from vellum.workflows.state.base import BaseState
@@ -34,8 +36,9 @@ def test_slack_trigger__basic():
     state = BaseState()
     trigger.bind_to_state(state)
     stored = state.meta.trigger_attributes
-    assert SlackTrigger.message in stored
-    assert stored[SlackTrigger.message] == "Hello world!"
+    message_ref = cast(TriggerAttributeReference[str], SlackTrigger.message)
+    assert message_ref in stored
+    assert stored[message_ref] == "Hello world!"
 
 
 def test_slack_trigger__with_thread():

--- a/src/vellum/workflows/triggers/tests/test_slack.py
+++ b/src/vellum/workflows/triggers/tests/test_slack.py
@@ -1,0 +1,164 @@
+"""Tests for SlackTrigger."""
+
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.triggers.slack import SlackTrigger
+
+
+def test_slack_trigger__process_event__basic():
+    """SlackTrigger.process_event parses Slack payload correctly."""
+    # GIVEN a Slack event payload
+    slack_payload = {
+        "event": {
+            "type": "message",
+            "text": "Hello world!",
+            "channel": "C123456",
+            "user": "U123456",
+            "ts": "1234567890.123456",
+        }
+    }
+
+    # WHEN we process the event
+    outputs = SlackTrigger.process_event(slack_payload)
+
+    # THEN outputs contain the correct data
+    assert outputs.message == "Hello world!"
+    assert outputs.channel == "C123456"
+    assert outputs.user == "U123456"
+    assert outputs.timestamp == "1234567890.123456"
+    assert outputs.thread_ts is None
+    assert outputs.event_type == "message"
+
+
+def test_slack_trigger__process_event__with_thread():
+    """SlackTrigger.process_event handles threaded messages."""
+    # GIVEN a Slack event payload with thread_ts
+    slack_payload = {
+        "event": {
+            "type": "message",
+            "text": "Reply in thread",
+            "channel": "C123456",
+            "user": "U123456",
+            "ts": "1234567891.123456",
+            "thread_ts": "1234567890.123456",
+        }
+    }
+
+    # WHEN we process the event
+    outputs = SlackTrigger.process_event(slack_payload)
+
+    # THEN thread_ts is populated
+    assert outputs.thread_ts == "1234567890.123456"
+
+
+def test_slack_trigger__process_event__empty_payload():
+    """SlackTrigger.process_event handles empty payload gracefully."""
+    # GIVEN an empty payload
+    slack_payload = {}
+
+    # WHEN we process the event
+    outputs = SlackTrigger.process_event(slack_payload)
+
+    # THEN it returns empty strings for required fields
+    assert outputs.message == ""
+    assert outputs.channel == ""
+    assert outputs.user == ""
+    assert outputs.timestamp == ""
+    assert outputs.thread_ts is None
+    assert outputs.event_type == "message"  # default value
+
+
+def test_slack_trigger__process_event__app_mention():
+    """SlackTrigger.process_event handles app_mention events."""
+    # GIVEN an app_mention event
+    slack_payload = {
+        "event": {
+            "type": "app_mention",
+            "text": "<@U0LAN0Z89> is it everything a river should be?",
+            "channel": "C123456",
+            "user": "U123456",
+            "ts": "1234567890.123456",
+        }
+    }
+
+    # WHEN we process the event
+    outputs = SlackTrigger.process_event(slack_payload)
+
+    # THEN event_type is app_mention
+    assert outputs.event_type == "app_mention"
+    assert outputs.message == "<@U0LAN0Z89> is it everything a river should be?"
+
+
+def test_slack_trigger__outputs_class():
+    """SlackTrigger.Outputs has correct fields."""
+    # GIVEN SlackTrigger.Outputs
+    # THEN it has all expected fields
+    assert hasattr(SlackTrigger.Outputs, "__annotations__")
+    annotations = SlackTrigger.Outputs.__annotations__
+    assert "message" in annotations
+    assert "channel" in annotations
+    assert "user" in annotations
+    assert "timestamp" in annotations
+    assert "thread_ts" in annotations
+    assert "event_type" in annotations
+
+
+def test_slack_trigger__graph_syntax():
+    """SlackTrigger can be used in graph syntax."""
+
+    # GIVEN a node
+    class TestNode(BaseNode):
+        pass
+
+    # WHEN we use SlackTrigger >> Node syntax
+    graph = SlackTrigger >> TestNode
+
+    # THEN a graph is created with trigger edge
+    assert graph is not None
+    trigger_edges = list(graph.trigger_edges)
+    assert len(trigger_edges) == 1
+    assert trigger_edges[0].trigger_class == SlackTrigger
+    assert trigger_edges[0].to_node == TestNode
+
+
+def test_slack_trigger__multiple_entrypoints():
+    """SlackTrigger works with multiple entry points."""
+
+    # GIVEN multiple nodes
+    class NodeA(BaseNode):
+        pass
+
+    class NodeB(BaseNode):
+        pass
+
+    # WHEN we use SlackTrigger >> {NodeA, NodeB} syntax
+    graph = SlackTrigger >> {NodeA, NodeB}
+
+    # THEN both nodes have trigger edges
+    trigger_edges = list(graph.trigger_edges)
+    assert len(trigger_edges) == 2
+    target_nodes = {edge.to_node for edge in trigger_edges}
+    assert target_nodes == {NodeA, NodeB}
+
+
+def test_slack_trigger__trigger_then_graph():
+    """SlackTrigger works with trigger >> node >> node syntax."""
+
+    # GIVEN two nodes
+    class StartNode(BaseNode):
+        pass
+
+    class EndNode(BaseNode):
+        pass
+
+    # WHEN we create SlackTrigger >> StartNode >> EndNode
+    graph = SlackTrigger >> StartNode >> EndNode
+
+    # THEN the graph has one trigger edge and one regular edge
+    trigger_edges = list(graph.trigger_edges)
+    assert len(trigger_edges) == 1
+    assert trigger_edges[0].trigger_class == SlackTrigger
+    assert trigger_edges[0].to_node == StartNode
+
+    edges = list(graph.edges)
+    assert len(edges) == 1
+    assert edges[0].to_node == EndNode

--- a/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
+++ b/tests/workflows/basic_emitter_workflow/tests/test_workflow.py
@@ -79,6 +79,7 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
             "workflow_inputs": {},
             "external_inputs": {},
             "node_outputs": {serialized_start_node_output_id: "Hello, World!"},
+            "trigger_attributes": {},
             "parent": None,
             "node_execution_cache": {
                 "node_executions_fulfilled": {serialized_start_node_id: [str(start_node_span_id)]},
@@ -115,6 +116,7 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
             "node_outputs": {
                 serialized_start_node_output_id: "Hello, World!",
             },
+            "trigger_attributes": {},
             "parent": None,
             "node_execution_cache": {
                 "node_executions_fulfilled": {
@@ -150,6 +152,7 @@ def test_run_workflow__happy_path(mock_uuid4_generator, mock_datetime_now):
                 serialized_start_node_output_id: "Hello, World!",
                 serialized_next_node_output_id: "Score: 13",
             },
+            "trigger_attributes": {},
             "node_execution_cache": {
                 "node_executions_fulfilled": {
                     serialized_start_node_id: [str(start_node_span_id)],


### PR DESCRIPTION
## Summary
Implement SlackTrigger as the first integration trigger for workflows, building on the IntegrationTrigger base class from #2718. Introduces trigger attribute descriptor system for referencing trigger data in downstream nodes.

## Changes

### Core Implementation
- Implement `SlackTrigger` with 6 trigger attributes: `message`, `channel`, `user`, `timestamp`, `thread_ts`, `event_type`
- Use `__init__()` to parse Slack Event API webhook payloads
- Support graph syntax: `SlackTrigger >> Node`

### Trigger Attribute System
- Add `TriggerAttributeReference` descriptor class
- Update `BaseTriggerMeta` to create descriptors from annotations
- Enable node references like `SlackTrigger.message`
- Add `bind_to_state()` to persist attributes

### State & Serialization
- Add `trigger_attributes` field to `StateMeta`
- Add `SLACK_MESSAGE` to `WorkflowTriggerType` enum
- Serialize trigger metadata in workflow JSON

### Testing
- 8 unit tests for SlackTrigger
- 3 serialization tests
- All 11 tests passing

## Dependencies
- **Requires #2718** to be merged first

## Follow-up
- APO-1836: Runtime execution support
- APO-1840: TypeScript codegen

🤖 Generated with [Claude Code](https://claude.com/claude-code)