### PR TITLE
Raise error when constructing outgoing edge from final output node

### DIFF
--- a/src/vellum/workflows/graph/graph.py
+++ b/src/vellum/workflows/graph/graph.py
@@ -232,12 +232,19 @@ class Graph:
             return self
 
         if hasattr(other, "Ports"):
+            # This is a workaround for circular imports
+            from vellum.workflows.nodes.bases.base import BaseNode
+
             for final_output_node in self._terminals:
                 if isinstance(final_output_node, NoPortsNode):
                     continue
                 subgraph = final_output_node >> other
                 self._extend_edges(subgraph.edges)
-            self._terminals = {port for port in other.Ports}
+
+            other_ports = {port for port in other.Ports}
+            if isinstance(other, type) and issubclass(other, BaseNode) and not other_ports:
+                other_ports = {NoPortsNode(other)}
+            self._terminals = other_ports
             return self
 
         # other is a Port

--- a/src/vellum/workflows/graph/graph.py
+++ b/src/vellum/workflows/graph/graph.py
@@ -103,7 +103,10 @@ class Graph:
 
     @staticmethod
     def from_edge(edge: Edge) -> "Graph":
-        return Graph(entrypoints={edge.from_port}, edges=[edge], terminals={port for port in edge.to_node.Ports})
+        terminals: Set[Union["Port", "NoPortsNode"]] = {port for port in edge.to_node.Ports}
+        if not terminals:
+            terminals = {NoPortsNode(edge.to_node)}
+        return Graph(entrypoints={edge.from_port}, edges=[edge], terminals=terminals)
 
     @staticmethod
     def from_trigger_edge(edge: TriggerEdge) -> "Graph":

--- a/src/vellum/workflows/graph/tests/test_graph.py
+++ b/src/vellum/workflows/graph/tests/test_graph.py
@@ -982,7 +982,6 @@ class TestFinalOutputNoPortsNode:
         self.validate_graph(subgraph, MyFinalOutput)
         self.validate_graph(graph, MyFinalOutput)
 
-    @pytest.mark.xfail(reason="We should preserve final output nodes as NoPortsNode.", strict=True)
     def test_rshift__set_with_node(self):
         # GIVEN
         class StartNode(BaseNode[BaseState]):

--- a/src/vellum/workflows/graph/tests/test_graph.py
+++ b/src/vellum/workflows/graph/tests/test_graph.py
@@ -936,7 +936,6 @@ class TestFinalOutputNoPortsNode:
         assert isinstance(node, NoPortsNode)
         assert node.node_class == final_output_node
 
-    @pytest.mark.xfail(reason="We should preserve final output nodes as NoPortsNode.", strict=True)
     def test_from_edge(self):
         # GIVEN
         class StartNode(BaseNode[BaseState]):

--- a/src/vellum/workflows/graph/tests/test_graph.py
+++ b/src/vellum/workflows/graph/tests/test_graph.py
@@ -951,7 +951,6 @@ class TestFinalOutputNoPortsNode:
         # THEN
         self.validate_graph(graph, MyFinalOutput)
 
-    @pytest.mark.xfail(reason="We should preserve final output nodes as NoPortsNode.", strict=True)
     def test_rshift__node(self):
         # GIVEN
         class StartNode(BaseNode[BaseState]):

--- a/src/vellum/workflows/workflows/tests/test_base_workflow.py
+++ b/src/vellum/workflows/workflows/tests/test_base_workflow.py
@@ -785,7 +785,6 @@ def test_base_workflow__run_node_with_inputs():
     assert fulfilled_event.body.outputs.result == "overridden_overridden_value_default_value2_not_overridden"
 
 
-@pytest.mark.xfail(reason="We should error when drawing an outgoing edge from a node with no ports.", strict=True)
 def test_base_workflow__invalid_graph__outgoing_edge_with_no_ports():
     """Test that graph construction fails if we attempt to create an outgoing edge from a node with no ports."""
 

--- a/src/vellum/workflows/workflows/tests/test_base_workflow.py
+++ b/src/vellum/workflows/workflows/tests/test_base_workflow.py
@@ -783,3 +783,29 @@ def test_base_workflow__run_node_with_inputs():
     # AND the execution result should use the overridden and non-overridden attributes
     fulfilled_event = events[1]
     assert fulfilled_event.body.outputs.result == "overridden_overridden_value_default_value2_not_overridden"
+
+
+@pytest.mark.xfail(reason="We should error when drawing an outgoing edge from a node with no ports.", strict=True)
+def test_base_workflow__invalid_graph__outgoing_edge_with_no_ports():
+    """Test that graph construction fails if we attempt to create an outgoing edge from a node with no ports."""
+
+    # GIVEN
+    class StartNode(BaseNode[BaseState]):
+        pass
+
+    class MyFinalOutput(BaseNode[BaseState]):
+        class Ports(BaseNode.Ports):
+            pass
+
+    class EndNode(BaseNode[BaseState]):
+        pass
+
+    # THEN
+    with pytest.raises(
+        ValueError,
+        match="Cannot create edges from graph because all terminal nodes have no ports defined: MyFinalOutput. "
+        + "Nodes with empty Ports classes cannot be connected to other nodes.",
+    ):
+
+        class InvalidWorkflow(BaseWorkflow[BaseInputs, BaseState]):
+            graph = StartNode >> MyFinalOutput >> EndNode


### PR DESCRIPTION
We added logic to guard against this a while back:
https://github.com/vellum-ai/vellum-python-sdks/blob/d38341c35b9726f1213c2de4bb82680271aac75d/src/vellum/workflows/graph/graph.py#L187-L192

We often didn't meet this condition because we often dropped `FInalOutputNodes` from `Graph._terminals` altogether during `Graph` construction. We instead need to preserve them as `NoPortsNode`