### PR TITLE
Infer File Extensions as Part of File Upload

### DIFF
--- a/src/vellum/utils/files/constants.py
+++ b/src/vellum/utils/files/constants.py
@@ -14,3 +14,34 @@ BASE64_DATA_URL_PATTERN = (
 
 # Regex pattern to match HTTP/HTTPS URLs
 URL_PATTERN = r"^(https?://[^\s]+)$"
+
+# Fallback MIME type to file extension mappings for types that mimetypes.guess_extension
+# might not handle well or returns undesirable extensions
+MIME_TYPE_TO_EXTENSION = {
+    "application/octet-stream": ".bin",
+    "text/plain": ".txt",
+    # Markdown variants
+    "text/markdown": ".md",
+    "text/x-markdown": ".md",
+    # YAML variants
+    "application/x-yaml": ".yaml",
+    "text/yaml": ".yaml",
+    "application/yaml": ".yaml",
+    # Compression formats
+    "application/gzip": ".gz",
+    "application/x-gzip": ".gz",
+}
+
+# File extension overrides to prefer more common extensions
+EXTENSION_OVERRIDES = {
+    # Image formats - prefer shorter extensions
+    ".jpe": ".jpg",
+    ".jpeg": ".jpg",
+    ".tif": ".tiff",
+    # HTML - prefer .html over .htm
+    ".htm": ".html",
+    # XML - prefer .xml over .xsl (mimetypes returns .xsl for application/xml)
+    ".xsl": ".xml",
+    # YAML - prefer .yaml over .yml for consistency
+    ".yml": ".yaml",
+}

--- a/src/vellum/utils/files/extensions.py
+++ b/src/vellum/utils/files/extensions.py
@@ -42,8 +42,8 @@ def ensure_filename_with_extension(filename: Optional[str], mime_type: str) -> s
         _, ext = os.path.splitext(filename)
         has_extension = bool(ext)
 
-    # If filename already has an extension, keep it
-    if has_extension:
+    # If the provided filename already has an extension, keep it
+    if filename and has_extension:
         return filename
 
     # Otherwise, infer extension from MIME type

--- a/src/vellum/utils/files/extensions.py
+++ b/src/vellum/utils/files/extensions.py
@@ -1,0 +1,59 @@
+"""File extension inference utilities."""
+
+import mimetypes
+import os
+from typing import Optional
+
+from vellum.utils.files.constants import EXTENSION_OVERRIDES, MIME_TYPE_TO_EXTENSION
+
+
+def ensure_filename_with_extension(filename: Optional[str], mime_type: str) -> str:
+    """
+    Ensure the filename has an appropriate extension, infering one based on the provided MIME type if necessary.
+
+    Args:
+        filename: Optional filename provided by the user
+        mime_type: The MIME type of the file (e.g., "application/pdf", "image/png"). This'll be used to infer the
+            extension if the filename lacks one.
+
+    Returns:
+        A filename with an appropriate extension
+
+    Examples:
+        >>> ensure_filename_with_extension(None, "application/pdf")
+        'file.pdf'
+        >>> ensure_filename_with_extension("document", "application/pdf")
+        'document.pdf'
+        >>> ensure_filename_with_extension("document.pdf", "application/pdf")
+        'document.pdf'
+        >>> ensure_filename_with_extension("document.pdf", "image/jpeg")
+        'document.pdf'  # Prioritizes existing extension
+    """
+    # Strip parameters from MIME type (e.g., "text/html; charset=utf-8" -> "text/html")
+    mime_type = mime_type.split(";")[0].strip()
+
+    # If no filename provided, start with "file"
+    if not filename:
+        base_name = "file"
+        has_extension = False
+    else:
+        base_name = filename
+        # Check if filename already has an extension
+        _, ext = os.path.splitext(filename)
+        has_extension = bool(ext)
+
+    # If filename already has an extension, keep it
+    if has_extension:
+        return filename
+
+    # Otherwise, infer extension from MIME type
+    extension = mimetypes.guess_extension(mime_type)
+
+    # Handle cases where mimetypes returns None or undesirable extensions
+    if not extension:
+        extension = MIME_TYPE_TO_EXTENSION.get(mime_type, ".bin")
+
+    # Some MIME types have multiple possible extensions; prefer the most common ones
+    extension = EXTENSION_OVERRIDES.get(extension, extension)
+
+    return f"{base_name}{extension}"

--- a/src/vellum/utils/files/tests/test_extensions.py
+++ b/src/vellum/utils/files/tests/test_extensions.py
@@ -1,0 +1,54 @@
+"""Tests for file extension inference utilities."""
+
+import pytest
+
+from vellum.utils.files.extensions import ensure_filename_with_extension
+
+
+@pytest.mark.parametrize(
+    ["filename", "mime_type", "expected"],
+    [
+        # None filename cases - should default to 'file' with inferred extension
+        pytest.param(None, "application/pdf", "file.pdf", id="none_filename_pdf"),
+        pytest.param(None, "image/png", "file.png", id="none_filename_png"),
+        pytest.param(None, "image/jpeg", "file.jpg", id="none_filename_jpeg_normalized"),
+        pytest.param(None, "text/plain", "file.txt", id="none_filename_txt"),
+        pytest.param(None, "video/mp4", "file.mp4", id="none_filename_mp4"),
+        pytest.param(None, "audio/mpeg", "file.mp3", id="none_filename_mp3"),
+        pytest.param(None, "text/markdown", "file.md", id="none_filename_markdown"),
+        pytest.param(None, "application/x-yaml", "file.yaml", id="none_filename_yaml_x"),
+        pytest.param(None, "text/yaml", "file.yaml", id="none_filename_yaml_text"),
+        pytest.param(None, "application/gzip", "file.gz", id="none_filename_gzip"),
+        pytest.param(None, "application/xml", "file.xml", id="none_filename_xml_normalized"),
+        pytest.param(None, "application/octet-stream", "file.bin", id="none_filename_octet_stream"),
+        pytest.param(None, "application/x-unknown-type", "file.bin", id="none_filename_unknown_mime"),
+        # Filename without extension - should add appropriate extension
+        pytest.param("document", "application/pdf", "document.pdf", id="document_without_ext_pdf"),
+        pytest.param("report", "application/pdf", "report.pdf", id="report_without_ext_pdf"),
+        pytest.param(
+            "report",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "report.docx",
+            id="report_without_ext_docx",
+        ),
+        pytest.param("config", "application/x-yaml", "config.yaml", id="config_without_ext_yaml_x"),
+        pytest.param("config", "text/yaml", "config.yaml", id="config_without_ext_yaml_text"),
+        pytest.param("README", "text/markdown", "README.md", id="readme_without_ext_markdown"),
+        pytest.param("data", "text/csv", "data.csv", id="data_without_ext_csv"),
+        pytest.param("data", "application/octet-stream", "data.bin", id="data_without_ext_bin"),
+        pytest.param("archive", "application/gzip", "archive.gz", id="archive_without_ext_gzip"),
+        pytest.param("file", "application/pdf", "file.pdf", id="file_without_ext_pdf"),
+        # Filename with extension - should keep existing extension
+        pytest.param("document.pdf", "application/pdf", "document.pdf", id="document_pdf_with_ext"),
+        pytest.param("image.png", "image/jpeg", "image.png", id="image_png_mismatched_mime"),
+        pytest.param("data.csv", "text/csv", "data.csv", id="data_csv_with_ext"),
+        pytest.param("config.yaml", "application/x-yaml", "config.yaml", id="config_yaml_with_ext"),
+        # MIME type with parameters - should strip parameters
+        pytest.param(None, "text/html; charset=utf-8", "file.html", id="none_filename_html_with_charset"),
+        pytest.param("page", "text/html; charset=utf-8", "page.html", id="page_without_ext_html_with_charset"),
+    ],
+)
+def test_ensure_filename_with_extension(filename, mime_type, expected):
+    """Test filename extension inference for various filename and MIME type combinations."""
+    result = ensure_filename_with_extension(filename, mime_type)
+    assert result == expected


### PR DESCRIPTION
The Vellum file upload API requires a file name with a valid extension. To supply this, we'll infer the extension as needed from the mimetype of the content.

In current state, the API returns a 400 when the `upload` api is used.