### PR TITLE
Fix lazy reference codegen

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/generate-code.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/generate-code.test.ts.snap
@@ -42,14 +42,12 @@ exports[`generateCode > should generate code for %1 chat-message-trigger.ts > tr
 "from vellum.workflows.references import LazyReference
 from vellum.workflows.triggers import ChatMessageTrigger
 
-from ..nodes.some_node import SomeNode
-
 
 class ChatMessage(ChatMessageTrigger):
     message: str
 
     class Config(ChatMessageTrigger.Config):
-        output = LazyReference(lambda: SomeNode.Outputs.result)
+        output = LazyReference("SomeNode.Outputs.result")
 
     class Display(ChatMessageTrigger.Display):
         label = "Chat Message"

--- a/tests/workflows/chat_message_trigger_execution/workflows/simple_chat_workflow.py
+++ b/tests/workflows/chat_message_trigger_execution/workflows/simple_chat_workflow.py
@@ -28,7 +28,7 @@ class SimpleChatTrigger(ChatMessageTrigger):
     """Chat trigger that appends workflow output as assistant message."""
 
     class Config(ChatMessageTrigger.Config):
-        output = LazyReference(lambda: SimpleChatWorkflow.Outputs.response)  # type: ignore[has-type]
+        output = LazyReference[str]("ResponseNode.Outputs.response")
 
 
 class SimpleChatWorkflow(BaseWorkflow[BaseInputs, ChatState]):


### PR DESCRIPTION
Changes ChatMessageTrigger codegen to use string-based `LazyReference("NodeName.Outputs.output")` instead of lambda-based references, avoiding circular import issues when referencing node outputs.

---

## Review & Testing Checklist for Human
- [ ] Verify string-based LazyReference correctly resolves node outputs at runtime (the resolution logic in `lazy.py` compares against `state.meta.node_outputs`)
- [ ] Confirm the codegen change to only handle `NODE_OUTPUT` type descriptors doesn't break any existing workflows that might use other output types
- [ ] Test that the Python test change from workflow output (`SimpleChatWorkflow.Outputs.response`) to node output (`ResponseNode.Outputs.response`) is correct - this was necessary because string-based LazyReference only resolves node outputs, not workflow outputs

### Test Plan
1. Run `make test` to verify all tests pass
2. Test a workflow with ChatMessageTrigger that references a node output to ensure the string-based LazyReference resolves correctly

### Notes
- Requested by: @vincent0426
- Session: https://app.devin.ai/sessions/f92185088f204baf9e41bb59e0ff5dfd