### PR TITLE
Refactor prompt block into base

### DIFF
--- a/ee/codegen/src/generators/base-prompt-block.ts
+++ b/ee/codegen/src/generators/base-prompt-block.ts
@@ -134,7 +134,7 @@ export abstract class BasePromptBlock<
       ...this.generateCommonFileInputArguments(promptBlock),
     ];
 
-    const audioBlock = python.instantiateClass({
+    const audioBlock = new ClassInstantiation({
       classReference: this.getPromptBlockRef(promptBlock),
       arguments_: classArgs,
     });
@@ -151,7 +151,7 @@ export abstract class BasePromptBlock<
       ...this.generateCommonFileInputArguments(promptBlock),
     ];
 
-    const videoBlock = python.instantiateClass({
+    const videoBlock = new ClassInstantiation({
       classReference: this.getPromptBlockRef(promptBlock),
       arguments_: classArgs,
     });
@@ -168,7 +168,7 @@ export abstract class BasePromptBlock<
       ...this.generateCommonFileInputArguments(promptBlock),
     ];
 
-    const imageBlock = python.instantiateClass({
+    const imageBlock = new ClassInstantiation({
       classReference: this.getPromptBlockRef(promptBlock),
       arguments_: classArgs,
     });
@@ -185,7 +185,7 @@ export abstract class BasePromptBlock<
       ...this.generateCommonFileInputArguments(promptBlock),
     ];
 
-    const documentBlock = python.instantiateClass({
+    const documentBlock = new ClassInstantiation({
       classReference: this.getPromptBlockRef(promptBlock),
       arguments_: classArgs,
     });
@@ -194,7 +194,7 @@ export abstract class BasePromptBlock<
     return documentBlock;
   }
 
-  protected getPromptBlockRef(promptBlock: T): python.Reference {
+  protected getPromptBlockRef(promptBlock: T): Reference {
     let pathName;
     switch (promptBlock.blockType) {
       case "JINJA":
@@ -225,7 +225,7 @@ export abstract class BasePromptBlock<
         pathName = "DocumentPromptBlock";
         break;
     }
-    return python.reference({
+    return new Reference({
       name: pathName,
       modulePath: VELLUM_CLIENT_MODULE_PATH,
     });
@@ -243,7 +243,7 @@ export abstract class BasePromptBlock<
     classArgs.push(
       new MethodArgument({
         name: "src",
-        value: python.TypeInstantiation.str(promptBlock.src),
+        value: new StrInstantiation(promptBlock.src),
       })
     );
 

--- a/ee/codegen/src/generators/prompt-block.ts
+++ b/ee/codegen/src/generators/prompt-block.ts
@@ -1,18 +1,13 @@
 import { python } from "@fern-api/python-ast";
 import { isNil } from "lodash";
 import {
-  AudioPromptBlock,
   ChatMessagePromptBlock,
-  DocumentPromptBlock,
-  ImagePromptBlock,
   JinjaPromptBlock,
   PlainTextPromptBlock,
   RichTextPromptBlock,
   VariablePromptBlock,
-  VideoPromptBlock,
 } from "vellum-ai/api";
 
-import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
 import {
   BasePromptBlock,
   PromptBlock as PromptBlockType,
@@ -20,72 +15,10 @@ import {
 import { ClassInstantiation } from "src/generators/extensions/class-instantiation";
 import { ListInstantiation } from "src/generators/extensions/list-instantiation";
 import { MethodArgument } from "src/generators/extensions/method-argument";
-import { Reference } from "src/generators/extensions/reference";
 import { StrInstantiation } from "src/generators/extensions/str-instantiation";
-import { Json } from "src/generators/json";
 
 export class PromptBlock extends BasePromptBlock<PromptBlockType> {
-  protected generateAstNode(promptBlock: PromptBlockType): ClassInstantiation {
-    switch (promptBlock.blockType) {
-      case "JINJA":
-        return this.generateJinjaPromptBlock(promptBlock);
-      case "CHAT_MESSAGE":
-        return this.generateChatMessagePromptBlock(promptBlock);
-      case "VARIABLE":
-        return this.generateVariablePromptBlock(promptBlock);
-      case "RICH_TEXT":
-        return this.generateRichTextPromptBlock(promptBlock);
-      case "PLAIN_TEXT":
-        return this.generatePlainTextPromptBlock(promptBlock);
-      case "AUDIO":
-        return this.generateAudioPromptBlock(promptBlock);
-      case "VIDEO":
-        return this.generateVideoPromptBlock(promptBlock);
-      case "IMAGE":
-        return this.generateImagePromptBlock(promptBlock);
-      case "DOCUMENT":
-        return this.generateDocumentPromptBlock(promptBlock);
-    }
-  }
-
-  private getPromptBlockRef(promptBlock: PromptBlockType): Reference {
-    let pathName;
-    switch (promptBlock.blockType) {
-      case "JINJA":
-        pathName = "JinjaPromptBlock";
-        break;
-      case "CHAT_MESSAGE":
-        pathName = "ChatMessagePromptBlock";
-        break;
-      case "VARIABLE":
-        pathName = "VariablePromptBlock";
-        break;
-      case "RICH_TEXT":
-        pathName = "RichTextPromptBlock";
-        break;
-      case "PLAIN_TEXT":
-        pathName = "PlainTextPromptBlock";
-        break;
-      case "AUDIO":
-        pathName = "AudioPromptBlock";
-        break;
-      case "VIDEO":
-        pathName = "VideoPromptBlock";
-        break;
-      case "IMAGE":
-        pathName = "ImagePromptBlock";
-        break;
-      case "DOCUMENT":
-        pathName = "DocumentPromptBlock";
-        break;
-    }
-    return new Reference({
-      name: pathName,
-      modulePath: VELLUM_CLIENT_MODULE_PATH,
-    });
-  }
-
-  private generateJinjaPromptBlock(
+  protected generateJinjaPromptBlock(
     promptBlock: JinjaPromptBlock
   ): ClassInstantiation {
     const classArgs: MethodArgument[] = [
@@ -121,7 +54,7 @@ export class PromptBlock extends BasePromptBlock<PromptBlockType> {
     return jinjaBlock;
   }
 
-  private generateChatMessagePromptBlock(
+  protected generateChatMessagePromptBlock(
     promptBlock: ChatMessagePromptBlock
   ): ClassInstantiation {
     const classArgs: MethodArgument[] = [
@@ -178,7 +111,7 @@ export class PromptBlock extends BasePromptBlock<PromptBlockType> {
     return chatBlock;
   }
 
-  private generateVariablePromptBlock(
+  protected generateVariablePromptBlock(
     promptBlock: VariablePromptBlock
   ): ClassInstantiation {
     const classArgs: MethodArgument[] = [
@@ -206,7 +139,7 @@ export class PromptBlock extends BasePromptBlock<PromptBlockType> {
     return variableBlock;
   }
 
-  private generatePlainTextPromptBlock(
+  protected generatePlainTextPromptBlock(
     promptBlock: PlainTextPromptBlock
   ): ClassInstantiation {
     const classArgs: MethodArgument[] = [
@@ -234,7 +167,7 @@ export class PromptBlock extends BasePromptBlock<PromptBlockType> {
     return plainBlock;
   }
 
-  private generateRichTextPromptBlock(
+  protected generateRichTextPromptBlock(
     promptBlock: RichTextPromptBlock
   ): ClassInstantiation {
     const classArgs: MethodArgument[] = [
@@ -263,102 +196,5 @@ export class PromptBlock extends BasePromptBlock<PromptBlockType> {
 
     this.inheritReferences(richBlock);
     return richBlock;
-  }
-
-  private generateCommonFileInputArguments(
-    promptBlock:
-      | AudioPromptBlock
-      | VideoPromptBlock
-      | ImagePromptBlock
-      | DocumentPromptBlock
-  ): MethodArgument[] {
-    const classArgs: MethodArgument[] = [];
-
-    classArgs.push(
-      new MethodArgument({
-        name: "src",
-        value: new StrInstantiation(promptBlock.src),
-      })
-    );
-
-    if (promptBlock.metadata) {
-      const metadataJson = new Json(promptBlock.metadata);
-      classArgs.push(
-        new MethodArgument({
-          name: "metadata",
-          value: metadataJson,
-        })
-      );
-    }
-
-    return classArgs;
-  }
-
-  private generateAudioPromptBlock(
-    promptBlock: AudioPromptBlock
-  ): ClassInstantiation {
-    const classArgs: MethodArgument[] = [
-      ...this.constructCommonClassArguments(promptBlock),
-      ...this.generateCommonFileInputArguments(promptBlock),
-    ];
-
-    const audioBlock = new ClassInstantiation({
-      classReference: this.getPromptBlockRef(promptBlock),
-      arguments_: classArgs,
-    });
-
-    this.inheritReferences(audioBlock);
-    return audioBlock;
-  }
-
-  private generateVideoPromptBlock(
-    promptBlock: VideoPromptBlock
-  ): ClassInstantiation {
-    const classArgs: MethodArgument[] = [
-      ...this.constructCommonClassArguments(promptBlock),
-      ...this.generateCommonFileInputArguments(promptBlock),
-    ];
-
-    const videoBlock = new ClassInstantiation({
-      classReference: this.getPromptBlockRef(promptBlock),
-      arguments_: classArgs,
-    });
-
-    this.inheritReferences(videoBlock);
-    return videoBlock;
-  }
-
-  private generateImagePromptBlock(
-    promptBlock: ImagePromptBlock
-  ): ClassInstantiation {
-    const classArgs: MethodArgument[] = [
-      ...this.constructCommonClassArguments(promptBlock),
-      ...this.generateCommonFileInputArguments(promptBlock),
-    ];
-
-    const imageBlock = new ClassInstantiation({
-      classReference: this.getPromptBlockRef(promptBlock),
-      arguments_: classArgs,
-    });
-
-    this.inheritReferences(imageBlock);
-    return imageBlock;
-  }
-
-  private generateDocumentPromptBlock(
-    promptBlock: DocumentPromptBlock
-  ): ClassInstantiation {
-    const classArgs: MethodArgument[] = [
-      ...this.constructCommonClassArguments(promptBlock),
-      ...this.generateCommonFileInputArguments(promptBlock),
-    ];
-
-    const documentBlock = new ClassInstantiation({
-      classReference: this.getPromptBlockRef(promptBlock),
-      arguments_: classArgs,
-    });
-
-    this.inheritReferences(documentBlock);
-    return documentBlock;
   }
 }

--- a/ee/codegen/src/generators/stateful-prompt-block.ts
+++ b/ee/codegen/src/generators/stateful-prompt-block.ts
@@ -1,7 +1,6 @@
 import { python } from "@fern-api/python-ast";
 import { isNil } from "lodash";
 
-import { VELLUM_CLIENT_MODULE_PATH } from "src/constants";
 import {
   BasePromptBlock,
   PromptTemplateBlockExcludingFunctionDefinition,
@@ -9,89 +8,19 @@ import {
 import { ClassInstantiation } from "src/generators/extensions/class-instantiation";
 import { ListInstantiation } from "src/generators/extensions/list-instantiation";
 import { MethodArgument } from "src/generators/extensions/method-argument";
-import { Reference } from "src/generators/extensions/reference";
 import { StrInstantiation } from "src/generators/extensions/str-instantiation";
-import { Json } from "src/generators/json";
 import {
-  AudioPromptTemplateBlock,
   ChatMessagePromptTemplateBlock,
-  DocumentPromptTemplateBlock,
-  ImagePromptTemplateBlock,
   JinjaPromptTemplateBlock,
   PlainTextPromptTemplateBlock,
   RichTextPromptTemplateBlock,
   VariablePromptTemplateBlock,
-  VideoPromptTemplateBlock,
 } from "src/types/vellum";
 
 // Flesh out unit tests for various prompt configurations
 // https://app.shortcut.com/vellum/story/5249
 export class StatefulPromptBlock extends BasePromptBlock<PromptTemplateBlockExcludingFunctionDefinition> {
-  protected generateAstNode(
-    promptBlock: PromptTemplateBlockExcludingFunctionDefinition
-  ): ClassInstantiation {
-    switch (promptBlock.blockType) {
-      case "JINJA":
-        return this.generateJinjaPromptBlock(promptBlock);
-      case "CHAT_MESSAGE":
-        return this.generateChatMessagePromptBlock(promptBlock);
-      case "VARIABLE":
-        return this.generateVariablePromptBlock(promptBlock);
-      case "RICH_TEXT":
-        return this.generateRichTextPromptBlock(promptBlock);
-      case "PLAIN_TEXT":
-        return this.generatePlainTextPromptBlock(promptBlock);
-      case "AUDIO":
-        return this.generateAudioPromptBlock(promptBlock);
-      case "VIDEO":
-        return this.generateVideoPromptBlock(promptBlock);
-      case "IMAGE":
-        return this.generateImagePromptBlock(promptBlock);
-      case "DOCUMENT":
-        return this.generateDocumentPromptBlock(promptBlock);
-    }
-  }
-
-  private getPromptBlockRef(
-    promptBlock: PromptTemplateBlockExcludingFunctionDefinition
-  ): Reference {
-    let pathName;
-    switch (promptBlock.blockType) {
-      case "JINJA":
-        pathName = "JinjaPromptBlock";
-        break;
-      case "CHAT_MESSAGE":
-        pathName = "ChatMessagePromptBlock";
-        break;
-      case "VARIABLE":
-        pathName = "VariablePromptBlock";
-        break;
-      case "RICH_TEXT":
-        pathName = "RichTextPromptBlock";
-        break;
-      case "PLAIN_TEXT":
-        pathName = "PlainTextPromptBlock";
-        break;
-      case "AUDIO":
-        pathName = "AudioPromptBlock";
-        break;
-      case "VIDEO":
-        pathName = "VideoPromptBlock";
-        break;
-      case "IMAGE":
-        pathName = "ImagePromptBlock";
-        break;
-      case "DOCUMENT":
-        pathName = "DocumentPromptBlock";
-        break;
-    }
-    return new Reference({
-      name: pathName,
-      modulePath: VELLUM_CLIENT_MODULE_PATH,
-    });
-  }
-
-  private generateJinjaPromptBlock(
+  protected generateJinjaPromptBlock(
     promptBlock: JinjaPromptTemplateBlock
   ): ClassInstantiation {
     const classArgs: MethodArgument[] = [
@@ -127,7 +56,7 @@ export class StatefulPromptBlock extends BasePromptBlock<PromptTemplateBlockExcl
     return jinjaBlock;
   }
 
-  private generateChatMessagePromptBlock(
+  protected generateChatMessagePromptBlock(
     promptBlock: ChatMessagePromptTemplateBlock
   ): ClassInstantiation {
     const classArgs: MethodArgument[] = [
@@ -191,7 +120,7 @@ export class StatefulPromptBlock extends BasePromptBlock<PromptTemplateBlockExcl
     return chatBlock;
   }
 
-  private generateVariablePromptBlock(
+  protected generateVariablePromptBlock(
     promptBlock: VariablePromptTemplateBlock
   ): ClassInstantiation {
     const classArgs: MethodArgument[] = [
@@ -217,7 +146,7 @@ export class StatefulPromptBlock extends BasePromptBlock<PromptTemplateBlockExcl
     return variableBlock;
   }
 
-  private generatePlainTextPromptBlock(
+  protected generatePlainTextPromptBlock(
     promptBlock: PlainTextPromptTemplateBlock
   ): ClassInstantiation {
     const classArgs: MethodArgument[] = [
@@ -245,7 +174,7 @@ export class StatefulPromptBlock extends BasePromptBlock<PromptTemplateBlockExcl
     return plainBlock;
   }
 
-  private generateRichTextPromptBlock(
+  protected generateRichTextPromptBlock(
     promptBlock: RichTextPromptTemplateBlock
   ): ClassInstantiation {
     const classArgs: MethodArgument[] = [
@@ -274,102 +203,5 @@ export class StatefulPromptBlock extends BasePromptBlock<PromptTemplateBlockExcl
 
     this.inheritReferences(richBlock);
     return richBlock;
-  }
-
-  private generateCommonFileInputArguments(
-    promptBlock:
-      | AudioPromptTemplateBlock
-      | VideoPromptTemplateBlock
-      | ImagePromptTemplateBlock
-      | DocumentPromptTemplateBlock
-  ): MethodArgument[] {
-    const classArgs: MethodArgument[] = [];
-
-    classArgs.push(
-      new MethodArgument({
-        name: "src",
-        value: new StrInstantiation(promptBlock.src),
-      })
-    );
-
-    if (promptBlock.metadata) {
-      const metadataJson = new Json(promptBlock.metadata);
-      classArgs.push(
-        new MethodArgument({
-          name: "metadata",
-          value: metadataJson,
-        })
-      );
-    }
-
-    return classArgs;
-  }
-
-  private generateAudioPromptBlock(
-    promptBlock: AudioPromptTemplateBlock
-  ): ClassInstantiation {
-    const classArgs: MethodArgument[] = [
-      ...this.constructCommonClassArguments(promptBlock),
-      ...this.generateCommonFileInputArguments(promptBlock),
-    ];
-
-    const audioBlock = new ClassInstantiation({
-      classReference: this.getPromptBlockRef(promptBlock),
-      arguments_: classArgs,
-    });
-
-    this.inheritReferences(audioBlock);
-    return audioBlock;
-  }
-
-  private generateVideoPromptBlock(
-    promptBlock: VideoPromptTemplateBlock
-  ): ClassInstantiation {
-    const classArgs: MethodArgument[] = [
-      ...this.constructCommonClassArguments(promptBlock),
-      ...this.generateCommonFileInputArguments(promptBlock),
-    ];
-
-    const videoBlock = new ClassInstantiation({
-      classReference: this.getPromptBlockRef(promptBlock),
-      arguments_: classArgs,
-    });
-
-    this.inheritReferences(videoBlock);
-    return videoBlock;
-  }
-
-  private generateImagePromptBlock(
-    promptBlock: ImagePromptTemplateBlock
-  ): ClassInstantiation {
-    const classArgs: MethodArgument[] = [
-      ...this.constructCommonClassArguments(promptBlock),
-      ...this.generateCommonFileInputArguments(promptBlock),
-    ];
-
-    const imageBlock = new ClassInstantiation({
-      classReference: this.getPromptBlockRef(promptBlock),
-      arguments_: classArgs,
-    });
-
-    this.inheritReferences(imageBlock);
-    return imageBlock;
-  }
-
-  private generateDocumentPromptBlock(
-    promptBlock: DocumentPromptTemplateBlock
-  ): ClassInstantiation {
-    const classArgs: MethodArgument[] = [
-      ...this.constructCommonClassArguments(promptBlock),
-      ...this.generateCommonFileInputArguments(promptBlock),
-    ];
-
-    const documentBlock = new ClassInstantiation({
-      classReference: this.getPromptBlockRef(promptBlock),
-      arguments_: classArgs,
-    });
-
-    this.inheritReferences(documentBlock);
-    return documentBlock;
   }
 }


### PR DESCRIPTION
## Summary

Refactors common prompt block generation logic from `PromptBlock` and `StatefulPromptBlock` into the `BasePromptBlock` base class to reduce code duplication.

**Changes:**
- Moved `generateAstNode()` switch statement to base class
- Moved `getPromptBlockRef()` to base class  
- Moved `generateCommonFileInputArguments()` to base class
- Moved file-related block generators (`generateAudioPromptBlock`, `generateVideoPromptBlock`, `generateImagePromptBlock`, `generateDocumentPromptBlock`) to base class
- Changed method visibility from `private` to `protected` in subclasses for methods that need to call base class helpers
- Subclasses now only implement abstract methods for their specific block types (Jinja, ChatMessage, Variable, PlainText, RichText)

## Review & Testing Checklist for Human

- [ ] Verify generated Python code output is identical before/after this refactoring by running snapshot tests (`npm run test:update` if snapshots need updating)
- [ ] Confirm all prompt block types (JINJA, CHAT_MESSAGE, VARIABLE, RICH_TEXT, PLAIN_TEXT, AUDIO, VIDEO, IMAGE, DOCUMENT) are handled correctly
- [ ] Check that the base class correctly uses custom extension classes (`ClassInstantiation`, `Reference`, `StrInstantiation`) instead of `python.*` functions

**Recommended test plan:** Run the full codegen test suite and verify any workflows using prompt blocks generate the same Python code as before.

### Notes

- Rebased with main and resolved merge conflicts
- Fixed TypeScript errors in base-prompt-block.ts to use custom extension classes consistently with the rest of the codebase

Link to Devin run: https://app.devin.ai/sessions/1bc7f4c72c0942bc8eab4fea3b9cdd18
Requested by: vincent@vellum.ai (@vincent0426)