### PR TITLE
use trigger path to id mapping from metadata json to generate id for triggers

### DIFF
--- a/ee/vellum_ee/workflows/display/base.py
+++ b/ee/vellum_ee/workflows/display/base.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 class WorkflowTriggerType(Enum):
     MANUAL = "MANUAL"
     INTEGRATION = "INTEGRATION"
+    SCHEDULED = "SCHEDULED"
 
 
 def get_trigger_type_mapping() -> Dict[Type["BaseTrigger"], WorkflowTriggerType]:

--- a/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
+++ b/ee/vellum_ee/workflows/display/nodes/vellum/code_execution_node.py
@@ -25,7 +25,7 @@ def _read_file_from_path_with_virtual_support(node_filepath: str, script_filepat
     full_filepath = os.path.join(node_filepath_dir, normalized_script_filepath)
 
     try:
-        with virtual_open(full_filepath, "r") as file:
+        with virtual_open(full_filepath) as file:
             return file.read()
     except (FileNotFoundError, IsADirectoryError):
         return None

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_scheduled_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_scheduled_trigger_serialization.py
@@ -12,6 +12,7 @@ from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.state.base import BaseState
 from vellum.workflows.triggers.base import _get_trigger_path_to_id_mapping
 from vellum.workflows.triggers.schedule import ScheduleTrigger
+from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
 
 
@@ -136,7 +137,10 @@ def test_scheduled_trigger_serialization_without_metadata_json():
     assert trigger["type"] == "SCHEDULED"
 
     # AND the id is the trigger class's default __id__ (hash-based)
-    expected_default_id = str(WeeklyScheduleTrigger.__id__)
+    expected_module_path = (
+        f"{__name__}.test_scheduled_trigger_serialization_without_metadata_json.<locals>.WeeklyScheduleTrigger"
+    )
+    expected_default_id = str(uuid4_from_hash(expected_module_path))
     assert trigger["id"] == expected_default_id
 
     # AND attributes are serialized

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_scheduled_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_scheduled_trigger_serialization.py
@@ -1,0 +1,145 @@
+from contextlib import contextmanager
+import json
+import os
+import tempfile
+from unittest.mock import patch
+from uuid import UUID
+from typing import Iterator, Tuple
+
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.inputs.base import BaseInputs
+from vellum.workflows.nodes.bases.base import BaseNode
+from vellum.workflows.state.base import BaseState
+from vellum.workflows.triggers.base import _get_trigger_path_to_id_mapping
+from vellum.workflows.triggers.schedule import ScheduleTrigger
+from vellum_ee.workflows.display.workflows.get_vellum_workflow_display_class import get_workflow_display
+
+
+@contextmanager
+def mock_metadata_json(trigger_class_name: str, trigger_id: UUID) -> Iterator[Tuple[str, UUID]]:
+    """
+    Context manager that mocks metadata.json with trigger ID mapping.
+
+    Args:
+        trigger_class_name: Name of the trigger class (e.g., "DailyScheduleTrigger")
+        trigger_id: The UUID to map the trigger to
+
+    Yields:
+        Tuple of (trigger_module_path, trigger_id)
+    """
+    # Create a temporary directory to simulate a workflow module
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create metadata.json with trigger mapping
+        metadata_path = os.path.join(tmpdir, "metadata.json")
+        trigger_module_path = f"{__name__}.{trigger_class_name}"
+
+        with open(metadata_path, "w") as f:
+            json.dump(
+                {
+                    "trigger_path_to_id_mapping": {
+                        trigger_module_path: str(trigger_id),
+                    }
+                },
+                f,
+            )
+
+        # Mock the workflow root finder to return our temp directory
+        # Mock os.path.exists to return True for our metadata.json
+        with patch("vellum.workflows.triggers.base._find_workflow_root_with_metadata", return_value=tmpdir):
+            with patch("vellum.workflows.triggers.base.os.path.exists", return_value=True):
+                with patch("vellum.workflows.triggers.base.virtual_open", open):
+                    # Clear the LRU cache to ensure fresh read
+                    _get_trigger_path_to_id_mapping.cache_clear()
+
+                    yield trigger_module_path, trigger_id
+
+
+def test_scheduled_trigger_serialization_with_metadata_json():
+    """ScheduleTrigger uses mapped ID from metadata.json when available."""
+
+    # GIVEN we have an expected trigger ID
+    expected_trigger_id = UUID("12345678-1234-1234-1234-123456789abc")
+
+    # AND we have metadata.json set up with the trigger mapping
+    # Note: Use the full qualified name including the test function name and <locals>
+    with mock_metadata_json(
+        "test_scheduled_trigger_serialization_with_metadata_json.<locals>.DailyScheduleTrigger",
+        expected_trigger_id,
+    ):
+        # Define the trigger class AFTER setting up mocks
+        # This ensures the metaclass reads from our mocked metadata.json
+        class DailyScheduleTrigger(ScheduleTrigger):
+            class Config:
+                cron = "0 9 * * *"  # Every day at 9am
+                timezone = "America/New_York"
+
+        class ProcessNode(BaseNode):
+            class Outputs(BaseNode.Outputs):
+                timestamp = DailyScheduleTrigger.current_run_at
+
+            def run(self) -> Outputs:
+                return self.Outputs()
+
+        # AND a workflow that has the scheduled trigger as the entrypoint
+        class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+            graph = DailyScheduleTrigger >> ProcessNode
+
+        # WHEN we serialize the workflow
+        # The trigger ID should be automatically loaded from metadata.json by the metaclass
+        result: dict = get_workflow_display(workflow_class=TestWorkflow).serialize()
+
+        # THEN we get the expected trigger
+        assert "triggers" in result
+        triggers = result["triggers"]
+        assert isinstance(triggers, list)
+        assert len(triggers) == 1
+
+        trigger = triggers[0]
+        assert isinstance(trigger, dict)
+        assert trigger["type"] == "SCHEDULED"
+
+        # AND the id is the one from metadata.json
+        assert trigger["id"] == str(expected_trigger_id)
+
+
+def test_scheduled_trigger_serialization_without_metadata_json():
+    """ScheduleTrigger uses default hash-based __id__ when no metadata.json is available."""
+
+    # GIVEN a scheduled trigger defined without metadata.json
+    class WeeklyScheduleTrigger(ScheduleTrigger):
+        class Config:
+            cron = "0 9 * * MON"  # Every Monday at 9am
+            timezone = "UTC"
+
+    class ProcessNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            timestamp = WeeklyScheduleTrigger.current_run_at
+
+        def run(self) -> Outputs:
+            return self.Outputs()
+
+    # AND a workflow that has the scheduled trigger as the entrypoint
+    class TestWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+        graph = WeeklyScheduleTrigger >> ProcessNode
+
+    # WHEN we serialize the workflow without metadata.json
+    result: dict = get_workflow_display(workflow_class=TestWorkflow).serialize()
+
+    # THEN we get the expected trigger
+    assert "triggers" in result
+    triggers = result["triggers"]
+    assert isinstance(triggers, list)
+    assert len(triggers) == 1
+
+    trigger = triggers[0]
+    assert isinstance(trigger, dict)
+    assert trigger["type"] == "SCHEDULED"
+
+    # AND the id is the trigger class's default __id__ (hash-based)
+    expected_default_id = str(WeeklyScheduleTrigger.__id__)
+    assert trigger["id"] == expected_default_id
+
+    # AND attributes are serialized
+    assert "attributes" in trigger
+    attributes = trigger["attributes"]
+    assert isinstance(attributes, list)

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -1,6 +1,5 @@
 from dataclasses import asdict, is_dataclass
 import inspect
-import sys
 from uuid import UUID
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
@@ -41,7 +40,6 @@ from vellum.workflows.expressions.not_between import NotBetweenExpression
 from vellum.workflows.expressions.not_in import NotInExpression
 from vellum.workflows.expressions.or_ import OrExpression
 from vellum.workflows.expressions.parse_json import ParseJsonExpression
-from vellum.workflows.loaders.base import BaseWorkflowFinder
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.displayable.bases.utils import primitive_to_vellum_value
 from vellum.workflows.nodes.utils import get_unadorned_node
@@ -56,25 +54,13 @@ from vellum.workflows.references.vellum_secret import VellumSecretReference
 from vellum.workflows.references.workflow_input import WorkflowInputReference
 from vellum.workflows.types.core import JsonArray, JsonObject
 from vellum.workflows.types.generics import is_workflow_class
+from vellum.workflows.utils.files import virtual_open
 from vellum.workflows.utils.functions import compile_function_definition
 from vellum.workflows.utils.uuids import uuid4_from_hash
 from vellum_ee.workflows.display.utils.exceptions import InvalidInputReferenceError, UnsupportedSerializationException
 
 if TYPE_CHECKING:
     from vellum_ee.workflows.display.types import WorkflowDisplayContext
-
-
-def virtual_open(file_path: str, mode: str = "r"):
-    """
-    Open a file, checking BaseWorkflowFinder instances first before falling back to regular open().
-    """
-    for finder in sys.meta_path:
-        if isinstance(finder, BaseWorkflowFinder):
-            result = finder.virtual_open(file_path)
-            if result is not None:
-                return result
-
-    return open(file_path, mode)
 
 
 def convert_descriptor_to_operator(descriptor: BaseDescriptor) -> LogicalOperator:

--- a/src/vellum/workflows/triggers/base.py
+++ b/src/vellum/workflows/triggers/base.py
@@ -1,10 +1,14 @@
 from abc import ABC, ABCMeta
+from functools import lru_cache
 import inspect
+import json
+import os
 from uuid import UUID
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, Tuple, Type, cast, get_origin
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, Optional, Tuple, Type, cast, get_origin
 
 from vellum.workflows.references.trigger import TriggerAttributeReference
 from vellum.workflows.types.utils import get_class_attr_names, infer_types
+from vellum.workflows.utils.files import virtual_open
 from vellum.workflows.utils.uuids import uuid4_from_hash
 
 if TYPE_CHECKING:
@@ -27,12 +31,84 @@ def _is_annotated(cls: Type, name: str) -> bool:
     return False
 
 
+def _find_workflow_root_with_metadata(trigger_module: str) -> Optional[str]:
+    """
+    Find the workflow root module by searching for metadata.json up the module hierarchy.
+
+    Args:
+        trigger_module: The trigger's module path (e.g., "workflows.my_workflow.triggers.my_trigger")
+
+    Returns:
+        The workflow root module path if found, None otherwise
+    """
+    module_parts = trigger_module.split(".")
+
+    # Try searching up the module hierarchy for metadata.json
+    for i in range(len(module_parts), 0, -1):
+        potential_root = ".".join(module_parts[:i])
+        module_dir = potential_root.replace(".", os.path.sep)
+        metadata_path = os.path.join(module_dir, "metadata.json")
+
+        if os.path.exists(metadata_path):
+            return potential_root
+
+    return None
+
+
+@lru_cache(maxsize=128)
+def _get_trigger_path_to_id_mapping(module_root: str) -> Dict[str, UUID]:
+    """
+    Read trigger path to ID mapping from metadata.json.
+
+    This function is cached to avoid repeated file reads. It looks for metadata.json
+    in the workflow module directory and extracts the trigger_path_to_id_mapping.
+
+    Args:
+        module_root: The root module path (e.g., "workflows.my_workflow")
+
+    Returns:
+        Dictionary mapping trigger module paths to their UUIDs
+    """
+    try:
+        # Convert module path to file path
+        module_dir = module_root.replace(".", os.path.sep)
+        metadata_path = os.path.join(module_dir, "metadata.json")
+
+        # Check if metadata.json exists
+        if not os.path.exists(metadata_path):
+            return {}
+
+        # Use virtual_open to support both regular and virtual environments
+        with virtual_open(metadata_path) as f:
+            metadata_json = json.load(f)
+            trigger_mapping = metadata_json.get("trigger_path_to_id_mapping", {})
+
+            # Convert string IDs to UUIDs
+            return {path: UUID(id_str) for path, id_str in trigger_mapping.items()}
+
+    except (FileNotFoundError, json.JSONDecodeError, ValueError, KeyError):
+        # If there's any error reading or parsing the file, return empty dict
+        return {}
+
+
 class BaseTriggerMeta(ABCMeta):
     def __new__(mcs, name: str, bases: Tuple[Type, ...], dct: Dict[str, Any]) -> Any:
         cls = super().__new__(mcs, name, bases, dct)
         trigger_class = cast(Type["BaseTrigger"], cls)
 
+        # Set default ID based on module and class name
         trigger_class.__id__ = uuid4_from_hash(f"{trigger_class.__module__}.{trigger_class.__qualname__}")
+
+        # Try to override with ID from metadata.json if available
+        # This approach is similar to how BaseNodeDisplay automatically sets node IDs
+        workflow_root = _find_workflow_root_with_metadata(trigger_class.__module__)
+        if workflow_root:
+            trigger_path_to_id_mapping = _get_trigger_path_to_id_mapping(workflow_root)
+            trigger_path = f"{trigger_class.__module__}.{trigger_class.__qualname__}"
+
+            if trigger_path in trigger_path_to_id_mapping:
+                # Override the default ID with the one from metadata.json
+                trigger_class.__id__ = trigger_path_to_id_mapping[trigger_path]
 
         return trigger_class
 

--- a/src/vellum/workflows/utils/files.py
+++ b/src/vellum/workflows/utils/files.py
@@ -1,0 +1,29 @@
+"""File utilities for workflows, including virtual file support."""
+
+import sys
+
+from vellum.workflows.loaders.base import BaseWorkflowFinder
+
+
+def virtual_open(file_path: str, mode: str = "r"):
+    """
+    Open a file, checking BaseWorkflowFinder instances first before falling back to regular open().
+
+    This function is used to support reading files in both regular and virtual environments
+    (e.g., when using VirtualFileLoader in serverless/Vembda deployments).
+
+    Args:
+        file_path: Path to the file to open
+        mode: File open mode (default: "r")
+
+    Returns:
+        A file-like object (either StringIO or a regular file handle)
+    """
+    # Check if there's a BaseWorkflowFinder in sys.meta_path
+    for finder in sys.meta_path:
+        if isinstance(finder, BaseWorkflowFinder):
+            result = finder.virtual_open(file_path)
+            if result is not None:
+                return result
+
+    return open(file_path, mode)

--- a/src/vellum/workflows/utils/files.py
+++ b/src/vellum/workflows/utils/files.py
@@ -5,7 +5,7 @@ import sys
 from vellum.workflows.loaders.base import BaseWorkflowFinder
 
 
-def virtual_open(file_path: str, mode: str = "r"):
+def virtual_open(file_path: str):
     """
     Open a file, checking BaseWorkflowFinder instances first before falling back to regular open().
 
@@ -14,7 +14,6 @@ def virtual_open(file_path: str, mode: str = "r"):
 
     Args:
         file_path: Path to the file to open
-        mode: File open mode (default: "r")
 
     Returns:
         A file-like object (either StringIO or a regular file handle)
@@ -26,4 +25,4 @@ def virtual_open(file_path: str, mode: str = "r"):
             if result is not None:
                 return result
 
-    return open(file_path, mode)
+    return open(file_path)


### PR DESCRIPTION
This PR helps introduce a new pattern for using mappings within our metadata.json to drive serialization of values. In this case it is for workflow trigger id's