### PR TITLE
Follow-up: Address comment from PR #3044

### DIFF
--- a/src/vellum/workflows/types/utils.py
+++ b/src/vellum/workflows/types/utils.py
@@ -22,6 +22,7 @@ from typing import (
 )
 
 from vellum import ArrayVellumValue, ArrayVellumValueRequest, ChatMessagePromptBlock
+from vellum.workflows.constants import undefined
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.types.core import Json, SpecialGenericAlias, UnderGenericAlias, UnionGenericAlias
 
@@ -125,7 +126,7 @@ def infer_types(object_: Type, attr_name: str, localns: Optional[Dict[str, Any]]
         # Python 3.13+: object class doesn't have __annotations__ by default
         # Use getattr with default to safely access annotations
         annotations = getattr(object_, "__annotations__", {})
-        annotation_value = annotations.get(attr_name, "<unknown>")
+        annotation_value = annotations.get(attr_name, undefined)
         raise AttributeError(
             f"Found 3.9+ typing syntax for field '{attr_name}' on class '{object_.__name__}' – {annotation_value}. Type annotations must be compatible with python version 3.8. "  # noqa: E501
         )


### PR DESCRIPTION
## Overview
This PR addresses a minor feedback item (nit) from PR #3044.

## Changes Made

### From PR #3044
- **File**: src/vellum/workflows/types/utils.py:129
  - **Change**: Replace `"<unknown>"` with `undefined` singleton as default value
  - **Rationale**: `"<unknown>"` is technically a valid type, so using the `undefined` singleton is cleaner and more semantically correct
  - **Comment**: https://github.com/vellum-ai/vellum-python-sdks/pull/3044#discussion_r2515880496
  - **Reviewer**: @dvargas92495

## Details

The reviewer suggested using `None` or the `undefined` singleton instead of the string `"<unknown>"` as a default value when annotations are not found. I chose to use `undefined` because:

1. It's semantically more appropriate for representing "no value found"
2. It's consistent with the codebase's use of the `undefined` singleton elsewhere
3. It avoids potential conflicts with actual type strings

## Testing
- All existing tests pass
- Type checking with mypy passes
- No functional changes made

## Related PRs
- #3044

---
*This PR was created with Claude Code*