### PR TITLE
Handle scenarios with null file input

### DIFF
--- a/ee/codegen/src/__test__/__snapshots__/generate-code.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/generate-code.test.ts.snap
@@ -287,6 +287,24 @@ if __name__ == "__main__":
 "
 `;
 
+exports[`generateCode > should generate code for %1 null-file-input.ts > sandbox.py 1`] = `
+"from vellum.workflows.inputs import DatasetRow
+from vellum.workflows.sandbox import WorkflowSandboxRunner
+
+from .inputs import Inputs
+from .workflow import Workflow
+
+dataset = [
+    DatasetRow(label="Scenario 1", inputs=Inputs()),
+]
+
+runner = WorkflowSandboxRunner(workflow=Workflow(), dataset=dataset)
+
+if __name__ == "__main__":
+    runner.run()
+"
+`;
+
 exports[`generateCode > should generate code for %1 scheduled-trigger.ts > triggers/scheduled.py 1`] = `
 "from vellum_ee.workflows.display.editor import NodeDisplayComment
 from vellum.workflows.triggers import ScheduleTrigger

--- a/ee/codegen/src/__test__/__snapshots__/generate-code.test.ts.snap
+++ b/ee/codegen/src/__test__/__snapshots__/generate-code.test.ts.snap
@@ -287,6 +287,18 @@ if __name__ == "__main__":
 "
 `;
 
+exports[`generateCode > should generate code for %1 null-file-input.ts > inputs.py 1`] = `
+"from typing import Optional
+
+from vellum import VellumDocument
+from vellum.workflows.inputs import BaseInputs
+
+
+class Inputs(BaseInputs):
+    document: Optional[VellumDocument] = None
+"
+`;
+
 exports[`generateCode > should generate code for %1 null-file-input.ts > sandbox.py 1`] = `
 "from vellum.workflows.inputs import DatasetRow
 from vellum.workflows.sandbox import WorkflowSandboxRunner
@@ -302,6 +314,23 @@ runner = WorkflowSandboxRunner(workflow=Workflow(), dataset=dataset)
 
 if __name__ == "__main__":
     runner.run()
