### PR TITLE
Break mixin cycle

### DIFF
--- a/src/vellum/utils/files/read.py
+++ b/src/vellum/utils/files/read.py
@@ -1,13 +1,15 @@
 """Convenience utilities for reading Vellum files."""
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from vellum.client import Vellum as VellumClient
 from vellum.utils.files.stream import stream_vellum_file
 from vellum.utils.files.types import VellumFileTypes
 
+if TYPE_CHECKING:
+    from vellum.client import Vellum as VellumClient
 
-def read_vellum_file(vellum_file: VellumFileTypes, *, vellum_client: Optional[VellumClient] = None) -> bytes:
+
+def read_vellum_file(vellum_file: VellumFileTypes, *, vellum_client: Optional["VellumClient"] = None) -> bytes:
     """
     Convenience function that reads the entire file content into memory.
 

--- a/src/vellum/utils/files/stream.py
+++ b/src/vellum/utils/files/stream.py
@@ -4,16 +4,18 @@ import base64
 from contextlib import contextmanager
 from io import BytesIO
 import re
-from typing import Generator, Iterator, Optional
+from typing import TYPE_CHECKING, Generator, Iterator, Optional
 
 import requests
 
-from vellum.client import Vellum as VellumClient
 from vellum.client.core.api_error import ApiError
 from vellum.utils.files.constants import BASE64_DATA_URL_PATTERN, URL_PATTERN, VELLUM_FILE_SRC_PATTERN
 from vellum.utils.files.exceptions import FileNotFoundError, FileRetrievalError, InvalidFileSourceError
 from vellum.utils.files.types import VellumFileTypes
-from vellum.workflows.vellum_client import create_vellum_client
+from vellum.utils.vellum_client import create_vellum_client
+
+if TYPE_CHECKING:
+    from vellum.client import Vellum as VellumClient
 
 
 @contextmanager
@@ -21,7 +23,7 @@ def stream_vellum_file(
     vellum_file: VellumFileTypes,
     *,
     chunk_size: int = 8192,
-    vellum_client: Optional[VellumClient] = None,
+    vellum_client: Optional["VellumClient"] = None,
 ) -> Generator[Iterator[bytes], None, None]:
     """
     Stream the file content in chunks using a context manager.

--- a/src/vellum/utils/files/stream.py
+++ b/src/vellum/utils/files/stream.py
@@ -12,7 +12,6 @@ from vellum.client.core.api_error import ApiError
 from vellum.utils.files.constants import BASE64_DATA_URL_PATTERN, URL_PATTERN, VELLUM_FILE_SRC_PATTERN
 from vellum.utils.files.exceptions import FileNotFoundError, FileRetrievalError, InvalidFileSourceError
 from vellum.utils.files.types import VellumFileTypes
-from vellum.utils.vellum_client import create_vellum_client
 
 if TYPE_CHECKING:
     from vellum.client import Vellum as VellumClient
