### PR TITLE
Support examples in tool decorator

### DIFF
--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -231,10 +231,7 @@ def compile_function_definition(function: Callable) -> FunctionDefinition:
     if defs:
         parameters["$defs"] = defs
     if input_examples is not None:
-        for prop_name in list(properties.keys()):
-            values = [ex[prop_name] for ex in input_examples if isinstance(ex, dict) and prop_name in ex]
-            if values:
-                properties[prop_name]["examples"] = values
+        parameters["examples"] = input_examples
 
     return FunctionDefinition(
         name=function.__name__,

--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -433,7 +433,6 @@ def tool(
     return decorator
 
 
-# Deprecated: use_tool_inputs will be removed in version 2.0.0.
 def use_tool_inputs(**inputs: Any) -> Callable[[Callable], Callable]:
     """
     Decorator to specify which parameters of a tool function should be provided

--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -198,7 +198,7 @@ def compile_function_definition(function: Callable) -> FunctionDefinition:
 
     # Get inputs from the decorator if present
     inputs = getattr(function, "__vellum_inputs__", {})
-    input_examples = getattr(function, "__vellum_input_examples__", None)
+    examples = getattr(function, "__vellum_examples__", None)
     exclude_params = set(inputs.keys())
 
     properties = {}
@@ -230,8 +230,8 @@ def compile_function_definition(function: Callable) -> FunctionDefinition:
     parameters = {"type": "object", "properties": properties, "required": required}
     if defs:
         parameters["$defs"] = defs
-    if input_examples is not None:
-        parameters["examples"] = input_examples
+    if examples is not None:
+        parameters["examples"] = examples
 
     return FunctionDefinition(
         name=function.__name__,
@@ -397,23 +397,23 @@ def compile_vellum_integration_tool_definition(
 def tool(
     *,
     inputs: Optional[dict[str, Any]] = None,
-    input_examples: Optional[List[dict[str, Any]]] = None,
+    examples: Optional[List[dict[str, Any]]] = None,
 ) -> Callable[[Callable], Callable]:
     """
     Decorator to configure a tool function.
 
     Currently supports specifying which parameters should come from parent workflow inputs
-    via the `inputs` mapping. Also supports providing `input_examples` which will be hoisted
+    via the `inputs` mapping. Also supports providing `examples` which will be hoisted
     into the JSON Schema `examples` keyword for this tool's parameters.
 
     Args:
         inputs: Mapping of parameter names to parent input references
-        input_examples: List of example argument objects for the tool
+        examples: List of example argument objects for the tool
 
     Example:
         @tool(inputs={
             "parent_input": ParentInputs.parent_input,
-        }, input_examples=[{"location": "San Francisco"}])
+        }, examples=[{"location": "San Francisco"}])
         def get_string(parent_input: str, user_query: str) -> str:
             return f"Parent: {parent_input}, Query: {user_query}"
     """
@@ -422,9 +422,9 @@ def tool(
         # Store the inputs mapping on the function for later use
         if inputs is not None:
             setattr(func, "__vellum_inputs__", inputs)
-        # Store the input examples on the function for later use
-        if input_examples is not None:
-            setattr(func, "__vellum_input_examples__", input_examples)
+        # Store the examples on the function for later use
+        if examples is not None:
+            setattr(func, "__vellum_examples__", examples)
         return func
 
     return decorator

--- a/src/vellum/workflows/utils/functions.py
+++ b/src/vellum/workflows/utils/functions.py
@@ -231,7 +231,10 @@ def compile_function_definition(function: Callable) -> FunctionDefinition:
     if defs:
         parameters["$defs"] = defs
     if input_examples is not None:
-        parameters["examples"] = input_examples
+        for prop_name in list(properties.keys()):
+            values = [ex[prop_name] for ex in input_examples if isinstance(ex, dict) and prop_name in ex]
+            if values:
+                properties[prop_name]["examples"] = values
 
     return FunctionDefinition(
         name=function.__name__,

--- a/src/vellum/workflows/utils/tests/test_functions.py
+++ b/src/vellum/workflows/utils/tests/test_functions.py
@@ -864,9 +864,9 @@ def test_tool__backward_compatibility_with_use_tool_inputs():
     assert getattr(tool_decorated, "__vellum_inputs__") == {"a": "value_a"}
 
 
-def test_tool_input_examples_included_in_schema():
+def test_tool_examples_included_in_schema():
     @tool(
-        input_examples=[
+        examples=[
             {"location": "San Francisco"},
             {"location": "New York", "units": "celsius"},
         ]

--- a/src/vellum/workflows/utils/tests/test_functions.py
+++ b/src/vellum/workflows/utils/tests/test_functions.py
@@ -876,8 +876,11 @@ def test_tool_input_examples_included_in_schema():
 
     compiled = compile_function_definition(get_current_weather)
     assert isinstance(compiled.parameters, dict)
-    assert compiled.parameters.get("examples") == [
-        {"location": "San Francisco"},
-        {"location": "New York", "units": "celsius"},
-    ]
-    assert compiled.parameters["properties"]["units"]["default"] == "fahrenheit"
+    assert compiled.parameters == {
+        "type": "object",
+        "properties": {
+            "location": {"type": "string", "examples": ["San Francisco", "New York"]},
+            "units": {"type": "string", "default": "fahrenheit", "examples": ["celsius"]},
+        },
+        "required": ["location"],
+    }

--- a/src/vellum/workflows/utils/tests/test_functions.py
+++ b/src/vellum/workflows/utils/tests/test_functions.py
@@ -879,8 +879,12 @@ def test_tool_input_examples_included_in_schema():
     assert compiled.parameters == {
         "type": "object",
         "properties": {
-            "location": {"type": "string", "examples": ["San Francisco", "New York"]},
-            "units": {"type": "string", "default": "fahrenheit", "examples": ["celsius"]},
+            "location": {"type": "string"},
+            "units": {"type": "string", "default": "fahrenheit"},
         },
         "required": ["location"],
+        "examples": [
+            {"location": "San Francisco"},
+            {"location": "New York", "units": "celsius"},
+        ],
     }

--- a/src/vellum/workflows/utils/tests/test_functions.py
+++ b/src/vellum/workflows/utils/tests/test_functions.py
@@ -862,3 +862,22 @@ def test_tool__backward_compatibility_with_use_tool_inputs():
     # THEN both should have identical __vellum_inputs__ attributes
     assert getattr(tool_decorated, "__vellum_inputs__") == getattr(use_tool_inputs_decorated, "__vellum_inputs__")
     assert getattr(tool_decorated, "__vellum_inputs__") == {"a": "value_a"}
+
+
+def test_tool_input_examples_included_in_schema():
+    @tool(
+        input_examples=[
+            {"location": "San Francisco"},
+            {"location": "New York", "units": "celsius"},
+        ]
+    )
+    def get_current_weather(location: str, units: str = "fahrenheit") -> str:
+        return "sunny"
+
+    compiled = compile_function_definition(get_current_weather)
+    assert isinstance(compiled.parameters, dict)
+    assert compiled.parameters.get("examples") == [
+        {"location": "San Francisco"},
+        {"location": "New York", "units": "celsius"},
+    ]
+    assert compiled.parameters["properties"]["units"]["default"] == "fahrenheit"


### PR DESCRIPTION
Adds support for an `examples` parameter in the `@tool` decorator, which gets hoisted into the JSON Schema `examples` keyword for the tool's parameters.

---

- Requested by: @vincent0426
- Session: https://app.devin.ai/sessions/8811cf59c2bc44fe83c8afe50afdb22a