### PR TITLE
Use module + class name for trigger path key mapping

### DIFF
--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -699,7 +699,7 @@ describe("WorkflowProjectGenerator", () => {
 
       const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8"));
       expect(metadata.trigger_path_to_id_mapping).toEqual({
-        "code.triggers.scheduled": "trigger-1",
+        "code.triggers.scheduled.ScheduleTrigger": "trigger-1",
       });
     });
   });

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -1110,7 +1110,10 @@ ${errors.slice(0, 3).map((err) => {
       Array.from(
         this.workflowContext.globalTriggerContextsByTriggerId.entries()
       ).map(([triggerId, triggerContext]) => [
-        triggerContext.triggerModulePath.join("."),
+        [
+          ...triggerContext.triggerModulePath,
+          triggerContext.triggerClassName,
+        ].join("."),
         triggerId,
       ])
     );

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_scheduled_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_scheduled_trigger_serialization.py
@@ -37,13 +37,15 @@ def mock_metadata_json(trigger_class_name: str, trigger_id: UUID) -> Iterator[Tu
         workflow_root_module = ".".join(test_module_parts[:-1])  # Remove last part
 
         relative_module_path = "." + test_module_parts[-1]
+        # Include the full trigger path with class name to match TypeScript codegen
+        relative_trigger_path = f"{relative_module_path}.{trigger_class_name}"
 
         with open(metadata_path, "w") as f:
             json.dump(
                 {
                     "trigger_path_to_id_mapping": {
-                        # Use relative module path (just the module, not the class name)
-                        relative_module_path: str(trigger_id),
+                        # Use full trigger path including class name
+                        relative_trigger_path: str(trigger_id),
                     }
                 },
                 f,

--- a/src/vellum/workflows/triggers/base.py
+++ b/src/vellum/workflows/triggers/base.py
@@ -31,6 +31,57 @@ def _is_annotated(cls: Type, name: str) -> bool:
     return False
 
 
+def _convert_to_relative_module_path(absolute_module_path: str, workflow_root: str) -> str:
+    """
+    Convert an absolute module path to a relative path from the workflow root.
+
+    Args:
+        absolute_module_path: The full module path (e.g., "workflow_id.triggers.scheduled")
+        workflow_root: The workflow root module (e.g., "workflow_id")
+
+    Returns:
+        Relative module path with leading dot (e.g., ".triggers.scheduled")
+    """
+    if not absolute_module_path.startswith(workflow_root):
+        return ""
+
+    remaining_path = absolute_module_path[len(workflow_root) :]
+    if remaining_path.startswith("."):
+        return remaining_path
+    else:
+        return "." + remaining_path
+
+
+def _get_trigger_id_from_metadata(trigger_module: str, trigger_class_name: str) -> Optional[UUID]:
+    """
+    Get the trigger ID from metadata.json for a given trigger module and class.
+
+    Args:
+        trigger_module: The trigger's module path (e.g., "workflow_id.triggers.scheduled")
+        trigger_class_name: The trigger's class name (e.g., "ScheduleTrigger")
+
+    Returns:
+        The UUID from metadata.json, or None if not found
+    """
+    workflow_root = _find_workflow_root_with_metadata(trigger_module)
+    if not workflow_root:
+        return None
+
+    trigger_path_to_id_mapping = _get_trigger_path_to_id_mapping(trigger_module)
+    if not trigger_path_to_id_mapping:
+        return None
+
+    # Convert module path to relative path and append class name
+    # e.g., "workflow_id.triggers.scheduled" + "ScheduleTrigger" -> ".triggers.scheduled.ScheduleTrigger"
+    relative_module_path = _convert_to_relative_module_path(trigger_module, workflow_root)
+    if not relative_module_path:
+        return None
+
+    # Append class name to get full trigger path
+    relative_trigger_path = f"{relative_module_path}.{trigger_class_name}"
+    return trigger_path_to_id_mapping.get(relative_trigger_path)
+
+
 def _find_workflow_root_with_metadata(trigger_module: str) -> Optional[str]:
     """
     Find the workflow root module by searching for metadata.json up the module hierarchy.
@@ -117,20 +168,11 @@ class BaseTriggerMeta(ABCMeta):
         # Set default ID based on module and class name
         trigger_class.__id__ = uuid4_from_hash(f"{trigger_class.__module__}.{trigger_class.__qualname__}")
 
-        trigger_path_to_id_mapping = _get_trigger_path_to_id_mapping(trigger_class.__module__)
+        # Try to override with ID from metadata.json if available
+        metadata_id = _get_trigger_id_from_metadata(trigger_class.__module__, trigger_class.__qualname__)
+        if metadata_id:
+            trigger_class.__id__ = metadata_id
 
-        # Convert absolute module path to relative path for lookup
-        workflow_root = _find_workflow_root_with_metadata(trigger_class.__module__)
-        if workflow_root and trigger_class.__module__.startswith(workflow_root):
-            remaining_path = trigger_class.__module__[len(workflow_root) :]
-            if remaining_path.startswith("."):
-                relative_trigger_module_path = remaining_path
-            else:
-                relative_trigger_module_path = "." + remaining_path
-
-            if relative_trigger_module_path in trigger_path_to_id_mapping:
-                # Override the default ID with the one from metadata.json
-                trigger_class.__id__ = trigger_path_to_id_mapping[relative_trigger_module_path]
         return trigger_class
 
     """


### PR DESCRIPTION
Addressed these two follow up points:
1. [Use classname to future proof multiple triggers in trigger path mapping](https://github.com/vellum-ai/vellum-python-sdks/pull/2965#discussion_r2492567345)
2. [Have helpers](https://github.com/vellum-ai/vellum-python-sdks/pull/2965#discussion_r2492558520)