### PR TITLE
Split validate helper into its own method

### DIFF
--- a/src/vellum/workflows/nodes/displayable/final_output_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/final_output_node/tests/test_node.py
@@ -43,9 +43,8 @@ def test_final_output_node__mismatched_output_type_should_raise_exception():
     # AND the error message should indicate the type mismatch
     assert (
         str(exc_info.value)
-        == "Output type mismatch in Output: FinalOutputNode is declared with output type 'list' but "
-        "the 'value' descriptor has type(s) ['str']. The output descriptor type must match the "
-        "declared FinalOutputNode output type."
+        == "Failed to validate output type for node 'Output': Output type mismatch: declared type 'list' but "
+        "the 'value' Output has type(s) ['str']. "
     )
 
 

--- a/src/vellum/workflows/utils/validate.py
+++ b/src/vellum/workflows/utils/validate.py
@@ -1,0 +1,38 @@
+from typing import get_origin
+
+
+def validate_target_types(declared_type: type, target_types: tuple[type, ...]) -> None:
+    type_mismatch = True
+    for target_type in target_types:
+        if target_type == declared_type:
+            type_mismatch = False
+            break
+
+        try:
+            if issubclass(target_type, declared_type) or issubclass(declared_type, target_type):
+                type_mismatch = False
+                break
+        except TypeError:
+            # Handle cases where types aren't classes (e.g., Union)
+            if str(target_type) == str(declared_type):
+                type_mismatch = False
+                break
+
+        descriptor_origin = get_origin(target_type)
+        declared_origin = get_origin(declared_type)
+
+        if descriptor_origin is None and declared_origin is None:
+            continue
+
+        if descriptor_origin == declared_type or declared_origin == target_type or descriptor_origin == declared_origin:
+            type_mismatch = False
+            break
+
+    if type_mismatch:
+        declared_type_name = getattr(declared_type, "__name__", str(declared_type))
+        descriptor_type_names = [getattr(t, "__name__", str(t)) for t in target_types]
+
+        raise ValueError(
+            f"Output type mismatch: declared type '{declared_type_name}' "
+            f"but the 'value' Output has type(s) {descriptor_type_names}. "
+        )


### PR DESCRIPTION
Splitting the actual node-agnostic type validation piece into its own helper since we will need to do some recursion in a future PR to validate args within a type