### PR TITLE
[APO-2233] Remove use tool inputs from src

### DIFF
--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_parent_input.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_parent_input.py
@@ -81,7 +81,7 @@ def test_serialize_workflow():
                             "forced": None,
                             "strict": None,
                         },
-                        "src": 'from vellum.workflows.utils.functions import use_tool_inputs\n\nfrom .inputs import ParentInputs\nfrom .nodes.dummy_node import DummyNode\n\n\n@use_tool_inputs(\n    parent_input=ParentInputs.parent_input,\n    dummy_input=DummyNode.Outputs.text,\n    constant_input="constant_input",\n)\ndef get_string(parent_input: str, dummy_input: str, constant_input: str, populated_input: str) -> str:\n    """\n    Get a string with the parent input, dummy input, and the populated input.\n    """\n    return f"parent input: {parent_input}, dummy input: {dummy_input}, constant input: {constant_input}, populated input: {populated_input}"  # noqa: E501\n',  # noqa: E501
+                        "src": 'from .inputs import ParentInputs\nfrom .nodes.dummy_node import DummyNode\n\ndef get_string(parent_input: str, dummy_input: str, constant_input: str, populated_input: str) -> str:\n    """\n    Get a string with the parent input, dummy input, and the populated input.\n    """\n    return f\'parent input: {parent_input}, dummy input: {dummy_input}, constant input: {constant_input}, populated input: {populated_input}\'\n',  # noqa: E501
                     }
                 ],
             },

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_basic_tool_calling_node_serialization.py
@@ -157,7 +157,7 @@ def test_serialize_workflow():
                                     "forced": None,
                                     "strict": None,
                                 },
-                                "src": 'import math\nfrom typing import Annotated\n\n\ndef get_current_weather(\n    location: Annotated[str, "The location to get the weather for"], unit: Annotated[str, "The unit of temperature"]\n) -> str:\n    """\n    Get the current weather in a given location.\n    """\n    return f"The current weather in {location} is sunny with a temperature of {get_temperature(70.1)} degrees {unit}."\n\n\ndef get_temperature(temperature: float) -> int:\n    """\n    Get the temperature in a given location.\n    """\n    return math.floor(temperature)\n',  # noqa: E501
+                                "src": 'import math\nfrom typing import Annotated\n\ndef get_current_weather(location: Annotated[str, \'The location to get the weather for\'], unit: Annotated[str, \'The unit of temperature\']) -> str:\n    """\n    Get the current weather in a given location.\n    """\n    return f\'The current weather in {location} is sunny with a temperature of {get_temperature(70.1)} degrees {unit}.\'\n\ndef get_temperature(temperature: float) -> int:\n    """\n    Get the temperature in a given location.\n    """\n    return math.floor(temperature)\n',  # noqa: E501
                             }
                         ],
                     },

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -269,7 +269,7 @@ class _RemoveUseToolInputsTransformer(ast.NodeTransformer):
     def __init__(self, function_name: str):
         self.function_name = function_name
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
         """Remove @use_tool_inputs decorators from the target function."""
         if node.name == self.function_name:
             node.decorator_list = [


### PR DESCRIPTION
after push, code should not have `@use_tool_inputs`

<img width="1620" height="981" alt="Screenshot 2025-11-25 at 10 42 10 AM" src="https://github.com/user-attachments/assets/183bfb01-4ecc-4b72-939d-c65e5dfd5bed" />
