### PR TITLE
Fix none optional input

### DIFF
--- a/src/vellum/workflows/inputs/base.py
+++ b/src/vellum/workflows/inputs/base.py
@@ -74,7 +74,7 @@ class BaseInputs(metaclass=_BaseInputsMeta):
         Initialize BaseInputs with provided keyword arguments.
 
         Validation logic:
-        1. Ensures all required fields (non-Optional types) either:
+        1. Ensures all required fields (values without defaults, regardless of Optional or not) either:
         - Have a value provided in kwargs, or
         - Have a default value defined in the class
         2. Validates that no None values are provided for required fields

--- a/src/vellum/workflows/inputs/base.py
+++ b/src/vellum/workflows/inputs/base.py
@@ -88,11 +88,11 @@ class BaseInputs(metaclass=_BaseInputsMeta):
         """
         for name, field_type in self.__class__.__annotations__.items():
             # Get the value (either from kwargs or class default)
-            value = kwargs.get(name)
+            value = kwargs.get(name, undefined)
             has_default = name in vars(self.__class__)
 
             # If no value provided, check for default
-            if value is None and has_default:
+            if value is undefined and has_default:
                 default_value = vars(self.__class__)[name]
                 # Check if default is a FieldInfo with default_factory
                 if isinstance(default_value, FieldInfo):
@@ -106,7 +106,7 @@ class BaseInputs(metaclass=_BaseInputsMeta):
                     # Regular default value
                     value = default_value
 
-            if value is None and not has_default:
+            if value is undefined and not has_default:
                 # Check if field_type allows None
                 origin = get_origin(field_type)
                 args = get_args(field_type)
@@ -118,7 +118,7 @@ class BaseInputs(metaclass=_BaseInputsMeta):
                     )
 
             # Set the value on the instance (either from kwargs or default)
-            if name in kwargs or (has_default and value is not None):
+            if value is not undefined:
                 setattr(self, name, value)
 
     def __iter__(self) -> Iterator[Tuple[InputReference, Any]]:

--- a/src/vellum/workflows/inputs/base.py
+++ b/src/vellum/workflows/inputs/base.py
@@ -112,14 +112,12 @@ class BaseInputs(metaclass=_BaseInputsMeta):
             is_optional = origin is Union and type(None) in args
 
             if value is undefined and not has_default:
-                if not is_optional:
-                    raise WorkflowInitializationException(
-                        message=f"Required input variables {name} should have defined value",
-                        code=WorkflowErrorCode.INVALID_INPUTS,
-                        workflow_definition=self.__class__.__parent_class__,
-                    )
-                # If field is Optional and no value provided, set to None
-                value = None
+                # All fields without defaults must be provided, even if Optional
+                raise WorkflowInitializationException(
+                    message=f"Required input variables {name} should have defined value",
+                    code=WorkflowErrorCode.INVALID_INPUTS,
+                    workflow_definition=self.__class__.__parent_class__,
+                )
 
             # Validate that None is not provided for non-Optional fields
             if value is None and not is_optional:

--- a/src/vellum/workflows/inputs/tests/test_inputs.py
+++ b/src/vellum/workflows/inputs/tests/test_inputs.py
@@ -42,6 +42,21 @@ def test_base_inputs_explicit_none():
     assert inputs.optional_string_with_default is None
 
 
+def test_base_inputs_explicit_none_should_raise_on_required_fields():
+    """
+    Test that None cannot be explicitly set as a value for required fields.
+    """
+
+    class TestInputs(BaseInputs):
+        required_string: str
+
+    with pytest.raises(WorkflowInitializationException) as exc_info:
+        TestInputs(required_string=None)
+
+    assert exc_info.value.code == WorkflowErrorCode.INVALID_INPUTS
+    assert "Required input variables required_string should have defined value" == str(exc_info.value)
+
+
 def test_base_inputs_empty_value():
     # GIVEN some input class with required and optional string fields
     class TestInputs(BaseInputs):

--- a/src/vellum/workflows/inputs/tests/test_inputs.py
+++ b/src/vellum/workflows/inputs/tests/test_inputs.py
@@ -51,7 +51,7 @@ def test_base_inputs_explicit_none_should_raise_on_required_fields():
         required_string: str
 
     with pytest.raises(WorkflowInitializationException) as exc_info:
-        TestInputs(required_string=None)
+        TestInputs(required_string=None)  # type: ignore[arg-type]  we know this will fail since required_string is not optional  # noqa: E501
 
     assert exc_info.value.code == WorkflowErrorCode.INVALID_INPUTS
     assert "Required input variables required_string should have defined value" == str(exc_info.value)

--- a/src/vellum/workflows/inputs/tests/test_inputs.py
+++ b/src/vellum/workflows/inputs/tests/test_inputs.py
@@ -32,7 +32,7 @@ def test_base_inputs_explicit_none():
     # GIVEN some input class with optional fields and fields with defaults
     class TestInputs(BaseInputs):
         optional_string: Optional[str]
-        optional_string_with_default: str = None
+        optional_string_with_default: Optional[str] = None
 
     # WHEN we explicitly pass None for optional fields
     inputs = TestInputs(optional_string=None)

--- a/src/vellum/workflows/inputs/tests/test_inputs.py
+++ b/src/vellum/workflows/inputs/tests/test_inputs.py
@@ -48,7 +48,7 @@ def test_base_inputs_explicit_none_should_raise_on_fields_without_defaults(field
     """
 
     class TestInputs(BaseInputs):
