### PR TITLE
docs: Add recent-workflow-doc-creator workflow example

### DIFF
--- a/examples/workflows/recent-workflow-doc-creator/workflow.py
+++ b/examples/workflows/recent-workflow-doc-creator/workflow.py
@@ -1,0 +1,26 @@
+from vellum.workflows import BaseWorkflow
+
+from .nodes.comments_output import CommentsOutput
+from .nodes.deployments_output import DeploymentsOutput
+from .nodes.fetch_recent_deployments import FetchRecentDeployments
+from .nodes.pr_urls_output import PrUrlsOutput
+from .nodes.process_deployments import ProcessDeployments
+from .triggers.scheduled import Scheduled
+
+
+class Workflow(BaseWorkflow):
+    graph = (
+        Scheduled
+        >> FetchRecentDeployments
+        >> ProcessDeployments
+        >> {
+            DeploymentsOutput,
+            CommentsOutput,
+            PrUrlsOutput,
+        }
+    )
+
+    class Outputs(BaseWorkflow.Outputs):
+        pr_results = PrUrlsOutput.Outputs.value
+        deployments_processed = CommentsOutput.Outputs.value
+        deployments_json = DeploymentsOutput.Outputs.value


### PR DESCRIPTION
## Summary

This PR adds a new workflow example demonstrating the **Recent Workflow Doc Creator** pattern - a scheduled automation workflow that automatically documents Vellum workflows by creating GitHub pull requests.

## What's Included

- `examples/workflows/recent-workflow-doc-creator/workflow.py` - The main workflow code
- `examples/workflows/recent-workflow-doc-creator/README.md` - Documentation explaining the workflow

## Workflow Features Demonstrated

This example showcases several important Vellum workflow patterns:

1. **Scheduled Triggers** - Cron-based scheduling with timezone support
2. **MapNode for Parallel Processing** - Processing multiple items concurrently with controlled parallelism
3. **ToolCallingNode with External Integrations** - Using Composio integrations to give AI agents access to GitHub APIs
4. **Nested Subworkflows** - Composing complex workflows from smaller, reusable pieces
5. **Custom BaseNode with API Calls** - Making paginated API calls within workflow nodes

## Why This Example is Useful

This workflow demonstrates a practical use case of using Vellum workflows for DevOps automation - specifically, automatically maintaining documentation by having an AI agent create PRs for newly deployed workflows. It's a great reference for users who want to:

- Build scheduled automation workflows
- Integrate AI agents with external tools (GitHub, etc.)
- Process lists of items in parallel
- Create complex multi-step workflows with subworkflows