### PR TITLE
Create Vellum File Read Utilities

### DIFF
--- a/src/vellum/utils/files/__init__.py
+++ b/src/vellum/utils/files/__init__.py
@@ -1,0 +1,14 @@
+from vellum.utils.files.exceptions import FileNotFoundError, FileRetrievalError, InvalidFileSourceError, VellumFileError
+from vellum.utils.files.read import read_vellum_file
+from vellum.utils.files.stream import stream_vellum_file
+from vellum.utils.files.types import VellumFileTypes
+
+__all__ = [
+    "read_vellum_file",
+    "stream_vellum_file",
+    "VellumFileTypes",
+    "VellumFileError",
+    "InvalidFileSourceError",
+    "FileRetrievalError",
+    "FileNotFoundError",
+]

--- a/src/vellum/utils/files/constants.py
+++ b/src/vellum/utils/files/constants.py
@@ -1,0 +1,16 @@
+"""Constants for Vellum file handling."""
+
+# Regex pattern to match Vellum uploaded file IDs in the format:
+# vellum:uploaded-file:12345678-1234-1234-1234-123456789abc
+VELLUM_FILE_SRC_PATTERN = r"vellum:uploaded-file:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+
+# Regex pattern to match base64 data URLs with optional MIME type and charset:
+# data:text/plain;charset=utf-8;base64,SGVsbG8=
+# data:image/png;base64,iVBORw0KGgo=
+# data:;base64,
+BASE64_DATA_URL_PATTERN = (
+    r"^data:([a-zA-Z0-9+/.-]+/[a-zA-Z0-9+.-]+)?(;charset=[a-zA-Z0-9-]+)?;base64,(.*)$"  # noqa: E501
+)
+
+# Regex pattern to match HTTP/HTTPS URLs
+URL_PATTERN = r"^(https?://[^\s]+)$"

--- a/src/vellum/utils/files/exceptions.py
+++ b/src/vellum/utils/files/exceptions.py
@@ -1,0 +1,25 @@
+"""Exceptions for Vellum file operations."""
+
+
+class VellumFileError(Exception):
+    """Base exception for all Vellum file errors."""
+
+    pass
+
+
+class InvalidFileSourceError(VellumFileError):
+    """Raised when a file source URL/identifier is malformed or unsupported."""
+
+    pass
+
+
+class FileRetrievalError(VellumFileError):
+    """Raised when a file cannot be retrieved from its source."""
+
+    pass
+
+
+class FileNotFoundError(FileRetrievalError):
+    """Raised when a file cannot be found at its source."""
+
+    pass

--- a/src/vellum/utils/files/read.py
+++ b/src/vellum/utils/files/read.py
@@ -1,0 +1,39 @@
+"""Convenience utilities for reading Vellum files."""
+
+from typing import Optional
+
+from vellum.client import Vellum as VellumClient
+from vellum.utils.files.stream import stream_vellum_file
+from vellum.utils.files.types import VellumFileTypes
+
+
+def read_vellum_file(vellum_file: VellumFileTypes, client: Optional[VellumClient] = None) -> bytes:
+    """
+    Convenience function that reads the entire file content into memory.
+
+    This function is implemented using stream_vellum_file() under the hood.
+    For large files (e.g., videos, large datasets), consider using
+    stream_vellum_file() directly to avoid memory issues.
+
+    Args:
+        vellum_file: A VellumDocument, VellumImage, VellumAudio, or VellumVideo instance
+        client: An optional Vellum client instance. If not provided, a default client will be created.
+
+    Returns:
+        bytes: The complete file content
+
+    Example:
+        ```python
+        from vellum import VellumDocument
+        from vellum.utils.files import read_vellum_file
+
+        document = VellumDocument(src="data:text/plain;base64,SGVsbG8gV29ybGQ=")
+        content = read_vellum_file(document)
+        print(content.decode('utf-8'))  # "Hello World"
+        ```
+    """
+    chunks = []
+    with stream_vellum_file(vellum_file, client=client) as chunk_iter:
+        for chunk in chunk_iter:
+            chunks.append(chunk)
+    return b"".join(chunks)