-        required_string: field_type
+        required_string: field_type  # type: ignore[valid-type]
 
     with pytest.raises(WorkflowInitializationException) as exc_info:
         TestInputs()  # type: ignore[call-arg]
@@ -66,7 +66,7 @@ def test_base_inputs_explicit_none_should_raise_on_required_fields_with_none():
         required_string: str
 
     with pytest.raises(WorkflowInitializationException) as exc_info:
-        TestInputs(required_string=None)  # type: ignore[call-arg]
+        TestInputs(required_string=None)  # type: ignore[arg-type]
 
     assert exc_info.value.code == WorkflowErrorCode.INVALID_INPUTS
     assert "Required input variables required_string should have defined value" == str(exc_info.value)

--- a/src/vellum/workflows/inputs/tests/test_inputs.py
+++ b/src/vellum/workflows/inputs/tests/test_inputs.py
@@ -24,6 +24,24 @@ def test_base_inputs_happy_path():
     assert inputs.optional_string is None
 
 
+def test_base_inputs_explicit_none():
+    """
+    Test that None can be explicitly set as a value, distinguishing it from not providing a value.
+    """
+
+    # GIVEN some input class with optional fields and fields with defaults
+    class TestInputs(BaseInputs):
+        optional_string: Optional[str]
+        optional_string_with_default: str = None
+
+    # WHEN we explicitly pass None for optional fields
+    inputs = TestInputs(optional_string=None)
+
+    # THEN None should be set as the value
+    assert inputs.optional_string is None
+    assert inputs.optional_string_with_default is None
+
+
 def test_base_inputs_empty_value():
     # GIVEN some input class with required and optional string fields
     class TestInputs(BaseInputs):

--- a/src/vellum/workflows/inputs/tests/test_inputs.py
+++ b/src/vellum/workflows/inputs/tests/test_inputs.py
@@ -37,12 +37,27 @@ def test_base_inputs_explicit_none():
     # WHEN we explicitly pass None for optional fields
     inputs = TestInputs(optional_string=None)
 
-    # THEN None should be set as the value
     assert inputs.optional_string is None
     assert inputs.optional_string_with_default is None
 
 
-def test_base_inputs_explicit_none_should_raise_on_required_fields():
+@pytest.mark.parametrize("field_type", [str, Optional[str]])
+def test_base_inputs_explicit_none_should_raise_on_fields_without_defaults(field_type):
+    """
+    Test that None cannot be explicitly set as a value for required fields.
+    """
+
+    class TestInputs(BaseInputs):
+        required_string: field_type
+
+    with pytest.raises(WorkflowInitializationException) as exc_info:
+        TestInputs()  # type: ignore[call-arg]
+
+    assert exc_info.value.code == WorkflowErrorCode.INVALID_INPUTS
+    assert "Required input variables required_string should have defined value" == str(exc_info.value)
+
+
+def test_base_inputs_explicit_none_should_raise_on_required_fields_with_none():
     """
     Test that None cannot be explicitly set as a value for required fields.
     """
@@ -51,7 +66,7 @@ def test_base_inputs_explicit_none_should_raise_on_required_fields():
         required_string: str
 
     with pytest.raises(WorkflowInitializationException) as exc_info:
-        TestInputs(required_string=None)  # type: ignore
+        TestInputs(required_string=None)  # type: ignore[call-arg]
 
     assert exc_info.value.code == WorkflowErrorCode.INVALID_INPUTS
     assert "Required input variables required_string should have defined value" == str(exc_info.value)

--- a/src/vellum/workflows/inputs/tests/test_inputs.py
+++ b/src/vellum/workflows/inputs/tests/test_inputs.py
@@ -51,7 +51,7 @@ def test_base_inputs_explicit_none_should_raise_on_required_fields():
         required_string: str
 
     with pytest.raises(WorkflowInitializationException) as exc_info:
-        TestInputs(required_string=None)  # type: ignore[arg-type]  we know this will fail since required_string is not optional  # noqa: E501
+        TestInputs(required_string=None)  # type: ignore
 
     assert exc_info.value.code == WorkflowErrorCode.INVALID_INPUTS
     assert "Required input variables required_string should have defined value" == str(exc_info.value)


### PR DESCRIPTION
#3084 

```python
class TestInputs(BaseInputs):
    required_string: str
    required_string_with_default: str = "hello"
    optional_string: Optional[str]
    optional_string_with_default: Optional[str] = None
```

- Inputs with default value allow undefined
- Optional still required inputs, but allow None