### PR TITLE
Fix flaky streaming node pipeline test

### DIFF
--- a/tests/workflows/streaming_node_pipeline/tests/test_workflow.py
+++ b/tests/workflows/streaming_node_pipeline/tests/test_workflow.py
@@ -1,6 +1,11 @@
+import pytest
+
 from tests.workflows.streaming_node_pipeline.workflow import Inputs, StreamingNodePipelineWorkflow
 
 
+# We're using a threading Event to coordinate work between nodes.
+# Add a timeout to guard against deadlocks.
+@pytest.mark.timeout(5)
 def test_workflow__happy_path():
     """
     Ensure that we can successfully pipeline the outputs from one streaming node to the next.


### PR DESCRIPTION
I assume we want to see the nodes' outputs interleaved in `final_events.outputs` 
https://github.com/vellum-ai/vellum-python-sdks/blob/ff6e8f1ec3b3391f0ef31b9dac9641c00ae4fafe/tests/workflows/streaming_node_pipeline/tests/test_workflow.py#L17-L24
to show that we stream one node's output to another, so we don't want to just sort the output for our asserts

Let's use an event to coordinate work between the nodes instead of sleeps. Assumes nodes run in separate threads: https://github.com/vellum-ai/vellum-python-sdks/blob/ff6e8f1ec3b3391f0ef31b9dac9641c00ae4fafe/src/vellum/workflows/runner/runner.py#L793