### PR TITLE
Validate new node mocks shape from Vellum frontend

### DIFF
--- a/ee/vellum_ee/workflows/display/tests/test_mocks.py
+++ b/ee/vellum_ee/workflows/display/tests/test_mocks.py
@@ -1,0 +1,120 @@
+from vellum.workflows import BaseInputs, BaseNode, BaseState, BaseWorkflow, MockNodeExecution
+from vellum_ee.workflows.display.utils.expressions import base_descriptor_validator
+
+
+def test_mocks__parse_from_app__descriptors():
+    # GIVEN a Base Node
+    class StartNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            foo: str
+
+    # AND workflow inputs
+    class Inputs(BaseInputs):
+        bar: str
+
+    # AND workflow state
+    class State(BaseState):
+        baz: str
+
+    # AND a workflow class with that Node
+    class MyWorkflow(BaseWorkflow[Inputs, State]):
+        graph = StartNode
+
+        class Outputs(BaseWorkflow.Outputs):
+            final_value = StartNode.Outputs.foo
+
+    # AND a mock workflow node execution from the app
+    raw_mock_workflow_node_executions = [
+        {
+            "node_id": str(StartNode.__id__),
+            "when_condition": {
+                "type": "BINARY_EXPRESSION",
+                "operator": ">=",
+                "lhs": {
+                    "type": "EXECUTION_COUNTER",
+                    "node_id": str(StartNode.__id__),
+                },
+                "rhs": {
+                    "type": "CONSTANT_VALUE",
+                    "value": {
+                        "type": "NUMBER",
+                        "value": 1,
+                    },
+                },
+            },
+            "then_outputs": {
+                "foo": "Hello foo",
+            },
+        },
+        {
+            "node_id": str(StartNode.__id__),
+            "when_condition": {
+                "type": "BINARY_EXPRESSION",
+                "operator": "==",
+                "lhs": {
+                    "type": "WORKFLOW_INPUT",
+                    "input_variable_id": str(Inputs.bar.id),
+                },
+                "rhs": {
+                    "type": "CONSTANT_VALUE",
+                    "value": {
+                        "type": "STRING",
+                        "value": "bar",
+                    },
+                },
+            },
+            "then_outputs": {
+                "foo": "Hello bar",
+            },
+        },
+        {
+            "node_id": str(StartNode.__id__),
+            "when_condition": {
+                "type": "BINARY_EXPRESSION",
+                "operator": "!=",
+                "lhs": {
+                    "type": "WORKFLOW_STATE",
+                    "state_variable_id": str(State.baz.id),
+                },
+                "rhs": {
+                    "type": "CONSTANT_VALUE",
+                    "value": {
+                        "type": "STRING",
+                        "value": "baz",
+                    },
+                },
+            },
+            "then_outputs": {
+                "foo": "Hello baz",
+            },
+        },
+    ]
+
+    # WHEN we parsed the raw data on `MockNodeExecution`
+    node_output_mocks = MockNodeExecution.validate_all(
+        raw_mock_workflow_node_executions,
+        MyWorkflow,
+        descriptor_validator=base_descriptor_validator,
+    )
+
+    # THEN we get the expected list of MockNodeExecution objects
+    assert node_output_mocks
+    assert len(node_output_mocks) == 3
+    assert node_output_mocks[0] == MockNodeExecution(
+        when_condition=StartNode.Execution.count.greater_than_or_equal_to(1),
+        then_outputs=StartNode.Outputs(
+            foo="Hello foo",
+        ),
+    )
+    assert node_output_mocks[1] == MockNodeExecution(
+        when_condition=Inputs.bar.equals("bar"),
+        then_outputs=StartNode.Outputs(
+            foo="Hello bar",
+        ),
+    )
+    assert node_output_mocks[2] == MockNodeExecution(
+        when_condition=State.baz.does_not_equal("baz"),
+        then_outputs=StartNode.Outputs(
+            foo="Hello baz",
+        ),
+    )

