### PR TITLE
Fix chat message trigger icon name

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/generate-code.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/generate-code.test.ts.snap
@@ -52,7 +52,7 @@ class ChatMessage(ChatMessageTrigger):
         x = 100
         y = 200
         z_index = 1
-        icon = "vellum:icon:message"
+        icon = "vellum:icon:message-dots"
         color = "blue"
 "
 `;

--- a/ee/codegen/src/__test__/generate-code-fixtures/chat-message-trigger.ts
+++ b/ee/codegen/src/__test__/generate-code-fixtures/chat-message-trigger.ts
@@ -88,7 +88,7 @@ export default {
           y: 200,
         },
         z_index: 1,
-        icon: "vellum:icon:message",
+        icon: "vellum:icon:message-dots",
         color: "blue",
       },
     },

--- a/ee/vellum_ee/assets/node-definitions.json
+++ b/ee/vellum_ee/assets/node-definitions.json
@@ -1230,7 +1230,7 @@
           "y": 0.0
         },
         "z_index": 0,
-        "icon": "vellum:icon:message",
+        "icon": "vellum:icon:message-dots",
         "color": "blue"
       }
     },

--- a/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_chat_message_trigger_serialization.py
+++ b/ee/vellum_ee/workflows/display/tests/workflow_serialization/test_chat_message_trigger_serialization.py
@@ -54,7 +54,7 @@ def test_simple_chat_workflow_serialization():
                     "y": 0.0,
                 },
                 "z_index": 0,
-                "icon": "vellum:icon:message",
+                "icon": "vellum:icon:message-dots",
                 "color": "blue",
             },
         }

--- a/src/vellum/workflows/triggers/chat_message.py
+++ b/src/vellum/workflows/triggers/chat_message.py
@@ -72,5 +72,5 @@ class ChatMessageTrigger(BaseTrigger):
 
     class Display(BaseTrigger.Display):
         label: str = "Chat Message"
-        icon: Optional[str] = "vellum:icon:message"
+        icon: Optional[str] = "vellum:icon:message-dots"
         color: Optional[str] = "blue"


### PR DESCRIPTION
Updates the ChatMessageTrigger icon from `vellum:icon:message` to `vellum:icon:message-dots` across all relevant files including source, tests, fixtures, and snapshots.

---

- Requested by: @vincent0426
- Session: https://app.devin.ai/sessions/70975e87dad14381822d32e6cadc16b0