### PR TITLE
Support default trigger attribute value

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/generate-code.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/generate-code.test.ts.snap
@@ -46,7 +46,7 @@ from ..nodes.some_node import SomeNode
 
 
 class ChatMessage(ChatMessageTrigger):
-    message: str
+    message: str = "Hello"
 
     class Config(ChatMessageTrigger.Config):
         output = LazyReference(lambda: SomeNode.Outputs.result)

--- a/ee/codegen/src/__test__/generate-code-fixtures/chat-message-trigger.ts
+++ b/ee/codegen/src/__test__/generate-code-fixtures/chat-message-trigger.ts
@@ -57,7 +57,15 @@ export default {
         {
           id: "message-attribute-id",
           key: "message",
-          type: "JSON",
+          type: "STRING",
+          required: true,
+          schema: null,
+          default: {
+            type: "STRING",
+            value: "Hello",
+          },
+          extensions: null,
+          definition: null,
         },
       ],
       exec_config: {

--- a/ee/codegen/src/generators/triggers/base-trigger.ts
+++ b/ee/codegen/src/generators/triggers/base-trigger.ts
@@ -16,6 +16,7 @@ import { IntInstantiation } from "src/generators/extensions/int-instantiation";
 import { MethodArgument } from "src/generators/extensions/method-argument";
 import { Reference } from "src/generators/extensions/reference";
 import { StrInstantiation } from "src/generators/extensions/str-instantiation";
+import { VellumValue } from "src/generators/vellum-variable-value";
 import { isNilOrEmpty } from "src/utils/typing";
 
 import type { AstNode } from "src/generators/extensions/ast-node";
@@ -228,12 +229,26 @@ export abstract class BaseTrigger<
    * All triggers have attributes, so this is a common helper.
    */
   protected createAttributeFields(): AstNode[] {
-    return this.trigger.attributes.map(
-      (attr) =>
-        new Field({
-          name: attr.key,
-          type: python.Type.str(),
-        })
-    );
+    return this.trigger.attributes.map((attr) => {
+      const field: Field = new Field({
+        name: attr.key,
+        type: python.Type.str(),
+      });
+
+      // Add default value if present
+      if (
+        attr.default &&
+        attr.default.value !== null &&
+        attr.default.value !== undefined
+      ) {
+        const vellumValue = new VellumValue({
+          vellumValue: attr.default,
+        });
+        this.inheritReferences(vellumValue);
+        field.initializer = vellumValue;
+      }
+
+      return field;
+    });
   }
 }

--- a/src/vellum/workflows/triggers/base.py
+++ b/src/vellum/workflows/triggers/base.py
@@ -277,9 +277,6 @@ class BaseTriggerMeta(ABCMeta):
         if isinstance(attribute, TriggerAttributeReference):
             return attribute
 
-        if name in cls.__dict__:
-            return attribute
-
         if not _is_annotated(cls, name):
             return attribute
 


### PR DESCRIPTION
Adds support for generating default values on trigger attributes in the code generator, and fixes the metaclass to ensure trigger attributes with defaults still return `TriggerAttributeReference` for graph wiring.

## Summary
The code generator now emits default values for trigger attributes (e.g., `message: str = "Hello"`). However, this required a fix in `BaseTriggerMeta.__getattribute__` - the previous logic returned raw values for attributes in `cls.__dict__`, which would break graph wiring since `ChatMessageTrigger.message` would resolve to `"Hello"` instead of a `TriggerAttributeReference`.

## Review & Testing Checklist for Human
- [ ] Verify that class-level access to a trigger attribute with a default (e.g., `ChatMessageTrigger.message`) returns a `TriggerAttributeReference`, not the literal default value
- [ ] Verify that trigger instances without explicit attribute values still fall back to the class default correctly via `to_trigger_attribute_values()`
- [ ] Check if any existing code relies on the removed `if name in cls.__dict__: return attribute` behavior in the metaclass

### Notes
- Requested by: @vincent0426
- Session: https://app.devin.ai/sessions/bf593ac8acd64f8ebfade41c0a61c33b