### PR TITLE
[APO-1877] Add serialization support for VellumIntegrationTrigger

### DIFF
--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 class WorkflowTriggerType(Enum):
     MANUAL = "MANUAL"
     SLACK_MESSAGE = "SLACK_MESSAGE"
+    VELLUM_INTEGRATION_TRIGGER = "VELLUM_INTEGRATION_TRIGGER"
 
 
 def get_trigger_type_mapping() -> Dict[Type["BaseTrigger"], WorkflowTriggerType]:
@@ -25,6 +26,10 @@ def get_trigger_type_mapping() -> Dict[Type["BaseTrigger"], WorkflowTriggerType]
 
     This is a function to avoid circular imports - it imports trigger classes
     only when called, not at module load time.
+
+    Note: VellumIntegrationTrigger classes are not included in this mapping
+    because they are factory-generated. They are handled specially in the
+    serialization logic by checking if they are subclasses of VellumIntegrationTrigger.
 
     Returns:
         Dictionary mapping trigger classes to their enum types

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_vellum_integration_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_vellum_integration_trigger_serialization.py
@@ -1,0 +1,142 @@
+"""Tests for VellumIntegrationTrigger serialization."""
+
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+from tests.workflows.basic_trigger_vellum_integration.workflow import VellumIntegrationTriggerWorkflow
+
+
+def test_serialize_vellum_integration_trigger_workflow():
+    """VellumIntegrationTrigger workflow serializes with exec_config format."""
+    workflow_display = get_workflow_display(workflow_class=VellumIntegrationTriggerWorkflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    assert serialized_workflow.keys() == {
+        "workflow_raw_data",
+        "input_variables",
+        "state_variables",
+        "output_variables",
+        "triggers",
+    }
+
+    triggers = serialized_workflow["triggers"]
+    assert len(triggers) == 1
+
+    trigger = triggers[0]
+    assert trigger["type"] == "VELLUM_INTEGRATION_TRIGGER"
+    assert trigger["id"] == "472448ae-3bb0-4ca5-86f3-0a19c023b2f7"
+
+    # VellumIntegrationTrigger should have exec_config, not attributes
+    assert "exec_config" in trigger
+    assert "attributes" not in trigger
+
+    exec_config = trigger["exec_config"]
+    assert exec_config == {
+        "provider": "COMPOSIO",
+        "integration_name": "SLACK",
+        "slug": "slack_new_message",
+        "trigger_nano_id": "abc123def456",
+        "attributes": {"channel": "C123456"},
+    }
+
+
+def test_vellum_integration_trigger_id_consistency():
+    """
+    Regression test: Ensure trigger IDs match between trigger definition and attribute references.
+
+    This test validates that when a node references trigger attributes, the trigger_id
+    in the output value matches the trigger's id in the triggers array. This prevents
+    bugs where trigger IDs are generated inconsistently.
+    """
+    workflow_display = get_workflow_display(workflow_class=VellumIntegrationTriggerWorkflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    triggers = serialized_workflow["triggers"]
+    assert len(triggers) == 1
+    trigger_id = triggers[0]["id"]
+
+    # Find the ProcessMessageNode in the serialized nodes
+    workflow_raw_data = serialized_workflow["workflow_raw_data"]
+    nodes = workflow_raw_data["nodes"]
+
+    process_node = next(
+        node for node in nodes if node.get("type") == "GENERIC" and node.get("label") == "Process Message Node"
+    )
+
+    # Verify the node has outputs that reference the trigger
+    assert "outputs" in process_node
+    outputs = process_node["outputs"]
+
+    # Check that all trigger attribute references use the correct trigger_id
+    for output in outputs:
+        if output.get("value", {}).get("type") == "TRIGGER_ATTRIBUTE":
+            output_trigger_id = output["value"]["trigger_id"]
+            assert output_trigger_id == trigger_id, (
+                f"Trigger ID mismatch: trigger definition has ID {trigger_id}, "
+                f"but output '{output['name']}' references trigger ID {output_trigger_id}. "
+                "This indicates inconsistent trigger ID generation."
+            )
+
+
+def test_vellum_integration_trigger_multiple_attributes():
+    """VellumIntegrationTrigger with multiple attribute references serializes correctly."""
+    workflow_display = get_workflow_display(workflow_class=VellumIntegrationTriggerWorkflow)
+    serialized_workflow: dict = workflow_display.serialize()
+
+    workflow_raw_data = serialized_workflow["workflow_raw_data"]
+    nodes = workflow_raw_data["nodes"]
+
+    process_node = next(
+        node for node in nodes if node.get("type") == "GENERIC" and node.get("label") == "Process Message Node"
+    )
+
+    outputs = process_node["outputs"]
+    assert len(outputs) == 2
+
+    # Verify both outputs reference trigger attributes
+    processed_message_output = next(o for o in outputs if o["name"] == "processed_message")
+    assert processed_message_output["value"]["type"] == "TRIGGER_ATTRIBUTE"
+    assert "attribute_id" in processed_message_output["value"]
+
+    channel_output = next(o for o in outputs if o["name"] == "channel")
+    assert channel_output["value"]["type"] == "TRIGGER_ATTRIBUTE"
+    assert "attribute_id" in channel_output["value"]
+
+
+def test_vellum_integration_trigger_without_attributes():
+    """VellumIntegrationTrigger without configuration attributes serializes correctly."""
+    from vellum.workflows import BaseWorkflow
+    from vellum.workflows.inputs.base import BaseInputs
+    from vellum.workflows.nodes.bases.base import BaseNode
+    from vellum.workflows.state.base import BaseState
+    from vellum.workflows.triggers.vellum_integration import VellumIntegrationTrigger
+
+    # Create trigger without attributes parameter
+    GitHubPush = VellumIntegrationTrigger.for_trigger(
+        provider="COMPOSIO",
+        integration_name="GITHUB",
+        slug="github_push_event",
+        trigger_nano_id="xyz789ghi012",
+    )
+
+    class SimpleNode(BaseNode):
+        pass
+
+    class SimpleWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+        graph = GitHubPush >> SimpleNode
+
+    workflow_display = get_workflow_display(workflow_class=SimpleWorkflow)
+    result = workflow_display.serialize()
+
+    triggers = result["triggers"]
+    assert len(triggers) == 1
+
+    trigger = triggers[0]
+    assert trigger["type"] == "VELLUM_INTEGRATION_TRIGGER"
+
+    # Attributes should be empty dict when not provided
+    exec_config = trigger["exec_config"]
+    assert exec_config["attributes"] == {}
+    assert exec_config["provider"] == "COMPOSIO"
+    assert exec_config["integration_name"] == "GITHUB"
+    assert exec_config["slug"] == "github_push_event"
+    assert exec_config["trigger_nano_id"] == "xyz789ghi012"

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_vellum_integration_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_vellum_integration_trigger_serialization.py
@@ -90,14 +90,19 @@ def test_vellum_integration_trigger_multiple_attributes():
     )
 
     outputs = process_node["outputs"]
+    assert isinstance(outputs, list), "outputs should be a list"
     assert len(outputs) == 2
 
     # Verify both outputs reference trigger attributes
-    processed_message_output = next(o for o in outputs if o["name"] == "processed_message")
+    processed_message_output = next(o for o in outputs if isinstance(o, dict) and o.get("name") == "processed_message")
+    assert isinstance(processed_message_output, dict), "output should be a dict"
+    assert isinstance(processed_message_output.get("value"), dict), "value should be a dict"
     assert processed_message_output["value"]["type"] == "TRIGGER_ATTRIBUTE"
     assert "attribute_id" in processed_message_output["value"]
 
-    channel_output = next(o for o in outputs if o["name"] == "channel")
+    channel_output = next(o for o in outputs if isinstance(o, dict) and o.get("name") == "channel")
+    assert isinstance(channel_output, dict), "output should be a dict"
+    assert isinstance(channel_output.get("value"), dict), "value should be a dict"
     assert channel_output["value"]["type"] == "TRIGGER_ATTRIBUTE"
     assert "attribute_id" in channel_output["value"]
 
@@ -128,13 +133,16 @@ def test_vellum_integration_trigger_without_attributes():
     result = workflow_display.serialize()
 
     triggers = result["triggers"]
+    assert isinstance(triggers, list), "triggers should be a list"
     assert len(triggers) == 1
 
     trigger = triggers[0]
+    assert isinstance(trigger, dict), "trigger should be a dict"
     assert trigger["type"] == "VELLUM_INTEGRATION_TRIGGER"
 
     # Attributes should be empty dict when not provided
     exec_config = trigger["exec_config"]
+    assert isinstance(exec_config, dict), "exec_config should be a dict"
     assert exec_config["attributes"] == {}
     assert exec_config["provider"] == "COMPOSIO"
     assert exec_config["integration_name"] == "GITHUB"

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, Tuple, Type
 
 from vellum.client import Vellum as VellumClient
 from vellum.workflows.descriptors.base import BaseDescriptor
@@ -22,6 +22,8 @@ from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDispl
 from vellum_ee.workflows.display.utils.registry import get_default_workflow_display_class
 
 if TYPE_CHECKING:
+    from vellum.workflows.triggers.base import BaseTrigger
+    from vellum.workflows.references.trigger import TriggerAttributeReference
     from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 
@@ -51,6 +53,9 @@ class WorkflowDisplayContext:
     workflow_output_displays: WorkflowOutputDisplays = field(default_factory=dict)
     edge_displays: EdgeDisplays = field(default_factory=dict)
     port_displays: PortDisplays = field(default_factory=dict)
+    trigger_attribute_usage: Dict[
+        Type["BaseTrigger"], Set["TriggerAttributeReference"]
+    ] = field(default_factory=dict)
     dry_run: bool = False
     _errors: List[Exception] = field(default_factory=list)
     _invalid_nodes: List[Type[BaseNode]] = field(default_factory=list)

--- a/ee/vellum_ee/workflows/display/types.py
+++ b/ee/vellum_ee/workflows/display/types.py
@@ -22,8 +22,8 @@ from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDispl
 from vellum_ee.workflows.display.utils.registry import get_default_workflow_display_class
 
 if TYPE_CHECKING:
-    from vellum.workflows.triggers.base import BaseTrigger
     from vellum.workflows.references.trigger import TriggerAttributeReference
+    from vellum.workflows.triggers.base import BaseTrigger
     from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
 
 
@@ -53,9 +53,7 @@ class WorkflowDisplayContext:
     workflow_output_displays: WorkflowOutputDisplays = field(default_factory=dict)
     edge_displays: EdgeDisplays = field(default_factory=dict)
     port_displays: PortDisplays = field(default_factory=dict)
-    trigger_attribute_usage: Dict[
-        Type["BaseTrigger"], Set["TriggerAttributeReference"]
-    ] = field(default_factory=dict)
+    trigger_attribute_usage: Dict[Type["BaseTrigger"], Set["TriggerAttributeReference"]] = field(default_factory=dict)
     dry_run: bool = False
     _errors: List[Exception] = field(default_factory=list)
     _invalid_nodes: List[Type[BaseNode]] = field(default_factory=list)

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -352,6 +352,11 @@ def serialize_value(executable_id: UUID, display_context: "WorkflowDisplayContex
         # Generate trigger ID using the appropriate method for each trigger type
         trigger_class = value.trigger_class
 
+        # Track trigger attribute usage for the current workflow serialization so that
+        # trigger definitions only include attributes referenced within the workflow.
+        trigger_usage = display_context.trigger_attribute_usage.setdefault(trigger_class, set())
+        trigger_usage.add(value)
+
         # Check if this is a VellumIntegrationTrigger (factory-generated)
         from vellum.workflows.triggers.vellum_integration import VellumIntegrationTrigger
 

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -349,9 +349,18 @@ def serialize_value(executable_id: UUID, display_context: "WorkflowDisplayContex
         }
 
     if isinstance(value, TriggerAttributeReference):
-        # Generate trigger ID using the same hash formula as in base_workflow_display.py
+        # Generate trigger ID using the appropriate method for each trigger type
         trigger_class = value.trigger_class
-        trigger_id = uuid4_from_hash(trigger_class.__qualname__)
+
+        # Check if this is a VellumIntegrationTrigger (factory-generated)
+        from vellum.workflows.triggers.vellum_integration import VellumIntegrationTrigger
+
+        if issubclass(trigger_class, VellumIntegrationTrigger):
+            # Use semantic identity for VellumIntegrationTrigger to ensure stability
+            trigger_id = trigger_class.get_trigger_id()
+        else:
+            # Use __qualname__ for regular triggers (ManualTrigger, SlackTrigger, etc.)
+            trigger_id = uuid4_from_hash(trigger_class.__qualname__)
 
         return {
             "type": "TRIGGER_ATTRIBUTE",

--- a/tests/workflows/basic_trigger_vellum_integration/workflow.py
+++ b/tests/workflows/basic_trigger_vellum_integration/workflow.py
@@ -1,0 +1,34 @@
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.inputs.base import BaseInputs
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.state.base import BaseState
+from vellum.workflows.triggers.vellum_integration import VellumIntegrationTrigger
+
+# Create a Slack trigger using the factory
+SlackNewMessage = VellumIntegrationTrigger.for_trigger(
+    provider="COMPOSIO",
+    integration_name="SLACK",
+    slug="slack_new_message",
+    trigger_nano_id="abc123def456",
+    attributes={"channel": "C123456"},
+)
+
+
+class ProcessMessageNode(BaseNode):
+    """Process a Slack message from VellumIntegrationTrigger."""
+
+    class Outputs(BaseNode.Outputs):
+        processed_message = SlackNewMessage.message
+        channel = SlackNewMessage.channel
+
+    def run(self) -> Outputs:
+        return self.Outputs()
+
+
+class VellumIntegrationTriggerWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+    """Example workflow triggered by VellumIntegrationTrigger (Slack)."""
+
+    graph = SlackNewMessage >> ProcessMessageNode
+
+    class Outputs(BaseWorkflow.Outputs):
+        result = ProcessMessageNode.Outputs.processed_message


### PR DESCRIPTION
The purpose of this PR is to add serialization support for `VellumIntegrationTrigger` with deterministic ID generation to ensure consistency between trigger definitions and attribute references.

## Changes Made
- Add `get_trigger_id()` method to `VellumIntegrationTrigger` using semantic identity (provider|integration|slug) for stable ID generation
- Implement `_serialize_vellum_integration_trigger()` in `BaseWorkflowDisplay` to serialize triggers in `exec_config` format
- Update `serialize_value()` in expressions.py to handle `TriggerAttributeReference` with proper trigger ID resolution
- Add `VELLUM_INTEGRATION_TRIGGER` enum value to `WorkflowTriggerType`
- Add comprehensive serialization tests including critical ID consistency validation (prevents regression bugs similar to PR #2747)
- Add test fixture workflow for `VellumIntegrationTrigger` integration testing

## Notes
- This follows the established pattern for trigger serialization while introducing `exec_config` format specific to `VellumIntegrationTrigger`
- The ID generation strategy uses semantic identity instead of `__qualname__` to prevent import path instability issues
- Validation tests ensure trigger IDs match between trigger definition and attribute references, preventing serialization bugs

---
*This PR was created with Claude Code*