### PR TITLE
Execution configuration types for integration triggers

### DIFF
--- a/src/vellum/workflows/types/__init__.py
+++ b/src/vellum/workflows/types/__init__.py
@@ -1,6 +1,9 @@
 from .core import CancelSignal, MergeBehavior
+from .trigger_exec_config import BaseIntegrationTriggerExecConfig, ComposioIntegrationTriggerExecConfig
 
 __all__ = [
+    "BaseIntegrationTriggerExecConfig",
     "CancelSignal",
+    "ComposioIntegrationTriggerExecConfig",
     "MergeBehavior",
 ]

--- a/src/vellum/workflows/types/trigger_exec_config.py
+++ b/src/vellum/workflows/types/trigger_exec_config.py
@@ -6,7 +6,7 @@ sent to/from the backend for integration triggers. They are used during
 serialization and deserialization of trigger configurations.
 """
 
-from typing import Any, Dict, Literal, Optional
+from typing import Literal
 
 from pydantic import Field
 
@@ -30,15 +30,15 @@ class ComposioIntegrationTriggerExecConfig(BaseIntegrationTriggerExecConfig):
     Execution configuration for Composio-based integration triggers.
 
     This configuration is used to identify and execute triggers through the Composio
-    integration provider. It includes the provider type, integration name, trigger name,
-    and optional dynamic attributes.
+    integration provider. It includes the provider type, integration name, slug,
+    and trigger nano ID used for event matching.
 
     Examples:
         >>> config = ComposioIntegrationTriggerExecConfig(
         ...     provider="COMPOSIO",
         ...     integration_name="SLACK",
-        ...     trigger_name="SLACK_NEW_MESSAGE",
-        ...     attributes={"channel": "C123456"}
+        ...     slug="slack_new_message",
+        ...     trigger_nano_id="abc123def456"
         ... )
         >>> config.provider
         <VellumIntegrationProviderType.COMPOSIO: 'COMPOSIO'>
@@ -47,14 +47,12 @@ class ComposioIntegrationTriggerExecConfig(BaseIntegrationTriggerExecConfig):
         type: Always "COMPOSIO_INTEGRATION_TRIGGER" for this config type
         provider: The integration provider (e.g., COMPOSIO)
         integration_name: The integration identifier (e.g., "SLACK", "GITHUB")
-        trigger_name: The specific trigger identifier (e.g., "SLACK_NEW_MESSAGE")
-        attributes: Optional dictionary of trigger-specific configuration attributes
+        slug: The slug of the integration trigger in Composio
+        trigger_nano_id: Composio's unique trigger identifier used for event matching
     """
 
     type: Literal["COMPOSIO_INTEGRATION_TRIGGER"] = "COMPOSIO_INTEGRATION_TRIGGER"
     provider: VellumIntegrationProviderType = Field(..., description="The integration provider (e.g., COMPOSIO)")
     integration_name: str = Field(..., description="The integration name (e.g., 'SLACK', 'GITHUB')")
-    trigger_name: str = Field(..., description="The specific trigger name (e.g., 'SLACK_NEW_MESSAGE')")
-    attributes: Optional[Dict[str, Any]] = Field(
-        default=None, description="Optional trigger-specific configuration attributes"
-    )
+    slug: str = Field(..., description="The slug of the integration trigger in Composio")
+    trigger_nano_id: str = Field(..., description="Composio's unique trigger identifier used for event matching")

--- a/src/vellum/workflows/types/trigger_exec_config.py
+++ b/src/vellum/workflows/types/trigger_exec_config.py
@@ -6,7 +6,7 @@ sent to/from the backend for integration triggers. They are used during
 serialization and deserialization of trigger configurations.
 """
 
-from typing import Literal
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import Field
 
@@ -31,14 +31,15 @@ class ComposioIntegrationTriggerExecConfig(BaseIntegrationTriggerExecConfig):
 
     This configuration is used to identify and execute triggers through the Composio
     integration provider. It includes the provider type, integration name, slug,
-    and trigger nano ID used for event matching.
+    trigger nano ID, and optional attributes for filtering.
 
     Examples:
         >>> config = ComposioIntegrationTriggerExecConfig(
         ...     provider="COMPOSIO",
         ...     integration_name="SLACK",
         ...     slug="slack_new_message",
-        ...     trigger_nano_id="abc123def456"
+        ...     trigger_nano_id="abc123def456",
+        ...     attributes={"channel": "C123456"}
         ... )
         >>> config.provider
         <VellumIntegrationProviderType.COMPOSIO: 'COMPOSIO'>
@@ -49,6 +50,7 @@ class ComposioIntegrationTriggerExecConfig(BaseIntegrationTriggerExecConfig):
         integration_name: The integration identifier (e.g., "SLACK", "GITHUB")
         slug: The slug of the integration trigger in Composio
         trigger_nano_id: Composio's unique trigger identifier used for event matching
+        attributes: Optional dictionary of trigger-specific configuration attributes for filtering
     """
 
     type: Literal["COMPOSIO_INTEGRATION_TRIGGER"] = "COMPOSIO_INTEGRATION_TRIGGER"