--- a/src/vellum/utils/files/stream.py
+++ b/src/vellum/utils/files/stream.py
@@ -88,9 +88,10 @@ def stream_vellum_file(
                 raise FileNotFoundError(f"Uploaded file not found: {vellum_uploaded_file_id}") from e
             raise FileRetrievalError(f"Failed to retrieve uploaded file: {vellum_uploaded_file_id}") from e
 
-        file_url = uploaded_file.file_url
-        if not file_url:
+        if not uploaded_file.file_url:
             raise FileRetrievalError(f"Uploaded file has no accessible URL: {vellum_uploaded_file_id}")
+
+        file_url = uploaded_file.file_url
 
     # Case 3: Direct URL
     elif re.match(URL_PATTERN, src):

--- a/src/vellum/utils/files/stream.py
+++ b/src/vellum/utils/files/stream.py
@@ -1,0 +1,129 @@
+"""Streaming utilities for reading Vellum files."""
+
+import base64
+from contextlib import contextmanager
+from io import BytesIO
+import re
+from typing import Generator, Iterator, Optional
+
+import requests
+
+from vellum.client import Vellum as VellumClient
+from vellum.client.core.api_error import ApiError
+from vellum.utils.files.constants import BASE64_DATA_URL_PATTERN, URL_PATTERN, VELLUM_FILE_SRC_PATTERN
+from vellum.utils.files.exceptions import FileNotFoundError, FileRetrievalError, InvalidFileSourceError
+from vellum.utils.files.types import VellumFileTypes
+from vellum.workflows.vellum_client import create_vellum_client
+
+
+@contextmanager
+def stream_vellum_file(
+    vellum_file: VellumFileTypes,
+    chunk_size: int = 8192,
+    client: Optional[VellumClient] = None,
+) -> Generator[Iterator[bytes], None, None]:
+    """
+    Stream the file content in chunks using a context manager.
+
+    This is the recommended way to read large files, as it avoids loading
+    the entire file into memory at once.
+
+    Args:
+        vellum_file: A VellumDocument, VellumImage, VellumAudio, or VellumVideo instance
+        chunk_size: Size of chunks to yield in bytes (default 8KB)
+        client: An optional Vellum client instance. If not provided, a default client will be created.
+
+    Yields:
+        Iterator[bytes]: Chunks of file content
+
+    Example:
+        ```python
+        from vellum import VellumVideo
+        from vellum.utils.files import stream_vellum_file
+
+        # Stream a large video file
+        video = VellumVideo(src="https://example.com/video.mp4")
+        with stream_vellum_file(video, chunk_size=10*1024*1024) as chunks:  # 10MB chunks
+            with open('output.mp4', 'wb') as f:
+                for chunk in chunks:
+                    f.write(chunk)
+
+        # Calculate hash without loading entire file
+        import hashlib
+        hasher = hashlib.sha256()
+        with stream_vellum_file(vellum_file) as chunks:
+            for chunk in chunks:
+                hasher.update(chunk)
+        hash_value = hasher.hexdigest()
+        ```
+    """
+    src = vellum_file.src
+
+    # Case 1: Base64 Data URL
+    # Note: Base64 content is already in memory, but we still provide
+    # a streaming interface for consistency
+    data_url_match = re.match(BASE64_DATA_URL_PATTERN, src)
+    if data_url_match:
+        base64_content = data_url_match.group(3)
+        decoded = base64.b64decode(base64_content)
+        stream = BytesIO(decoded)
+        try:
+            yield _chunk_iterator(stream, chunk_size)
+        finally:
+            stream.close()
+        return
+
+    file_url: str
+
+    # Case 2: Vellum Uploaded File
+    match = re.match(VELLUM_FILE_SRC_PATTERN, src, re.IGNORECASE)
+    if match:
+        vellum_uploaded_file_id = match.group(1)
+        vellum_client = client or create_vellum_client()
+
+        try:
+            uploaded_file = vellum_client.uploaded_files.retrieve(vellum_uploaded_file_id)
+        except ApiError as e:
+            if e.status_code == 404:
+                raise FileNotFoundError(f"Uploaded file not found: {vellum_uploaded_file_id}") from e
+            raise FileRetrievalError(f"Failed to retrieve uploaded file: {vellum_uploaded_file_id}") from e
+
+        file_url = uploaded_file.file_url
+        if not file_url:
+            raise FileRetrievalError(f"Uploaded file has no accessible URL: {vellum_uploaded_file_id}")
+
+    # Case 3: Direct URL
+    elif re.match(URL_PATTERN, src):
+        file_url = src
+    else:
+        raise InvalidFileSourceError(
+            f"Invalid file source: {src}. "
+            "Expected a base64 data URL (data:...;base64,...), "
+            "a Vellum uploaded file ID (vellum:uploaded-file:...), "
+            "or an HTTP/HTTPS URL."
+        )
+
+    # Stream from URL
+    try:
+        response = requests.get(file_url, stream=True)
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        if e.response.status_code == 404:
+            raise FileNotFoundError(f"File not found at URL: {file_url}") from e
+        raise FileRetrievalError(f"Failed to retrieve file from URL: {file_url}") from e
+    except requests.RequestException as e:
+        raise FileRetrievalError(f"Network error while retrieving file: {file_url}") from e
+
+    try:
+        yield response.iter_content(chunk_size=chunk_size)
+    finally:
+        response.close()
+
+
+def _chunk_iterator(stream: BytesIO, chunk_size: int) -> Iterator[bytes]:
+    """Helper to read a BytesIO stream in chunks."""
+    while True:
+        chunk = stream.read(chunk_size)
+        if not chunk:
+            break
+        yield chunk

--- a/src/vellum/utils/files/tests/test_read.py
+++ b/src/vellum/utils/files/tests/test_read.py
@@ -1,0 +1,204 @@
+import pytest
+import base64
+from unittest.mock import Mock, patch
+
+from vellum import VellumAudio, VellumDocument, VellumImage, VellumVideo
+from vellum.utils.files import FileRetrievalError, InvalidFileSourceError, read_vellum_file
+
+# Sample content for different file types
+SAMPLE_TEXT_CONTENT = b"This is a sample text document content."
+SAMPLE_IMAGE_CONTENT = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"  # Minimal PNG header
+SAMPLE_AUDIO_CONTENT = b"RIFF\x00\x00\x00\x00WAVEfmt "  # Minimal WAV header
+SAMPLE_VIDEO_CONTENT = b"\x00\x00\x00\x20ftypmp42"  # Minimal MP4 header
+
+
+@pytest.mark.parametrize(
+    ["file_type", "content", "mime_type"],
+    [
+        (VellumDocument, SAMPLE_TEXT_CONTENT, "text/plain"),
+        (VellumImage, SAMPLE_IMAGE_CONTENT, "image/png"),
+        (VellumAudio, SAMPLE_AUDIO_CONTENT, "audio/wav"),
+        (VellumVideo, SAMPLE_VIDEO_CONTENT, "video/mp4"),
+    ],
+)
+def test_read_vellum_file_base64_data_url_with_mime_type(file_type, content, mime_type):
+    """Test reading files from base64 data URLs with MIME types."""
+    # Encode content as base64
+    base64_content = base64.b64encode(content).decode("utf-8")
+    src = f"data:{mime_type};base64,{base64_content}"
+
+    # Create the appropriate file type
+    vellum_file = file_type(src=src)
+
+    # Read the file
+    result = read_vellum_file(vellum_file)
+
+    # Verify the content matches
+    assert result == content
+
+
+@pytest.mark.parametrize(
+    ["file_type", "content"],
+    [
+        (VellumDocument, SAMPLE_TEXT_CONTENT),
+        (VellumImage, SAMPLE_IMAGE_CONTENT),
+        (VellumAudio, SAMPLE_AUDIO_CONTENT),
+        (VellumVideo, SAMPLE_VIDEO_CONTENT),
+    ],
+)
+def test_read_vellum_file_base64_data_url_without_mime_type(file_type, content):
+    """Test reading files from base64 data URLs without MIME types."""
+    # Encode content as base64
+    base64_content = base64.b64encode(content).decode("utf-8")
+    src = f"data:;base64,{base64_content}"
+
+    # Create the appropriate file type
+    vellum_file = file_type(src=src)
+
+    # Read the file
+    result = read_vellum_file(vellum_file)
+
+    # Verify the content matches
+    assert result == content
+
+
+@pytest.mark.parametrize(
+    ["file_type", "content", "mime_type", "charset"],
+    [
+        (VellumDocument, SAMPLE_TEXT_CONTENT, "text/plain", "utf-8"),
+        (VellumDocument, SAMPLE_TEXT_CONTENT, "text/html", "iso-8859-1"),
+        (VellumImage, SAMPLE_IMAGE_CONTENT, "image/png", "utf-8"),
+    ],
+)
+def test_read_vellum_file_base64_data_url_with_charset(file_type, content, mime_type, charset):
+    """Test reading files from base64 data URLs with charset specifications."""
+    # Encode content as base64
+    base64_content = base64.b64encode(content).decode("utf-8")
+    src = f"data:{mime_type};charset={charset};base64,{base64_content}"
+
+    # Create the appropriate file type
+    vellum_file = file_type(src=src)
+
+    # Read the file
+    result = read_vellum_file(vellum_file)
+
+    # Verify the content matches
+    assert result == content
+
+
+@pytest.mark.parametrize(
+    ["file_type", "content"],
+    [
+        (VellumDocument, b""),  # Empty file
+        (VellumImage, b"x" * 1000),  # Larger content
+        (VellumAudio, b"\x00\x01\x02\x03\x04"),  # Binary content with special bytes
+        (VellumVideo, b"Unicode content: \xc3\xa9\xc3\xa0\xc3\xb1"),  # UTF-8 encoded content
+    ],
+)
+def test_read_vellum_file_base64_edge_cases(file_type, content):
+    """Test reading files with edge case content (empty, large, special characters)."""
+    # Encode content as base64
+    base64_content = base64.b64encode(content).decode("utf-8")
+    src = f"data:application/octet-stream;base64,{base64_content}"
+
+    # Create the appropriate file type
+    vellum_file = file_type(src=src)
+
+    # Read the file
+    result = read_vellum_file(vellum_file)
+
+    # Verify the content matches
+    assert result == content
+
+
+@pytest.mark.parametrize(
+    "file_type",
+    [VellumDocument, VellumImage, VellumAudio, VellumVideo],
+)
+def test_read_vellum_file_from_url(file_type):
+    """Test reading files from direct URLs."""
+    content = b"URL fetched content"
+    url = "https://example.com/file.dat"
+
+    vellum_file = file_type(src=url)
+
+    with patch("vellum.utils.files.stream.requests.get") as mock_get:
+        mock_response = Mock()
+        # Mock streaming interface
+        mock_response.iter_content = Mock(return_value=iter([content]))
+        mock_response.raise_for_status = Mock()
+        mock_response.close = Mock()
+        mock_get.return_value = mock_response
+
+        result = read_vellum_file(vellum_file)
+
+        assert result == content
+        mock_get.assert_called_once_with(url, stream=True)
+        mock_response.raise_for_status.assert_called_once()
+        mock_response.close.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "file_type",
+    [VellumDocument, VellumImage, VellumAudio, VellumVideo],
+)
+def test_read_vellum_file_from_vellum_uploaded_file(file_type):
+    """Test reading files from Vellum uploaded file IDs."""
+    content = b"Vellum uploaded content"
+    file_id = "12345678-1234-1234-1234-123456789abc"
+    src = f"vellum:uploaded-file:{file_id}"
+    file_url = "https://s3.amazonaws.com/example/file.dat"
+
+    vellum_file = file_type(src=src)
+
+    with patch("vellum.utils.files.stream.create_vellum_client") as mock_create_client, patch(
+        "vellum.utils.files.stream.requests.get"
+    ) as mock_get:
+        # Mock the Vellum client
+        mock_client = Mock()
+        uploaded_file_mock = Mock()
+        uploaded_file_mock.file_url = file_url
+        mock_client.uploaded_files.retrieve.return_value = uploaded_file_mock
+        mock_create_client.return_value = mock_client
+
+        # Mock the file download with streaming interface
+        file_response = Mock()
+        file_response.iter_content = Mock(return_value=iter([content]))
+        file_response.raise_for_status = Mock()
+        file_response.close = Mock()
+
+        mock_get.return_value = file_response
+
+        result = read_vellum_file(vellum_file)
+
+        assert result == content
+        mock_client.uploaded_files.retrieve.assert_called_once_with(file_id)
+        mock_get.assert_called_once_with(file_url, stream=True)
+        file_response.close.assert_called_once()
+
+
+def test_read_vellum_file_invalid_src():
+    """Test that invalid src raises InvalidFileSourceError."""
+    vellum_file = VellumDocument(src="invalid://source")
+
+    with pytest.raises(InvalidFileSourceError, match="Invalid file source"):
+        read_vellum_file(vellum_file)
+
+
+def test_read_vellum_file_vellum_uploaded_file_missing_url():
+    """Test that missing file_url in API response raises FileRetrievalError."""
+    file_id = "12345678-1234-1234-1234-123456789abc"
+    src = f"vellum:uploaded-file:{file_id}"
+
+    vellum_file = VellumDocument(src=src)
+
+    # Mock the create_vellum_client to return a client with an uploaded file without a file_url
+    with patch("vellum.utils.files.stream.create_vellum_client") as mock_create_client:
+        mock_client = Mock()
+        uploaded_file_mock = Mock()
+        uploaded_file_mock.file_url = None
+        mock_client.uploaded_files.retrieve.return_value = uploaded_file_mock
+        mock_create_client.return_value = mock_client
+
+        with pytest.raises(FileRetrievalError, match="has no accessible URL"):
+            read_vellum_file(vellum_file)

