### PR TITLE
Link triggers and entrypoint nodes through shared IDs

### DIFF
--- a/ee/codegen_integration/fixtures/simple_manual_trigger_workflow/display_data/simple_manual_trigger_workflow.json
+++ b/ee/codegen_integration/fixtures/simple_manual_trigger_workflow/display_data/simple_manual_trigger_workflow.json
@@ -2,12 +2,29 @@
   "workflow_raw_data": {
     "nodes": [
       {
+        "id": "b09c1902-3cca-4c79-b775-4c32e3e88466",
+        "type": "ENTRYPOINT",
+        "inputs": [],
+        "data": {
+          "label": "Entrypoint Node",
+          "source_handle_id": "eba8fd73-57ab-4d7b-8f75-b54dbe5fc8ba"
+        },
+        "display_data": {
+          "position": {
+            "x": 0.0,
+            "y": -50.0
+          }
+        },
+        "base": null,
+        "definition": null
+      },
+      {
         "id": "3669684e-500e-4034-be4a-7ee70824b272",
         "label": "Simple Node",
         "type": "GENERIC",
         "display_data": {
           "position": {
-            "x": 0.0,
+            "x": 200.0,
             "y": -50.0
           }
         },
@@ -82,7 +99,7 @@
         ],
         "display_data": {
           "position": {
-            "x": 200.0,
+            "x": 400.0,
             "y": -50.0
           }
         },
@@ -128,6 +145,14 @@
       }
     ],
     "edges": [
+      {
+        "id": "9eaed9b1-5803-4bc4-bdba-b614f4f465b5",
+        "source_node_id": "b09c1902-3cca-4c79-b775-4c32e3e88466",
+        "source_handle_id": "eba8fd73-57ab-4d7b-8f75-b54dbe5fc8ba",
+        "target_node_id": "3669684e-500e-4034-be4a-7ee70824b272",
+        "target_handle_id": "7da60409-5790-43fa-80b2-ad88da2812df",
+        "type": "DEFAULT"
+      },
       {
         "id": "55ad304f-eddc-40d7-ad19-1e6a2b5fc02a",
         "source_node_id": "3669684e-500e-4034-be4a-7ee70824b272",

--- a/ee/codegen_integration/fixtures/simple_manual_trigger_workflow/display_data/simple_manual_trigger_workflow.json
+++ b/ee/codegen_integration/fixtures/simple_manual_trigger_workflow/display_data/simple_manual_trigger_workflow.json
@@ -2,29 +2,12 @@
   "workflow_raw_data": {
     "nodes": [
       {
-        "id": "63884a7b-c01c-4cbc-b8d4-abe0a8796f6b",
-        "type": "ENTRYPOINT",
-        "inputs": [],
-        "data": {
-          "label": "Entrypoint Node",
-          "source_handle_id": "eba8fd73-57ab-4d7b-8f75-b54dbe5fc8ba"
-        },
-        "display_data": {
-          "position": {
-            "x": 0.0,
-            "y": -50.0
-          }
-        },
-        "base": null,
-        "definition": null
-      },
-      {
         "id": "3669684e-500e-4034-be4a-7ee70824b272",
         "label": "Simple Node",
         "type": "GENERIC",
         "display_data": {
           "position": {
-            "x": 200.0,
+            "x": 0.0,
             "y": -50.0
           }
         },
@@ -99,7 +82,7 @@
         ],
         "display_data": {
           "position": {
-            "x": 400.0,
+            "x": 200.0,
             "y": -50.0
           }
         },
@@ -145,14 +128,6 @@
       }
     ],
     "edges": [
-      {
-        "id": "9eaed9b1-5803-4bc4-bdba-b614f4f465b5",
-        "source_node_id": "63884a7b-c01c-4cbc-b8d4-abe0a8796f6b",
-        "source_handle_id": "eba8fd73-57ab-4d7b-8f75-b54dbe5fc8ba",
-        "target_node_id": "3669684e-500e-4034-be4a-7ee70824b272",
-        "target_handle_id": "7da60409-5790-43fa-80b2-ad88da2812df",
-        "type": "DEFAULT"
-      },
       {
         "id": "55ad304f-eddc-40d7-ad19-1e6a2b5fc02a",
         "source_node_id": "3669684e-500e-4034-be4a-7ee70824b272",

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_manual_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_manual_trigger_serialization.py
@@ -46,8 +46,8 @@ def test_manual_trigger_multiple_entrypoints():
     nodes = workflow_data["nodes"]
     assert isinstance(nodes, list)
 
-    # With triggers, only the 2 actual nodes exist (no entrypoint node)
-    assert len(nodes) == 2
+    # With triggers, 3 nodes exist: ENTRYPOINT (for backwards compat) + 2 actual nodes
+    assert len(nodes) == 3
 
     assert "triggers" in result
     triggers = result["triggers"]
@@ -57,12 +57,13 @@ def test_manual_trigger_multiple_entrypoints():
     assert triggers[0] == {"id": "b09c1902-3cca-4c79-b775-4c32e3e88466", "type": "MANUAL", "attributes": []}
 
 
-def test_manual_trigger_replaces_entrypoint_node():
+def test_manual_trigger_entrypoint_node_id():
     """
-    TDD: Triggers should REPLACE entrypoint nodes, not coexist with them.
+    Backwards compatibility: Workflows with triggers should have an ENTRYPOINT node
+    whose ID matches the trigger ID.
 
-    When a workflow has a trigger, the serialized workflow_raw_data should NOT
-    contain an ENTRYPOINT node. The trigger IS the entry point.
+    This allows existing systems that expect ENTRYPOINT nodes to continue working,
+    while linking the entrypoint to the trigger through shared ID.
     """
 
     class FirstNode(BaseNode):
@@ -85,27 +86,35 @@ def test_manual_trigger_replaces_entrypoint_node():
 
     trigger = triggers[0]
     assert isinstance(trigger, dict)
+    trigger_id = trigger["id"]
     assert trigger["type"] == "MANUAL"
 
-    # TDD: The key assertion - NO ENTRYPOINT node should exist
+    # Verify ENTRYPOINT node exists for backwards compatibility
     workflow_data = result["workflow_raw_data"]
     assert isinstance(workflow_data, dict)
 
     nodes = workflow_data["nodes"]
     assert isinstance(nodes, list)
 
-    # Check that NO node has type "ENTRYPOINT"
+    # Find the ENTRYPOINT node
     entrypoint_nodes = [node for node in nodes if isinstance(node, dict) and node.get("type") == "ENTRYPOINT"]
-    assert len(entrypoint_nodes) == 0, (
-        "Workflows with triggers should NOT have ENTRYPOINT nodes. "
-        f"Found {len(entrypoint_nodes)} ENTRYPOINT node(s). "
-        "Triggers should REPLACE entrypoint nodes, not coexist with them."
+    assert len(entrypoint_nodes) == 1, (
+        "Workflows with triggers should have exactly one ENTRYPOINT node for backwards compatibility. "
+        f"Found {len(entrypoint_nodes)} ENTRYPOINT node(s)."
     )
 
-    # Should only have the two actual nodes
-    assert len(nodes) == 2
-    node_labels = {node.get("label") for node in nodes if isinstance(node, dict)}
-    assert node_labels == {"First Node", "Second Node"}
+    # KEY ASSERTION: Entrypoint node ID should match trigger ID
+    entrypoint_node = entrypoint_nodes[0]
+    assert entrypoint_node["id"] == trigger_id, (
+        f"Entrypoint node ID ({entrypoint_node['id']}) should match trigger ID ({trigger_id}) "
+        "to link the entrypoint with its trigger."
+    )
+
+    # Should have 3 nodes total: ENTRYPOINT, FirstNode, SecondNode
+    assert len(nodes) == 3
+    node_types = {node.get("type") for node in nodes if isinstance(node, dict)}
+    assert "ENTRYPOINT" in node_types
+    assert "GENERIC" in node_types  # FirstNode and SecondNode are GENERIC
 
 
 def test_unknown_trigger_type():

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_manual_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_manual_trigger_serialization.py
@@ -46,7 +46,7 @@ def test_manual_trigger_multiple_entrypoints():
     nodes = workflow_data["nodes"]
     assert isinstance(nodes, list)
 
-    # With triggers, 3 nodes exist: ENTRYPOINT (for backwards compat) + 2 actual nodes
+    # entrypoint + 2 nodes
     assert len(nodes) == 3
 
     assert "triggers" in result
@@ -55,66 +55,6 @@ def test_manual_trigger_multiple_entrypoints():
 
     assert len(triggers) == 1
     assert triggers[0] == {"id": "b09c1902-3cca-4c79-b775-4c32e3e88466", "type": "MANUAL", "attributes": []}
-
-
-def test_manual_trigger_entrypoint_node_id():
-    """
-    Backwards compatibility: Workflows with triggers should have an ENTRYPOINT node
-    whose ID matches the trigger ID.
-
-    This allows existing systems that expect ENTRYPOINT nodes to continue working,
-    while linking the entrypoint to the trigger through shared ID.
-    """
-
-    class FirstNode(BaseNode):
-        pass
-
-    class SecondNode(BaseNode):
-        pass
-
-    class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
-        graph = ManualTrigger >> FirstNode >> SecondNode
-
-    result = get_workflow_display(workflow_class=TestWorkflow).serialize()
-    assert isinstance(result, dict)
-
-    # Verify trigger exists
-    assert "triggers" in result
-    triggers = result["triggers"]
-    assert isinstance(triggers, list)
-    assert len(triggers) == 1
-
-    trigger = triggers[0]
-    assert isinstance(trigger, dict)
-    trigger_id = trigger["id"]
-    assert trigger["type"] == "MANUAL"
-
-    # Verify ENTRYPOINT node exists for backwards compatibility
-    workflow_data = result["workflow_raw_data"]
-    assert isinstance(workflow_data, dict)
-
-    nodes = workflow_data["nodes"]
-    assert isinstance(nodes, list)
-
-    # Find the ENTRYPOINT node
-    entrypoint_nodes = [node for node in nodes if isinstance(node, dict) and node.get("type") == "ENTRYPOINT"]
-    assert len(entrypoint_nodes) == 1, (
-        "Workflows with triggers should have exactly one ENTRYPOINT node for backwards compatibility. "
-        f"Found {len(entrypoint_nodes)} ENTRYPOINT node(s)."
-    )
-
-    # KEY ASSERTION: Entrypoint node ID should match trigger ID
-    entrypoint_node = entrypoint_nodes[0]
-    assert entrypoint_node["id"] == trigger_id, (
-        f"Entrypoint node ID ({entrypoint_node['id']}) should match trigger ID ({trigger_id}) "
-        "to link the entrypoint with its trigger."
-    )
-
-    # Should have 3 nodes total: ENTRYPOINT, FirstNode, SecondNode
-    assert len(nodes) == 3
-    node_types = {node.get("type") for node in nodes if isinstance(node, dict)}
-    assert "ENTRYPOINT" in node_types
-    assert "GENERIC" in node_types  # FirstNode and SecondNode are GENERIC
 
 
 def test_unknown_trigger_type():

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_manual_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_manual_trigger_serialization.py
@@ -75,18 +75,27 @@ def test_manual_trigger_replaces_entrypoint_node():
         graph = ManualTrigger >> FirstNode >> SecondNode
 
     result = get_workflow_display(workflow_class=TestWorkflow).serialize()
+    assert isinstance(result, dict)
 
     # Verify trigger exists
     assert "triggers" in result
-    assert len(result["triggers"]) == 1
-    assert result["triggers"][0]["type"] == "MANUAL"
+    triggers = result["triggers"]
+    assert isinstance(triggers, list)
+    assert len(triggers) == 1
+
+    trigger = triggers[0]
+    assert isinstance(trigger, dict)
+    assert trigger["type"] == "MANUAL"
 
     # TDD: The key assertion - NO ENTRYPOINT node should exist
     workflow_data = result["workflow_raw_data"]
+    assert isinstance(workflow_data, dict)
+
     nodes = workflow_data["nodes"]
+    assert isinstance(nodes, list)
 
     # Check that NO node has type "ENTRYPOINT"
-    entrypoint_nodes = [node for node in nodes if node.get("type") == "ENTRYPOINT"]
+    entrypoint_nodes = [node for node in nodes if isinstance(node, dict) and node.get("type") == "ENTRYPOINT"]
     assert len(entrypoint_nodes) == 0, (
         "Workflows with triggers should NOT have ENTRYPOINT nodes. "
         f"Found {len(entrypoint_nodes)} ENTRYPOINT node(s). "
@@ -95,7 +104,7 @@ def test_manual_trigger_replaces_entrypoint_node():
 
     # Should only have the two actual nodes
     assert len(nodes) == 2
-    node_labels = {node.get("label") for node in nodes}
+    node_labels = {node.get("label") for node in nodes if isinstance(node, dict)}
     assert node_labels == {"First Node", "Second Node"}
 
 

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -179,30 +179,34 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
         serialized_nodes: Dict[UUID, JsonObject] = {}
         edges: JsonArray = []
 
-        # Check if workflow has a trigger - if so, trigger replaces the entrypoint
-        # Get all trigger edges from the workflow's subgraphs
+        # Get all trigger edges from the workflow's subgraphs to check if trigger exists
         trigger_edges = []
         for subgraph in self._workflow.get_subgraphs():
             trigger_edges.extend(list(subgraph.trigger_edges))
-        has_trigger = len(trigger_edges) > 0
 
-        # Add a single synthetic node for the workflow entrypoint (only if no trigger exists)
-        # When a trigger exists, it IS the entry point, so we don't need an ENTRYPOINT node
-        entrypoint_node_id = self.display_context.workflow_display.entrypoint_node_id
+        # Determine entrypoint node ID: use trigger ID if trigger exists, otherwise use default
+        # This maintains backwards compatibility while linking trigger and entrypoint
+        if len(trigger_edges) > 0:
+            trigger_class = trigger_edges[0].trigger_class
+            entrypoint_node_id = get_trigger_id(trigger_class)
+        else:
+            entrypoint_node_id = self.display_context.workflow_display.entrypoint_node_id
+
         entrypoint_node_source_handle_id = self.display_context.workflow_display.entrypoint_node_source_handle_id
-        if not has_trigger:
-            serialized_nodes[entrypoint_node_id] = {
-                "id": str(entrypoint_node_id),
-                "type": "ENTRYPOINT",
-                "inputs": [],
-                "data": {
-                    "label": "Entrypoint Node",
-                    "source_handle_id": str(entrypoint_node_source_handle_id),
-                },
-                "display_data": self.display_context.workflow_display.entrypoint_node_display.dict(),
-                "base": None,
-                "definition": None,
-            }
+
+        # Always add entrypoint node for backwards compatibility
+        serialized_nodes[entrypoint_node_id] = {
+            "id": str(entrypoint_node_id),
+            "type": "ENTRYPOINT",
+            "inputs": [],
+            "data": {
+                "label": "Entrypoint Node",
+                "source_handle_id": str(entrypoint_node_source_handle_id),
+            },
+            "display_data": self.display_context.workflow_display.entrypoint_node_display.dict(),
+            "base": None,
+            "definition": None,
+        }
 
         # Add all the nodes in the workflows
         for node in self._workflow.get_all_nodes():
@@ -349,28 +353,27 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
                 ValueError("Unable to serialize terminal nodes that are not referenced by workflow outputs.")
             )
 
-        # Add edges from entrypoint node to first nodes (only if no trigger exists)
-        # When a trigger exists, there are no entrypoint edges since the trigger IS the entry point
-        if not has_trigger:
-            for target_node, entrypoint_display in self.display_context.entrypoint_displays.items():
-                unadorned_target_node = get_unadorned_node(target_node)
-                # Skip edges to invalid nodes
-                if self._is_node_invalid(unadorned_target_node):
-                    continue
+        # Add edges from entrypoint node to first nodes
+        # These edges always exist for backwards compatibility
+        for target_node, entrypoint_display in self.display_context.entrypoint_displays.items():
+            unadorned_target_node = get_unadorned_node(target_node)
+            # Skip edges to invalid nodes
+            if self._is_node_invalid(unadorned_target_node):
+                continue
 
-                target_node_display = self.display_context.node_displays[unadorned_target_node]
-                entrypoint_edge_dict: Dict[str, Json] = {
-                    "id": str(entrypoint_display.edge_display.id),
-                    "source_node_id": str(entrypoint_node_id),
-                    "source_handle_id": str(entrypoint_node_source_handle_id),
-                    "target_node_id": str(target_node_display.node_id),
-                    "target_handle_id": str(target_node_display.get_trigger_id()),
-                    "type": "DEFAULT",
-                }
-                display_data = self._serialize_edge_display_data(entrypoint_display.edge_display)
-                if display_data is not None:
-                    entrypoint_edge_dict["display_data"] = display_data
-                edges.append(entrypoint_edge_dict)
+            target_node_display = self.display_context.node_displays[unadorned_target_node]
+            entrypoint_edge_dict: Dict[str, Json] = {
+                "id": str(entrypoint_display.edge_display.id),
+                "source_node_id": str(entrypoint_node_id),
+                "source_handle_id": str(entrypoint_node_source_handle_id),
+                "target_node_id": str(target_node_display.node_id),
+                "target_handle_id": str(target_node_display.get_trigger_id()),
+                "type": "DEFAULT",
+            }
+            display_data = self._serialize_edge_display_data(entrypoint_display.edge_display)
+            if display_data is not None:
+                entrypoint_edge_dict["display_data"] = display_data
+            edges.append(entrypoint_edge_dict)
 
         for (source_node_port, target_node), edge_display in self.display_context.edge_displays.items():
             unadorned_source_node_port = get_unadorned_port(source_node_port)

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -179,21 +179,30 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
         serialized_nodes: Dict[UUID, JsonObject] = {}
         edges: JsonArray = []
 
-        # Add a single synthetic node for the workflow entrypoint
+        # Check if workflow has a trigger - if so, trigger replaces the entrypoint
+        # Get all trigger edges from the workflow's subgraphs
+        trigger_edges = []
+        for subgraph in self._workflow.get_subgraphs():
+            trigger_edges.extend(list(subgraph.trigger_edges))
+        has_trigger = len(trigger_edges) > 0
+
+        # Add a single synthetic node for the workflow entrypoint (only if no trigger exists)
+        # When a trigger exists, it IS the entry point, so we don't need an ENTRYPOINT node
         entrypoint_node_id = self.display_context.workflow_display.entrypoint_node_id
         entrypoint_node_source_handle_id = self.display_context.workflow_display.entrypoint_node_source_handle_id
-        serialized_nodes[entrypoint_node_id] = {
-            "id": str(entrypoint_node_id),
-            "type": "ENTRYPOINT",
-            "inputs": [],
-            "data": {
-                "label": "Entrypoint Node",
-                "source_handle_id": str(entrypoint_node_source_handle_id),
-            },
-            "display_data": self.display_context.workflow_display.entrypoint_node_display.dict(),
-            "base": None,
-            "definition": None,
-        }
+        if not has_trigger:
+            serialized_nodes[entrypoint_node_id] = {
+                "id": str(entrypoint_node_id),
+                "type": "ENTRYPOINT",
+                "inputs": [],
+                "data": {
+                    "label": "Entrypoint Node",
+                    "source_handle_id": str(entrypoint_node_source_handle_id),
+                },
+                "display_data": self.display_context.workflow_display.entrypoint_node_display.dict(),
+                "base": None,
+                "definition": None,
+            }
 
         # Add all the nodes in the workflows
         for node in self._workflow.get_all_nodes():
@@ -340,26 +349,28 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
                 ValueError("Unable to serialize terminal nodes that are not referenced by workflow outputs.")
             )
 
-        # Add an edge for each edge in the workflow
-        for target_node, entrypoint_display in self.display_context.entrypoint_displays.items():
-            unadorned_target_node = get_unadorned_node(target_node)
-            # Skip edges to invalid nodes
-            if self._is_node_invalid(unadorned_target_node):
-                continue
+        # Add edges from entrypoint node to first nodes (only if no trigger exists)
+        # When a trigger exists, there are no entrypoint edges since the trigger IS the entry point
+        if not has_trigger:
+            for target_node, entrypoint_display in self.display_context.entrypoint_displays.items():
+                unadorned_target_node = get_unadorned_node(target_node)
+                # Skip edges to invalid nodes
+                if self._is_node_invalid(unadorned_target_node):
+                    continue
 
-            target_node_display = self.display_context.node_displays[unadorned_target_node]
-            entrypoint_edge_dict: Dict[str, Json] = {
-                "id": str(entrypoint_display.edge_display.id),
-                "source_node_id": str(entrypoint_node_id),
-                "source_handle_id": str(entrypoint_node_source_handle_id),
-                "target_node_id": str(target_node_display.node_id),
-                "target_handle_id": str(target_node_display.get_trigger_id()),
-                "type": "DEFAULT",
-            }
-            display_data = self._serialize_edge_display_data(entrypoint_display.edge_display)
-            if display_data is not None:
-                entrypoint_edge_dict["display_data"] = display_data
-            edges.append(entrypoint_edge_dict)
+                target_node_display = self.display_context.node_displays[unadorned_target_node]
+                entrypoint_edge_dict: Dict[str, Json] = {
+                    "id": str(entrypoint_display.edge_display.id),
+                    "source_node_id": str(entrypoint_node_id),
+                    "source_handle_id": str(entrypoint_node_source_handle_id),
+                    "target_node_id": str(target_node_display.node_id),
+                    "target_handle_id": str(target_node_display.get_trigger_id()),
+                    "type": "DEFAULT",
+                }
+                display_data = self._serialize_edge_display_data(entrypoint_display.edge_display)
+                if display_data is not None:
+                    entrypoint_edge_dict["display_data"] = display_data
+                edges.append(entrypoint_edge_dict)
 
         for (source_node_port, target_node), edge_display in self.display_context.edge_displays.items():
             unadorned_source_node_port = get_unadorned_port(source_node_port)


### PR DESCRIPTION
## Problem
Workflows with triggers were creating both trigger and ENTRYPOINT nodes with different IDs, making their relationship unclear.

## Solution
Link triggers and entrypoints through shared IDs while maintaining backwards compatibility:
- ENTRYPOINT nodes always exist (backwards compatibility)
- When trigger exists: entrypoint node ID = trigger ID
- When no trigger: use default entrypoint ID

## Changes
- `base_workflow_display.py`: Use trigger ID as entrypoint node ID when triggers exist
- Updated fixtures to show matching IDs (e.g., `b09c1902-3cca-4c79-b775-4c32e3e88466`)

---
*This PR was created with Claude Code*