### PR TITLE
Fix subworkflow node shadowing from star imports

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/project.test.ts.snap
@@ -563,8 +563,8 @@ class GetCurrentWeatherNodeDisplay(BaseNodeDisplay[GetCurrentWeatherNode]):
 exports[`WorkflowProjectGenerator > function > should generate inline workflow tool 'no packages' > code/display/nodes/tool_call_get_current_weather_node/weather_function/__init__.py 1`] = `
 "# flake8: noqa: F401, F403
 
+from . import workflow
 from .nodes import *
-from .workflow import *
 "
 `;
 
@@ -884,8 +884,8 @@ class GetCurrentWeatherNodeDisplay(BaseNodeDisplay[GetCurrentWeatherNode]):
 exports[`WorkflowProjectGenerator > function > should generate inline workflow tool 'with packages' > code/display/nodes/tool_call_get_current_weather_node/weather_function/__init__.py 1`] = `
 "# flake8: noqa: F401, F403
 
+from . import workflow
 from .nodes import *
-from .workflow import *
 "
 `;
 

--- a/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/inline-subworkflow-node.test.ts.snap
@@ -22,9 +22,9 @@ from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosit
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay, BaseRetryNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 
+from . import workflow
 from ....nodes.my_node import MyNode
 from .nodes import *
-from .workflow import *
 
 
 @BaseRetryNodeDisplay.wrap(node_id=UUID("ae49ef72-6ad7-441a-a20d-76c71ad851ef"))
@@ -52,9 +52,9 @@ from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosit
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 
+from . import workflow
 from ....nodes.inline_subworkflow_node import InlineSubworkflowNode
 from .nodes import *
-from .workflow import *
 
 
 class InlineSubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[InlineSubworkflowNode]):
@@ -104,9 +104,9 @@ from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosit
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 
+from . import workflow
 from ....nodes.my_node import MyNode
 from .nodes import *
-from .workflow import *
 
 
 class MyNodeDisplay(BaseInlineSubworkflowNodeDisplay[MyNode]):

--- a/ee/codegen/src/__test__/nodes/__snapshots__/map-node.test.ts.snap
+++ b/ee/codegen/src/__test__/nodes/__snapshots__/map-node.test.ts.snap
@@ -9,9 +9,9 @@ from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosit
 from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 
+from . import workflow
 from ....nodes.map_node import MapNode
 from .nodes import *
-from .workflow import *
 
 
 class MapNodeDisplay(BaseMapNodeDisplay[MapNode]):
@@ -67,9 +67,9 @@ from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosit
 from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 
+from . import workflow
 from ....nodes.map_node import MapNode
 from .nodes import *
-from .workflow import *
 
 
 class MapNodeDisplay(BaseMapNodeDisplay[MapNode]):

--- a/ee/codegen/src/__test__/project.test.ts
+++ b/ee/codegen/src/__test__/project.test.ts
@@ -354,6 +354,7 @@ describe("WorkflowProjectGenerator", () => {
           "simple_workflow_node_with_output_values",
           "faa_q_and_a_bot",
           "simple_scheduled_trigger",
+          "subworkflow_with_custom_inner_node",
         ],
         fixtureMocks: fixtureMocks,
       })