--- a/src/vellum/utils/files/tests/test_stream.py
+++ b/src/vellum/utils/files/tests/test_stream.py
@@ -1,0 +1,199 @@
+import pytest
+import base64
+from unittest.mock import Mock, patch
+
+from vellum import VellumAudio, VellumDocument, VellumImage, VellumVideo
+from vellum.utils.files import InvalidFileSourceError, stream_vellum_file
+
+# Sample content for different file types
+SAMPLE_TEXT_CONTENT = b"This is a sample text document content."
+SAMPLE_IMAGE_CONTENT = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"  # Minimal PNG header
+SAMPLE_AUDIO_CONTENT = b"RIFF\x00\x00\x00\x00WAVEfmt "  # Minimal WAV header
+SAMPLE_VIDEO_CONTENT = b"\x00\x00\x00\x20ftypmp42"  # Minimal MP4 header
+
+
+@pytest.mark.parametrize(
+    ["file_type", "content", "mime_type"],
+    [
+        (VellumDocument, SAMPLE_TEXT_CONTENT, "text/plain"),
+        (VellumImage, SAMPLE_IMAGE_CONTENT, "image/png"),
+        (VellumAudio, SAMPLE_AUDIO_CONTENT, "audio/wav"),
+        (VellumVideo, SAMPLE_VIDEO_CONTENT, "video/mp4"),
+    ],
+)
+def test_stream_vellum_file_base64_data_url(file_type, content, mime_type):
+    """Test streaming files from base64 data URLs."""
+    # Encode content as base64
+    base64_content = base64.b64encode(content).decode("utf-8")
+    src = f"data:{mime_type};base64,{base64_content}"
+
+    # Create the appropriate file type
+    vellum_file = file_type(src=src)
+
+    # Stream the file and collect chunks
+    chunks = []
+    with stream_vellum_file(vellum_file) as chunk_iter:
+        for chunk in chunk_iter:
+            chunks.append(chunk)
+
+    # Verify the content matches
+    result = b"".join(chunks)
+    assert result == content
+
+
+@pytest.mark.parametrize(
+    ["file_type", "content"],
+    [
+        (VellumDocument, SAMPLE_TEXT_CONTENT),
+        (VellumImage, SAMPLE_IMAGE_CONTENT),
+        (VellumAudio, SAMPLE_AUDIO_CONTENT),
+        (VellumVideo, SAMPLE_VIDEO_CONTENT),
+    ],
+)
+def test_stream_vellum_file_with_custom_chunk_size(file_type, content):
+    """Test that custom chunk size is respected."""
+    # Encode content as base64
+    base64_content = base64.b64encode(content).decode("utf-8")
+    src = f"data:application/octet-stream;base64,{base64_content}"
+
+    vellum_file = file_type(src=src)
+
+    # Stream with small chunk size
+    chunk_size = 5
+    chunks = []
+    with stream_vellum_file(vellum_file, chunk_size=chunk_size) as chunk_iter:
+        for chunk in chunk_iter:
+            chunks.append(chunk)
+            # Each chunk should be <= chunk_size (last chunk may be smaller)
+            assert len(chunk) <= chunk_size
+
+    # Verify the content matches when reassembled
+    result = b"".join(chunks)
+    assert result == content
+
+    # Verify we got multiple chunks for content larger than chunk_size
+    if len(content) > chunk_size:
+        assert len(chunks) > 1
+
+
+@pytest.mark.parametrize(
+    "file_type",
+    [VellumDocument, VellumImage, VellumAudio, VellumVideo],
+)
+def test_stream_vellum_file_from_url(file_type):
+    """Test streaming files from direct URLs."""
+    content = b"URL fetched content that will be streamed"
+    url = "https://example.com/file.dat"
+
+    vellum_file = file_type(src=url)
+
+    with patch("vellum.utils.files.stream.requests.get") as mock_get:
+        mock_response = Mock()
+        # Simulate streaming response with iter_content
+        mock_response.iter_content = Mock(return_value=iter([content[:20], content[20:]]))
+        mock_response.raise_for_status = Mock()
+        mock_response.close = Mock()
+        mock_get.return_value = mock_response
+
+        chunks = []
+        with stream_vellum_file(vellum_file) as chunk_iter:
+            for chunk in chunk_iter:
+                chunks.append(chunk)
+
+        result = b"".join(chunks)
+        assert result == content
+        mock_get.assert_called_once_with(url, stream=True)
+        mock_response.raise_for_status.assert_called_once()
+        mock_response.close.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "file_type",
+    [VellumDocument, VellumImage, VellumAudio, VellumVideo],
+)
+def test_stream_vellum_file_from_vellum_uploaded_file(file_type):
+    """Test streaming files from Vellum uploaded file IDs."""
+    content = b"Vellum uploaded content to stream"
+    file_id = "12345678-1234-1234-1234-123456789abc"
+    src = f"vellum:uploaded-file:{file_id}"
+    file_url = "https://s3.amazonaws.com/example/file.dat"
+
+    vellum_file = file_type(src=src)
+
+    with patch("vellum.utils.files.stream.create_vellum_client") as mock_create_client, patch(
+        "vellum.utils.files.stream.requests.get"
+    ) as mock_get:
+        # Mock the Vellum client
+        mock_client = Mock()
+        uploaded_file_mock = Mock()
+        uploaded_file_mock.file_url = file_url
+        mock_client.uploaded_files.retrieve.return_value = uploaded_file_mock
+        mock_create_client.return_value = mock_client
+
+        # Mock the file download with streaming
+        file_response = Mock()
+        file_response.iter_content = Mock(return_value=iter([content[:15], content[15:]]))
+        file_response.raise_for_status = Mock()
+        file_response.close = Mock()
+
+        mock_get.return_value = file_response
+
+        chunks = []
+        with stream_vellum_file(vellum_file) as chunk_iter:
+            for chunk in chunk_iter:
+                chunks.append(chunk)
+
+        result = b"".join(chunks)
+        assert result == content
+        mock_client.uploaded_files.retrieve.assert_called_once_with(file_id)
+        mock_get.assert_called_once_with(file_url, stream=True)
+        file_response.close.assert_called_once()
+
+
+def test_stream_vellum_file_context_manager_cleanup():
+    """Test that the context manager properly cleans up resources."""
+    content = b"Test content"
+    base64_content = base64.b64encode(content).decode("utf-8")
+    src = f"data:text/plain;base64,{base64_content}"
+
+    vellum_file = VellumDocument(src=src)
+
+    # Test that we can use the iterator only within the context
+    with stream_vellum_file(vellum_file) as chunk_iter:
+        chunks = list(chunk_iter)
+
+    # After the context, the iterator should be exhausted
+    assert b"".join(chunks) == content
+
+
+def test_stream_vellum_file_invalid_src():
+    """Test that invalid src raises InvalidFileSourceError even in streaming mode."""
+    vellum_file = VellumDocument(src="invalid://source")
+
+    with pytest.raises(InvalidFileSourceError, match="Invalid file source"):
+        with stream_vellum_file(vellum_file) as chunk_iter:
+            list(chunk_iter)
+
+
+def test_stream_vellum_file_large_file_simulation():
+    """Test streaming a large file to verify memory efficiency."""
+    # Simulate a large file by creating content in chunks
+    large_content = b"x" * 10000  # 10KB
+    base64_content = base64.b64encode(large_content).decode("utf-8")
+    src = f"data:application/octet-stream;base64,{base64_content}"
+
+    vellum_file = VellumDocument(src=src)
+
+    # Stream with 1KB chunks
+    chunk_size = 1024
+    total_bytes = 0
+    chunk_count = 0
+
+    with stream_vellum_file(vellum_file, chunk_size=chunk_size) as chunk_iter:
+        for chunk in chunk_iter:
+            total_bytes += len(chunk)
+            chunk_count += 1
+            assert len(chunk) <= chunk_size
+
+    assert total_bytes == len(large_content)
+    assert chunk_count >= len(large_content) // chunk_size

