### PR TITLE
Fix vellum resolver ids

### DIFF
--- a/src/vellum/workflows/resolvers/resolver.py
+++ b/src/vellum/workflows/resolvers/resolver.py
@@ -78,8 +78,8 @@ class VellumResolver(BaseWorkflowResolver):
 
         return LoadStateResult(
             state=state,
-            previous_trace_id=response.previous_trace_id,
-            previous_span_id=response.previous_span_id,
+            previous_trace_id=response.trace_id,
+            previous_span_id=response.span_id,
             root_trace_id=response.root_trace_id,
             root_span_id=response.root_span_id,
         )

--- a/src/vellum/workflows/resolvers/resolver.py
+++ b/src/vellum/workflows/resolvers/resolver.py
@@ -62,24 +62,10 @@ class VellumResolver(BaseWorkflowResolver):
             logger.warning("No workflow class registered, falling back to BaseState")
             state = BaseState(**response.state)
 
-        if (
-            response.previous_trace_id is None
-            or response.root_trace_id is None
-            or response.previous_span_id is None
-            or response.root_span_id is None
-        ):
-            return LoadStateResult(
-                state=state,
-                previous_trace_id=response.trace_id,
-                previous_span_id=response.span_id,
-                root_trace_id=response.trace_id,
-                root_span_id=response.span_id,
-            )
-
         return LoadStateResult(
             state=state,
             previous_trace_id=response.trace_id,
             previous_span_id=response.span_id,
-            root_trace_id=response.root_trace_id,
-            root_span_id=response.root_span_id,
+            root_trace_id=response.root_trace_id or response.trace_id,
+            root_span_id=response.root_span_id or response.span_id,
         )

--- a/src/vellum/workflows/resolvers/tests/test_resolver.py
+++ b/src/vellum/workflows/resolvers/tests/test_resolver.py
@@ -44,11 +44,12 @@ def test_load_state_with_context_success():
 
     previous_trace_id = str(uuid4())
     previous_span_id = str(uuid4())
+    trace_id = str(uuid4())
     root_trace_id = str(uuid4())
     root_span_id = str(uuid4())
 
     mock_response = WorkflowResolvedState(
-        trace_id=str(uuid4()),
+        trace_id=trace_id,
         timestamp=datetime.now(),
         span_id=str(execution_id),
         state=state_dict,
@@ -79,8 +80,8 @@ def test_load_state_with_context_success():
     assert str(result.state.meta.span_id) != prev_span_id
 
     # AND should have span link info
-    assert result.previous_trace_id == previous_trace_id
-    assert result.previous_span_id == previous_span_id
+    assert result.previous_trace_id == trace_id
+    assert result.previous_span_id == str(execution_id)
     assert result.root_trace_id == root_trace_id
     assert result.root_span_id == root_span_id
 


### PR DESCRIPTION
This bug was leading to all messages in the thread resolving to the same previous_span_id. This PR fixes