### PR TITLE
Add validation guarding against parent node output references

### DIFF
--- a/ee/vellum_ee/workflows/tests/test_serialize_module.py
+++ b/ee/vellum_ee/workflows/tests/test_serialize_module.py
@@ -432,7 +432,6 @@ class InvalidWorkflow(BaseWorkflow):
     assert "contact Vellum support" in error_message
 
 
-@pytest.mark.xfail(reason="We currently allow parent node output references, but shouldn't", strict=True)
 def test_serialize_module__with_invalid_parent_node_output_reference():
     """
     Tests that serialize_module surfaces an error for workflows with nodes

--- a/ee/vellum_ee/workflows/tests/test_serialize_module.py
+++ b/ee/vellum_ee/workflows/tests/test_serialize_module.py
@@ -445,4 +445,7 @@ def test_serialize_module__with_invalid_parent_node_output_reference():
     assert result.errors[0].message == (
         "'ReportGeneratorNode.Outputs.report_content' references parent class output 'InlinePromptNode.Outputs.text'. "
         "Referencing outputs from a node's parent class is not allowed."
+        "\n"
+        "'ReportGeneratorNode.Outputs.report_json' references parent class output 'InlinePromptNode.Outputs.json'. "
+        "Referencing outputs from a node's parent class is not allowed."
     )

--- a/ee/vellum_ee/workflows/tests/test_serialize_module.py
+++ b/ee/vellum_ee/workflows/tests/test_serialize_module.py
@@ -430,3 +430,20 @@ class InvalidWorkflow(BaseWorkflow):
     assert "Invalid graph structure detected" in error_message
     assert "Nested sets or unsupported graph types are not allowed" in error_message
     assert "contact Vellum support" in error_message
+
+
+@pytest.mark.xfail(reason="We currently allow parent node output references, but shouldn't", strict=True)
+def test_serialize_module__with_invalid_parent_node_output_reference():
+    """
+    Tests that serialize_module surfaces an error for workflows with nodes
+    that reference their parent class's outputs.
+    """
+    module_path = "tests.workflows.invalid_parent_node_output_reference"
+
+    result = BaseWorkflowDisplay.serialize_module(module_path)
+
+    assert len(result.errors) == 1
+    assert result.errors[0].message == (
+        "Node ReportGeneratorNode references parent class output 'InlinePromptNode.Outputs.report_content'. "
+        "Referencing parent class outputs is not allowed."
+    )

--- a/ee/vellum_ee/workflows/tests/test_serialize_module.py
+++ b/ee/vellum_ee/workflows/tests/test_serialize_module.py
@@ -443,6 +443,6 @@ def test_serialize_module__with_invalid_parent_node_output_reference():
 
     assert len(result.errors) == 1
     assert result.errors[0].message == (
-        "Node ReportGeneratorNode references parent class output 'InlinePromptNode.Outputs.report_content'. "
-        "Referencing parent class outputs is not allowed."
+        "'ReportGeneratorNode.Outputs.report_content' references parent class output 'InlinePromptNode.Outputs.text'. "
+        "Referencing outputs from a node's parent class is not allowed."
     )

--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -75,17 +75,16 @@ def _validate_no_parent_output_references(node_cls: Type["BaseNode"]) -> None:
     """
     Validates that the node does not reference parent class outputs.
     """
-    class_outputs = vars(node_cls.Outputs)
-
-    for name, value in class_outputs.items():
-        if not isinstance(value, OutputReference):
+    for node_output in node_cls.Outputs:
+        node_value = node_output.instance
+        if not isinstance(node_value, OutputReference):
             continue
 
-        parent_node_class = value.outputs_class.__parent_class__
+        parent_node_class = node_value.outputs_class.__parent_class__
         if parent_node_class in node_cls.__mro__:
             raise ValueError(
-                f"'{node_cls.Outputs.__qualname__}.{name}' references parent class output "
-                f"'{value.outputs_class.__qualname__}.{value.name}'. "
+                f"'{node_cls.Outputs.__qualname__}.{node_output.name}' references parent class output "
+                f"'{node_value.outputs_class.__qualname__}.{node_value.name}'. "
                 "Referencing outputs from a node's parent class is not allowed."
             )
 

--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -614,7 +614,5 @@ class BaseNode(Generic[StateType], ABC, BaseExecutable, metaclass=BaseNodeMeta):
         """
         Subclasses can override this method to implement their specific validation logic.
         Called during serialization or explicit validation.
-
-        Default implementation performs no validation.
         """
         pass

--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -605,9 +605,16 @@ class BaseNode(Generic[StateType], ABC, BaseExecutable, metaclass=BaseNodeMeta):
     def __validate__(cls) -> None:
         """
         Validates the node.