--- a/src/vellum/utils/files/types.py
+++ b/src/vellum/utils/files/types.py
@@ -1,0 +1,7 @@
+"""Type definitions for Vellum files."""
+
+from typing import Union
+
+from vellum import VellumAudio, VellumDocument, VellumImage, VellumVideo
+
+VellumFileTypes = Union[VellumDocument, VellumImage, VellumVideo, VellumAudio]


### PR DESCRIPTION
This is the first of a few PRs that help aim to improve the DevExp of interacting with vellum file values within workflows.

Specifically, it exposes two new utilities:
– A higher level `read_vellum_file`
- A lower level `stream_vellum_file`

These will later be used to implement the optimal API, which I view to be:

```python
vellum_document = VellumDocument(...)
contents = vellum_document.read()
content_iterator = vellum_document.stream()
```

Additional API's I want to support
```python
vellum_document = VellumDocument(...)
vellum_document.upload()  # Lazily creates an UploadedFile entity in Vellum and returns a new VellumFile instance with an updated `src` value
```

--------------

Here are some examples of Custom Nodes that we could support in Workflows if we had all the above.

```python
class OCRNode(BaseNode):
    """Example of a custom node that needs to read the contents of a Vellum Value that represents a file"""

    file: VellumDocument | VellumImage  # Note that `src` within could be base64, a public url, signed url, or `vellum:uploaded-files:<id>`

    class Outputs(BaseNode.Outputs):
        text: str

    def run(self):
        contents = self.file.read()

        # Send the contents to an OCR api...
        text = ...
        return self.Outputs(text=text)
```

```python
class ImageGenerationNode(BaseNode):
    """Example of a custom node that needs to save a generated artifact so it can be viewed later"""

    class Outputs(BaseNode.Outputs):
        image: VellumImage

    def run(self):
        prompt = "Generate an image of a hotdog"

        # Hit an image generation API that returns one of base64, public url, or signed url with expiry...
        result = ...
        
        image = VellumImage(src=result)

        # Note: If we didn't want to hit the Vellum backend and were cool with just passing around a base64/public/signed url
        #     then we'd just do this:
        # return self.Outputs(image=image)

        # If we want to reduce the size of the value that's being passed between nodes (i.e. base64's) and/or
        #     make it easy to view the generated artifact later (i.e. support viewing beyond original expiry)
        #     then we'd want to do this:
        uploaded_image = image.upload()
        return self.Outputs(image=uploaded_image)
```

Current limitations as of 11/19/2025
1. The Vellum UI renders suboptimal representations of these multi-modal variable types in the Workflow Sandbox Console and probably other UI surfaces
2. Workflows do not yet support these multi-modal types as workflow-level inputs, start variables, or outputs. Crucially, this means you cannot yet output say, a `VellumImage` as a Workflow Output (even though a Custom Node might produce one as its output)