### PR TITLE
Derive node class from parent context when emitting node log events

### DIFF
--- a/tests/workflows/emit_log_event/workflow.py
+++ b/tests/workflows/emit_log_event/workflow.py
@@ -14,7 +14,6 @@ class LoggingNode(BaseNode):
             severity="INFO",
             message="Custom log message",
             attributes={"key": "value", "count": 42},
-            node=self,
         )
         return self.Outputs(result="done")
 


### PR DESCRIPTION
Technically a breaking change since we've removed an argument, but this feature is still in development