+        """
+        _validate_no_parent_output_references(cls)
+        cls.__validate_node_specific__()
+
+    @classmethod
+    def __validate_node_specific__(cls) -> None:
+        """
         Subclasses can override this method to implement their specific validation logic.
         Called during serialization or explicit validation.
 
         Default implementation performs no validation.
         """
-        _validate_no_parent_output_references(cls)
+        pass

--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -84,9 +84,9 @@ def _validate_no_parent_output_references(node_cls: Type["BaseNode"]) -> None:
         parent_node_class = value.outputs_class.__parent_class__
         if parent_node_class in node_cls.__mro__:
             raise ValueError(
-                f"Node {node_cls.__name__} references parent class output "
-                f"'{value.outputs_class.__qualname__}.{name}'. "
-                "Referencing parent class outputs is not allowed."
+                f"'{node_cls.Outputs.__qualname__}.{name}' references parent class output "
+                f"'{value.outputs_class.__qualname__}.{value.name}'. "
+                "Referencing outputs from a node's parent class is not allowed."
             )
 
 

--- a/src/vellum/workflows/nodes/bases/base.py
+++ b/src/vellum/workflows/nodes/bases/base.py
@@ -75,6 +75,7 @@ def _validate_no_parent_output_references(node_cls: Type["BaseNode"]) -> None:
     """
     Validates that the node does not reference parent class outputs.
     """
+    errors = []
     for node_output in node_cls.Outputs:
         node_value = node_output.instance
         if not isinstance(node_value, OutputReference):
@@ -82,11 +83,14 @@ def _validate_no_parent_output_references(node_cls: Type["BaseNode"]) -> None:
 
         parent_node_class = node_value.outputs_class.__parent_class__
         if parent_node_class in node_cls.__mro__:
-            raise ValueError(
+            errors.append(
                 f"'{node_cls.Outputs.__qualname__}.{node_output.name}' references parent class output "
                 f"'{node_value.outputs_class.__qualname__}.{node_value.name}'. "
                 "Referencing outputs from a node's parent class is not allowed."
             )
+
+    if errors:
+        raise ValueError("\n".join(errors))
 
 
 class BaseNodeMeta(ABCMeta):

--- a/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
@@ -558,7 +558,7 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
         return blocks
 
     @classmethod
-    def __validate__(cls) -> None:
+    def __validate_node_specific__(cls) -> None:
         """
         Validates the node configuration, including JSON schema structure in parameters.
 
@@ -566,7 +566,6 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
             jsonschema.exceptions.SchemaError: If the JSON schema structure is invalid
         """
 
-        super().__validate__()
         parameters_ref = getattr(cls, "parameters", None)
         if parameters_ref is None:
             return

--- a/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/bases/inline_prompt_node/node.py
@@ -59,11 +59,9 @@ from vellum.workflows.errors import WorkflowErrorCode
 from vellum.workflows.errors.types import vellum_error_to_workflow_error
 from vellum.workflows.events.types import default_serializer
 from vellum.workflows.exceptions import NodeException
-from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.displayable.bases.base_prompt_node import BasePromptNode
 from vellum.workflows.nodes.displayable.bases.utils import process_additional_prompt_outputs
 from vellum.workflows.outputs import BaseOutput
-from vellum.workflows.references.output import OutputReference
 from vellum.workflows.types import MergeBehavior
 from vellum.workflows.types.definition import (
     ComposioToolDefinition,
@@ -137,25 +135,6 @@ def _validate_json_schema_structure(schema: dict) -> None:
         jsonschema.exceptions.SchemaError: If the schema structure is invalid
     """
     jsonschema.Draft7Validator.check_schema(schema)
-
-
-def _validate_no_parent_output_references(node_cls: Type[BaseNode]) -> None:
-    """
-    Validates that the node does not reference parent class outputs.
-    """
-    class_outputs = vars(node_cls.Outputs)
-
-    for name, value in class_outputs.items():
-        if not isinstance(value, OutputReference):
-            continue
-
-        parent_node_class = value.outputs_class.__parent_class__
-        if parent_node_class in node_cls.__mro__:
-            raise ValueError(
-                f"Node {node_cls.__name__} references parent class output "
-                f"'{value.outputs_class.__qualname__}.{name}'. "
-                "Referencing parent class outputs is not allowed."
-            )
 
 
 class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
