### PR TITLE
Add a hacky `_is_vellum_value_subtype` helper

### DIFF
--- a/src/vellum/workflows/utils/tests/test_vellum_variables.py
+++ b/src/vellum/workflows/utils/tests/test_vellum_variables.py
@@ -1,10 +1,12 @@
 import pytest
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from vellum import ChatMessage, SearchResult, VellumAudio, VellumDocument, VellumImage, VellumValue
+import vellum.client.types as vellum_types
 from vellum.workflows.types.core import Json
 from vellum.workflows.utils.vellum_variables import (
+    _is_vellum_value_subtype,
     primitive_type_to_vellum_variable_type,
     vellum_variable_type_to_openapi_type,
 )
@@ -64,3 +66,48 @@ def test_primitive_type_to_vellum_variable_type(type_, expected):
 )
 def test_vellum_variable_type_to_openapi_type(vellum_type, expected):
     assert vellum_variable_type_to_openapi_type(vellum_type) == expected
+
+
+class _SomeType:
+    pass
+
+
+_STRING_OR_NUMBER_VELLUM_VALUE = Union[vellum_types.StringVellumValue, vellum_types.NumberVellumValue]
+
+
+@pytest.mark.parametrize(
+    ["type_", "expected_is_vellum_value_subtype"],
+    [
+        # Individual union members
+        (vellum_types.StringVellumValue, True),
+        (vellum_types.NumberVellumValue, True),
+        (vellum_types.JsonVellumValue, True),
+        (vellum_types.AudioVellumValue, True),
+        (vellum_types.VideoVellumValue, True),
+        (vellum_types.ImageVellumValue, True),
+        (vellum_types.DocumentVellumValue, True),
+        (vellum_types.FunctionCallVellumValue, True),
+        (vellum_types.ErrorVellumValue, True),
+        (vellum_types.ArrayVellumValue, True),
+        (vellum_types.ChatHistoryVellumValue, True),
+        (vellum_types.SearchResultsVellumValue, True),
+        (vellum_types.ThinkingVellumValue, True),
+        # Misc union types
+        (Union[vellum_types.StringVellumValue, vellum_types.NumberVellumValue], True),
+        (_STRING_OR_NUMBER_VELLUM_VALUE, True),
+        (Union[vellum_types.StringVellumValue], True),
+        (Union["vellum_types.StringVellumValue"], False),
+        # Random types
+        (int, False),
+        (_SomeType, False),
+        (List[int], False),
+        (Union[int, str], False),
+        (Optional[int], False),
+        (List["_SomeType"], False),
+        # Handle non-types gracefully
+        (1, False),
+        (_SomeType(), False),
+    ],
+)
+def test_is_vellum_value_subtype(type_, expected_is_vellum_value_subtype):
+    assert _is_vellum_value_subtype(type_) == expected_is_vellum_value_subtype


### PR DESCRIPTION
Used in https://github.com/vellum-ai/vellum-python-sdks/pull/3452

We only want to infer a type of `ArrayVellumValue` if the array elements are subtypes of `VellumValue`.

## Thoughts
1. Our current implementation of `_is_subtype` is broken and it also doesn't account for unions. I decided to implement a helper that was more restricted in scope.
```python
[ins] In [4]: from vellum.workflows.utils.vellum_variables import _is_subtype

[ins] In [5]: from typing import List

[ins] In [6]: _is_subtype(List[str], List)
Out[6]: False

[ins] In [7]: _is_subtype(List[str], list)
Out[7]: True

[ins] In [8]: _is_subtype(list[str], list)
Out[8]: True
```
2. CI should test against all supported versions of Python
3. I don't like this approach, and (not) handling forward refs makes me like it even less. Would be great to move away from handrolled type introspection, and lean towards native python / JSON types