### PR TITLE
Add custom pydantic models for `NodeExecutionLogEvent`

### DIFF
--- a/src/vellum/workflows/events/node.py
+++ b/src/vellum/workflows/events/node.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generic, List, Literal, Optional, S
 from pydantic import SerializationInfo, field_serializer, model_serializer
 
 from vellum.client.core.pydantic_utilities import UniversalBaseModel
+from vellum.client.types import SeverityEnum
 from vellum.utils.json_encoder import VellumJsonEncoder
 from vellum.workflows.errors import WorkflowError
 from vellum.workflows.expressions.accessor import AccessorExpression
@@ -182,6 +183,17 @@ class NodeExecutionResumedEvent(_BaseNodeEvent):
     body: NodeExecutionResumedBody
 
 
+class NodeExecutionLogBody(_BaseNodeExecutionBody):
+    attributes: Optional[Dict[str, Any]] = None
+    severity: SeverityEnum
+    message: str
+
+
+class NodeExecutionLogEvent(_BaseNodeEvent):
+    name: Literal["node.execution.log"] = "node.execution.log"
+    body: NodeExecutionLogBody
+
+
 NodeEvent = Union[
     NodeExecutionInitiatedEvent,
     NodeExecutionStreamingEvent,
@@ -189,4 +201,5 @@ NodeEvent = Union[
     NodeExecutionRejectedEvent,
     NodeExecutionPausedEvent,
     NodeExecutionResumedEvent,
+    NodeExecutionLogEvent,
 ]

--- a/src/vellum/workflows/events/tests/test_event.py
+++ b/src/vellum/workflows/events/tests/test_event.py
@@ -17,6 +17,8 @@ from vellum.workflows.events.node import (
     NodeExecutionFulfilledEvent,
     NodeExecutionInitiatedBody,
     NodeExecutionInitiatedEvent,
+    NodeExecutionLogBody,
+    NodeExecutionLogEvent,
     NodeExecutionStreamingBody,
     NodeExecutionStreamingEvent,
 )
@@ -476,6 +478,41 @@ mock_node_uuid = str(MockNode.__id__)
                 "links": None,
             },
         ),
+        (
+            NodeExecutionLogEvent(
+                id=UUID("123e4567-e89b-12d3-a456-426614174000"),
+                timestamp=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+                trace_id=UUID("123e4567-e89b-12d3-a456-426614174000"),
+                span_id=UUID("123e4567-e89b-12d3-a456-426614174000"),
+                body=NodeExecutionLogBody(
+                    node_definition=MockNode,
+                    attributes={"foo": "bar"},
+                    severity="INFO",
+                    message="Test log message",
+                ),
+            ),
+            {
+                "id": "123e4567-e89b-12d3-a456-426614174000",
+                "api_version": "2024-10-25",
+                "timestamp": "2024-01-01T12:00:00Z",
+                "trace_id": "123e4567-e89b-12d3-a456-426614174000",
+                "span_id": "123e4567-e89b-12d3-a456-426614174000",
+                "name": "node.execution.log",
+                "body": {
+                    "node_definition": {
+                        "id": mock_node_uuid,
+                        "name": "MockNode",
+                        "module": module_root + ["events", "tests", "test_event"],
+                        "exclude_from_monitoring": False,
+                    },
+                    "attributes": {"foo": "bar"},
+                    "severity": "INFO",
+                    "message": "Test log message",
+                },
+                "parent": None,
+                "links": None,
+            },
+        ),
     ],
     ids=[
         "workflow.execution.initiated",
@@ -488,6 +525,7 @@ mock_node_uuid = str(MockNode.__id__)
         "node.execution.fulfilled",
         "fulfilled_node_with_undefined_outputs",
         "mocked_node",
+        "node.execution.log",
     ],
 )
 def test_event_serialization(event, expected_json):

--- a/src/vellum/workflows/events/workflow.py
+++ b/src/vellum/workflows/events/workflow.py
@@ -18,6 +18,7 @@ from ..triggers import BaseTrigger
 from .node import (
     NodeExecutionFulfilledEvent,
     NodeExecutionInitiatedEvent,
+    NodeExecutionLogEvent,
     NodeExecutionPausedEvent,
     NodeExecutionRejectedEvent,
     NodeExecutionResumedEvent,
@@ -311,6 +312,7 @@ GenericWorkflowEvent = Union[
     NodeExecutionRejectedEvent,
     NodeExecutionPausedEvent,
     NodeExecutionResumedEvent,
+    NodeExecutionLogEvent,
 ]
 
 WorkflowEvent = Union[

--- a/src/vellum/workflows/workflows/base.py
+++ b/src/vellum/workflows/workflows/base.py
@@ -39,6 +39,8 @@ from vellum.workflows.events.node import (
     NodeExecutionFulfilledEvent,
     NodeExecutionInitiatedBody,
     NodeExecutionInitiatedEvent,
+    NodeExecutionLogBody,
+    NodeExecutionLogEvent,
     NodeExecutionPausedBody,
     NodeExecutionPausedEvent,
     NodeExecutionRejectedBody,
@@ -1016,6 +1018,7 @@ NodeExecutionRejectedBody.model_rebuild()
 NodeExecutionPausedBody.model_rebuild()
 NodeExecutionResumedBody.model_rebuild()
 NodeExecutionStreamingBody.model_rebuild()
+NodeExecutionLogBody.model_rebuild()
 
 WorkflowExecutionInitiatedEvent.model_rebuild()
 WorkflowExecutionFulfilledEvent.model_rebuild()
@@ -1031,5 +1034,6 @@ NodeExecutionRejectedEvent.model_rebuild()
 NodeExecutionPausedEvent.model_rebuild()
 NodeExecutionResumedEvent.model_rebuild()
 NodeExecutionStreamingEvent.model_rebuild()
+NodeExecutionLogEvent.model_rebuild()
 
 StateMeta.model_rebuild()


### PR DESCRIPTION
Matching existing patterns, this has custom serialization for `body.node_definition`

ref: APO-2413