### PR TITLE
Fix bool inputs incorrectly compiled as NumberInput in code execution nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ exclude = "(.git|venv|src/vellum/client|tests/client|scripts|examples/workflows|
 
 [tool.flake8]
 max-line-length = 120
-exclude = ".git,.venv,ee/codegen/node_modules,ee/codegen_integration/fixtures,scripts,src/vellum/__init__.py,src/vellum/client,src/vellum/core,src/vellum/environment.py,src/vellum/errors,src/vellum/raw_client.py,src/vellum/resources,src/vellum/types,tests/client,examples/workflows,ee/codegen/python_file_merging/tests/fixtures"
+exclude = ".git,.venv,venv,ee/codegen/node_modules,ee/codegen_integration/fixtures,scripts,src/vellum/__init__.py,src/vellum/client,src/vellum/core,src/vellum/environment.py,src/vellum/errors,src/vellum/raw_client.py,src/vellum/resources,src/vellum/types,tests/client,examples/workflows,ee/codegen/python_file_merging/tests/fixtures"
 ignore = "E203, W503, E704, U100, U101"
 
 [tool.coverage.run]

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/node.py
@@ -213,6 +213,13 @@ class CodeExecutionNode(BaseNode[StateType], Generic[StateType, _OutputType], me
                         value=cast(Dict[str, Any], input_value),
                     )
                 )
+            elif isinstance(input_value, bool):
+                compiled_inputs.append(
+                    JsonInput(
+                        name=input_name,
+                        value=input_value,
+                    )
+                )
             elif isinstance(input_value, (float, int)):
                 compiled_inputs.append(
                     NumberInput(

--- a/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_node.py
+++ b/src/vellum/workflows/nodes/displayable/code_execution_node/tests/test_node.py
@@ -1442,6 +1442,60 @@ def main(secret: str) -> str:
     )
 
 
+def test_run_node__bool_input(vellum_client):
+    """Confirm that CodeExecutionNodes handle boolean inputs correctly via the API path.
+
+    In Python, bool is a subclass of int, so isinstance(True, int) returns True.
+    This test ensures that boolean values are compiled as JsonInput rather than
+    NumberInput, which would incorrectly convert True to 1.0 and False to 0.0.
+    """
+
+    # GIVEN a node that subclasses CodeExecutionNode with a boolean input
+    class State(BaseState):
+        pass
+
+    fixture = os.path.abspath(os.path.join(__file__, "../fixtures/main.py"))
+
+    class ExampleCodeExecutionNode(CodeExecutionNode[State, int]):
+        filepath = fixture
+        runtime = "PYTHON_3_11_6"
+        packages = [
+            CodeExecutionPackage(
+                name="openai",
+                version="1.0.0",
+            )
+        ]
+
+        code_inputs = {
+            "flag": True,
+        }
+
+    # AND we know what the Code Execution Node will respond with
+    mock_code_execution = CodeExecutorResponse(
+        log="",
+        output=NumberVellumValue(value=1),
+    )
+    vellum_client.execute_code.return_value = mock_code_execution
+
+    # WHEN we run the node
+    node = ExampleCodeExecutionNode(state=State())
+    outputs = node.run()
+
+    # THEN the node should have produced the outputs we expect
+    assert outputs == {"result": 1, "log": ""}
+
+    # AND we should have invoked the Code with a JsonInput for the boolean value,
+    # not a NumberInput which would incorrectly convert True to 1.0
+    from vellum import JsonInput
+
+    assert vellum_client.execute_code.call_args_list[0].kwargs["input_values"] == [
+        JsonInput(
+            name="flag",
+            value=True,
+        )
+    ]
+
+
 def test_run_node__undefined_input_skipped():
     """
     Confirm that when an undefined value is passed as an input, it is skipped rather than raising an error.


### PR DESCRIPTION
## Summary
- In Python, `bool` is a subclass of `int`, so `isinstance(True, int)` returns `True`. This caused `_compile_code_inputs` to convert boolean values to `NumberInput` (`True` -> `1.0`, `False` -> `0.0`) instead of preserving them as booleans via `JsonInput`.
- This bug specifically affects the API execution path (used when packages, non-default runtimes, or secrets are present), which is the path used in deployed workflows. The inline execution path (used in sandbox) passes values directly and handles booleans correctly.
- The fix adds a `bool` isinstance check before the `(float, int)` check in the type dispatch chain within `_compile_code_inputs`.

## Test plan
- [x] Added failing test `test_run_node__bool_input` that verifies boolean inputs are compiled as `JsonInput(value=True)` rather than `NumberInput(value=1.0)`
- [x] All 49 code execution node tests pass
- [x] All 3 workflow-level code execution tests pass
- [x] All serialization tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-python-sdks/pull/3729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
