### PR TITLE
Write generated test files to isolated `fixtureDir`

### DIFF
--- a/ee/codegen/src/__test__/generate-code.test.ts
+++ b/ee/codegen/src/__test__/generate-code.test.ts
@@ -42,7 +42,7 @@ describe("generateCode", () => {
     fs.mkdirSync(fixtureDir, { recursive: true });
 
     async function expectProjectFileToMatchSnapshot(filePath: string[]) {
-      const moduleRoot = join(tempDir, moduleName);
+      const moduleRoot = join(fixtureDir, moduleName);
       const completeFilePath = join(moduleRoot, ...filePath);
       const snapshotName = filePath.join("/");
 
@@ -58,7 +58,7 @@ describe("generateCode", () => {
     }
 
     const project = new WorkflowProjectGenerator({
-      absolutePathToOutputDirectory: tempDir,
+      absolutePathToOutputDirectory: fixtureDir,
       workflowVersionExecConfigData,
       moduleName,
       vellumApiKey,


### PR DESCRIPTION
ref: APO-2784

I was trying to reproduce a bug where `sandbox.py` files *weren't* getting written, and I noticed that my snapshot test used the generated `sandbox.py` file from the previous test.

For a given test run, our test harness has a bug where it writes files to the same top level temp dir, instead of to namespaced directories within that temp dir. This causes test pollution if we don't clean up or overwrite all previously generated files.