### PR TITLE
docs: Add recent-workflow-doc-creator workflow example

### DIFF
--- a/examples/workflows/recent-workflow-doc-creator/README.md
+++ b/examples/workflows/recent-workflow-doc-creator/README.md
@@ -1,0 +1,44 @@
+# Recent Workflow Documentation Creator
+
+This workflow automatically creates GitHub pull requests to document recently deployed Vellum workflows.
+
+## Description
+
+A scheduled workflow that runs daily to:
+1. Fetch all workflow deployments created in the last 24 hours
+2. Process each deployment by fetching its workflow code
+3. Use a GitHub agent to create pull requests with workflow examples
+
+## Key Features
+
+- **Scheduled Trigger**: Runs automatically at 10:00 AM Mountain Time daily
+- **Map Node Pattern**: Processes multiple deployments concurrently (max concurrency of 4)
+- **Tool-Calling Agent**: Uses Claude with GitHub integration tools to:
+  - Create new branches
+  - Commit workflow code and README files
+  - Open pull requests
+- **Parallel Outputs**: Returns multiple outputs simultaneously (PR URLs, comments, deployments JSON)
+
+## Workflow Structure
+
+```
+Scheduled Trigger → FetchRecentDeployments → ProcessDeployments (Map) → {
+    DeploymentsOutput,
+    CommentsOutput,
+    PrUrlsOutput
+}
+```
+
+## Notable Patterns
+
+1. **Subworkflow with Map Node**: The `ProcessDeployments` node is a Map Node that contains its own subworkflow for processing each deployment.
+
+2. **Vellum Integration Tools**: Uses `VellumIntegrationToolDefinition` with Composio's GitHub integration for branch/file/PR operations.
+
+3. **Custom Node Display**: Nodes use custom icons and colors for better visual organization in the UI.
+
+4. **API Client Access**: Accesses the Vellum client via `self._context.vellum_client` for fetching deployment data.
+
+## Use Case
+
+This workflow is perfect for teams who want to automatically document their workflows as they're deployed, maintaining an up-to-date examples repository without manual intervention.

--- a/examples/workflows/recent-workflow-doc-creator/workflow.py
+++ b/examples/workflows/recent-workflow-doc-creator/workflow.py
@@ -1,0 +1,26 @@
+from vellum.workflows import BaseWorkflow
+
+from .nodes.comments_output import CommentsOutput
+from .nodes.deployments_output import DeploymentsOutput
+from .nodes.fetch_recent_deployments import FetchRecentDeployments
+from .nodes.pr_urls_output import PrUrlsOutput
+from .nodes.process_deployments import ProcessDeployments
+from .triggers.scheduled import Scheduled
+
+
+class Workflow(BaseWorkflow):
+    graph = (
+        Scheduled
+        >> FetchRecentDeployments
+        >> ProcessDeployments
+        >> {
+            DeploymentsOutput,
+            CommentsOutput,
+            PrUrlsOutput,
+        }
+    )
+
+    class Outputs(BaseWorkflow.Outputs):
+        pr_results = PrUrlsOutput.Outputs.value
+        deployments_processed = CommentsOutput.Outputs.value
+        deployments_json = DeploymentsOutput.Outputs.value


### PR DESCRIPTION
## Summary

This PR adds the `recent-workflow-doc-creator` workflow as an example in the examples/workflows directory.

## About This Workflow

The **Recent Workflow Documentation Creator** is a scheduled workflow that automatically creates GitHub pull requests to document recently deployed Vellum workflows. It demonstrates several advanced Vellum patterns:

### Key Features

- **Scheduled Trigger**: Runs daily at 10:00 AM Mountain Time using a cron schedule
- **Map Node Pattern**: Processes multiple deployments concurrently (max concurrency of 4)
- **Tool-Calling Agent**: Uses Claude with GitHub integration tools (via Composio) to:
  - Create new branches
  - Commit workflow code and README files
  - Open pull requests
- **Parallel Outputs**: Returns multiple outputs simultaneously (PR URLs, comments, deployments JSON)

### Workflow Flow

```
Scheduled Trigger → FetchRecentDeployments → ProcessDeployments (Map) → {
    DeploymentsOutput,
    CommentsOutput,
    PrUrlsOutput
}
```

### Why This Example is Useful

1. Demonstrates **scheduled workflows** with cron triggers
2. Shows how to use **Map Nodes** for parallel processing with subworkflows
3. Illustrates **Tool-Calling Nodes** with external integrations (GitHub via Composio)
4. Examples of **custom node displays** with icons and colors
5. Shows accessing the **Vellum client context** for API calls within nodes

This workflow is perfect for teams who want to automate documentation of their workflows as they're deployed.