### PR TITLE
Migrate last direct usage of `MypyTypeAlias` -> `_create_type_alias`

### DIFF
--- a/src/vellum/plugins/vellum_mypy.py
+++ b/src/vellum/plugins/vellum_mypy.py
@@ -574,13 +574,14 @@ class VellumMypyPlugin(Plugin):
 
         new_fulfilled_event = fulfilled_event.copy_modified(args=(Instance(outputs_node, []),))
         return TypeAliasType(
-            alias=MypyTypeAlias(
+            alias=_create_type_alias(
                 target=UnionType(
                     items=[new_fulfilled_event] + alias_target.items[1:],
                 ),
                 fullname=alias.fullname,
                 line=alias.line,
                 column=alias.column,
+                module=getattr(alias, "module", None),
             ),
             args=ctx.default_return_type.args,
             line=ctx.default_return_type.line,


### PR DESCRIPTION
Building off https://github.com/vellum-ai/vellum-python-sdks/pull/3590, I noticed some crashes when testing mypy 1.19.1

ref APO-2945