### PR TITLE
Fix chat message trigger serialization for workflow output

### DIFF
--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -140,14 +140,16 @@ def get_child_descriptor(value: LazyReference, display_context: "WorkflowDisplay
     if isinstance(value._get, str):
         reference_parts = value._get.split(".")
         if len(reference_parts) < 3:
-            raise Exception(
+            raise InvalidOutputReferenceError(
                 f"Failed to parse lazy reference: {value._get}. Only Node and Workflow Output references are supported."
             )
 
         output_name = reference_parts[-1]
         nested_class_name = reference_parts[-2]
         if nested_class_name != "Outputs":
-            raise Exception(f"Failed to parse lazy reference: {value._get}. Outputs are the only supported references.")
+            raise InvalidOutputReferenceError(
+                f"Failed to parse lazy reference: {value._get}. Outputs are the only supported references."
+            )
 
         reference_class_name = ".".join(reference_parts[:-2])
 
@@ -161,7 +163,7 @@ def get_child_descriptor(value: LazyReference, display_context: "WorkflowDisplay
         if workflow_class.__name__ == reference_class_name:
             return getattr(workflow_class.Outputs, output_name)
 
-        raise Exception(
+        raise InvalidOutputReferenceError(
             f"Failed to parse lazy reference: {value._get}. "
             f"Could not find node or workflow class '{reference_class_name}'."
         )

--- a/ee/vellum_ee/workflows/display/utils/expressions.py
+++ b/ee/vellum_ee/workflows/display/utils/expressions.py
@@ -162,7 +162,8 @@ def get_child_descriptor(value: LazyReference, display_context: "WorkflowDisplay
             return getattr(workflow_class.Outputs, output_name)
 
         raise Exception(
-            f"Failed to parse lazy reference: {value._get}. Could not find node or workflow class '{reference_class_name}'."
+            f"Failed to parse lazy reference: {value._get}. "
+            f"Could not find node or workflow class '{reference_class_name}'."
         )
 
     return value._get()

--- a/tests/workflows/chat_message_trigger_execution/workflows/simple_chat_workflow.py
+++ b/tests/workflows/chat_message_trigger_execution/workflows/simple_chat_workflow.py
@@ -28,7 +28,7 @@ class SimpleChatTrigger(ChatMessageTrigger):
     """Chat trigger that appends workflow output as assistant message."""
 
     class Config(ChatMessageTrigger.Config):
-        output = LazyReference(lambda: SimpleChatWorkflow.Outputs.response)  # type: ignore[has-type]
+        output = LazyReference("SimpleChatWorkflow.Outputs.response")  # type: ignore[has-type]
 
 
 class SimpleChatWorkflow(BaseWorkflow[BaseInputs, ChatState]):


### PR DESCRIPTION
## Summary

Adds support for string-based `LazyReference` to workflow outputs (in addition to node outputs) and replaces raw `Exception` with `InvalidOutputReferenceError` for known error cases in lazy reference parsing.

## Review & Testing Checklist for Human

- [ ] Verify that existing lambda-based `LazyReference` to workflow outputs still works (e.g., `LazyReference(lambda: Workflow.Outputs.foo)`)
- [ ] Verify that string-based `LazyReference` to node outputs still works (e.g., `LazyReference("NodeA.Outputs.result")`)
- [ ] Confirm the new string-based workflow output reference serializes correctly as `WORKFLOW_OUTPUT` type

### Test Plan
Run the new test and related tests:
```bash
poetry run pytest ee/vellum_ee/workflows/display/tests/workflow_serialization/generic_nodes/test_attributes_serialization.py -v -k "lazy_reference"
```

### Notes
- Added test for error case when referenced class is not found (`test_serialize_node__lazy_reference_with_string__class_not_found`)
- Requested by: @vincent0426
- Session: https://app.devin.ai/sessions/a8f55565b9894803b70464dbe10c1682