### PR TITLE
Add Support for `expiry_seconds` to `get_signed_url` Helpers

### DIFF
--- a/src/vellum/utils/files/mixin.py
+++ b/src/vellum/utils/files/mixin.py
@@ -1,3 +1,4 @@
+import typing
 from typing import Any, ContextManager, Iterator, Optional
 
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
@@ -89,6 +90,7 @@ class VellumFileMixin(UniversalBaseModel):
     def get_signed_url(
         self: Any,
         *,
+        expiry_seconds: typing.Optional[int] = 7 * 24 * 60 * 60,  # 7 days
         vellum_client: Optional[Any] = None,
     ) -> str:
         """
@@ -99,9 +101,10 @@ class VellumFileMixin(UniversalBaseModel):
         and returns a signed url for accessing the file.
 
         Args:
+            expiry_seconds: The number of seconds until the signed URL expires. Defaults to 7 days.
             vellum_client: An optional Vellum client instance. If not provided, a default client will be created.
 
         Returns:
             str: A signed URL for accessing the uploaded file
         """
-        return get_signed_url(self, vellum_client=vellum_client)
+        return get_signed_url(self, expiry_seconds=expiry_seconds, vellum_client=vellum_client)

--- a/src/vellum/utils/files/tests/test_mixin.py
+++ b/src/vellum/utils/files/tests/test_mixin.py
@@ -154,7 +154,7 @@ def test_vellum_file_mixin_get_signed_url_method():
         # THEN the file should be uploaded and signed URL returned
         assert result == signed_url
         mock_client.uploaded_files.create.assert_called_once()
-        mock_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id)
+        mock_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id, expiry_seconds=604800)
 
 
 def test_vellum_file_mixin_get_signed_url_method_with_custom_client():
@@ -179,7 +179,7 @@ def test_vellum_file_mixin_get_signed_url_method_with_custom_client():
     # THEN the custom client should be used
     assert result == signed_url
     custom_client.uploaded_files.create.assert_called_once()
-    custom_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id)
+    custom_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id, expiry_seconds=604800)
 
 
 def test_vellum_file_mixin_get_signed_url_method_already_uploaded():
@@ -202,4 +202,4 @@ def test_vellum_file_mixin_get_signed_url_method_already_uploaded():
         # THEN the signed URL should be returned without uploading again
         assert result == signed_url
         mock_client.uploaded_files.create.assert_not_called()
-        mock_client.uploaded_files.retrieve.assert_called_once_with(file_id)
+        mock_client.uploaded_files.retrieve.assert_called_once_with(file_id, expiry_seconds=604800)

--- a/src/vellum/utils/files/tests/test_urls.py
+++ b/src/vellum/utils/files/tests/test_urls.py
@@ -40,7 +40,7 @@ def test_get_signed_url_from_base64(mock_vellum_client, file_type):
     # THEN the file should be uploaded and signed URL returned
     assert result == signed_url
     mock_vellum_client.uploaded_files.create.assert_called_once()
-    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id)
+    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id, expiry_seconds=604800)
 
 
 @pytest.mark.parametrize("file_type", [VellumDocument, VellumImage, VellumAudio, VellumVideo])
@@ -70,7 +70,7 @@ def test_get_signed_url_from_http_url(mock_get, mock_vellum_client, file_type):
     assert result == signed_url
     mock_get.assert_called_once_with(url, stream=True)
     mock_vellum_client.uploaded_files.create.assert_called_once()
-    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id)
+    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id, expiry_seconds=604800)
 
 
 @pytest.mark.parametrize("file_type", [VellumDocument, VellumImage, VellumAudio, VellumVideo])
@@ -92,7 +92,7 @@ def test_get_signed_url_already_uploaded(mock_vellum_client, file_type):
     # THEN the signed URL should be returned without uploading again
     assert result == signed_url
     mock_vellum_client.uploaded_files.create.assert_not_called()
-    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(file_id)
+    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(file_id, expiry_seconds=604800)
 
 
 @pytest.mark.parametrize(
@@ -119,7 +119,7 @@ def test_get_signed_url_case_insensitive_vellum_src(mock_vellum_client, src_patt
 
     # THEN the signed URL should be returned regardless of case
     assert result == signed_url
-    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(file_id)
+    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(file_id, expiry_seconds=604800)
 
 
 @pytest.mark.parametrize("file_type", [VellumDocument, VellumImage, VellumAudio, VellumVideo])
@@ -147,7 +147,7 @@ def test_get_signed_url_with_custom_client(mock_upload, file_type):
     # THEN the custom client should be used
     assert result == signed_url
     mock_upload.assert_called_once_with(vellum_file, vellum_client=custom_client)
-    custom_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id)
+    custom_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id, expiry_seconds=604800)
 
 
 def test_get_signed_url_invalid_uploaded_file_format(mock_vellum_client):
@@ -221,7 +221,7 @@ def test_get_signed_url_uses_default_client_when_not_provided(mock_vellum_client
 
     # THEN the default client should be created and used
     assert result == signed_url
-    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(file_id)
+    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(file_id, expiry_seconds=604800)
 
 
 @pytest.mark.parametrize("file_type", [VellumDocument, VellumImage, VellumAudio, VellumVideo])
@@ -249,4 +249,4 @@ def test_get_signed_url_preserves_file_type(mock_upload, mock_vellum_client, fil
     assert result == signed_url
     # The file type should be consistent throughout the process
     mock_upload.assert_called_once_with(vellum_file, vellum_client=None)
-    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id)
+    mock_vellum_client.uploaded_files.retrieve.assert_called_once_with(uploaded_file_id, expiry_seconds=604800)

--- a/src/vellum/utils/files/urls.py
+++ b/src/vellum/utils/files/urls.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import typing
 from typing import TYPE_CHECKING, Optional
 
 from vellum.client.core.api_error import ApiError
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 def get_signed_url(
     vellum_file: VellumFileTypes,
     *,
+    expiry_seconds: typing.Optional[int] = 7 * 24 * 60 * 60,  # 7 days
     vellum_client: Optional["VellumClient"] = None,
 ) -> str:
     """
@@ -30,6 +32,7 @@ def get_signed_url(
 
     Args:
         vellum_file: A VellumDocument, VellumImage, VellumAudio, or VellumVideo instance
+        expiry_seconds: The number of seconds until the signed URL expires. Defaults to 7 days.
         vellum_client: An optional Vellum client instance. If not provided, a default client will be created.
 
     Returns:
@@ -56,7 +59,9 @@ def get_signed_url(
 
     # Fetch the signed URL for this file from Vellum
     try:
-        vellum_uploaded_file = vellum_client.uploaded_files.retrieve(vellum_uploaded_file_id)
+        vellum_uploaded_file = vellum_client.uploaded_files.retrieve(
+            vellum_uploaded_file_id, expiry_seconds=expiry_seconds
+        )
     except ApiError as e:
         raise FileRetrievalError("Failed to retrieve file from Vellum") from e
 


### PR DESCRIPTION
This makes use of the newly available `expiry_seconds` parameter from the Vellum API when retrieving the signed url for a VellumFile.