### PR TITLE
Emit log events for code exec nodes

### DIFF
--- a/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
@@ -105,7 +105,7 @@ class CodeExecutionNode(BaseNode[StateType], Generic[StateType, _OutputType], me
         code, filepath = self._resolve_code()
         if not self.packages and self.runtime == "PYTHON_3_11_6" and not self._has_secrets_in_code_inputs():
             logs, result = run_code_inline(code, self.code_inputs, output_type, filepath, self._context.vellum_client)
-            return self.Outputs(result=result, log=logs)
+            outputs = self.Outputs(result=result, log=logs)
 
         else:
             input_values = self._compile_code_inputs()
@@ -130,7 +130,13 @@ class CodeExecutionNode(BaseNode[StateType], Generic[StateType, _OutputType], me
                     message=f"Expected an output of type '{expected_output_type}', received '{actual_type}'",
                 )
 
-            return self.Outputs(result=code_execution_result.output.value, log=code_execution_result.log)
+            outputs = self.Outputs(result=code_execution_result.output.value, log=code_execution_result.log)
+
+        self._context.emit_log_event(
+            severity="INFO",
+            message=outputs.log,
+        )
+        return outputs
 
     def _handle_api_error(self, e: ApiError) -> None:
         body = e.body if isinstance(e.body, dict) else {}

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
@@ -130,11 +130,12 @@ class CodeExecutionNode(BaseNode[StateType], Generic[StateType, _OutputType], me
                     message=f"Expected an output of type '{expected_output_type}', received '{actual_type}'",
                 )
 
-            outputs = self.Outputs(result=code_execution_result.output.value, log=code_execution_result.log)
+            logs = code_execution_result.log
+            outputs = self.Outputs(result=code_execution_result.output.value, log=logs)
 
         self._context.emit_log_event(
             severity="INFO",
-            message=outputs.log,
+            message=logs,
         )
         return outputs
 

--- a/tests/workflows/basic_code_execution_node/tests/test_workflow.py
+++ b/tests/workflows/basic_code_execution_node/tests/test_workflow.py
@@ -1,7 +1,14 @@
+from unittest import mock
+
 from vellum import CodeExecutorResponse, NumberVellumValue
+from vellum.workflows.events.node import NodeExecutionLogBody, NodeExecutionLogEvent
+from vellum.workflows.workflows.event_filters import all_workflow_event_filter
 
 from tests.workflows.basic_code_execution_node.try_workflow import TrySimpleCodeExecutionWorkflow
-from tests.workflows.basic_code_execution_node.workflow import SimpleCodeExecutionWithFilepathWorkflow
+from tests.workflows.basic_code_execution_node.workflow import (
+    SimpleCodeExecutionNode,
+    SimpleCodeExecutionWithFilepathWorkflow,
+)
 
 
 def test_run_workflow__happy_path(vellum_client):
@@ -44,3 +51,42 @@ def test_run_workflow__try_wrapped(vellum_client):
 
     # AND the output should match the mapped items
     assert final_event.outputs == {"result": 0, "log": "hello"}
+
+
+def test_run_workflow__emits_log_event(vellum_client):
+    # GIVEN a workflow that references a Code Execution example
+    workflow = SimpleCodeExecutionWithFilepathWorkflow()
+
+    mock_code_execution = CodeExecutorResponse(
+        log="hello",
+        output=NumberVellumValue(value=0),
+    )
+    vellum_client.execute_code.return_value = mock_code_execution
+
+    # WHEN the workflow is streamed
+    events = list(workflow.stream(event_filter=all_workflow_event_filter))
+
+    # THEN we should emit an event for the log output
+    node_events = [e for e in events if e.name in ["node.execution.initiated", "node.execution.fulfilled"]]
+    expected_trace_id = node_events[0].trace_id
+    expected_span_id = node_events[0].span_id
+
+    # AND a log event should have been emitted with the code execution log
+    log_events = [e for e in events if e.name == "node.execution.log"]
+    assert log_events == [
+        NodeExecutionLogEvent.model_construct(
+            id=mock.ANY,
+            timestamp=mock.ANY,
+            api_version="2024-10-25",
+            trace_id=expected_trace_id,
+            span_id=expected_span_id,
+            parent=None,
+            links=None,
+            body=NodeExecutionLogBody(
+                node_definition=SimpleCodeExecutionNode,
+                attributes=None,
+                severity="INFO",
+                message="hello",
+            ),
+        )
+    ]


### PR DESCRIPTION
ref: APO-2949

Integrate the logs emitted by code exec with the recently introduced log events infra

<img width="1163" height="281" alt="Screenshot 2026-02-06 at 10 38 46 AM" src="https://github.com/user-attachments/assets/cebd1608-3d0d-4cee-8bb8-755ee569fa9e" />
<img width="1163" height="281" alt="Screenshot 2026-02-06 at 10 38 50 AM" src="https://github.com/user-attachments/assets/aec6218a-6a93-458d-a4f7-5de3da38eca3" />