--- a/ee/codegen/src/generators/base-persisted-file.ts
+++ b/ee/codegen/src/generators/base-persisted-file.ts
@@ -152,7 +152,7 @@ export abstract class BasePersistedFile extends AstNode {
 
   protected abstract getFileStatements(): AstNode[] | undefined;
 
-  protected getFileImports(): StarImport[] | undefined {
+  protected getFileImports(): (StarImport | Reference)[] | undefined {
     return undefined;
   }
 

--- a/ee/codegen/src/generators/extensions/protected-python-file.ts
+++ b/ee/codegen/src/generators/extensions/protected-python-file.ts
@@ -30,7 +30,7 @@ export declare namespace PythonFile {
     /* Any comments that should be at the top of the file */
     comments?: Comment[];
     /* Any explicit imports that should be included */
-    imports?: StarImport[];
+    imports?: (StarImport | Reference)[];
   }
 }
 

--- a/ee/codegen/src/generators/init-file.ts
+++ b/ee/codegen/src/generators/init-file.ts
@@ -1,5 +1,6 @@
 import { BasePersistedFile } from "./base-persisted-file";
 import { Comment } from "./extensions/comment";
+import { Reference } from "./extensions/reference";
 import { StarImport } from "./extensions/star-import";
 
 import { AstNode } from "src/generators/extensions/ast-node";
@@ -8,7 +9,7 @@ export declare namespace InitFile {
   interface Args extends BasePersistedFile.Args {
     modulePath: string[] | Readonly<string[]>;
     statements?: AstNode[];
-    imports?: StarImport[];
+    imports?: (StarImport | Reference)[];
     comments?: Comment[];
   }
 }
@@ -16,7 +17,7 @@ export declare namespace InitFile {
 export class InitFile extends BasePersistedFile {
   private readonly modulePath: string[];
   private readonly statements: AstNode[];
-  private readonly imports: StarImport[] | undefined;
+  private readonly imports: (StarImport | Reference)[] | undefined;
   private readonly comments: Comment[] | undefined;
 
   public constructor({
@@ -47,7 +48,7 @@ export class InitFile extends BasePersistedFile {
     return this.statements;
   }
 
-  protected getFileImports(): StarImport[] | undefined {
+  protected getFileImports(): (StarImport | Reference)[] | undefined {
     return this.imports;
   }
 

--- a/ee/codegen/src/project.ts
+++ b/ee/codegen/src/project.ts
@@ -42,7 +42,7 @@ import {
   ProjectSerializationError,
   WorkflowGenerationError,
 } from "src/generators/errors";
-import { StarImport, Comment } from "src/generators/extensions";
+import { Comment, Reference, StarImport } from "src/generators/extensions";
 import { AstNode } from "src/generators/extensions/ast-node";
 import { ApiNode } from "src/generators/nodes/api-node";
 import { BaseNode } from "src/generators/nodes/bases";
@@ -454,7 +454,7 @@ ${errors.slice(0, 3).map((err) => {
 
   private generateDisplayRootInitFile(): InitFile {
     const statements: AstNode[] = [];
-    const imports: StarImport[] = [];
+    const imports: (StarImport | Reference)[] = [];
     const comments: Comment[] = [];
 
     const parentNode = this.workflowContext.parentNode;
@@ -467,8 +467,9 @@ ${errors.slice(0, 3).map((err) => {
         );
 
         imports.push(
-          new StarImport({
-            modulePath: [".workflow"],
+          new Reference({
+            name: "workflow",
+            modulePath: ["."],
           })
         );
         comments.push(new Comment({ docs: "flake8: noqa: F401, F403" }));
@@ -480,8 +481,9 @@ ${errors.slice(0, 3).map((err) => {
           })
         );
         imports.push(
-          new StarImport({
-            modulePath: [...parentModulePath, "workflow"],
+          new Reference({
+            name: "workflow",
+            modulePath: [...parentModulePath, ""],
           })
         );
         statements.push(...parentNode.generateNodeDisplayClasses());

--- a/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_inline_subworkflow_node/code/display/nodes/subworkflow_node/__init__.py
@@ -6,9 +6,9 @@ from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosit
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 
+from . import workflow
 from ....nodes.subworkflow_node import SubworkflowNode
 from .nodes import *
-from .workflow import *
 
 
 class SubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[SubworkflowNode]):

--- a/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/__init__.py
+++ b/ee/codegen_integration/fixtures/simple_map_node/code/display/nodes/map_node/__init__.py
@@ -6,9 +6,9 @@ from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosit
 from vellum_ee.workflows.display.nodes import BaseMapNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 
+from . import workflow
 from ....nodes.map_node import MapNode
 from .nodes import *
-from .workflow import *
 
 
 class MapNodeDisplay(BaseMapNodeDisplay[MapNode]):

--- a/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/__init__.py
+++ b/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa: F401, F403
+
+from .display import *

--- a/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/display/nodes/node/__init__.py
+++ b/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/display/nodes/node/__init__.py
@@ -6,9 +6,9 @@ from vellum_ee.workflows.display.editor import NodeDisplayComment, NodeDisplayDa
 from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
 from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
 
+from . import workflow
 from ....nodes.node import MySubworkflowNode
 from .nodes import *
-from .workflow import *
 
 
 class MySubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[MySubworkflowNode]):

--- a/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/display/nodes/node/__init__.py
+++ b/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/display/nodes/node/__init__.py
@@ -1,0 +1,35 @@
+# flake8: noqa: F401, F403
+
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayComment, NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from ....nodes.node import MySubworkflowNode
+from .nodes import *
+from .workflow import *
+
+
+class MySubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[MySubworkflowNode]):
+    label = "My Node"
+    node_id = UUID("04fea948-6682-47b8-8646-bab40e720038")
+    target_handle_id = UUID("9dec56e2-4ac1-4040-b0a5-0b1b395a8af2")
+    workflow_input_ids_by_name = {}
+    output_display = {
+        MySubworkflowNode.Outputs.result: NodeOutputDisplay(
+            id=UUID("4b59eb8b-8f00-4e8f-91d6-423eff3d4663"), name="result"
+        )
+    }
+    port_displays = {
+        MySubworkflowNode.Ports.default: PortDisplayOverrides(id=UUID("0cb70d33-28e5-4d90-ad50-f3b59f6ed4b1"))
+    }
+    display_data = NodeDisplayData(
+        position=NodeDisplayPosition(x=470, y=0),
+        z_index=2,
+        width=370,
+        height=124,
+        icon="vellum:icon:diagram-sankey",
+        color="grass",
+        comment=NodeDisplayComment(expanded=True, value="An inline subworkflow node."),
+    )

--- a/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/display/nodes/node/nodes/my_subworkflow.py
+++ b/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/display/nodes/node/nodes/my_subworkflow.py
@@ -1,0 +1,20 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.nodes import BaseNodeDisplay
+from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides
+
+from .....nodes.node.nodes.my_subworkflow import MySubworkflowNode
+
+
+class MySubworkflowNodeDisplay(BaseNodeDisplay[MySubworkflowNode]):
+    node_id = UUID("fce721b0-2e11-4070-9acd-502292dd682b")
+    output_display = {
+        MySubworkflowNode.Outputs.result: NodeOutputDisplay(
+            id=UUID("eadbf483-a1de-4287-9b8a-3624901c856f"), name="result"
+        )
+    }
+    port_displays = {
+        MySubworkflowNode.Ports.default: PortDisplayOverrides(id=UUID("675ad077-fa40-42b3-a0f9-7770b0371755"))
+    }
+    display_data = NodeDisplayData(position=NodeDisplayPosition(x=0, y=0), icon="vellum:icon:square", color="peach")

--- a/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/display/nodes/node/workflow.py
+++ b/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/display/nodes/node/workflow.py
@@ -1,0 +1,37 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.base import (
+    EdgeDisplay,
+    EntrypointDisplay,
+    WorkflowDisplayData,
+    WorkflowDisplayDataViewport,
+    WorkflowMetaDisplay,
+    WorkflowOutputDisplay,
+)
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
+
+from ....nodes.node.nodes.my_subworkflow import MySubworkflowNode
+from ....nodes.node.workflow import MyNodeWorkflow
+
+
+class MyNodeWorkflowDisplay(BaseWorkflowDisplay[MyNodeWorkflow]):
+    workflow_display = WorkflowMetaDisplay(
+        entrypoint_node_id=UUID("0fc5a026-f775-43f6-9761-dd68f3b3dbb4"),
+        entrypoint_node_source_handle_id=UUID("eb9225cc-863b-4ef4-adb4-93f058ebb573"),
+        entrypoint_node_display=NodeDisplayData(
+            position=NodeDisplayPosition(x=-30, y=0), z_index=1, icon="vellum:icon:play", color="default"
+        ),
+        display_data=WorkflowDisplayData(viewport=WorkflowDisplayDataViewport(x=0, y=0, zoom=1)),
+    )
+    entrypoint_displays = {
+        MySubworkflowNode: EntrypointDisplay(
+            id=UUID("0fc5a026-f775-43f6-9761-dd68f3b3dbb4"),
+            edge_display=EdgeDisplay(id=UUID("1a526045-0550-488b-a6c4-29bc86050bcd")),
+        )
+    }
+    output_displays = {
+        MyNodeWorkflow.Outputs.result: WorkflowOutputDisplay(
+            id=UUID("4b59eb8b-8f00-4e8f-91d6-423eff3d4663"), name="result"
+        )
+    }

--- a/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/display/workflow.py
+++ b/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/display/workflow.py
@@ -1,0 +1,40 @@
+from uuid import UUID
+
+from vellum_ee.workflows.display.base import (
+    EdgeDisplay,
+    EntrypointDisplay,
+    WorkflowDisplayData,
+    WorkflowDisplayDataViewport,
+    WorkflowMetaDisplay,
+    WorkflowOutputDisplay,
+)
+from vellum_ee.workflows.display.editor import NodeDisplayData, NodeDisplayPosition
+from vellum_ee.workflows.display.workflows import BaseWorkflowDisplay
+
+from ..nodes.node import MySubworkflowNode
+from ..workflow import Workflow
+
+
+class WorkflowDisplay(BaseWorkflowDisplay[Workflow]):
+    workflow_display = WorkflowMetaDisplay(
+        entrypoint_node_id=UUID("63884a7b-c01c-4cbc-b8d4-abe0a8796f6b"),
+        entrypoint_node_source_handle_id=UUID("eba8fd73-57ab-4d7b-8f75-b54dbe5fc8ba"),
+        entrypoint_node_display=NodeDisplayData(
+            position=NodeDisplayPosition(x=-30, y=0),
+            z_index=1,
+            width=306,
+            height=88,
+            icon="vellum:icon:play",
+            color="default",
+        ),
+        display_data=WorkflowDisplayData(viewport=WorkflowDisplayDataViewport(x=0, y=0, zoom=1)),
+    )
+    entrypoint_displays = {
+        MySubworkflowNode: EntrypointDisplay(
+            id=UUID("63884a7b-c01c-4cbc-b8d4-abe0a8796f6b"),
+            edge_display=EdgeDisplay(id=UUID("227a29f5-cfaf-4dc4-b9d9-7a5bd5c508ad")),
+        )
+    }
+    output_displays = {
+        Workflow.Outputs.result: WorkflowOutputDisplay(id=UUID("6a2f0fad-8670-4cee-b2b2-c94ad3b4807f"), name="result")
+    }

--- a/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/nodes/node/__init__.py
+++ b/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/nodes/node/__init__.py
@@ -1,0 +1,13 @@
+from vellum.workflows.nodes.displayable import InlineSubworkflowNode
+
+from .workflow import MyNodeWorkflow
+
+
+class MySubworkflowNode(InlineSubworkflowNode):
+    """An inline subworkflow node."""
+
+    subworkflow = MyNodeWorkflow
+
+    class Display(InlineSubworkflowNode.Display):
+        icon = "vellum:icon:diagram-sankey"
+        color = "grass"

--- a/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/nodes/node/nodes/my_subworkflow.py
+++ b/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/nodes/node/nodes/my_subworkflow.py
@@ -1,0 +1,10 @@
+from vellum.workflows import BaseNode
+
+
+class MySubworkflowNode(BaseNode):
+    class Outputs(BaseNode.Outputs):
+        result: str
+
+    class Display(BaseNode.Display):
+        icon = "vellum:icon:square"
+        color = "peach"

--- a/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/nodes/node/workflow.py
+++ b/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/nodes/node/workflow.py
@@ -1,0 +1,10 @@
+from vellum.workflows import BaseWorkflow
+
+from .nodes.my_subworkflow import MySubworkflowNode
+
+
+class MyNodeWorkflow(BaseWorkflow):
+    graph = MySubworkflowNode
+
+    class Outputs(BaseWorkflow.Outputs):
+        result = MySubworkflowNode.Outputs.result

--- a/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/workflow.py
+++ b/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/code/workflow.py
@@ -1,0 +1,10 @@
+from vellum.workflows import BaseWorkflow
+
+from .nodes.node import MySubworkflowNode
+
+
+class Workflow(BaseWorkflow):
+    graph = MySubworkflowNode
+
+    class Outputs(BaseWorkflow.Outputs):
+        result = MySubworkflowNode.Outputs.result

--- a/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/display_data/subworkflow_with_custom_inner_node.json
+++ b/ee/codegen_integration/fixtures/subworkflow_with_custom_inner_node/display_data/subworkflow_with_custom_inner_node.json
@@ -1,0 +1,266 @@
+{
+  "workflow_raw_data": {
+    "nodes": [
+      {
+        "id": "63884a7b-c01c-4cbc-b8d4-abe0a8796f6b",
+        "type": "ENTRYPOINT",
+        "inputs": [],
+        "data": {
+          "label": "Entrypoint Node",
+          "source_handle_id": "eba8fd73-57ab-4d7b-8f75-b54dbe5fc8ba"
+        },
+        "display_data": {
+          "position": {
+            "x": -30.0,
+            "y": 0.0
+          },
+          "z_index": 1,
+          "width": 306,
+          "height": 88,
+          "icon": "vellum:icon:play",
+          "color": "default"
+        },
+        "base": null,
+        "definition": null
+      },
+      {
+        "id": "04fea948-6682-47b8-8646-bab40e720038",
+        "type": "SUBWORKFLOW",
+        "inputs": [],
+        "data": {
+          "label": "My Node",
+          "error_output_id": null,
+          "source_handle_id": "0cb70d33-28e5-4d90-ad50-f3b59f6ed4b1",
+          "target_handle_id": "9dec56e2-4ac1-4040-b0a5-0b1b395a8af2",
+          "variant": "INLINE",
+          "workflow_raw_data": {
+            "nodes": [
+              {
+                "id": "0fc5a026-f775-43f6-9761-dd68f3b3dbb4",
+                "type": "ENTRYPOINT",
+                "inputs": [],
+                "data": {
+                  "label": "Entrypoint Node",
+                  "source_handle_id": "eb9225cc-863b-4ef4-adb4-93f058ebb573"
+                },
+                "display_data": {
+                  "position": {
+                    "x": -30.0,
+                    "y": 0.0
+                  },
+                  "z_index": 1,
+                  "icon": "vellum:icon:play",
+                  "color": "default"
+                },
+                "base": null,
+                "definition": null
+              },
+              {
+                "id": "fce721b0-2e11-4070-9acd-502292dd682b",
+                "label": "My Subworkflow Node",
+                "type": "GENERIC",
+                "adornments": null,
+                "attributes": [],
+                "display_data": {
+                  "position": {
+                    "x": 0.0,
+                    "y": 0.0
+                  },
+                  "icon": "vellum:icon:square",
+                  "color": "peach"
+                },
+                "base": {
+                  "name": "BaseNode",
+                  "module": [
+                    "vellum",
+                    "workflows",
+                    "nodes",
+                    "bases",
+                    "base"
+                  ]
+                },
+                "definition": {
+                  "name": "MySubworkflowNode",
+                  "module": [
+                    "codegen_integration",
+                    "fixtures",
+                    "subworkflow_with_custom_inner_node",
+                    "code",
+                    "nodes",
+                    "node",
+                    "nodes",
+                    "my_subworkflow"
+                  ]
+                },
+                "trigger": {
+                  "id": "1715c001-55ef-40c0-a60a-4d0c2e424cc4",
+                  "merge_behavior": "AWAIT_ATTRIBUTES"
+                },
+                "ports": [
+                  {
+                    "id": "675ad077-fa40-42b3-a0f9-7770b0371755",
+                    "name": "default",
+                    "type": "DEFAULT"
+                  }
+                ],
+                "outputs": [
+                  {
+                    "id": "eadbf483-a1de-4287-9b8a-3624901c856f",
+                    "name": "result",
+                    "type": "STRING",
+                    "value": null,
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edges": [
+              {
+                "id": "1a526045-0550-488b-a6c4-29bc86050bcd",
+                "source_node_id": "0fc5a026-f775-43f6-9761-dd68f3b3dbb4",
+                "source_handle_id": "eb9225cc-863b-4ef4-adb4-93f058ebb573",
+                "target_node_id": "fce721b0-2e11-4070-9acd-502292dd682b",
+                "target_handle_id": "1715c001-55ef-40c0-a60a-4d0c2e424cc4",
+                "type": "DEFAULT"
+              }
+            ],
+            "display_data": {
+              "viewport": {
+                "x": 0.0,
+                "y": 0.0,
+                "zoom": 1.0
+              }
+            },
+            "definition": {
+              "name": "MyNodeWorkflow",
+              "module": [
+                "codegen_integration",
+                "fixtures",
+                "subworkflow_with_custom_inner_node",
+                "code",
+                "nodes",
+                "node",
+                "workflow"
+              ]
+            },
+            "output_values": [
+              {
+                "output_variable_id": "4b59eb8b-8f00-4e8f-91d6-423eff3d4663",
+                "value": {
+                  "type": "NODE_OUTPUT",
+                  "node_id": "fce721b0-2e11-4070-9acd-502292dd682b",
+                  "node_output_id": "eadbf483-a1de-4287-9b8a-3624901c856f"
+                }
+              }
+            ]
+          },
+          "input_variables": [],
+          "output_variables": [
+            {
+              "id": "4b59eb8b-8f00-4e8f-91d6-423eff3d4663",
+              "key": "result",
+              "type": "STRING"
+            }
+          ]
+        },
+        "display_data": {
+          "position": {
+            "x": 470.0,
+            "y": 0.0
+          },
+          "z_index": 2,
+          "width": 370,
+          "height": 124,
+          "comment": {
+            "value": "An inline subworkflow node.",
+            "expanded": true
+          },
+          "icon": "vellum:icon:diagram-sankey",
+          "color": "grass"
+        },
+        "base": {
+          "name": "InlineSubworkflowNode",
+          "module": [
+            "vellum",
+            "workflows",
+            "nodes",
+            "core",
+            "inline_subworkflow_node",
+            "node"
+          ]
+        },
+        "definition": {
+          "name": "MySubworkflowNode",
+          "module": [
+            "codegen_integration",
+            "fixtures",
+            "subworkflow_with_custom_inner_node",
+            "code",
+            "nodes",
+            "node"
+          ]
+        },
+        "trigger": {
+          "id": "9dec56e2-4ac1-4040-b0a5-0b1b395a8af2",
+          "merge_behavior": "AWAIT_ATTRIBUTES"
+        },
+        "ports": [
+          {
+            "id": "0cb70d33-28e5-4d90-ad50-f3b59f6ed4b1",
+            "name": "default",
+            "type": "DEFAULT"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "id": "227a29f5-cfaf-4dc4-b9d9-7a5bd5c508ad",
+        "source_node_id": "63884a7b-c01c-4cbc-b8d4-abe0a8796f6b",
+        "source_handle_id": "eba8fd73-57ab-4d7b-8f75-b54dbe5fc8ba",
+        "target_node_id": "04fea948-6682-47b8-8646-bab40e720038",
+        "target_handle_id": "9dec56e2-4ac1-4040-b0a5-0b1b395a8af2",
+        "type": "DEFAULT"
+      }
+    ],
+    "display_data": {
+      "viewport": {
+        "x": 0.0,
+        "y": 0.0,
+        "zoom": 1.0
+      }
+    },
+    "definition": {
+      "name": "Workflow",
+      "module": [
+        "codegen_integration",
+        "fixtures",
+        "subworkflow_with_custom_inner_node",
+        "code",
+        "workflow"
+      ]
+    },
+    "output_values": [
+      {
+        "output_variable_id": "6a2f0fad-8670-4cee-b2b2-c94ad3b4807f",
+        "value": {
+          "type": "NODE_OUTPUT",
+          "node_id": "04fea948-6682-47b8-8646-bab40e720038",
+          "node_output_id": "4b59eb8b-8f00-4e8f-91d6-423eff3d4663"
+        }
+      }
+    ]
+  },
+  "input_variables": [],
+  "state_variables": [],
+  "output_variables": [
+    {
+      "id": "6a2f0fad-8670-4cee-b2b2-c94ad3b4807f",
+      "key": "result",
+      "type": "STRING"
+    }
+  ],
+  "runner_config": {}
+}


### PR DESCRIPTION
## Changes
Migrate display `__init__` files away from star imports of the sibling `workflow` modules
```diff
-from .workflow import *
+from . import workflow
```
to prevent shadowing explicitly imported symbols

## Problem
Say we have a workflow structured like this, where `MySubworkflowNode` is an inline subworkflow node:
```
Workflow
|--MySubworkflowNode (InlineSubworkflowNode)
    |--MyNodeWorkflow
        |--MySubworkflowNode (some custom node)
```
See https://github.com/vellum-ai/vellum-python-sdks/pull/3588/commits/2d2d06d334ebbf034cb13e8a05245c22e18e4386#diff-6449b80fb80f0c5e78e24829dc820952afa0379ebdd4e2326359d119fe924302 for directory structure.

Currently we generate a `display` directory for the inner subworkflow node whose `__init__.py` file looks something like
```python
from uuid import UUID

from vellum_ee.workflows.display.editor import NodeDisplayComment, NodeDisplayData, NodeDisplayPosition
from vellum_ee.workflows.display.nodes import BaseInlineSubworkflowNodeDisplay
from vellum_ee.workflows.display.nodes.types import NodeOutputDisplay, PortDisplayOverrides

from ....nodes.node import MySubworkflowNode  # parent node, InlineSubworkflowNode
from .nodes import *
from .workflow import *


class MySubworkflowNodeDisplay(BaseInlineSubworkflowNodeDisplay[MySubworkflowNode]):
    ...
```

and where the sibling `workflow.py` file looks something like
```python
from vellum.workflows import BaseWorkflow

from .nodes.node import MySubworkflowNode  # some child custom node


class Workflow(BaseWorkflow):
    graph = MySubworkflowNode

    class Outputs(BaseWorkflow.Outputs):
        result = MySubworkflowNode.Outputs.result
```

The star import from the `workflow` module pulls in the child node, which shadows the intended import of the parent `MySubworkflowNode`, which causes serialization to fail.

## Thoughts
1. Alternatively / additionally, we could define `__all__ = ["MyNodeWorkflowDisplay"]` in `workflow.py` to limit the symbols pulled in by star imports.
2. I think the various `from .nodes import *` imports are also no-ops as of https://github.com/vellum-ai/vellum-python-sdks/pull/3214. Importing the sibling `workflow` module that defines the subclass of `BaseWorkflowDisplay` should register the node classes.
3. Separately, do we want to update codegen to deduplicate node names between a parent workflow and subworkflow?