### PR TITLE
Fix codegen incorrectly relativizing imports sharing top-level package

### DIFF
--- a/ee/codegen/src/__test__/python-file-imports.test.ts
+++ b/ee/codegen/src/__test__/python-file-imports.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { PythonFile } from "src/generators/extensions/protected-python-file";
+import { Reference } from "src/generators/extensions/reference";
+
+describe("PythonFile import writing", () => {
+  it("should relativize imports within the same module tree", () => {
+    const ref = new Reference({
+      name: "Inputs",
+      modulePath: ["my_project", "inputs"],
+    });
+
+    const file = new PythonFile({
+      path: ["my_project", "workflow", "nodes", "my_node"],
+      rootModulePath: ["my_project", "workflow"],
+      statements: [],
+      imports: [ref],
+    });
+
+    const output = file.toString();
+
+    expect(output).toContain("from ...inputs import Inputs");
+    expect(output).not.toContain("my_project");
+  });
+
+  it("should NOT relativize imports from a sibling sub-package that only shares the top-level package", () => {
+    const externalRef = new Reference({
+      name: "MyHelper",
+      modulePath: ["org", "shared", "utils", "helpers"],
+    });
+
+    const file = new PythonFile({
+      path: [
+        "org",
+        "app",
+        "support",
+        "my_workflow",
+        "workflow",
+        "nodes",
+        "my_node",
+      ],
+      rootModulePath: ["org", "app", "support", "my_workflow", "workflow"],
+      statements: [],
+      imports: [externalRef],
+    });
+
+    const output = file.toString();
+
+    expect(output).toContain("from org.shared.utils.helpers import MyHelper");
+    expect(output).not.toMatch(/\.{4,}/);
+  });
+});

--- a/ee/codegen/src/generators/base-persisted-file.ts
+++ b/ee/codegen/src/generators/base-persisted-file.ts
@@ -51,7 +51,7 @@ class ImportSortedPythonFile extends PythonFile {
         lastPriority = priority;
       }
 
-      if (refModulePath[0] === this.path[0]) {
+      if (this.shouldRelativize(refModulePath)) {
         // Relativize the import
         // Calculate the common prefix length
         let commonPrefixLength = 0;
@@ -126,7 +126,7 @@ class ImportSortedPythonFile extends PythonFile {
       return 0;
     }
 
-    if (modulePath[0] === this.path[0]) {
+    if (this.shouldRelativize(modulePath)) {
       return 1;
     }
 
@@ -172,6 +172,7 @@ export abstract class BasePersistedFile extends AstNode {
       statements: fileStatements,
       imports: this.getFileImports(),
       comments: this.getComments(),
+      rootModulePath: this.workflowContext.getRootModulePath(),
     });
 
     file.inheritReferences(this);

--- a/ee/codegen/src/generators/extensions/protected-python-file.ts
+++ b/ee/codegen/src/generators/extensions/protected-python-file.ts
@@ -31,12 +31,15 @@ export declare namespace PythonFile {
     comments?: Comment[];
     /* Any explicit imports that should be included */
     imports?: (StarImport | Reference)[];
+    /* The root module path prefix; only imports starting with this prefix will be relativized */
+    rootModulePath?: ModulePath;
   }
 }
 
 export class PythonFile extends AstNode {
   public readonly path: ModulePath;
   public readonly isInitFile: boolean;
+  public readonly rootModulePath: ModulePath | undefined;
   private readonly statements: AstNode[] = [];
   private readonly comments: Comment[];
 
@@ -46,10 +49,12 @@ export class PythonFile extends AstNode {
     isInitFile = false,
     comments,
     imports,
+    rootModulePath,
   }: PythonFile.Args) {
     super();
     this.path = path;
     this.isInitFile = isInitFile;
+    this.rootModulePath = rootModulePath;
 
     statements?.forEach((statement) => this.addStatement(statement));
 
@@ -251,7 +256,7 @@ export class PythonFile extends AstNode {
         continue;
       }
 
-      if (refModulePath[0] === this.path[0]) {
+      if (this.shouldRelativize(refModulePath)) {
         // Relativize the import
         // Calculate the common prefix length
         let commonPrefixLength = 0;
@@ -296,6 +301,20 @@ export class PythonFile extends AstNode {
     if (Object.keys(uniqueReferences).length > 0) {
       writer.newLine();
     }
+  }
+
+  protected shouldRelativize(refModulePath: ModulePath): boolean {
+    if (refModulePath[0] !== this.path[0]) {
+      return false;
+    }
+    if (!this.rootModulePath || this.rootModulePath.length === 0) {
+      return true;
+    }
+    const rootPrefix = this.rootModulePath.slice(0, -1);
+    if (refModulePath.length < rootPrefix.length) {
+      return false;
+    }
+    return rootPrefix.every((part, idx) => refModulePath[idx] === part);
   }
 
   protected isDefinedInFile(modulePath: readonly string[]): boolean {


### PR DESCRIPTION
## Summary
- When a workflow has a multi-segment module name (e.g., `org.app.support.my_workflow`), the codegen's `writeImports` only checked the first path element (`path[0]`) to decide whether to relativize an import
- This caused imports from sibling sub-packages (e.g., `org.shared.utils`) to be incorrectly converted to relative imports with too many dots (e.g., `......shared.utils`), producing "attempted relative import beyond top-level package" errors in the sandbox
- Adds `rootModulePath` to `PythonFile` to define the workflow's module boundary — only imports starting with this prefix are relativized
- When `rootModulePath` is not provided, the old first-element check is preserved for backward compatibility

## Test plan
- [x] Added unit test that reproduces the bug (deep module path + sibling sub-package import)
- [x] Added unit test for existing behavior (same module tree imports still relativized)
- [x] Full codegen test suite passes (736 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)