### PR TITLE
[APO-1836] Add sourceHandleId to triggers and fix entrypoint display codegen

### DIFF
--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -1054,9 +1054,6 @@ describe("Workflow", () => {
 
       const triggerId = "trigger-1";
 
-      // With triggers, entrypoint node exists with ID matching the trigger ID
-      const entrypointNode = entrypointNodeDataFactory(triggerId);
-
       const firstNode = genericNodeFactory({
         id: "first-node",
         label: "FirstNode",
@@ -1119,9 +1116,6 @@ describe("Workflow", () => {
       const writer = new Writer();
 
       const triggerId = "trigger-1";
-
-      // With triggers, entrypoint node exists with ID matching the trigger ID
-      const entrypointNode = entrypointNodeDataFactory(triggerId);
 
       const firstNode = genericNodeFactory({
         id: "first-node",

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -1055,9 +1055,7 @@ describe("Workflow", () => {
       const triggerId = "trigger-1";
 
       // Manual triggers have an associated entrypoint node with ID matching the trigger
-      const entrypointNodeWithTriggerId = entrypointNodeDataFactory({
-        id: triggerId,
-      });
+      const entrypointNodeWithTriggerId = entrypointNodeDataFactory(triggerId);
 
       const firstNode = genericNodeFactory({
         id: "first-node",

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -1067,14 +1067,23 @@ describe("Workflow", () => {
         label: "SecondNode",
       });
 
-      const edges = edgesFactory([
-        [entrypointNode, firstNode],
-        [firstNode, secondNode],
-      ]);
+      // When a trigger is present, it IS the entry point - no entrypoint node needed
+      // Create edge from trigger to firstNode, then firstNode to secondNode
+      const edges = [
+        {
+          id: "trigger-edge",
+          type: "DEFAULT" as const,
+          sourceNodeId: triggerId,
+          sourceHandleId: "default",
+          targetNodeId: firstNode.id,
+          targetHandleId: "default",
+        },
+        ...edgesFactory([[firstNode, secondNode]]),
+      ];
 
       const workflowContext = workflowContextFactory({
         workflowRawData: {
-          nodes: [entrypointNode, firstNode, secondNode],
+          nodes: [firstNode, secondNode],
           edges,
         },
         triggers: [
@@ -1124,14 +1133,23 @@ describe("Workflow", () => {
         label: "SecondNode",
       });
 
-      const edges = edgesFactory([
-        [entrypointNode, firstNode],
-        [firstNode, secondNode],
-      ]);
+      // When a trigger is present, it IS the entry point - no entrypoint node needed
+      // Create edge from trigger to firstNode, then firstNode to secondNode
+      const edges = [
+        {
+          id: "trigger-edge",
+          type: "DEFAULT" as const,
+          sourceNodeId: triggerId,
+          sourceHandleId: "default",
+          targetNodeId: firstNode.id,
+          targetHandleId: "default",
+        },
+        ...edgesFactory([[firstNode, secondNode]]),
+      ];
 
       const workflowContext = workflowContextFactory({
         workflowRawData: {
-          nodes: [entrypointNode, firstNode, secondNode],
+          nodes: [firstNode, secondNode],
           edges,
         },
         triggers: [

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -1128,7 +1128,7 @@ describe("Workflow", () => {
           id: "trigger-edge",
           type: "DEFAULT" as const,
           sourceNodeId: triggerId,
-          sourceHandleId: "default",
+          sourceHandleId: triggerId,  // Use trigger ID as handle ID
           targetNodeId: firstNode.id,
           targetHandleId: "default",
         },
@@ -1150,6 +1150,7 @@ describe("Workflow", () => {
             ],
             className: "SlackMessageTrigger",
             modulePath: ["tests", "fixtures", "triggers", "slack_message"],
+            sourceHandleId: triggerId,  // Use trigger ID as handle ID
           },
         ],
       });

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -1128,7 +1128,7 @@ describe("Workflow", () => {
           id: "trigger-edge",
           type: "DEFAULT" as const,
           sourceNodeId: triggerId,
-          sourceHandleId: triggerId,  // Use trigger ID as handle ID
+          sourceHandleId: triggerId, // Use trigger ID as handle ID
           targetNodeId: firstNode.id,
           targetHandleId: "default",
         },
@@ -1150,7 +1150,7 @@ describe("Workflow", () => {
             ],
             className: "SlackMessageTrigger",
             modulePath: ["tests", "fixtures", "triggers", "slack_message"],
-            sourceHandleId: triggerId,  // Use trigger ID as handle ID
+            sourceHandleId: triggerId, // Use trigger ID as handle ID
           },
         ],
       });

--- a/ee/codegen/src/__test__/graph-attribute.test.ts
+++ b/ee/codegen/src/__test__/graph-attribute.test.ts
@@ -1054,6 +1054,11 @@ describe("Workflow", () => {
 
       const triggerId = "trigger-1";
 
+      // Manual triggers have an associated entrypoint node with ID matching the trigger
+      const entrypointNodeWithTriggerId = entrypointNodeDataFactory({
+        id: triggerId,
+      });
+
       const firstNode = genericNodeFactory({
         id: "first-node",
         label: "FirstNode",
@@ -1064,23 +1069,14 @@ describe("Workflow", () => {
         label: "SecondNode",
       });
 
-      // When a trigger is present, it IS the entry point - no entrypoint node needed
-      // Create edge from trigger to firstNode, then firstNode to secondNode
-      const edges = [
-        {
-          id: "trigger-edge",
-          type: "DEFAULT" as const,
-          sourceNodeId: triggerId,
-          sourceHandleId: "default",
-          targetNodeId: firstNode.id,
-          targetHandleId: "default",
-        },
-        ...edgesFactory([[firstNode, secondNode]]),
-      ];
+      const edges = edgesFactory([
+        [entrypointNodeWithTriggerId, firstNode],
+        [firstNode, secondNode],
+      ]);
 
       const workflowContext = workflowContextFactory({
         workflowRawData: {
-          nodes: [firstNode, secondNode],
+          nodes: [entrypointNodeWithTriggerId, firstNode, secondNode],
           edges,
         },
         triggers: [

--- a/ee/codegen/src/__test__/utils/triggers.test.ts
+++ b/ee/codegen/src/__test__/utils/triggers.test.ts
@@ -29,6 +29,7 @@ describe("getTriggerClassInfo", () => {
       ],
       className: "SlackMessageTrigger",
       modulePath: ["tests", "fixtures", "triggers", "slack_message"],
+      sourceHandleId: "integration-trigger-id",
     };
 
     const result = getTriggerClassInfo(trigger);

--- a/ee/codegen/src/__test__/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.test.ts
+++ b/ee/codegen/src/__test__/workflow-value-descriptor-reference/trigger-attribute-workflow-reference.test.ts
@@ -104,6 +104,7 @@ describe("TriggerAttributeWorkflowReference", () => {
           ],
           className: "SlackMessageTrigger",
           modulePath: ["tests", "fixtures", "triggers", "slack_message"],
+          sourceHandleId: "integration-trigger-id",
         },
       ],
     });
@@ -137,6 +138,7 @@ describe("TriggerAttributeWorkflowReference", () => {
           ],
           className: "SlackMessageTrigger",
           modulePath: ["tests", "fixtures", "triggers", "slack_message"],
+          sourceHandleId: "integration-trigger-id",
         },
       ],
     });

--- a/ee/codegen/src/context/workflow-context/workflow-context.ts
+++ b/ee/codegen/src/context/workflow-context/workflow-context.ts
@@ -308,6 +308,18 @@ export class WorkflowContext {
   }
 
   public getEntrypointNodeEdges(): WorkflowEdge[] {
+    // First, check if we have triggers and edges from those triggers
+    if (this.triggers && this.triggers.length > 0) {
+      const triggerIds = new Set(this.triggers.map((t) => t.id));
+      const triggerEdges = this.workflowRawData.edges.filter((edge) =>
+        triggerIds.has(edge.sourceNodeId)
+      );
+      if (triggerEdges.length > 0) {
+        return triggerEdges;
+      }
+    }
+
+    // Fall back to ENTRYPOINT node for backward compatibility
     const entrypointNode = this.tryGetEntrypointNode();
     if (!entrypointNode) {
       return [];

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -106,11 +106,8 @@ export class GraphAttribute extends AstNode {
       }
     }
 
-    // Check if entrypoint exists and get its edges
-    const entrypointNode = this.workflowContext.tryGetEntrypointNode();
-    const edges = entrypointNode
-      ? this.workflowContext.getEntrypointNodeEdges()
-      : [];
+    // Get edges from entrypoint (either from trigger entrypoints or ENTRYPOINT node)
+    const edges = this.workflowContext.getEntrypointNodeEdges();
 
     // If no edges from entrypoint, return empty
     // Single disconnected nodes should be handled as unused_graphs, not main graph
@@ -365,8 +362,15 @@ export class GraphAttribute extends AstNode {
     const entrypointNode = this.workflowContext.tryGetEntrypointNode();
     const entrypointNodeId = entrypointNode?.id;
 
+    // Check if this edge comes from a trigger
+    const triggers = this.workflowContext.triggers;
+    const isTriggerSource = triggers?.some((t) => t.id === edge.sourceNodeId);
+
     let sourceNode: BaseNodeContext<WorkflowDataNode> | null;
-    if (entrypointNodeId && edge.sourceNodeId === entrypointNodeId) {
+    if (
+      (entrypointNodeId && edge.sourceNodeId === entrypointNodeId) ||
+      isTriggerSource
+    ) {
       sourceNode = null;
     } else {
       sourceNode = this.resolveNodeId(edge.sourceNodeId);

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -414,7 +414,8 @@ export class Workflow {
                     python.methodArgument({
                       name: "id",
                       value: python.TypeInstantiation.uuid(
-                        entrypointNode?.id ?? ""
+                        // Use trigger ID when no entrypoint node exists (IntegrationTrigger workflows)
+                        entrypointNode?.id ?? edge.sourceNodeId
                       ),
                     }),
                     python.methodArgument({

--- a/ee/codegen/src/generators/workflow.ts
+++ b/ee/codegen/src/generators/workflow.ts
@@ -444,10 +444,17 @@ export class Workflow {
     const edgeDisplayEntries: { key: AstNode; value: AstNode }[] =
       this.getEdges().reduce<{ key: AstNode; value: AstNode }[]>(
         (acc, edge) => {
-          // Stable id references of edges connected to entrypoint nodes are handles separately as part of
+          // Stable id references of edges connected to entrypoint nodes or triggers are handled separately as part of
           // `entrypoint_displays` and don't need to be taken care of here.
           const entrypointNode = this.workflowContext.tryGetEntrypointNode();
-          if (entrypointNode && edge.sourceNodeId === entrypointNode.id) {
+          const triggers = this.workflowContext.triggers;
+          const isTriggerSource = triggers?.some(
+            (t) => t.id === edge.sourceNodeId
+          );
+          if (
+            (entrypointNode && edge.sourceNodeId === entrypointNode.id) ||
+            isTriggerSource
+          ) {
             return acc;
           }
 

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -796,6 +796,7 @@ export type WorkflowTrigger =
       id: string;
       type: WorkflowTriggerType.MANUAL;
       attributes: NodeAttribute[];
+      sourceHandleId?: string;
     }
   | {
       id: string;
@@ -803,6 +804,7 @@ export type WorkflowTrigger =
       attributes: NodeAttribute[];
       className: string;
       modulePath: string[];
+      sourceHandleId?: string;
     };
 
 export interface WorkflowRawData {

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -796,7 +796,6 @@ export type WorkflowTrigger =
       id: string;
       type: WorkflowTriggerType.MANUAL;
       attributes: NodeAttribute[];
-      sourceHandleId?: string;
     }
   | {
       id: string;
@@ -804,7 +803,7 @@ export type WorkflowTrigger =
       attributes: NodeAttribute[];
       className: string;
       modulePath: string[];
-      sourceHandleId?: string;
+      sourceHandleId: string;
     };
 
 export interface WorkflowRawData {


### PR DESCRIPTION
## Summary

Implements trigger edge support in TypeScript codegen where IntegrationTriggers use trigger IDs directly in edges without ENTRYPOINT nodes, and adds sourceHandleId to trigger type definitions.

## Changes

- **Added `sourceHandleId` to IntegrationTrigger type** (required field)
  - IntegrationTrigger workflows use trigger ID as sourceHandleId
  - ManualTrigger type does NOT have sourceHandleId (not needed)
- **Updated test to use `triggerId` as `sourceHandleId`** in both edges and trigger objects
- **Fixed entrypoint display UUID generation bug** - use `edge.sourceNodeId` when `entrypointNode` is null to prevent `UUID('')` ValueError
- **Updated `getEntrypointNodeEdges()`** to check for edges from triggers first, then fall back to ENTRYPOINT nodes
- **Updated graph generation logic** to treat trigger sources like ENTRYPOINT nodes
- **Updated workflow edge filtering** to exclude edges from triggers

## Technical Approach

### Edge Structure
```typescript
{
  sourceNodeId: "trigger-1",       // Trigger ID
  sourceHandleId: "trigger-1",     // Same as trigger ID
  targetNodeId: "first-node"
}
```

### Trigger Type Structure
```typescript
export type WorkflowTrigger =
  | {
      id: string;
      type: WorkflowTriggerType.MANUAL;
      attributes: NodeAttribute[];
      // No sourceHandleId - uses ENTRYPOINT node
    }
  | {
      id: string;
      type: WorkflowTriggerType.INTEGRATION;
      attributes: NodeAttribute[];
      className: string;
      modulePath: string[];
      sourceHandleId: string;  // Required - acts as edge source
    };
```

### Architecture
- **IntegrationTrigger**: No ENTRYPOINT node, edges come directly from trigger, requires sourceHandleId
- **ManualTrigger**: ENTRYPOINT node created, edges come from ENTRYPOINT node, no sourceHandleId needed
- **Type safety**: sourceHandleId is required for IntegrationTrigger, absent from ManualTrigger

## Bug Fixes

Fixed Codex Review feedback: When IntegrationTrigger workflows don't have an ENTRYPOINT node, the entrypoint display instantiation was using `entrypointNode?.id ?? ""` which created invalid `UUID('')` causing ValueError at runtime. Now uses `edge.sourceNodeId` (the trigger ID) as fallback.

## Tests

- ✅ All trigger codegen tests pass
- ✅ TypeScript type checking passes
- ✅ Prettier formatting passes
- ✅ Expected graph output: `IntegrationTrigger >> FirstNode >> SecondNode`

## Related

- Works with PR #2836 (Python serialization changes)
- Split from original PR #2832