+"
+`;
+
+exports[`generateCode > should generate code for %1 null-file-input.ts > workflow.py 1`] = `
+"from vellum.workflows import BaseWorkflow
+from vellum.workflows.state import BaseState
+
+from .inputs import Inputs
+from .nodes.final_output import FinalOutput
+from .nodes.templating import Templating
+
+
+class Workflow(BaseWorkflow[Inputs, BaseState]):
+    graph = Templating >> FinalOutput
+
+    class Outputs(BaseWorkflow.Outputs):
+        final_output = FinalOutput.Outputs.value
 "
 `;
 

--- a/ee/codegen/src/__test__/generate-code-fixtures/null-file-input.ts
+++ b/ee/codegen/src/__test__/generate-code-fixtures/null-file-input.ts
@@ -162,5 +162,5 @@ export default {
   ],
   state_variables: [],
   triggers: [],
-  assertions: ["sandbox.py"],
+  assertions: ["sandbox.py", "workflow.py", "inputs.py"],
 };

--- a/ee/codegen/src/__test__/generate-code-fixtures/null-file-input.ts
+++ b/ee/codegen/src/__test__/generate-code-fixtures/null-file-input.ts
@@ -1,0 +1,166 @@
+export default {
+  workflow_raw_data: {
+    nodes: [
+      {
+        id: "7be676ae-b011-454b-aa59-0c26385a543c",
+        type: "ENTRYPOINT",
+        data: {
+          label: "Entrypoint Node",
+          source_handle_id: "3006c2ba-2638-4494-9154-9a716ab2af63",
+        },
+        inputs: [],
+      },
+      {
+        id: "b1ede5dd-2c27-442f-bf59-77a87caf2184",
+        type: "TERMINAL",
+        data: {
+          name: "final-output",
+          label: "Final Output",
+          target_handle_id: "2892f5b0-a6c9-4854-ac53-cf5e17b9ae16",
+          output_id: "cff5b127-113b-42ed-aa08-d300ac3583c1",
+          output_type: "DOCUMENT",
+          node_input_id: "d8104087-048f-40db-bec8-2762a9eee6b0",
+        },
+        inputs: [
+          {
+            id: "d8104087-048f-40db-bec8-2762a9eee6b0",
+            key: "node_input",
+            value: {
+              rules: [],
+              combinator: "OR",
+            },
+          },
+        ],
+        trigger: {
+          id: "2892f5b0-a6c9-4854-ac53-cf5e17b9ae16",
+          merge_behavior: "AWAIT_ANY",
+        },
+        outputs: [
+          {
+            id: "cff5b127-113b-42ed-aa08-d300ac3583c1",
+            name: "value",
+            type: "DOCUMENT",
+            value: {
+              type: "NODE_OUTPUT",
+              node_id: "a1bd3a26-21b8-44e8-8c1c-213cb5f7d5e2",
+              node_output_id: "3728d2d3-e38c-4d5c-a02e-05853f71ef2a",
+            },
+            schema: {
+              type: "string",
+            },
+          },
+        ],
+      },
+      {
+        id: "a1bd3a26-21b8-44e8-8c1c-213cb5f7d5e2",
+        type: "TEMPLATING",
+        data: {
+          output_id: "3728d2d3-e38c-4d5c-a02e-05853f71ef2a",
+          error_output_id: null,
+          label: "Templating",
+          source_handle_id: "c329bedf-030b-4654-a185-12ce657240ff",
+          target_handle_id: "3d66d0dd-45f6-4098-a534-f84ea600e1c9",
+          template_node_input_id: "31eab6ad-f3a3-4abc-acc1-2f50fe970a3b",
+          output_type: "STRING",
+        },
+        inputs: [
+          {
+            id: "31eab6ad-f3a3-4abc-acc1-2f50fe970a3b",
+            key: "template",
+            value: {
+              rules: [],
+              combinator: "OR",
+            },
+          },
+        ],
+        trigger: {
+          id: "3d66d0dd-45f6-4098-a534-f84ea600e1c9",
+          merge_behavior: "AWAIT_ATTRIBUTES",
+        },
+        ports: [
+          {
+            id: "c329bedf-030b-4654-a185-12ce657240ff",
+            type: "DEFAULT",
+            name: "default",
+          },
+        ],
+        adornments: null,
+      },
+    ],
+    edges: [
+      {
+        id: "5a9b5158-67e1-4dd1-bea0-2d48bd10fa22",
+        type: "DEFAULT",
+        source_node_id: "7be676ae-b011-454b-aa59-0c26385a543c",
+        source_handle_id: "3006c2ba-2638-4494-9154-9a716ab2af63",
+        target_node_id: "a1bd3a26-21b8-44e8-8c1c-213cb5f7d5e2",
+        target_handle_id: "3d66d0dd-45f6-4098-a534-f84ea600e1c9",
+      },
+      {
+        id: "6b92f989-825a-44f8-8c0e-22151749f0d7",
+        type: "DEFAULT",
+        source_node_id: "a1bd3a26-21b8-44e8-8c1c-213cb5f7d5e2",
+        source_handle_id: "c329bedf-030b-4654-a185-12ce657240ff",
+        target_node_id: "b1ede5dd-2c27-442f-bf59-77a87caf2184",
+        target_handle_id: "2892f5b0-a6c9-4854-ac53-cf5e17b9ae16",
+      },
+    ],
+    output_values: [
+      {
+        output_variable_id: "cff5b127-113b-42ed-aa08-d300ac3583c1",
+        value: {
+          type: "NODE_OUTPUT",
+          node_id: "b1ede5dd-2c27-442f-bf59-77a87caf2184",
+          node_output_id: "cff5b127-113b-42ed-aa08-d300ac3583c1",
+        },
+      },
+    ],
+  },
+  dataset: [
+    {
+      id: "3ef81970-e156-426a-ad01-84a8d9de9ce6",
+      label: "Scenario 1",
+      inputs: [
+        {
+          name: "document",
+          type: "DOCUMENT",
+          value: null,
+        },
+      ],
+      mocks: [],
+      workflow_trigger_id: null,
+    },
+  ],
+  input_variables: [
+    {
+      id: "3757936a-81e2-4c4c-be2b-86497b25f411",
+      key: "document",
+      type: "DOCUMENT",
+      required: false,
+      default: {
+        type: "DOCUMENT",
+        value: null,
+      },
+      extensions: {
+        color: "deepPurple",
+        description: null,
+        title: null,
+      },
+      schema: null,
+    },
+  ],
+  output_variables: [
+    {
+      id: "cff5b127-113b-42ed-aa08-d300ac3583c1",
+      key: "final-output",
+      type: "DOCUMENT",
+      required: null,
+      default: null,
+      extensions: null,
+      schema: null,
+    },
+  ],
+  state_variables: [],
+  triggers: [],
+  assertions: ["sandbox.py"],
+};

--- a/ee/codegen/src/serializers/vellum.ts
+++ b/ee/codegen/src/serializers/vellum.ts
@@ -20,12 +20,12 @@ import {
 import {
   ChatMessageRole as ChatMessageRoleSerializer,
   LogicalOperator as LogicalOperatorSerializer,
+  NamedTestCaseVariableValueRequest as NamedTestCaseVariableValueRequestSerializer,
   PromptBlockState as PromptBlockStateSerializer,
   PromptParameters as PromptParametersSerializer,
   VellumValue as VellumValueSerializer,
   VellumVariable as VellumVariableSerializer,
   VellumVariableType as VellumVariableTypeSerializer,
-  WorkflowInput as WorkflowInputSerializer,
 } from "vellum-ai/serialization";
 import { ConditionCombinator as ConditionCombinatorSerializer } from "vellum-ai/serialization/types/ConditionCombinator";
 
@@ -118,8 +118,8 @@ import {
   WorkflowEdgeDisplayData,
   WorkflowInputWorkflowReference,
   WorkflowNode,
-  WorkflowOutputWorkflowReference,
   WorkflowOutputValue,
+  WorkflowOutputWorkflowReference,
   WorkflowRawData,
   WorkflowSandboxDatasetRowMock,
   WorkflowSandboxRoutingConfig,
@@ -2646,7 +2646,7 @@ export declare namespace WorkflowDisplayDataSerializer {
 }
 
 export const WorkflowSandboxInputsSerializer = listSchema(
-  WorkflowInputSerializer
+  NamedTestCaseVariableValueRequestSerializer
 );
 
 export declare namespace WorkflowSandboxDatasetRowMockSerializer {

--- a/ee/codegen/src/types/vellum.ts
+++ b/ee/codegen/src/types/vellum.ts
@@ -7,6 +7,7 @@ import {
   ChatMessageRequest,
   ChatMessageRole,
   FunctionDefinition,
+  NamedTestCaseVariableValueRequest,
   PromptBlockState,
   PromptParameters,
   SearchResult,
@@ -14,7 +15,6 @@ import {
   VellumValue,
   VellumVariable,
   VellumVariableType,
-  WorkflowInput,
 } from "vellum-ai/api/types";
 
 import { Reference } from "src/generators/extensions/reference";
@@ -892,7 +892,7 @@ export interface WorkflowVersionExecConfig {
   triggers?: WorkflowTrigger[];
 }
 
-export type WorkflowSandboxInputs = WorkflowInput[];
+export type WorkflowSandboxInputs = NamedTestCaseVariableValueRequest[];
 export interface WorkflowSandboxDatasetRowMock {
   node_id: string;
   when_condition?: WorkflowValueDescriptor;


### PR DESCRIPTION
There's a mismatch between (1) our webapp scenario serializers and (2) the serializers used to validate datasets for codegen. (1) Allows null file inputs, but (2) doesn't and marks the inputs as invalid during codegen.
