### PR TITLE
Handle chat message trigger with vellum value

### DIFF
--- a/src/vellum/workflows/triggers/chat_message.py
+++ b/src/vellum/workflows/triggers/chat_message.py
@@ -47,7 +47,10 @@ class ChatMessageTrigger(BaseTrigger):
         # Convert message from VellumValue format to ChatMessageContent format if needed
         if "message" in kwargs:
             message = kwargs["message"]
-            if isinstance(message, list):
+            # Handle string messages by converting to a list with a single StringChatMessageContent
+            if isinstance(message, str):
+                kwargs["message"] = [StringChatMessageContent(value=message)]
+            elif isinstance(message, list):
                 converted_message = []
                 for item in message:
                     # If it's already a ChatMessageContent type, keep it as-is
@@ -119,6 +122,4 @@ class ChatMessageTrigger(BaseTrigger):
         return resolve_value(output, state)
 
     class Display(BaseTrigger.Display):
-        label: str = "Chat Message"
-        icon: Optional[str] = "vellum:icon:message-dots"
-        color: Optional[str] = "blue"
+        name: Optional[str] = "Chat"

--- a/src/vellum/workflows/triggers/chat_message.py
+++ b/src/vellum/workflows/triggers/chat_message.py
@@ -1,7 +1,5 @@
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from pydantic import ValidationError
-
 from vellum.client.core.pydantic_utilities import parse_obj_as
 from vellum.client.types import (
     ArrayChatMessageContent,
@@ -71,10 +69,7 @@ class ChatMessageTrigger(BaseTrigger):
                     else:
                         # Get the dict representation (either from Pydantic model or already a dict)
                         item_dict = item.model_dump() if hasattr(item, "model_dump") else item
-                        try:
-                            converted_message.append(parse_obj_as(ChatMessageContent, item_dict))  # type: ignore[arg-type]  # noqa: E501
-                        except ValidationError as e:
-                            raise ValueError(f"Invalid message content: {e}") from e
+                        converted_message.append(parse_obj_as(ChatMessageContent, item_dict))  # type: ignore[arg-type]  # noqa: E501
 
                 kwargs["message"] = converted_message
 

--- a/src/vellum/workflows/triggers/chat_message.py
+++ b/src/vellum/workflows/triggers/chat_message.py
@@ -117,4 +117,6 @@ class ChatMessageTrigger(BaseTrigger):
         return resolve_value(output, state)
 
     class Display(BaseTrigger.Display):
-        name: Optional[str] = "Chat"
+        label: str = "Chat Message"
+        icon: Optional[str] = "vellum:icon:message-dots"
+        color: Optional[str] = "blue"

--- a/src/vellum/workflows/triggers/chat_message.py
+++ b/src/vellum/workflows/triggers/chat_message.py
@@ -37,7 +37,6 @@ class ChatMessageTrigger(BaseTrigger):
         message: The incoming chat message content.
     """
 
-    name: str = "chat"
     message: List[ArrayChatMessageContentItem]
 
     class Config(BaseTrigger.Config):

--- a/src/vellum/workflows/triggers/chat_message.py
+++ b/src/vellum/workflows/triggers/chat_message.py
@@ -1,6 +1,18 @@
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from vellum.client.types import ArrayChatMessageContent, ArrayChatMessageContentItem, ChatMessage, ChatMessageContent
+from vellum.client.core.pydantic_utilities import parse_obj_as
+from vellum.client.types import (
+    ArrayChatMessageContent,
+    ArrayChatMessageContentItem,
+    AudioChatMessageContent,
+    ChatMessage,
+    ChatMessageContent,
+    DocumentChatMessageContent,
+    FunctionCallChatMessageContent,
+    ImageChatMessageContent,
+    StringChatMessageContent,
+    VideoChatMessageContent,
+)
 from vellum.workflows.descriptors.base import BaseDescriptor
 from vellum.workflows.descriptors.utils import resolve_value
 from vellum.workflows.references.lazy import LazyReference
@@ -27,6 +39,38 @@ class ChatMessageTrigger(BaseTrigger):
 
     class Config(BaseTrigger.Config):
         output: Optional[BaseDescriptor[Any]] = None
+
+    def __init__(self, **kwargs: Any):
+        """Initialize ChatMessageTrigger, converting VellumValue objects to ChatMessageContent if needed."""
+        # Convert message from VellumValue format to ChatMessageContent format if needed
+        if "message" in kwargs:
+            message = kwargs["message"]
+            if isinstance(message, list):
+                converted_message = []
+                for item in message:
+                    # If it's already a ChatMessageContent type, keep it as-is
+                    if isinstance(
+                        item,
+                        (
+                            StringChatMessageContent,
+                            ImageChatMessageContent,
+                            AudioChatMessageContent,
+                            VideoChatMessageContent,
+                            DocumentChatMessageContent,
+                            FunctionCallChatMessageContent,
+                        ),
+                    ):
+                        converted_message.append(item)
+                    # Convert VellumValue objects or dicts to ChatMessageContent
+                    # Use discriminated union validation
+                    else:
+                        # Get the dict representation (either from Pydantic model or already a dict)
+                        item_dict = item.model_dump() if hasattr(item, "model_dump") else item
+                        converted_message.append(parse_obj_as(ChatMessageContent, item_dict))
+
+                kwargs["message"] = converted_message
+
+        super().__init__(**kwargs)
 
     def __on_workflow_initiated__(self, state: "BaseState") -> None:
         """Appends user message to state.chat_history at workflow start."""

--- a/src/vellum/workflows/triggers/tests/test_chat_message.py
+++ b/src/vellum/workflows/triggers/tests/test_chat_message.py
@@ -152,6 +152,31 @@ def test_chat_message_trigger__converts_dict_format():
     assert trigger.message[0].value == "Hello from dict!"
 
 
+def test_chat_message_trigger__converts_string_message():
+    """Tests that ChatMessageTrigger converts string messages to ChatMessageContent list."""
+
+    # GIVEN a message as a string
+    string_message = "Hello, world!"
+
+    # WHEN a ChatMessageTrigger is created with a string message
+    trigger = ChatMessageTrigger(message=string_message)
+
+    # THEN the message is converted to a list with a single StringChatMessageContent
+    assert len(trigger.message) == 1
+    assert isinstance(trigger.message[0], StringChatMessageContent)
+    assert trigger.message[0].value == "Hello, world!"
+
+    # AND the trigger works correctly with state
+    state = ChatState()
+    trigger.__on_workflow_initiated__(state)
+
+    assert len(state.chat_history) == 1
+    assert state.chat_history[0].role == "USER"
+    assert state.chat_history[0].content == ArrayChatMessageContent(
+        value=[StringChatMessageContent(value="Hello, world!")]
+    )
+
+
 def test_chat_message_trigger__raises_value_error_for_invalid_content():
     """Tests that ChatMessageTrigger raises ValueError for invalid message content."""
 

--- a/src/vellum/workflows/triggers/tests/test_chat_message.py
+++ b/src/vellum/workflows/triggers/tests/test_chat_message.py
@@ -175,17 +175,3 @@ def test_chat_message_trigger__converts_string_message():
     assert state.chat_history[0].content == ArrayChatMessageContent(
         value=[StringChatMessageContent(value="Hello, world!")]
     )
-
-
-def test_chat_message_trigger__raises_value_error_for_invalid_content():
-    """Tests that ChatMessageTrigger raises ValueError for invalid message content."""
-
-    # GIVEN a message with invalid content (missing required fields)
-    invalid_message = [
-        {"invalid_field": "not a valid ChatMessageContent"},
-    ]
-
-    # WHEN a ChatMessageTrigger is created with invalid content
-    # THEN a ValueError is raised
-    with pytest.raises(ValueError, match="Invalid message content"):
-        ChatMessageTrigger(message=invalid_message)

--- a/src/vellum/workflows/triggers/tests/test_chat_message.py
+++ b/src/vellum/workflows/triggers/tests/test_chat_message.py
@@ -11,6 +11,7 @@ from vellum.client.types import (
     ChatMessage,
     ImageChatMessageContent,
     StringChatMessageContent,
+    StringVellumValue,
     VellumImage,
 )
 from vellum.workflows.nodes.bases.base import BaseNode
@@ -105,3 +106,47 @@ def test_chat_message_trigger__graph_syntax():
     assert len(list(graph.trigger_edges)) == 1
     assert list(graph.trigger_edges)[0].trigger_class == ChatMessageTrigger
     assert list(graph.trigger_edges)[0].to_node == TestNode
+
+
+def test_chat_message_trigger__converts_vellum_value_objects():
+    """Tests that ChatMessageTrigger converts VellumValue objects to ChatMessageContent."""
+
+    # GIVEN a message as VellumValue objects (as received from codegen/API)
+    vellum_value_message = [
+        StringVellumValue(type="STRING", value="Hello, world!"),
+    ]
+
+    # WHEN a ChatMessageTrigger is created with VellumValue objects
+    trigger = ChatMessageTrigger(message=vellum_value_message)
+
+    # THEN the message is converted to ChatMessageContent
+    assert len(trigger.message) == 1
+    assert isinstance(trigger.message[0], StringChatMessageContent)
+    assert trigger.message[0].value == "Hello, world!"
+
+    # AND the trigger works correctly with state
+    state = ChatState()
+    trigger.__on_workflow_initiated__(state)
+
+    assert len(state.chat_history) == 1
+    assert state.chat_history[0].role == "USER"
+    assert state.chat_history[0].content == ArrayChatMessageContent(
+        value=[StringChatMessageContent(value="Hello, world!")]
+    )
+
+
+def test_chat_message_trigger__converts_dict_format():
+    """Tests that ChatMessageTrigger converts dict format to ChatMessageContent."""
+
+    # GIVEN a message as dict objects (alternative API format)
+    dict_message = [
+        {"type": "STRING", "value": "Hello from dict!"},
+    ]
+
+    # WHEN a ChatMessageTrigger is created with dict objects
+    trigger = ChatMessageTrigger(message=dict_message)
+
+    # THEN the message is converted to ChatMessageContent
+    assert len(trigger.message) == 1
+    assert isinstance(trigger.message[0], StringChatMessageContent)
+    assert trigger.message[0].value == "Hello from dict!"

--- a/src/vellum/workflows/triggers/tests/test_chat_message.py
+++ b/src/vellum/workflows/triggers/tests/test_chat_message.py
@@ -150,3 +150,17 @@ def test_chat_message_trigger__converts_dict_format():
     assert len(trigger.message) == 1
     assert isinstance(trigger.message[0], StringChatMessageContent)
     assert trigger.message[0].value == "Hello from dict!"
+
+
+def test_chat_message_trigger__raises_value_error_for_invalid_content():
+    """Tests that ChatMessageTrigger raises ValueError for invalid message content."""
+
+    # GIVEN a message with invalid content (missing required fields)
+    invalid_message = [
+        {"invalid_field": "not a valid ChatMessageContent"},
+    ]
+
+    # WHEN a ChatMessageTrigger is created with invalid content
+    # THEN a ValueError is raised
+    with pytest.raises(ValueError, match="Invalid message content"):
+        ChatMessageTrigger(message=invalid_message)


### PR DESCRIPTION
## Summary

Adds conversion logic to `ChatMessageTrigger.__init__` to handle VellumValue objects (e.g., `StringVellumValue`) and dict formats from codegen/API, converting them to the appropriate `ChatMessageContent` types.

## Review & Testing Checklist for Human

- [ ] Verify that all `ChatMessageContent` types that should pass through are included in the isinstance check (currently: String, Image, Audio, Video, Document, FunctionCall - notably `ArrayChatMessageContent` is excluded)
- [ ] Test with other VellumValue types beyond `StringVellumValue` to ensure conversion works correctly
- [ ] Verify the conversion works in an actual workflow execution with a ChatMessageTrigger

### Notes

- The `parse_obj_as` call required a `# type: ignore[arg-type]` comment because mypy doesn't like Union types as the first argument - this follows the existing pattern in `raw_client.py`
- Requested by: @vincent0426
- Session: https://app.devin.ai/sessions/f6d7dee87a924966ad5f2d82e559d731