### PR TITLE
Improve Call Signature of File Upload Utils

### DIFF
--- a/src/vellum/utils/files/read.py
+++ b/src/vellum/utils/files/read.py
@@ -7,7 +7,7 @@ from vellum.utils.files.stream import stream_vellum_file
 from vellum.utils.files.types import VellumFileTypes
 
 
-def read_vellum_file(vellum_file: VellumFileTypes, client: Optional[VellumClient] = None) -> bytes:
+def read_vellum_file(vellum_file: VellumFileTypes, *, vellum_client: Optional[VellumClient] = None) -> bytes:
     """
     Convenience function that reads the entire file content into memory.
 
@@ -17,7 +17,7 @@ def read_vellum_file(vellum_file: VellumFileTypes, client: Optional[VellumClient
 
     Args:
         vellum_file: A VellumDocument, VellumImage, VellumAudio, or VellumVideo instance
-        client: An optional Vellum client instance. If not provided, a default client will be created.
+        vellum_client: An optional Vellum client instance. If not provided, a default client will be created.
 
     Returns:
         bytes: The complete file content
@@ -33,7 +33,7 @@ def read_vellum_file(vellum_file: VellumFileTypes, client: Optional[VellumClient
         ```
     """
     chunks = []
-    with stream_vellum_file(vellum_file, client=client) as chunk_iter:
+    with stream_vellum_file(vellum_file, vellum_client=vellum_client) as chunk_iter:
         for chunk in chunk_iter:
             chunks.append(chunk)
     return b"".join(chunks)

--- a/src/vellum/utils/files/stream.py
+++ b/src/vellum/utils/files/stream.py
@@ -19,8 +19,9 @@ from vellum.workflows.vellum_client import create_vellum_client
 @contextmanager
 def stream_vellum_file(
     vellum_file: VellumFileTypes,
+    *,
     chunk_size: int = 8192,
-    client: Optional[VellumClient] = None,
+    vellum_client: Optional[VellumClient] = None,
 ) -> Generator[Iterator[bytes], None, None]:
     """
     Stream the file content in chunks using a context manager.
@@ -31,7 +32,7 @@ def stream_vellum_file(
     Args:
         vellum_file: A VellumDocument, VellumImage, VellumAudio, or VellumVideo instance
         chunk_size: Size of chunks to yield in bytes (default 8KB)
-        client: An optional Vellum client instance. If not provided, a default client will be created.
+        vellum_client: An optional Vellum client instance. If not provided, a default client will be created.
 
     Yields:
         Iterator[bytes]: Chunks of file content
@@ -79,7 +80,7 @@ def stream_vellum_file(
     match = re.match(VELLUM_FILE_SRC_PATTERN, src, re.IGNORECASE)
     if match:
         vellum_uploaded_file_id = match.group(1)
-        vellum_client = client or create_vellum_client()
+        vellum_client = vellum_client or create_vellum_client()
 
         try:
             uploaded_file = vellum_client.uploaded_files.retrieve(vellum_uploaded_file_id)

--- a/src/vellum/utils/files/tests/test_upload.py
+++ b/src/vellum/utils/files/tests/test_upload.py
@@ -140,7 +140,7 @@ def test_upload_vellum_file_with_custom_client(file_type):
     custom_client.uploaded_files.create.return_value = Mock(id=uploaded_file_id)
 
     # WHEN uploading the file with the custom client
-    result = upload_vellum_file(vellum_file, client=custom_client)
+    result = upload_vellum_file(vellum_file, vellum_client=custom_client)
 
     # THEN the custom client should be used for the upload
     assert result.src == f"vellum:uploaded-file:{uploaded_file_id}"

--- a/src/vellum/utils/files/upload.py
+++ b/src/vellum/utils/files/upload.py
@@ -21,8 +21,9 @@ logger = logging.getLogger(__name__)
 
 def upload_vellum_file(
     vellum_file: VellumFileTypes,
+    *,
     filename: Optional[str] = None,
-    client: Optional[VellumClient] = None,
+    vellum_client: Optional[VellumClient] = None,
 ) -> VellumFileTypes:
     """
     Upload a file to Vellum and return a new VellumFile with the uploaded source.
@@ -34,7 +35,7 @@ def upload_vellum_file(
     Args:
         vellum_file: A VellumDocument, VellumImage, VellumAudio, or VellumVideo instance
         filename: Optional filename to use when uploading. If not provided, the API will determine a default.
-        client: An optional Vellum client instance. If not provided, a default client will be created.
+        vellum_client: An optional Vellum client instance. If not provided, a default client will be created.
 
     Returns:
         VellumFileTypes: A new VellumFile of the same type with the vellum:uploaded-file:{id} source
@@ -70,7 +71,7 @@ def upload_vellum_file(
         )
         return vellum_file
 
-    vellum_client = client or create_vellum_client()
+    vellum_client = vellum_client or create_vellum_client()
 
     # Case 2: Base64 Data URL
     data_url_match = re.match(BASE64_DATA_URL_PATTERN, src)


### PR DESCRIPTION
A quick improvement to the call signature of our file upload helpers. Namely:
1. We use the more explict/consistent `vellum_client` kwarg instead of `vellum`.
2. We enforce the use of named args