@@ -586,8 +565,8 @@ class BaseInlinePromptNode(BasePromptNode[StateType], Generic[StateType]):
         Raises:
             jsonschema.exceptions.SchemaError: If the JSON schema structure is invalid
         """
-        _validate_no_parent_output_references(cls)
 
+        super().__validate__()
         parameters_ref = getattr(cls, "parameters", None)
         if parameters_ref is None:
             return

--- a/src/vellum/workflows/nodes/displayable/final_output_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/final_output_node/node.py
@@ -77,6 +77,7 @@ class FinalOutputNode(BaseNode[StateType], Generic[StateType, _OutputType], meta
 
     @classmethod
     def __validate__(cls) -> None:
+        super().__validate__()
         cls._validate_output_type_consistency()
 
     @classmethod

--- a/src/vellum/workflows/nodes/displayable/final_output_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/final_output_node/node.py
@@ -76,8 +76,7 @@ class FinalOutputNode(BaseNode[StateType], Generic[StateType, _OutputType], meta
     __simulates_workflow_output__ = True
 
     @classmethod
-    def __validate__(cls) -> None:
-        super().__validate__()
+    def __validate_node_specific__(cls) -> None:
         cls._validate_output_type_consistency()
 
     @classmethod

--- a/src/vellum/workflows/nodes/displayable/final_output_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/final_output_node/tests/test_node.py
@@ -2,11 +2,11 @@ import pytest
 from typing import Any, Dict
 
 from vellum.workflows.exceptions import NodeException
+from vellum.workflows.nodes.bases import BaseNode
 from vellum.workflows.nodes.core.map_node import MapNode
 from vellum.workflows.nodes.core.templating_node import TemplatingNode
 from vellum.workflows.nodes.displayable.final_output_node import FinalOutputNode
 from vellum.workflows.nodes.displayable.inline_prompt_node import InlinePromptNode
-from vellum.workflows.references.output import OutputReference
 from vellum.workflows.state.base import BaseState
 from vellum.workflows.types.core import Json
 from vellum.workflows.workflows.base import BaseWorkflow
@@ -94,16 +94,15 @@ def test_final_output_node__dict_and_Dict_should_be_compatible():
 
     # GIVEN a FinalOutputNode declared with dict output type
     # AND the value descriptor has Dict[str, Any] type
+    class SomeCustomNode(BaseNode):
+        class Outputs(BaseNode.Outputs):
+            value: Dict[str, Any]
+
     class DictOutputNode(FinalOutputNode[BaseState, dict]):
         """Output with dict type."""
 
         class Outputs(FinalOutputNode.Outputs):
-            value = OutputReference(
-                name="value",
-                types=(Dict[str, Any],),
-                instance=None,
-                outputs_class=FinalOutputNode.Outputs,
-            )
+            value = SomeCustomNode.Outputs.value
 
     # WHEN attempting to validate the node class
     # THEN validation should pass without raising an exception

--- a/tests/workflows/invalid_parent_node_output_reference/workflow.py
+++ b/tests/workflows/invalid_parent_node_output_reference/workflow.py
@@ -25,6 +25,8 @@ class ReportGeneratorNode(InlinePromptNode):
         # BAD: This references the parent class's output.
         # It gets dropped during serialization AND it isn't resolved during execution.
         report_content: str = InlinePromptNode.Outputs.text
+        report_json = InlinePromptNode.Outputs.json
+        a: str = "a"
 
 
 class WorkflowWithParentOutputReference(BaseWorkflow[Inputs, BaseState]):

--- a/tests/workflows/invalid_parent_node_output_reference/workflow.py
+++ b/tests/workflows/invalid_parent_node_output_reference/workflow.py
@@ -1,0 +1,34 @@
+from vellum import ChatMessagePromptBlock, JinjaPromptBlock
+from vellum.workflows import BaseWorkflow
+from vellum.workflows.inputs import BaseInputs
+from vellum.workflows.nodes import InlinePromptNode
+from vellum.workflows.state import BaseState
+
+
+class Inputs(BaseInputs):
+    topic: str
+
+
+class ReportGeneratorNode(InlinePromptNode):
+    """An InlinePromptNode that defines a custom output referencing the parent class output."""
+
+    ml_model = "gpt-4o"
+    blocks = [
+        ChatMessagePromptBlock(
+            chat_role="SYSTEM",
+            blocks=[JinjaPromptBlock(template="Write a report about {{ topic }}")],
+        ),
+    ]
+    prompt_inputs = {"topic": Inputs.topic}
+
+    class Outputs(InlinePromptNode.Outputs):
+        # BAD: This references the parent class's output.
+        # It gets dropped during serialization AND it isn't resolved during execution.
+        report_content: str = InlinePromptNode.Outputs.text
+
+
+class WorkflowWithParentOutputReference(BaseWorkflow[Inputs, BaseState]):
+    graph = ReportGeneratorNode
+
+    class Outputs(BaseWorkflow.Outputs):
+        result = ReportGeneratorNode.Outputs.report_content


### PR DESCRIPTION
Prevent users from defining custom `Outputs` classes where an output references something from the parent class
```python
class MyPromptNode(InlinePromptNode):
    class Outputs(InlinePromptNode.Outputs):
        custom_output: str = InlinePromptNode.Outputs.text
```

Here `custom_output` doesn't get resolved during execution and remains `undefined`. Separately, I think custom outputs for an `InlinePromptNode` will just get dropped during serialization and possibly should be forbidden