### PR TITLE
Move create_vellum_client to vellum.utils and reexport

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -82,7 +82,8 @@ def mock_uuid4_generator(mocker: MockerFixture) -> Callable[[str], UUIDGenerator
 
 @pytest.fixture
 def vellum_client_class(mocker: MockerFixture) -> Any:
-    vellum_client_class = mocker.patch("vellum.workflows.vellum_client.Vellum")
+    vellum_client_class = mocker.patch("vellum.utils.vellum_client.Vellum")
+    mocker.patch("vellum.workflows.vellum_client.Vellum", vellum_client_class)
     return vellum_client_class
 
 

--- a/src/vellum/utils/__init__.py
+++ b/src/vellum/utils/__init__.py
@@ -1,0 +1,3 @@
+from vellum.utils.vellum_client import create_vellum_client
+
+__all__ = ["create_vellum_client"]

--- a/src/vellum/utils/__init__.py
+++ b/src/vellum/utils/__init__.py
@@ -1,3 +1,0 @@
-from vellum.utils.vellum_client import create_vellum_client
-
-__all__ = ["create_vellum_client"]

--- a/src/vellum/utils/vellum_client.py
+++ b/src/vellum/utils/vellum_client.py
@@ -1,0 +1,40 @@
+import os
+from typing import List, Optional
+
+from vellum import Vellum, VellumEnvironment
+from vellum.client.types.api_version_enum import ApiVersionEnum
+
+
+def create_vellum_client(
+    api_key: Optional[str] = None,
+    api_url: Optional[str] = None,
+    api_version: Optional[ApiVersionEnum] = None,
+) -> Vellum:
+    if api_key is None:
+        api_key = os.getenv("VELLUM_API_KEY", default="")
+
+    return Vellum(
+        api_key=api_key,
+        environment=create_vellum_environment(api_url),
+        api_version=api_version,
+    )
+
+
+def create_vellum_environment(api_url: Optional[str] = None) -> VellumEnvironment:
+    return VellumEnvironment(
+        default=_resolve_env([api_url, "VELLUM_DEFAULT_API_URL", "VELLUM_API_URL"], "https://api.vellum.ai"),
+        documents=_resolve_env([api_url, "VELLUM_DOCUMENTS_API_URL", "VELLUM_API_URL"], "https://documents.vellum.ai"),
+        predict=_resolve_env([api_url, "VELLUM_PREDICT_API_URL", "VELLUM_API_URL"], "https://predict.vellum.ai"),
+    )
+
+
+def _resolve_env(names: List[Optional[str]], default: str = "") -> str:
+    for name in names:
+        if not name:
+            continue
+
+        value = os.getenv(name)
+        if value:
+            return value
+
+    return default

--- a/src/vellum/workflows/vellum_client.py
+++ b/src/vellum/workflows/vellum_client.py
@@ -1,40 +1,4 @@
-import os
-from typing import List, Optional
+from vellum import Vellum
+from vellum.utils.vellum_client import create_vellum_client, create_vellum_environment
 
-from vellum import Vellum, VellumEnvironment
-from vellum.client.types.api_version_enum import ApiVersionEnum
-
-
-def create_vellum_client(
-    api_key: Optional[str] = None,
-    api_url: Optional[str] = None,
-    api_version: Optional[ApiVersionEnum] = None,
-) -> Vellum:
-    if api_key is None:
-        api_key = os.getenv("VELLUM_API_KEY", default="")
-
-    return Vellum(
-        api_key=api_key,
-        environment=create_vellum_environment(api_url),
-        api_version=api_version,
-    )
-
-
-def create_vellum_environment(api_url: Optional[str] = None) -> VellumEnvironment:
-    return VellumEnvironment(
-        default=_resolve_env([api_url, "VELLUM_DEFAULT_API_URL", "VELLUM_API_URL"], "https://api.vellum.ai"),
-        documents=_resolve_env([api_url, "VELLUM_DOCUMENTS_API_URL", "VELLUM_API_URL"], "https://documents.vellum.ai"),
-        predict=_resolve_env([api_url, "VELLUM_PREDICT_API_URL", "VELLUM_API_URL"], "https://predict.vellum.ai"),
-    )
-
-
-def _resolve_env(names: List[Optional[str]], default: str = "") -> str:
-    for name in names:
-        if not name:
-            continue
-
-        value = os.getenv(name)
-        if value:
-            return value
-
-    return default
+__all__ = ["Vellum", "create_vellum_client", "create_vellum_environment"]


### PR DESCRIPTION
- Moved create_vellum_client, create_vellum_environment, and _resolve_env helper functions to src/vellum/utils/vellum_client.py
- Updated src/vellum/workflows/vellum_client.py to reexport these functions for backward compatibility
- Also reexport Vellum class to maintain existing imports