### PR TITLE
Function call outputs

### DIFF
--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -546,6 +546,16 @@ class BaseNode(Generic[StateType], ABC, BaseExecutable, metaclass=BaseNodeMeta):
     def run(self) -> NodeRunResponse:
         return self.Outputs()
 
+    def _get_inputs(self) -> Dict[Union[NodeReference, AccessorExpression], Any]:
+        """
+        Returns the inputs to include in execution events.
+        Override this method to filter or modify inputs before they are serialized in events.
+
+        Returns:
+            Dict of inputs to include in execution events
+        """
+        return self._inputs
+
     def __cancel__(self, message: str) -> None:
         """
         Called when the node should be cancelled. Override this method to propagate

--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -554,7 +554,7 @@ class BaseNode(Generic[StateType], ABC, BaseExecutable, metaclass=BaseNodeMeta):
         Returns:
             Dict of inputs to include in execution events
         """
-        return self._inputs
+        return dict(self._inputs)
 
     def __cancel__(self, message: str) -> None:
         """

--- a/src/vellum/workflows/runner/runner.py
+++ b/src/vellum/workflows/runner/runner.py
@@ -493,7 +493,7 @@ class WorkflowRunner(Generic[StateType]):
             span_id=span_id,
             body=NodeExecutionInitiatedBody(
                 node_definition=node.__class__,
-                inputs=node._inputs,
+                inputs=node._get_inputs(),
             ),
             parent=execution.parent_context,
         )


### PR DESCRIPTION
If this changes too many things, we could filter in frontend which is more simple and straightforward https://github.com/vellum-ai/vellum/pull/17164

# Filter out `function_call_output` from FunctionNode execution event inputs

## Summary

This PR ensures that `FunctionNode` execution events only include the `arguments` input and exclude the `function_call_output` input. This prevents serialization errors and provides cleaner execution event data for the frontend.

## Problem

When `FunctionNode` execution events were serialized, they included both `function_call_output` and `arguments` in the inputs. The `function_call_output` contains a `FunctionCallArgumentsDescriptor` that was not supported by the serialization system, causing `UnsupportedSerializationException` errors. Additionally, `function_call_output` is an internal implementation detail that shouldn't be exposed in execution events.

## Solution

1. **Override `_get_inputs()` in `FunctionNode`**: Filter out `function_call_output` from the inputs dictionary before serialization by checking the descriptor's name.

2. **Improve `FunctionCallArgumentsDescriptor`**:
   - Changed it to inherit from `AccessorExpression` so it can be serialized automatically without special handling in the serializer
   - Updated `resolve()` to find the first `FUNCTION_CALL` output in the results array instead of assuming it's at index 0, which fixes issues when there are both `STRING` and `FUNCTION_CALL` outputs

## Changes

### `src/vellum/workflows/nodes/displayable/tool_calling_node/utils.py`

- **`FunctionNode._get_inputs()`**: Added override to filter out `function_call_output` from inputs
- **`FunctionCallArgumentsDescriptor`**: 
  - Now inherits from `AccessorExpression` for automatic serialization
  - Updated `resolve()` to iterate through results to find the first `FUNCTION_CALL` output
- **`create_function_node()`**: Changed `arguments` attribute to use `FunctionCallArgumentsDescriptor` instead of hardcoded accessor

## Impact

- **Frontend**: Execution events now only show `arguments` input, making the UI cleaner and avoiding serialization errors
- **Backward Compatibility**: No breaking changes - this only affects what's included in execution event inputs
- **Runtime Behavior**: No changes to how function nodes execute, only what's serialized in events
