### PR TITLE
Remove last_run_at from sdk side

### DIFF
--- a/src/vellum/workflows/triggers/schedule.py
+++ b/src/vellum/workflows/triggers/schedule.py
@@ -12,7 +12,6 @@ class ScheduleTrigger(BaseTrigger):
 
     current_run_at: datetime
     next_run_at: datetime
-    last_run_at: datetime
 
     class Config:
         cron: str


### PR DESCRIPTION
Didn't realize we update the `_run_at` fields on the publish side, so we don't actually have the last_run_at field. Squeezing the breaking change in before it makes it to a release