@@ -56,3 +58,6 @@ class ComposioIntegrationTriggerExecConfig(BaseIntegrationTriggerExecConfig):
     integration_name: str = Field(..., description="The integration name (e.g., 'SLACK', 'GITHUB')")
     slug: str = Field(..., description="The slug of the integration trigger in Composio")
     trigger_nano_id: str = Field(..., description="Composio's unique trigger identifier used for event matching")
+    attributes: Optional[Dict[str, Any]] = Field(
+        default=None, description="Optional trigger-specific configuration attributes for filtering"
+    )

--- a/src/vellum/workflows/types/trigger_exec_config.py
+++ b/src/vellum/workflows/types/trigger_exec_config.py
@@ -1,0 +1,60 @@
+"""
+Execution configuration dataclasses for integration triggers.
+
+These classes define the structure of execution configuration data that is
+sent to/from the backend for integration triggers. They are used during
+serialization and deserialization of trigger configurations.
+"""
+
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import Field
+
+from vellum.client.core.pydantic_utilities import UniversalBaseModel
+from vellum.workflows.constants import VellumIntegrationProviderType
+
+
+class BaseIntegrationTriggerExecConfig(UniversalBaseModel):
+    """
+    Base class for integration trigger execution configurations.
+
+    This class defines the common structure for all integration trigger exec configs,
+    regardless of the provider. Specific providers should extend this class.
+    """
+
+    type: str = Field(..., description="The type of integration trigger exec config")
+
+
+class ComposioIntegrationTriggerExecConfig(BaseIntegrationTriggerExecConfig):
+    """
+    Execution configuration for Composio-based integration triggers.
+
+    This configuration is used to identify and execute triggers through the Composio
+    integration provider. It includes the provider type, integration name, trigger name,
+    and optional dynamic attributes.
+
+    Examples:
+        >>> config = ComposioIntegrationTriggerExecConfig(
+        ...     provider="COMPOSIO",
+        ...     integration_name="SLACK",
+        ...     trigger_name="SLACK_NEW_MESSAGE",
+        ...     attributes={"channel": "C123456"}
+        ... )
+        >>> config.provider
+        <VellumIntegrationProviderType.COMPOSIO: 'COMPOSIO'>
+
+    Attributes:
+        type: Always "COMPOSIO_INTEGRATION_TRIGGER" for this config type
+        provider: The integration provider (e.g., COMPOSIO)
+        integration_name: The integration identifier (e.g., "SLACK", "GITHUB")
+        trigger_name: The specific trigger identifier (e.g., "SLACK_NEW_MESSAGE")
+        attributes: Optional dictionary of trigger-specific configuration attributes
+    """
+
+    type: Literal["COMPOSIO_INTEGRATION_TRIGGER"] = "COMPOSIO_INTEGRATION_TRIGGER"
+    provider: VellumIntegrationProviderType = Field(..., description="The integration provider (e.g., COMPOSIO)")
+    integration_name: str = Field(..., description="The integration name (e.g., 'SLACK', 'GITHUB')")
+    trigger_name: str = Field(..., description="The specific trigger name (e.g., 'SLACK_NEW_MESSAGE')")
+    attributes: Optional[Dict[str, Any]] = Field(
+        default=None, description="Optional trigger-specific configuration attributes"
+    )


### PR DESCRIPTION
## Summary
Add execution configuration types for integration triggers to support serialization/deserialization of trigger configurations.

This PR introduces:
- `BaseIntegrationTriggerExecConfig` - Base class for all integration trigger exec configs
- `ComposioIntegrationTriggerExecConfig` - Specific implementation for Composio provider triggers

## Part of PR Series
This is **PR 1 of 2** in the APO-1833 integration triggers feature:
1. **This PR**: Trigger execution config types (foundation)
2. Coming next: VellumIntegrationTrigger implementation

## Details
These types define the structure of execution configuration data sent to/from the backend for integration triggers. They enable proper communication with integration providers like Composio.

The types are:
- Self-contained pure data structures (Pydantic models)
- Provider-extensible through inheritance
- Ready for use in trigger serialization/deserialization

## Dependencies
None - this PR can be reviewed and merged independently.

## Testing
- Types are validated through Pydantic
- Will be exercised by integration trigger implementation in next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)