### PR TITLE
[APO-1879] Add codegen support for VellumIntegrationTrigger

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -286,6 +286,11 @@ exports[`Workflow > graph > should generate correct graph for expression referen
 "
 `;
 
+exports[`Workflow > graph > should generate correct graph when workflow has a VellumIntegrationTrigger 1`] = `
+"SlackMessageTrigger >> FirstNode >> SecondNode
+"
+`;
+
 exports[`Workflow > graph > should generate correct graph when workflow has a manual trigger 1`] = `
 "ManualTrigger >> FirstNode >> SecondNode
 "

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -1128,8 +1128,8 @@ describe("Workflow", () => {
             id: "trigger-1",
             type: "INTEGRATION",
             attributes: [
-              { id: "attr-1", name: "message", type: "STRING", value: null },
-              { id: "attr-2", name: "channel", type: "STRING", value: null },
+              { id: "attr-1", name: "message", value: null },
+              { id: "attr-2", name: "channel", value: null },
             ],
             class_name: "SlackMessageTrigger",
             module_path: ["tests", "fixtures", "triggers", "slack_message"],

--- a/ee/codegen/src/__test__/utils/triggers.test.ts
+++ b/ee/codegen/src/__test__/utils/triggers.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+
+import { getTriggerClassInfo } from "src/utils/triggers";
+import { WorkflowTrigger } from "src/types/vellum";
+
+describe("getTriggerClassInfo", () => {
+  it("should return correct info for MANUAL trigger", () => {
+    const trigger: WorkflowTrigger = {
+      id: "manual-trigger-id",
+      type: "MANUAL",
+      attributes: [],
+    };
+
+    const result = getTriggerClassInfo(trigger);
+
+    expect(result).toEqual({
+      className: "ManualTrigger",
+      modulePath: ["vellum", "workflows", "triggers", "manual"],
+    });
+  });
+
+  it("should return correct info for INTEGRATION trigger", () => {
+    const trigger: WorkflowTrigger = {
+      id: "integration-trigger-id",
+      type: "INTEGRATION",
+      attributes: [
+        { id: "attr-1", name: "message", type: "STRING", value: null },
+        { id: "attr-2", name: "channel", type: "STRING", value: null },
+      ],
+      class_name: "SlackMessageTrigger",
+      module_path: [
+        "ee",
+        "vellum_ee",
+        "workflows",
+        "display",
+        "tests",
+        "workflow_serialization",
+        "test_vellum_integration_trigger_serialization",
+      ],
+    };
+
+    const result = getTriggerClassInfo(trigger);
+
+    expect(result).toEqual({
+      className: "SlackMessageTrigger",
+      modulePath: [
+        "ee",
+        "vellum_ee",
+        "workflows",
+        "display",
+        "tests",
+        "workflow_serialization",
+        "test_vellum_integration_trigger_serialization",
+      ],
+    });
+  });
+
+  it("should return null for INTEGRATION trigger without class_name", () => {
+    const trigger: WorkflowTrigger = {
+      id: "integration-trigger-id",
+      type: "INTEGRATION",
+      attributes: [],
+      // Missing class_name and module_path
+    };
+
+    const result = getTriggerClassInfo(trigger);
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null for unknown trigger type", () => {
+    const trigger: WorkflowTrigger = {
+      id: "unknown-trigger-id",
+      type: "UNKNOWN_TYPE",
+      attributes: [],
+    };
+
+    const result = getTriggerClassInfo(trigger);
+
+    expect(result).toBeNull();
+  });
+});

--- a/ee/codegen/src/__test__/utils/triggers.test.ts
+++ b/ee/codegen/src/__test__/utils/triggers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 
-import { getTriggerClassInfo } from "src/utils/triggers";
 import { WorkflowTrigger } from "src/types/vellum";
+import { getTriggerClassInfo } from "src/utils/triggers";
 
 describe("getTriggerClassInfo", () => {
   it("should return correct info for MANUAL trigger", () => {

--- a/ee/codegen/src/__test__/utils/triggers.test.ts
+++ b/ee/codegen/src/__test__/utils/triggers.test.ts
@@ -24,8 +24,8 @@ describe("getTriggerClassInfo", () => {
       id: "integration-trigger-id",
       type: "INTEGRATION",
       attributes: [
-        { id: "attr-1", name: "message", type: "STRING", value: null },
-        { id: "attr-2", name: "channel", type: "STRING", value: null },
+        { id: "attr-1", name: "message", value: null },
+        { id: "attr-2", name: "channel", value: null },
       ],
       class_name: "SlackMessageTrigger",
       module_path: [

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/__snapshots__/trigger-attribute-workflow-reference.test.ts.snap
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/__snapshots__/trigger-attribute-workflow-reference.test.ts.snap
@@ -1,11 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`TriggerAttributeWorkflowReference > should generate correct AST for ManualTrigger.config reference 1`] = `
+"ManualTrigger.config
+"
+`;
+
 exports[`TriggerAttributeWorkflowReference > should generate correct AST for ManualTrigger.input reference 1`] = `
 "ManualTrigger.input
 "
 `;
 
-exports[`TriggerAttributeWorkflowReference > should generate correct AST for ManualTrigger.config reference 1`] = `
-"ManualTrigger.config
+exports[`TriggerAttributeWorkflowReference > should generate correct AST for VellumIntegrationTrigger.channel reference 1`] = `
+"SlackMessageTrigger.channel
+"
+`;
+
+exports[`TriggerAttributeWorkflowReference > should generate correct AST for VellumIntegrationTrigger.message reference 1`] = `
+"SlackMessageTrigger.message
 "
 `;

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.test.ts
@@ -96,8 +96,8 @@ describe("TriggerAttributeWorkflowReference", () => {
           id: "integration-trigger-id",
           type: "INTEGRATION",
           attributes: [
-            { id: "message-id", name: "message", type: "STRING", value: null },
-            { id: "channel-id", name: "channel", type: "STRING", value: null },
+            { id: "message-id", name: "message", value: null },
+            { id: "channel-id", name: "channel", value: null },
           ],
           class_name: "SlackMessageTrigger",
           module_path: ["tests", "fixtures", "triggers", "slack_message"],
@@ -129,8 +129,8 @@ describe("TriggerAttributeWorkflowReference", () => {
           id: "integration-trigger-id",
           type: "INTEGRATION",
           attributes: [
-            { id: "message-id", name: "message", type: "STRING", value: null },
-            { id: "channel-id", name: "channel", type: "STRING", value: null },
+            { id: "message-id", name: "message", value: null },
+            { id: "channel-id", name: "channel", value: null },
           ],
           class_name: "SlackMessageTrigger",
           module_path: ["tests", "fixtures", "triggers", "slack_message"],

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.test.ts
@@ -88,4 +88,70 @@ describe("TriggerAttributeWorkflowReference", () => {
 
     expect(pointer.getAstNode()).toBeUndefined();
   });
+
+  it("should generate correct AST for VellumIntegrationTrigger.message reference", async () => {
+    const integrationWorkflowContext = workflowContextFactory({
+      triggers: [
+        {
+          id: "integration-trigger-id",
+          type: "INTEGRATION",
+          attributes: [
+            { id: "message-id", name: "message", type: "STRING", value: null },
+            { id: "channel-id", name: "channel", type: "STRING", value: null },
+          ],
+          class_name: "SlackMessageTrigger",
+          module_path: ["tests", "fixtures", "triggers", "slack_message"],
+        },
+      ],
+    });
+
+    const triggerAttributeReference: WorkflowValueDescriptorReference = {
+      type: "TRIGGER_ATTRIBUTE",
+      triggerId: "integration-trigger-id",
+      attributeId: "message-id",
+    };
+
+    const pointer = new TriggerAttributeWorkflowReference({
+      workflowContext: integrationWorkflowContext,
+      nodeInputWorkflowReferencePointer: triggerAttributeReference,
+    });
+
+    const writer = new Writer();
+    pointer.write(writer);
+
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
+
+  it("should generate correct AST for VellumIntegrationTrigger.channel reference", async () => {
+    const integrationWorkflowContext = workflowContextFactory({
+      triggers: [
+        {
+          id: "integration-trigger-id",
+          type: "INTEGRATION",
+          attributes: [
+            { id: "message-id", name: "message", type: "STRING", value: null },
+            { id: "channel-id", name: "channel", type: "STRING", value: null },
+          ],
+          class_name: "SlackMessageTrigger",
+          module_path: ["tests", "fixtures", "triggers", "slack_message"],
+        },
+      ],
+    });
+
+    const triggerAttributeReference: WorkflowValueDescriptorReference = {
+      type: "TRIGGER_ATTRIBUTE",
+      triggerId: "integration-trigger-id",
+      attributeId: "channel-id",
+    };
+
+    const pointer = new TriggerAttributeWorkflowReference({
+      workflowContext: integrationWorkflowContext,
+      nodeInputWorkflowReferencePointer: triggerAttributeReference,
+    });
+
+    const writer = new Writer();
+    pointer.write(writer);
+
+    expect(await writer.toStringFormatted()).toMatchSnapshot();
+  });
 });

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -162,7 +162,7 @@ export class GraphAttribute extends AstNode {
     if (triggers && triggers.length > 0 && graphMutableAst.type !== "empty") {
       const trigger = triggers[0];
       if (trigger) {
-        const triggerInfo = getTriggerClassInfo(trigger.type);
+        const triggerInfo = getTriggerClassInfo(trigger);
         if (triggerInfo) {
           const triggerReference: GraphTriggerReference = {
             type: "trigger_reference",

--- a/ee/codegen/src/generators/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.ts
+++ b/ee/codegen/src/generators/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.ts
@@ -27,8 +27,8 @@ export class TriggerAttributeWorkflowReference extends BaseNodeInputWorkflowRefe
       return undefined;
     }
 
-    // Get the trigger class information based on trigger type
-    const triggerClassInfo = getTriggerClassInfo(trigger.type);
+    // Get the trigger class information based on trigger
+    const triggerClassInfo = getTriggerClassInfo(trigger);
     if (!triggerClassInfo) {
       return undefined;
     }

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -2263,21 +2263,47 @@ export const WorkflowOutputValueSerializer: ObjectSchema<
   value: WorkflowValueDescriptorSerializer.optional(),
 });
 
-export const WorkflowTriggerSerializer: ObjectSchema<
-  WorkflowTriggerSerializer.Raw,
-  WorkflowTrigger
-> = objectSchema({
+const ManualTriggerSerializer = objectSchema({
   id: stringSchema(),
-  type: stringSchema(),
+  type: stringLiteralSchema("MANUAL"),
   attributes: listSchema(NodeAttributeSerializer),
 });
 
-export declare namespace WorkflowTriggerSerializer {
+export declare namespace ManualTriggerSerializer {
   interface Raw {
     id: string;
-    type: string;
+    type: "MANUAL";
     attributes: NodeAttributeSerializer.Raw[];
   }
+}
+
+const IntegrationTriggerSerializer = objectSchema({
+  id: stringSchema(),
+  type: stringLiteralSchema("INTEGRATION"),
+  attributes: listSchema(NodeAttributeSerializer),
+  className: propertySchema("class_name", stringSchema()),
+  modulePath: propertySchema("module_path", listSchema(stringSchema())),
+});
+
+export declare namespace IntegrationTriggerSerializer {
+  interface Raw {
+    id: string;
+    type: "INTEGRATION";
+    attributes: NodeAttributeSerializer.Raw[];
+    class_name: string;
+    module_path: string[];
+  }
+}
+
+export const WorkflowTriggerSerializer = unionSchema("type", {
+  MANUAL: ManualTriggerSerializer,
+  INTEGRATION: IntegrationTriggerSerializer,
+}) as unknown as Schema<WorkflowTriggerSerializer.Raw, WorkflowTrigger>;
+
+export declare namespace WorkflowTriggerSerializer {
+  type Raw =
+    | ManualTriggerSerializer.Raw
+    | IntegrationTriggerSerializer.Raw;
 }
 
 export const WorkflowRawDataSerializer: ObjectSchema<

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -2301,9 +2301,7 @@ export const WorkflowTriggerSerializer = unionSchema("type", {
 }) as unknown as Schema<WorkflowTriggerSerializer.Raw, WorkflowTrigger>;
 
 export declare namespace WorkflowTriggerSerializer {
-  type Raw =
-    | ManualTriggerSerializer.Raw
-    | IntegrationTriggerSerializer.Raw;
+  type Raw = ManualTriggerSerializer.Raw | IntegrationTriggerSerializer.Raw;
 }
 
 export const WorkflowRawDataSerializer: ObjectSchema<

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -790,6 +790,8 @@ export interface WorkflowTrigger {
   id: string;
   type: string;
   attributes: NodeAttribute[];
+  class_name?: string; // Only present for INTEGRATION triggers
+  module_path?: string[]; // Only present for INTEGRATION triggers
 }
 
 export interface WorkflowRawData {

--- a/ee/codegen/src/utils/triggers.ts
+++ b/ee/codegen/src/utils/triggers.ts
@@ -1,4 +1,5 @@
 import { VELLUM_WORKFLOW_TRIGGERS_MODULE_PATH } from "src/constants";
+import { WorkflowTrigger } from "src/types/vellum";
 
 export interface TriggerClassInfo {
   className: string;
@@ -6,13 +7,22 @@ export interface TriggerClassInfo {
 }
 
 export function getTriggerClassInfo(
-  triggerType: string
+  trigger: WorkflowTrigger
 ): TriggerClassInfo | null {
-  switch (triggerType) {
+  switch (trigger.type) {
     case "MANUAL":
       return {
         className: "ManualTrigger",
         modulePath: [...VELLUM_WORKFLOW_TRIGGERS_MODULE_PATH, "manual"],
+      };
+    case "INTEGRATION":
+      // For INTEGRATION triggers, class_name and module_path are required from serialization
+      if (!trigger.class_name || !trigger.module_path) {
+        return null;
+      }
+      return {
+        className: trigger.class_name,
+        modulePath: trigger.module_path,
       };
     default:
       return null;

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_vellum_integration_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_vellum_integration_trigger_serialization.py
@@ -1,5 +1,7 @@
 """Tests for VellumIntegrationTrigger serialization."""
 
+from typing import cast
+
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode
@@ -40,19 +42,19 @@ def test_vellum_integration_trigger_serialization():
 
     # Verify triggers field exists
     assert "triggers" in result
-    triggers = result["triggers"]
+    triggers = cast(list, result["triggers"])
     assert isinstance(triggers, list)
     assert len(triggers) == 1
 
-    trigger = triggers[0]
+    trigger = cast(dict, triggers[0])
     assert trigger["type"] == "INTEGRATION"
 
     # Check that attributes are serialized
     assert "attributes" in trigger
-    attributes = trigger["attributes"]
+    attributes = cast(list, trigger["attributes"])
     assert len(attributes) == 3
 
-    attribute_names = {attr["name"] for attr in attributes}
+    attribute_names = {cast(dict, attr)["name"] for attr in attributes}
     assert attribute_names == {"message", "channel", "user"}
 
     # RED: These assertions should fail because we haven't implemented class_name and module_path yet
@@ -61,5 +63,6 @@ def test_vellum_integration_trigger_serialization():
 
     assert "module_path" in trigger, "Trigger should include module_path for codegen"
     # The module path should be a list of strings representing the module hierarchy
-    assert isinstance(trigger["module_path"], list)
-    assert all(isinstance(part, str) for part in trigger["module_path"])
+    module_path = trigger["module_path"]
+    assert isinstance(module_path, list)
+    assert all(isinstance(part, str) for part in module_path)

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_vellum_integration_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_vellum_integration_trigger_serialization.py
@@ -1,7 +1,5 @@
 """Tests for VellumIntegrationTrigger serialization."""
 
-from typing import cast
-
 from vellum.workflows import BaseWorkflow
 from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes.bases.base import BaseNode
@@ -38,23 +36,23 @@ def test_vellum_integration_trigger_serialization():
     class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
         graph = SlackMessageTrigger >> ProcessNode
 
-    result = get_workflow_display(workflow_class=TestWorkflow).serialize()
+    result: dict = get_workflow_display(workflow_class=TestWorkflow).serialize()
 
     # Verify triggers field exists
     assert "triggers" in result
-    triggers = cast(list, result["triggers"])
+    triggers = result["triggers"]
     assert isinstance(triggers, list)
     assert len(triggers) == 1
 
-    trigger = cast(dict, triggers[0])
+    trigger = triggers[0]
     assert trigger["type"] == "INTEGRATION"
 
     # Check that attributes are serialized
     assert "attributes" in trigger
-    attributes = cast(list, trigger["attributes"])
+    attributes = trigger["attributes"]
     assert len(attributes) == 3
 
-    attribute_names = {cast(dict, attr)["name"] for attr in attributes}
+    attribute_names = {attr["name"] for attr in attributes}
     assert attribute_names == {"message", "channel", "user"}
 
     # RED: These assertions should fail because we haven't implemented class_name and module_path yet

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_vellum_integration_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_vellum_integration_trigger_serialization.py
@@ -1,0 +1,65 @@
+"""Tests for VellumIntegrationTrigger serialization."""
+
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.inputs.base import BaseInputs
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.state.base import BaseState
+from vellum.workflows.triggers.vellum_integration import VellumIntegrationTrigger
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+
+def test_vellum_integration_trigger_serialization():
+    """VellumIntegrationTrigger subclass serializes with class name and module path."""
+
+    # Create a custom VellumIntegrationTrigger subclass
+    class SlackMessageTrigger(VellumIntegrationTrigger):
+        """Custom Slack message trigger."""
+
+        message: str
+        channel: str
+        user: str
+
+        class Config:
+            provider = "COMPOSIO"
+            integration_name = "SLACK"
+            slug = "slack_new_message"
+
+    class ProcessNode(BaseNode):
+        """Node that processes the trigger."""
+
+        class Outputs(BaseNode.Outputs):
+            result = SlackMessageTrigger.message
+
+        def run(self) -> Outputs:
+            return self.Outputs()
+
+    class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+        graph = SlackMessageTrigger >> ProcessNode
+
+    result = get_workflow_display(workflow_class=TestWorkflow).serialize()
+
+    # Verify triggers field exists
+    assert "triggers" in result
+    triggers = result["triggers"]
+    assert isinstance(triggers, list)
+    assert len(triggers) == 1
+
+    trigger = triggers[0]
+    assert trigger["type"] == "INTEGRATION"
+
+    # Check that attributes are serialized
+    assert "attributes" in trigger
+    attributes = trigger["attributes"]
+    assert len(attributes) == 3
+
+    attribute_names = {attr["name"] for attr in attributes}
+    assert attribute_names == {"message", "channel", "user"}
+
+    # RED: These assertions should fail because we haven't implemented class_name and module_path yet
+    assert "class_name" in trigger, "Trigger should include class_name for codegen"
+    assert trigger["class_name"] == "SlackMessageTrigger"
+
+    assert "module_path" in trigger, "Trigger should include module_path for codegen"
+    # The module path should be a list of strings representing the module hierarchy
+    assert isinstance(trigger["module_path"], list)
+    assert all(isinstance(part, str) for part in trigger["module_path"])

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -524,7 +524,7 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
         # For INTEGRATION triggers, include class name and module path for codegen
         if trigger_type == WorkflowTriggerType.INTEGRATION:
             trigger_data["class_name"] = trigger_class.__name__
-            trigger_data["module_path"] = trigger_class.__module__.split(".")
+            trigger_data["module_path"] = cast(Json, trigger_class.__module__.split("."))
 
         return cast(JsonArray, [trigger_data])
 

--- a/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
+++ b/ee/vellum_ee/workflows/display/workflows/base_workflow_display.py
@@ -521,6 +521,11 @@ class BaseWorkflowDisplay(Generic[WorkflowType]):
             "attributes": trigger_attributes,
         }
 
+        # For INTEGRATION triggers, include class name and module path for codegen
+        if trigger_type == WorkflowTriggerType.INTEGRATION:
+            trigger_data["class_name"] = trigger_class.__name__
+            trigger_data["module_path"] = trigger_class.__module__.split(".")
+
         return cast(JsonArray, [trigger_data])
 
     def _serialize_edge_display_data(self, edge_display: EdgeDisplay) -> Optional[JsonObject]:


### PR DESCRIPTION
Implements TypeScript codegen support for custom `VellumIntegrationTrigger` subclasses (e.g., `SlackMessageTrigger`).

## Changes
- Serialize `class_name` and `module_path` from Python to TypeScript
- Add `WorkflowTrigger` discriminated union type (`MANUAL` | `INTEGRATION`)
- Generate proper imports and graph construction for integration triggers
- Comprehensive test coverage (all TypeScript + mypy checks pass)

## Example Generated Code
```python
from tests.fixtures.triggers.slack_message import SlackMessageTrigger

class MyWorkflow(BaseWorkflow):
    graph = SlackMessageTrigger >> ProcessMessageNode
```