--- a/ee/vellum_ee/workflows/tests/test_serialize_module.py
+++ b/ee/vellum_ee/workflows/tests/test_serialize_module.py
@@ -264,6 +264,7 @@ def test_serialize_module_with_node_output_mock_when_conditions():
     node_id = str(ProcessNode.__id__)
 
     assert first_mock == {
+        "type": "NODE_EXECUTION",
         "node_id": node_id,
         "when_condition": {
             "type": "BINARY_EXPRESSION",
@@ -286,6 +287,7 @@ def test_serialize_module_with_node_output_mock_when_conditions():
 
     second_mock = first_scenario["mocks"][1]
     assert second_mock == {
+        "type": "NODE_EXECUTION",
         "node_id": node_id,
         "when_condition": {
             "type": "BINARY_EXPRESSION",
@@ -316,6 +318,7 @@ def test_serialize_module_with_node_output_mock_when_conditions():
 
     third_mock = second_scenario["mocks"][0]
     assert third_mock == {
+        "type": "NODE_EXECUTION",
         "node_id": node_id,
         "when_condition": {
             "type": "BINARY_EXPRESSION",

--- a/src/vellum/utils/uuid.py
+++ b/src/vellum/utils/uuid.py
@@ -1,8 +1,25 @@
 import uuid
-from typing import Union
+from typing import Any, Literal, Union, overload
+from typing_extensions import TypeGuard
 
 
-def is_valid_uuid(val: Union[str, uuid.UUID, None]) -> bool:
+@overload
+def is_valid_uuid(val: None) -> Literal[False]: ...
+
+
+@overload
+def is_valid_uuid(val: str) -> TypeGuard[str]: ...
+
+
+@overload
+def is_valid_uuid(val: uuid.UUID) -> TypeGuard[uuid.UUID]: ...
+
+
+@overload
+def is_valid_uuid(val: Any) -> Literal[False]: ...
+
+
+def is_valid_uuid(val: Any) -> TypeGuard[Union[str, uuid.UUID]]:
     try:
         uuid.UUID(str(val))
         return True

--- a/src/vellum/workflows/__init__.py
+++ b/src/vellum/workflows/__init__.py
@@ -26,6 +26,7 @@ from .nodes import (
     WebSearchNode,
 )
 from .nodes.displayable.tool_calling_node import ToolCallingNode
+from .nodes.mocks import MockNodeExecution
 from .ports import Port
 from .references.environment_variable import EnvironmentVariableReference
 from .references.lazy import LazyReference
@@ -64,6 +65,7 @@ __all__ = [
     "MapNode",
     "MCPServer",
     "MergeBehavior",
+    "MockNodeExecution",
     "NodeException",
     "NoteNode",
     "Port",

--- a/src/vellum/workflows/nodes/tests/test_mocks.py
+++ b/src/vellum/workflows/nodes/tests/test_mocks.py
@@ -2,16 +2,14 @@ import uuid
 
 from vellum.client.types.string_vellum_value import StringVellumValue
 from vellum.workflows import BaseWorkflow
-from vellum.workflows.inputs.base import BaseInputs
 from vellum.workflows.nodes import InlinePromptNode
 from vellum.workflows.nodes.bases.base import BaseNode
 from vellum.workflows.nodes.mocks import MockNodeExecution
-from vellum.workflows.state.base import BaseState
 from vellum_ee.workflows.display.nodes.base_node_display import BaseNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay
 
 
-# This test represents the legacy shape of our mocks.
+# These tests represent the legacy shape of our mocks.
 def test_mocks__parse_from_app():
     # GIVEN a PromptNode
     class PromptNode(InlinePromptNode):
@@ -206,113 +204,5 @@ def test_mocks__use_id_from_display():
         when_condition=StartNode.Execution.count.greater_than_or_equal_to(0.0),
         then_outputs=StartNode.Outputs(
             foo="Hello",
-        ),
-    )
-
-
-def test_mocks__parse_from_app__descriptors():
-    # GIVEN a Base Node
-    class StartNode(BaseNode):
-        class Outputs(BaseNode.Outputs):
-            foo: str
-
-    # AND workflow inputs
-    class Inputs(BaseInputs):
-        bar: str
-
-    # AND workflow state
-    class State(BaseState):
-        baz: str
-
-    # AND a workflow class with that Node
-    class MyWorkflow(BaseWorkflow[Inputs, State]):
-        graph = StartNode
-
-        class Outputs(BaseWorkflow.Outputs):
-            final_value = StartNode.Outputs.foo
-
-    # AND a mock workflow node execution from the app
-    raw_mock_workflow_node_executions = [
-        {
-            "node_id": str(StartNode.__id__),
-            "when_condition": {
-                "type": "BINARY_EXPRESSION",
-                "operator": ">=",
-                "lhs": {
-                    "type": "EXECUTION_COUNTER",
-                    "node_id": str(StartNode.__id__),
-                },
-                "rhs": {
-                    "type": "CONSTANT_VALUE",
-                    "value": "1",
-                },
-            },
-            "then_outputs": {
-                "foo": "Hello foo",
-            },
-        },
-        {
-            "node_id": str(StartNode.__id__),
-            "when_condition": {
-                "type": "BINARY_EXPRESSION",
-                "operator": "==",
-                "lhs": {
-                    "type": "INPUT_VARIABLE",
-                    "input_variable_id": Inputs.bar.id,
-                },
-                "rhs": {
-                    "type": "CONSTANT_VALUE",
-                    "value": "bar",
-                },
-            },
-            "then_outputs": {
-                "foo": "Hello bar",
-            },
-        },
-        {
-            "node_id": str(StartNode.__id__),
-            "when_condition": {
-                "type": "BINARY_EXPRESSION",
-                "operator": "!=",
-                "lhs": {
-                    "type": "INPUT_VARIABLE",
-                    "state_variable_id": State.baz.id,
-                },
-                "rhs": {
-                    "type": "CONSTANT_VALUE",
-                    "value": "baz",
-                },
-            },
-            "then_outputs": {
-                "foo": "Hello baz",
-            },
-        },
-    ]
-
-    # WHEN we parsed the raw data on `MockNodeExecution`
-    node_output_mocks = MockNodeExecution.validate_all(
-        raw_mock_workflow_node_executions,
-        MyWorkflow,
-    )
-
-    # THEN we get the expected list of MockNodeExecution objects
-    assert node_output_mocks
-    assert len(node_output_mocks) == 3
-    assert node_output_mocks[0] == MockNodeExecution(
-        when_condition=Inputs.bar.equals("bar"),
-        then_outputs=StartNode.Outputs(
-            foo="Hello",
-        ),
-    )
-    assert node_output_mocks[1] == MockNodeExecution(
-        when_condition=StartNode.Execution.count.greater_than_or_equal_to(0.0),
-        then_outputs=StartNode.Outputs(
-            foo="Hello bar",
-        ),
-    )
-    assert node_output_mocks[2] == MockNodeExecution(
-        when_condition=State.baz.not_equals("baz"),
-        then_outputs=StartNode.Outputs(
-            foo="Hello baz",
         ),
     )

--- a/src/vellum/workflows/tests/test_dataset_row.py
+++ b/src/vellum/workflows/tests/test_dataset_row.py
@@ -184,6 +184,7 @@ def test_dataset_row_with_node_output_mocks():
     # AND the mock output should be serialized as a dict with the correct structure
     mock_data = serialized_dict["mocks"][0]
     assert mock_data == {
+        "type": "NODE_EXECUTION",
         "node_id": str(DummyNode.__id__),
         "when_condition": {"type": "CONSTANT_VALUE", "value": {"type": "JSON", "value": True}},
         "then_outputs": {"result": "mocked output"},


### PR DESCRIPTION
We started serializing a new shape based on workflow value descriptors. This PR validates that we can accept that new shape once the Vellum App side cuts over to using it