@@ -82,7 +81,10 @@ def stream_vellum_file(
     match = re.match(VELLUM_FILE_SRC_PATTERN, src, re.IGNORECASE)
     if match:
         vellum_uploaded_file_id = match.group(1)
-        vellum_client = vellum_client or create_vellum_client()
+        if vellum_client is None:
+            from vellum.utils.vellum_client import create_vellum_client
+
+            vellum_client = create_vellum_client()
 
         try:
             uploaded_file = vellum_client.uploaded_files.retrieve(vellum_uploaded_file_id)

--- a/src/vellum/utils/files/tests/test_mixin.py
+++ b/src/vellum/utils/files/tests/test_mixin.py
@@ -113,7 +113,7 @@ def test_vellum_file_mixin_upload_method():
     uploaded_file_id = "12345678-1234-1234-1234-123456789abc"
 
     # WHEN uploading using the mixin's .upload() method
-    with patch("vellum.utils.files.upload.create_vellum_client") as mock_create_client:
+    with patch("vellum.utils.vellum_client.create_vellum_client") as mock_create_client:
         mock_client = Mock()
         mock_client.uploaded_files.create.return_value = Mock(id=uploaded_file_id)
         mock_create_client.return_value = mock_client

--- a/src/vellum/utils/files/tests/test_read.py
+++ b/src/vellum/utils/files/tests/test_read.py
@@ -151,7 +151,7 @@ def test_read_vellum_file_from_vellum_uploaded_file(file_type):
 
     vellum_file = file_type(src=src)
 
-    with patch("vellum.utils.files.stream.create_vellum_client") as mock_create_client, patch(
+    with patch("vellum.utils.vellum_client.create_vellum_client") as mock_create_client, patch(
         "vellum.utils.files.stream.requests.get"
     ) as mock_get:
         # Mock the Vellum client
@@ -193,7 +193,7 @@ def test_read_vellum_file_vellum_uploaded_file_missing_url():
     vellum_file = VellumDocument(src=src)
 
     # Mock the create_vellum_client to return a client with an uploaded file without a file_url
-    with patch("vellum.utils.files.stream.create_vellum_client") as mock_create_client:
+    with patch("vellum.utils.vellum_client.create_vellum_client") as mock_create_client:
         mock_client = Mock()
         uploaded_file_mock = Mock()
         uploaded_file_mock.file_url = None

--- a/src/vellum/utils/files/tests/test_stream.py
+++ b/src/vellum/utils/files/tests/test_stream.py
@@ -120,7 +120,7 @@ def test_stream_vellum_file_from_vellum_uploaded_file(file_type):
 
     vellum_file = file_type(src=src)
 
-    with patch("vellum.utils.files.stream.create_vellum_client") as mock_create_client, patch(
+    with patch("vellum.utils.vellum_client.create_vellum_client") as mock_create_client, patch(
         "vellum.utils.files.stream.requests.get"
     ) as mock_get:
         # Mock the Vellum client

--- a/src/vellum/utils/files/tests/test_upload.py
+++ b/src/vellum/utils/files/tests/test_upload.py
@@ -19,7 +19,7 @@ SAMPLE_VIDEO_CONTENT = b"\x00\x00\x00\x20ftypmp42"  # Minimal MP4 header
 def mock_vellum_client():
     """Fixture that provides a mock Vellum client."""
     mock_client = Mock()
-    with patch("vellum.utils.files.upload.create_vellum_client", return_value=mock_client):
+    with patch("vellum.utils.vellum_client.create_vellum_client", return_value=mock_client):
         yield mock_client
 
 

--- a/src/vellum/utils/files/types.py
+++ b/src/vellum/utils/files/types.py
@@ -1,7 +1,8 @@
 """Type definitions for Vellum files."""
 
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
-from vellum import VellumAudio, VellumDocument, VellumImage, VellumVideo
+if TYPE_CHECKING:
+    from vellum.client import VellumAudio, VellumDocument, VellumImage, VellumVideo
 
-VellumFileTypes = Union[VellumDocument, VellumImage, VellumVideo, VellumAudio]
+VellumFileTypes = Union["VellumDocument", "VellumImage", "VellumVideo", "VellumAudio"]

--- a/src/vellum/utils/files/types.py
+++ b/src/vellum/utils/files/types.py
@@ -3,6 +3,6 @@
 from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
-    from vellum.client import VellumAudio, VellumDocument, VellumImage, VellumVideo
+    from vellum import VellumAudio, VellumDocument, VellumImage, VellumVideo
 
 VellumFileTypes = Union["VellumDocument", "VellumImage", "VellumVideo", "VellumAudio"]

--- a/src/vellum/utils/files/upload.py
+++ b/src/vellum/utils/files/upload.py
@@ -4,17 +4,19 @@ import base64
 from io import BytesIO
 import logging
 import re
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import requests
 
-from vellum.client import Vellum as VellumClient
 from vellum.client.core.api_error import ApiError
 from vellum.client.core.file import File
 from vellum.utils.files.constants import BASE64_DATA_URL_PATTERN, URL_PATTERN, VELLUM_FILE_SRC_PATTERN
 from vellum.utils.files.exceptions import FileNotFoundError, FileRetrievalError, InvalidFileSourceError
 from vellum.utils.files.types import VellumFileTypes
-from vellum.workflows.vellum_client import create_vellum_client
+from vellum.utils.vellum_client import create_vellum_client
+
+if TYPE_CHECKING:
+    from vellum.client import Vellum as VellumClient
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +25,7 @@ def upload_vellum_file(
     vellum_file: VellumFileTypes,
     *,
     filename: Optional[str] = None,
-    vellum_client: Optional[VellumClient] = None,
+    vellum_client: Optional["VellumClient"] = None,
 ) -> VellumFileTypes:
     """
     Upload a file to Vellum and return a new VellumFile with the uploaded source.

--- a/src/vellum/utils/files/upload.py
+++ b/src/vellum/utils/files/upload.py
@@ -13,7 +13,6 @@ from vellum.client.core.file import File
 from vellum.utils.files.constants import BASE64_DATA_URL_PATTERN, URL_PATTERN, VELLUM_FILE_SRC_PATTERN
 from vellum.utils.files.exceptions import FileNotFoundError, FileRetrievalError, InvalidFileSourceError
 from vellum.utils.files.types import VellumFileTypes
-from vellum.utils.vellum_client import create_vellum_client
 
 if TYPE_CHECKING:
     from vellum.client import Vellum as VellumClient
@@ -73,7 +72,10 @@ def upload_vellum_file(
         )
         return vellum_file
 
-    vellum_client = vellum_client or create_vellum_client()
+    if vellum_client is None:
+        from vellum.utils.vellum_client import create_vellum_client
+
+        vellum_client = create_vellum_client()
 
     # Case 2: Base64 Data URL
     data_url_match = re.match(BASE64_DATA_URL_PATTERN, src)

--- a/src/vellum/utils/vellum_client.py
+++ b/src/vellum/utils/vellum_client.py
@@ -1,15 +1,20 @@
 import os
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
-from vellum import Vellum, VellumEnvironment
 from vellum.client.types.api_version_enum import ApiVersionEnum
+
+if TYPE_CHECKING:
+    from vellum.client import Vellum
+    from vellum.client.environment import VellumEnvironment
 
 
 def create_vellum_client(
     api_key: Optional[str] = None,
     api_url: Optional[str] = None,
     api_version: Optional[ApiVersionEnum] = None,
-) -> Vellum:
+) -> "Vellum":
+    from vellum.client import Vellum
+
     if api_key is None:
         api_key = os.getenv("VELLUM_API_KEY", default="")
 
@@ -20,7 +25,9 @@ def create_vellum_client(
     )
 
 
-def create_vellum_environment(api_url: Optional[str] = None) -> VellumEnvironment:
+def create_vellum_environment(api_url: Optional[str] = None) -> "VellumEnvironment":
+    from vellum.client.environment import VellumEnvironment
+
     return VellumEnvironment(
         default=_resolve_env([api_url, "VELLUM_DEFAULT_API_URL", "VELLUM_API_URL"], "https://api.vellum.ai"),
         documents=_resolve_env([api_url, "VELLUM_DOCUMENTS_API_URL", "VELLUM_API_URL"], "https://documents.vellum.ai"),

--- a/src/vellum/utils/vellum_client.py
+++ b/src/vellum/utils/vellum_client.py
@@ -1,20 +1,16 @@
 import os
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 
+from vellum.client import Vellum
+from vellum.client.environment import VellumEnvironment
 from vellum.client.types.api_version_enum import ApiVersionEnum
-
-if TYPE_CHECKING:
-    from vellum.client import Vellum
-    from vellum.client.environment import VellumEnvironment
 
 
 def create_vellum_client(
     api_key: Optional[str] = None,
     api_url: Optional[str] = None,
     api_version: Optional[ApiVersionEnum] = None,
-) -> "Vellum":
-    from vellum.client import Vellum
-
+) -> Vellum:
     if api_key is None:
         api_key = os.getenv("VELLUM_API_KEY", default="")
 
@@ -25,9 +21,7 @@ def create_vellum_client(
     )
 
 
-def create_vellum_environment(api_url: Optional[str] = None) -> "VellumEnvironment":
-    from vellum.client.environment import VellumEnvironment
-
+def create_vellum_environment(api_url: Optional[str] = None) -> VellumEnvironment:
     return VellumEnvironment(
         default=_resolve_env([api_url, "VELLUM_DEFAULT_API_URL", "VELLUM_API_URL"], "https://api.vellum.ai"),
         documents=_resolve_env([api_url, "VELLUM_DOCUMENTS_API_URL", "VELLUM_API_URL"], "https://documents.vellum.ai"),

--- a/src/vellum/utils/vellum_client.py
+++ b/src/vellum/utils/vellum_client.py
@@ -1,8 +1,7 @@
 import os
 from typing import List, Optional
 
-from vellum.client import Vellum
-from vellum.client.environment import VellumEnvironment
+from vellum import Vellum, VellumEnvironment
 from vellum.client.types.api_version_enum import ApiVersionEnum
 
 


### PR DESCRIPTION
vellum.client.types.vellum_document (client type) imports VellumFileMixin from vellum.utils.files.mixin
vellum.utils.files.mixin imports read_vellum_file from vellum.utils.files.read
vellum.utils.files.read imports stream_vellum_file from vellum.utils.files.stream
vellum.utils.files.stream imports create_vellum_client from vellum.utils.vellum_client
vellum.utils.vellum_client imports Vellum from vellum.client
vellum.client imports vellum.client.types.vellum_document (back to step 1)
This creates a cycle: vellum.client → vellum.client.types.vellum_document → vellum.utils.files.* → vellum.client