### PR TITLE
Include metadata json file during pull

### DIFF
--- a/ee/vellum_cli/pull.py
+++ b/ee/vellum_cli/pull.py
@@ -323,8 +323,6 @@ def pull_command(
                     if file_name == ERROR_LOG_FILE_NAME:
                         error_content = content
                         continue
-                    if file_name == METADATA_FILE_NAME:
-                        continue
 
                     target_file = os.path.join(target_dir, file_name)
                     os.makedirs(os.path.dirname(target_file), exist_ok=True)


### PR DESCRIPTION
## Preserve metadata.json dataset_row_index_to_id_mapping to avoid duplicate scenarios on push

### Problem

Pushing workflows with dataset scenarios was creating duplicate scenarios because `dataset_row_index_to_id_mapping` from `metadata.json` was not preserved. As a result, the push logic treated rows as new and generated new IDs instead of reusing existing ones.

### Root Cause

1. **Backend**: When merging pull results with existing metadata, `CodegenMetadata` did not preserve `dataset_row_index_to_id_mapping` from `existing_metadata`.
2. **CLI**: The pull command was not reliably writing `metadata.json` to the workflow directory.

### Solution

1. **Backend** (`app/core/internal_apis/codegen/api.py`): Preserve `dataset_row_index_to_id_mapping` from existing metadata when building `CodegenMetadata`.
2. **CLI** (`vellum_cli/pull.py`): Ensure `metadata.json` (including `dataset_row_index_to_id_mapping`) from the pull response is written to the workflow directory.

### Testing

- Backend: `test_codegen_api__preserves_dataset_row_index_to_id_mapping_from_existing_metadata`
- CLI: `test_pull__writes_metadata_json_with_dataset_row_index_to_id_mapping`