### PR TITLE
Fix codegen graph logic for cylic ports

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/graph-attribute.test.ts.snap
@@ -264,8 +264,11 @@ exports[`Workflow > graph > should be pointing to the correct terminal nodes fro
 exports[`Workflow > graph > should correctly handle cycle edges with port references 1`] = `
 "{
     NodeA.Ports.if_port >> ErrorNode,
-    NodeA.Ports.else_port >> NodeB.Ports.else_port >> NodeC >> FinalOutput,
-    NodeB.Ports.if_port >> NodeA,
+    NodeA.Ports.else_port
+    >> {
+        NodeB.Ports.if_port >> NodeA,
+        NodeB.Ports.else_port >> NodeC >> FinalOutput,
+    },
 }
 "
 `;

--- a/ee/codegen/src/generators/graph-attribute.ts
+++ b/ee/codegen/src/generators/graph-attribute.ts
@@ -1170,9 +1170,9 @@ export class GraphAttribute extends AstNode {
       };
     }
 
-    // If it's a right_shift, check if the RHS contains/starts with the source node
+    // If it's a right_shift, check if the LHS or RHS contains the source node
     if (mutableAst.type === "right_shift") {
-      // Check if the RHS starts with or contains the source node
+      // Check if the RHS contains the source node - process RHS
       if (this.isNodeInBranch(sourceNode, mutableAst.rhs)) {
         return {
           type: "right_shift",
@@ -1182,6 +1182,19 @@ export class GraphAttribute extends AstNode {
             cycleEdge,
             mutableAst.rhs
           ),
+        };
+      }
+      // Check if the LHS contains the source node - process LHS
+      // This handles cases like {NodeB, NodeX} >> MergeNode where the source is in the left set
+      if (this.isNodeInBranch(sourceNode, mutableAst.lhs)) {
+        return {
+          type: "right_shift",
+          lhs: this.insertCycleEdgeIntoBranch(
+            sourceNode,
+            cycleEdge,
+            mutableAst.lhs
+          ),
+          rhs: mutableAst.rhs,
         };
       }
     }


### PR DESCRIPTION
https://github.com/vellum-ai/vellum-python-sdks/pull/3396

This addresses the flawed logic in my first attempt ☝️ 