### PR TITLE
Expose `vellum_client` for inline code exec

### DIFF
--- a/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
@@ -104,7 +104,7 @@ class CodeExecutionNode(BaseNode[StateType], Generic[StateType, _OutputType], me
         output_type = self.__class__.get_output_type()
         code, filepath = self._resolve_code()
         if not self.packages and self.runtime == "PYTHON_3_11_6" and not self._has_secrets_in_code_inputs():
-            logs, result = run_code_inline(code, self.code_inputs, output_type, filepath)
+            logs, result = run_code_inline(code, self.code_inputs, output_type, filepath, self._context.vellum_client)
             return self.Outputs(result=result, log=logs)
 
         else:

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/utils.py
@@ -4,6 +4,7 @@ import sys
 import traceback
 from typing import Any, Optional, Tuple, Union
 
+from vellum import Vellum
 from vellum.workflows.constants import undefined
 from vellum.workflows.errors.types import WorkflowErrorCode
 from vellum.workflows.exceptions import NodeException
@@ -41,6 +42,7 @@ def run_code_inline(
     inputs: EntityInputsInterface,
     output_type: Any,
     filepath: str,
+    vellum_client: Vellum,
 ) -> Tuple[str, Any]:
     log_buffer = io.StringIO()
 
@@ -54,6 +56,7 @@ def run_code_inline(
         "__arg__inputs": wrapped_inputs,
         "__arg__out": None,
         "print": _inline_print,
+        "vellum_client": vellum_client,
     }
     run_args = [f"{name}=__arg__inputs['{name}']" for name, value in inputs.items() if value is not undefined]
     execution_code = f"""\


### PR DESCRIPTION
Make `vellum_client`  accessible when we're
1. using the built-in code execution node
2. using Python 3.11 with no custom packages or secrets

I'm introducing this as a global so users don't have to modify their function signatures and so we don't have to modify the inputs we pass in